### PR TITLE
[SDP-828] stellar-auth: increase the refresh authentication token period

### DIFF
--- a/stellar-auth/pkg/auth/jwt_manager.go
+++ b/stellar-auth/pkg/auth/jwt_manager.go
@@ -9,7 +9,7 @@ import (
 	jwtgo "github.com/golang-jwt/jwt/v4"
 )
 
-const defaultRefreshTimeout = 30
+const defaultRefreshTimeoutInMinutes = 2
 
 type JWTManager interface {
 	GenerateToken(ctx context.Context, user *User, expiresAt time.Time) (string, error)
@@ -86,7 +86,7 @@ func (m *defaultJWTManager) RefreshToken(ctx context.Context, tokenString string
 
 	// We only generate new tokens when enough time
 	// is elapsed.
-	if time.Until(c.ExpiresAt.Time) > defaultRefreshTimeout*time.Second {
+	if time.Until(c.ExpiresAt.Time) > defaultRefreshTimeoutInMinutes*time.Minute {
 		return tokenString, nil
 	}
 

--- a/stellar-auth/pkg/auth/jwt_manager_test.go
+++ b/stellar-auth/pkg/auth/jwt_manager_test.go
@@ -95,8 +95,8 @@ func Test_DefaultJWTManager_RefreshToken(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("returns the same token when is above 30 secs until expires", func(t *testing.T) {
-		expiresAt := time.Now().Add(time.Second * 31)
+	t.Run("returns the same token when is above the refresh period", func(t *testing.T) {
+		expiresAt := time.Now().Add(time.Minute * (defaultRefreshTimeoutInMinutes + 1))
 		token, err := jwtManager.GenerateToken(ctx, &User{}, expiresAt)
 		require.NoError(t, err)
 
@@ -108,7 +108,7 @@ func Test_DefaultJWTManager_RefreshToken(t *testing.T) {
 	})
 
 	t.Run("returns a refreshed token", func(t *testing.T) {
-		expiresAt := time.Now().Add(time.Second * 30)
+		expiresAt := time.Now().Add(time.Minute * defaultRefreshTimeoutInMinutes)
 		token, err := jwtManager.GenerateToken(ctx, &User{}, expiresAt)
 		require.NoError(t, err)
 

--- a/stellar-auth/pkg/auth/manager.go
+++ b/stellar-auth/pkg/auth/manager.go
@@ -95,7 +95,7 @@ func WithCustomJWTManagerOption(jwtManager JWTManager) AuthManagerOption {
 	}
 }
 
-// WithExpirationTimeInMinutesOption sets the JWT token expiration time in minutes. Default is `5 minutes`.
+// WithExpirationTimeInMinutesOption sets the JWT token expiration time in minutes. Default is `15 minutes`.
 func WithExpirationTimeInMinutesOption(minutes int) AuthManagerOption {
 	return func(am *defaultAuthManager) {
 		am.expirationTimeInMinutes = time.Minute * time.Duration(minutes)


### PR DESCRIPTION
### What

Increase the authentication token refresh period from 30s to 2min.

### Why

We are facing too many logouts due to the low refresh window we have for the authentication token. 

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
