### PR TITLE
[SDP-821] misc: add XLM asset support

### DIFF
--- a/cmd/db_test.go
+++ b/cmd/db_test.go
@@ -199,10 +199,12 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 	assets, err = models.Assets.GetAll(ctx)
 	require.NoError(t, err)
 
-	assert.Len(t, assets, 1)
+	assert.Len(t, assets, 2)
 	assert.Equal(t, "USDC", assets[0].Code)
 	assert.NotEqual(t, testnetUSDCIssuer, assets[0].Issuer)
 	assert.Equal(t, services.DefaultAssetsNetworkMap[utils.PubnetNetworkType]["USDC"], assets[0].Issuer)
+	assert.Equal(t, "XLM", assets[1].Code)
+	assert.Empty(t, assets[1].Issuer)
 
 	// Validating wallets
 	wallets, err = models.Wallets.GetAll(ctx)
@@ -222,6 +224,8 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 		"updating/inserting assets for the 'pubnet' network",
 		"Code: USDC",
 		fmt.Sprintf("Issuer: %s", services.DefaultAssetsNetworkMap[utils.PubnetNetworkType]["USDC"]),
+		"Code: XLM",
+		"Issuer: ",
 		"updating/inserting wallets for the 'pubnet' network",
 		"Name: Vibrant Assist",
 		"Homepage: https://vibrantapp.com/assist",

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -133,6 +133,22 @@ services:
                 "max_amount": 10000
               },
               "withdraw": {"enabled": false}
+            },
+            {
+              "sep24_enabled": true,
+              "schema": "stellar",
+              "code": "native",
+              "issuer": "",
+              "distribution_account": "${DISTRIBUTION_PUBLIC_KEY}",
+              "significant_decimals": 7,
+              "deposit": {
+                "enabled": true,
+                "fee_minimum": 0,
+                "fee_percent": 0,
+                "min_amount": 1,
+                "max_amount": 10000
+              },
+              "withdraw": {"enabled": false}
             }
           ]
         }

--- a/helmchart/sdp/values.yaml
+++ b/helmchart/sdp/values.yaml
@@ -253,6 +253,22 @@ anchorPlatform:
                 "max_amount": 10000
               },
               "withdraw": {"enabled": false}
+            },
+            {
+              "sep24_enabled": true,
+              "schema": "stellar",
+              "code": "native",
+              "issuer": "",
+              "distribution_account": "GDDSLDRLMIYZJOXPBWVTRU267TPXIJEYW6PSV7FMDBLFVZZI5AI4QV4F",
+              "significant_decimals": 7,
+              "deposit": {
+                "enabled": true,
+                "fee_minimum": 0,
+                "fee_percent": 0,
+                "min_amount": 1,
+                "max_amount": 10000
+              },
+              "withdraw": {"enabled": false}
             }
           ]
         }

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -9,6 +9,7 @@ import (
 	"image"
 	"image/color"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ const (
 func CreateAssetFixture(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, code, issuer string) *Asset {
 	issuerAddress := issuer
 
-	if issuerAddress == "" {
+	if issuerAddress == "" && strings.ToUpper(code) != "XLM" {
 		issuer, err := utils.RandomString(56)
 		require.NoError(t, err)
 		issuerAddress = issuer

--- a/internal/db/migrations/2023-08-15.0-alter-issuer-constraints.sql
+++ b/internal/db/migrations/2023-08-15.0-alter-issuer-constraints.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+
+ALTER TABLE public.assets
+    DROP CONSTRAINT asset_issuer_length_check RESTRICT,
+    ADD CONSTRAINT asset_issuer_length_check CHECK ((code = 'XLM' AND char_length(issuer) = 0) OR char_length(issuer) = 56);
+
+ALTER TABLE public.submitter_transactions
+    ADD CONSTRAINT asset_issuer_length_check CHECK ((asset_code = 'XLM' AND char_length(asset_issuer) = 0) OR char_length(asset_issuer) = 56);
+
+-- +migrate Down
+
+ALTER TABLE public.assets
+    DROP CONSTRAINT asset_issuer_length_check RESTRICT,
+    ADD CONSTRAINT asset_issuer_length_check CHECK (char_length(issuer) = 56);
+
+ALTER TABLE public.submitter_transactions
+    DROP CONSTRAINT asset_issuer_length_check RESTRICT;

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -164,6 +164,46 @@ func Test_AssetHandlerAddAsset(t *testing.T) {
 		assert.Equal(t, "adding trustline for asset USDT:GBHC5ADV2XYITXCYC5F6X6BM2OYTYHV4ZU2JF6QWJORJQE2O7RKH2LAQ", entries[0].Message)
 	})
 
+	t.Run("successfully create the native asset", func(t *testing.T) {
+		data.DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
+
+		getEntries := log.DefaultLogger.StartTest(log.WarnLevel)
+
+		horizonClientMock.
+			On("AccountDetail", horizonclient.AccountRequest{
+				AccountID: distributionKP.Address(),
+			}).
+			Return(horizon.Account{
+				AccountID: distributionKP.Address(),
+				Sequence:  123,
+				Balances: []horizon.Balance{
+					{
+						Balance: "10000",
+						Asset: base.Asset{
+							Type: "native",
+							Code: "XLM",
+						},
+					},
+				},
+			}, nil).
+			Once()
+
+		rr := httptest.NewRecorder()
+
+		requestBody, _ := json.Marshal(AssetRequest{Code: "XLM"})
+
+		req, _ := http.NewRequest(http.MethodPost, "/assets", strings.NewReader(string(requestBody)))
+		http.HandlerFunc(handler.CreateAsset).ServeHTTP(rr, req)
+
+		resp := rr.Result()
+
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		entries := getEntries()
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "not performing either add or remove trustline", entries[0].Message)
+	})
+
 	t.Run("successfully create an asset with a trustline already set", func(t *testing.T) {
 		data.DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 
@@ -891,6 +931,37 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 		assert.EqualError(t, err, errCouldNotRemoveTrustline.Error())
 	})
 
+	t.Run("doesn't remove the trustline in case it's already removed", func(t *testing.T) {
+		getEntries := log.DefaultLogger.StartTest(log.WarnLevel)
+
+		horizonClientMock.
+			On("AccountDetail", horizonclient.AccountRequest{
+				AccountID: distributionKP.Address(),
+			}).
+			Return(horizon.Account{
+				AccountID: distributionKP.Address(),
+				Sequence:  123,
+				Balances: []horizon.Balance{
+					{
+						Balance: "100",
+						Asset: base.Asset{
+							Type:   "",
+							Code:   "XLM",
+							Issuer: "",
+						},
+					},
+				},
+			}, nil).
+			Once()
+
+		err := handler.handleUpdateAssetTrustlineForDistributionAccount(ctx, nil, assetToRemoveTrustline)
+		assert.NoError(t, err)
+
+		entries := getEntries()
+		assert.Len(t, entries, 2)
+		assert.Equal(t, "not removing trustline for the asset USDT:GA24LJXFG73JGARIBG2GP6V5TNUUOS6BD23KOFCW3INLDY5KPKS7GACZ because it could not be found on the blockchain", entries[0].Message)
+	})
+
 	t.Run("doesn't add new trustline if distribution account already have trustline for the asset", func(t *testing.T) {
 		horizonClientMock.
 			On("AccountDetail", horizonclient.AccountRequest{
@@ -922,6 +993,61 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 
 		err := handler.handleUpdateAssetTrustlineForDistributionAccount(ctx, assetToAddTrustline, nil)
 		assert.NoError(t, err)
+	})
+
+	t.Run("does not perform either add or remove for the native asset", func(t *testing.T) {
+		horizonClientMock.
+			On("AccountDetail", horizonclient.AccountRequest{
+				AccountID: distributionKP.Address(),
+			}).
+			Return(horizon.Account{
+				AccountID: distributionKP.Address(),
+				Sequence:  123,
+				Balances: []horizon.Balance{
+					{
+						Balance: "100",
+						Asset: base.Asset{
+							Type:   "",
+							Code:   "XLM",
+							Issuer: "",
+						},
+					},
+					{
+						Balance: "100",
+						Asset: base.Asset{
+							Type:   "",
+							Code:   assetToAddTrustline.Code,
+							Issuer: assetToAddTrustline.Issuer,
+						},
+					},
+				},
+			}, nil).
+			Twice()
+
+		nativeAsset := &txnbuild.CreditAsset{
+			Code:   "XLM",
+			Issuer: "",
+		}
+
+		// add trustline
+		getEntries := log.DefaultLogger.StartTest(log.WarnLevel)
+
+		err := handler.handleUpdateAssetTrustlineForDistributionAccount(ctx, nativeAsset, nil)
+		require.NoError(t, err)
+
+		entries := getEntries()
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "not performing either add or remove trustline", entries[0].Message)
+
+		// remove trustline
+		getEntries = log.DefaultLogger.StartTest(log.WarnLevel)
+
+		err = handler.handleUpdateAssetTrustlineForDistributionAccount(ctx, nil, nativeAsset)
+		require.NoError(t, err)
+
+		entries = getEntries()
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "not performing either add or remove trustline", entries[0].Message)
 	})
 
 	horizonClientMock.AssertExpectations(t)

--- a/internal/serve/httphandler/stellar_toml_handler.go
+++ b/internal/serve/httphandler/stellar_toml_handler.go
@@ -57,7 +57,8 @@ func (s *StellarTomlHandler) buildOrganizationDocumentation(organization data.Or
 func (s *StellarTomlHandler) buildCurrencyInformation(assets []data.Asset) string {
 	strAssets := ""
 	for _, asset := range assets {
-		strAssets += fmt.Sprintf(`
+		if asset.Code != "XLM" {
+			strAssets += fmt.Sprintf(`
 		[[CURRENCIES]]
 		code = %q
 		issuer = %q
@@ -66,6 +67,16 @@ func (s *StellarTomlHandler) buildCurrencyInformation(assets []data.Asset) strin
 		status = "live"
 		desc = "%s"
 	`, asset.Code, asset.Issuer, asset.Code)
+		} else {
+			strAssets += `
+		[[CURRENCIES]]
+		code = "native"
+		status = "live"
+		is_asset_anchored = true
+		anchor_asset_type = "crypto"
+		desc = "XLM, the native token of the Stellar Network."
+	`
+		}
 	}
 
 	return strAssets

--- a/internal/serve/httphandler/stellar_toml_handler_test.go
+++ b/internal/serve/httphandler/stellar_toml_handler_test.go
@@ -162,10 +162,28 @@ func Test_StellarTomlHandler_buildCurrencyInformation(t *testing.T) {
 		assert.Equal(t, wantStr, currencyInformation)
 	})
 
+	t.Run("build currency information with native asset", func(t *testing.T) {
+		data.DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
+		asset := data.CreateAssetFixture(t, ctx, dbConnectionPool, "XLM", "")
+
+		currencyInformation := s.buildCurrencyInformation([]data.Asset{*asset})
+		wantStr := `
+		[[CURRENCIES]]
+		code = "native"
+		status = "live"
+		is_asset_anchored = true
+		anchor_asset_type = "crypto"
+		desc = "XLM, the native token of the Stellar Network."
+	`
+
+		assert.Equal(t, wantStr, currencyInformation)
+	})
+
 	t.Run("build currency information with multiple assets", func(t *testing.T) {
 		assets := data.ClearAndCreateAssetFixtures(t, ctx, dbConnectionPool)
+		xlm := data.CreateAssetFixture(t, ctx, dbConnectionPool, "XLM", "")
 
-		currencyInformation := s.buildCurrencyInformation(assets)
+		currencyInformation := s.buildCurrencyInformation(append(assets, *xlm))
 		wantStr := `
 		[[CURRENCIES]]
 		code = "EURT"
@@ -182,6 +200,13 @@ func Test_StellarTomlHandler_buildCurrencyInformation(t *testing.T) {
 		anchor_asset_type = "fiat"
 		status = "live"
 		desc = "USDC"
+	
+		[[CURRENCIES]]
+		code = "native"
+		status = "live"
+		is_asset_anchored = true
+		anchor_asset_type = "crypto"
+		desc = "XLM, the native token of the Stellar Network."
 	`
 
 		assert.Equal(t, wantStr, currencyInformation)

--- a/internal/services/send_payments_service.go
+++ b/internal/services/send_payments_service.go
@@ -120,7 +120,7 @@ func validatePaymentReadyForSending(p *data.Payment) error {
 		return fmt.Errorf("payment asset code is empty for payment %s", p.ID)
 	}
 	// 3. payment.asset.Issuer is used as transaction.AssetIssuer
-	if strings.TrimSpace(p.Asset.Issuer) == "" {
+	if strings.TrimSpace(p.Asset.Issuer) == "" && strings.TrimSpace(strings.ToUpper(p.Asset.Code)) != "XLM" {
 		return fmt.Errorf("payment asset issuer is empty for payment %s", p.ID)
 	}
 	// 4. payment.Amount is used as transaction.Amount

--- a/internal/services/send_payments_service_test.go
+++ b/internal/services/send_payments_service_test.go
@@ -96,19 +96,21 @@ func Test_SendPaymentsService_SendBatchPayments(t *testing.T) {
 		require.NoError(t, err)
 
 		// payments that can be sent
+		var payment *data.Payment
 		for _, p := range []*data.Payment{payment1, payment2, payment3} {
-			payment, err := models.Payment.Get(ctx, p.ID, dbConnectionPool)
+			payment, err = models.Payment.Get(ctx, p.ID, dbConnectionPool)
 			require.NoError(t, err)
 			require.Equal(t, data.PendingPaymentStatus, payment.Status)
 		}
 
 		// payments that can't be sent (rw status is not REGISTERED)
-		payment, err := models.Payment.Get(ctx, payment4.ID, dbConnectionPool)
+		payment, err = models.Payment.Get(ctx, payment4.ID, dbConnectionPool)
 		require.NoError(t, err)
 		require.Equal(t, data.ReadyPaymentStatus, payment.Status)
 
 		// validate transactions
-		transactions, err := tssModel.GetAllByPaymentIDs(ctx, []string{payment1.ID, payment2.ID, payment3.ID, payment4.ID})
+		var transactions []*txSubStore.Transaction
+		transactions, err = tssModel.GetAllByPaymentIDs(ctx, []string{payment1.ID, payment2.ID, payment3.ID, payment4.ID})
 		require.NoError(t, err)
 		require.Len(t, transactions, 3)
 

--- a/internal/services/setup_assets_for_network_service.go
+++ b/internal/services/setup_assets_for_network_service.go
@@ -17,9 +17,11 @@ type AssetsNetworkMapType map[utils.NetworkType]map[string]string
 var DefaultAssetsNetworkMap = AssetsNetworkMapType{
 	utils.PubnetNetworkType: {
 		"USDC": "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+		"XLM":  "",
 	},
 	utils.TestnetNetworkType: {
 		"USDC": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+		"XLM":  "",
 	},
 }
 

--- a/internal/services/setup_assets_for_network_service_test.go
+++ b/internal/services/setup_assets_for_network_service_test.go
@@ -49,14 +49,18 @@ func Test_SetupAssetsForProperNetwork(t *testing.T) {
 		assets, err := models.Assets.GetAll(ctx)
 		require.NoError(t, err)
 
-		assert.Len(t, assets, 1)
+		assert.Len(t, assets, 2)
 		assert.Equal(t, "USDC", assets[0].Code)
 		assert.Equal(t, "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", assets[0].Issuer)
+		assert.Equal(t, "XLM", assets[1].Code)
+		assert.Empty(t, assets[1].Issuer)
 
 		expectedLogs := []string{
 			"updating/inserting assets for the 'testnet' network",
 			"Code: USDC",
 			"Issuer: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+			"Code: XLM",
+			"Issuer: ",
 		}
 
 		logs := buf.String()

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -712,6 +712,12 @@ func Test_TransactionWorker_buildAndSignTransaction(t *testing.T) {
 			assetIssuer:           "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
 			getAccountResponseObj: horizon.Account{Sequence: accountSequence},
 		},
+		{
+			name:                  "🎉 successfully build and sign a transaction with native asset",
+			assetCode:             "XLM",
+			assetIssuer:           "",
+			getAccountResponseObj: horizon.Account{Sequence: accountSequence},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What

Add support to disburse the Stellar Network native token - XLM. Also, add it to the asset default list.

### Why

The SDP should be able to disburse XLM.

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
