### PR TITLE
[Chore] Increase base fee

### DIFF
--- a/cmd/channel_accounts.go
+++ b/cmd/channel_accounts.go
@@ -118,7 +118,7 @@ func (c *ChannelAccountsCommand) CreateCommand(toolOpts *txSubSvc.ChannelAccount
 			Usage:       "The max base fee for submitting a stellar transaction",
 			OptType:     types.Int,
 			ConfigKey:   &toolOpts.MaxBaseFee,
-			FlagDefault: txnbuild.MinBaseFee,
+			FlagDefault: 100 * txnbuild.MinBaseFee,
 			Required:    true,
 		},
 		{
@@ -235,7 +235,7 @@ func (c *ChannelAccountsCommand) EnsureCommand(toolOpts *txSubSvc.ChannelAccount
 			Usage:       "The max base fee for submitting a stellar transaction",
 			OptType:     types.Int,
 			ConfigKey:   &toolOpts.MaxBaseFee,
-			FlagDefault: txnbuild.MinBaseFee,
+			FlagDefault: 100 * txnbuild.MinBaseFee,
 			Required:    true,
 		},
 		{
@@ -311,7 +311,7 @@ func (c *ChannelAccountsCommand) DeleteCommand(toolOpts *txSubSvc.ChannelAccount
 			Usage:       "The max base fee for submitting a stellar transaction",
 			OptType:     types.Int,
 			ConfigKey:   &toolOpts.MaxBaseFee,
-			FlagDefault: txnbuild.MinBaseFee,
+			FlagDefault: 100 * txnbuild.MinBaseFee,
 			Required:    true,
 		},
 	}

--- a/cmd/channel_accounts_test.go
+++ b/cmd/channel_accounts_test.go
@@ -103,7 +103,7 @@ func Test_ChannelAccountsCommand_CreateCommand(t *testing.T) {
 		caServiceMock.
 			On("CreateChannelAccountsOnChain", context.Background(), txSubSvc.ChannelAccountServiceOptions{
 				NumChannelAccounts: 2,
-				MaxBaseFee:         txnbuild.MinBaseFee,
+				MaxBaseFee:         100 * txnbuild.MinBaseFee,
 				RootSeed:           distributionSeed,
 				EncryptKey:         encryptKey,
 			}).
@@ -235,7 +235,7 @@ func Test_ChannelAccountsCommand_EnsureCommand(t *testing.T) {
 	t.Run("executs the ensure command successfully", func(t *testing.T) {
 		caServiceMock.
 			On("EnsureChannelAccountsCount", context.Background(), txSubSvc.ChannelAccountServiceOptions{
-				MaxBaseFee:         txnbuild.MinBaseFee,
+				MaxBaseFee:         100 * txnbuild.MinBaseFee,
 				NumChannelAccounts: 2,
 				RootSeed:           distributionSeed,
 				EncryptKey:         encryptKey,
@@ -309,7 +309,7 @@ func Test_ChannelAccountsCommand_DeleteCommand(t *testing.T) {
 		parentCmdMock.SetArgs(args)
 		caServiceMock.
 			On("DeleteChannelAccount", context.Background(), txSubSvc.ChannelAccountServiceOptions{
-				MaxBaseFee:       txnbuild.MinBaseFee,
+				MaxBaseFee:       100 * txnbuild.MinBaseFee,
 				ChannelAccountID: "acc-id",
 				RootSeed:         distributionSeed,
 			}).

--- a/cmd/transaction_submitter.go
+++ b/cmd/transaction_submitter.go
@@ -123,7 +123,7 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 			Usage:       "The max base fee for submitting a Stellar transaction",
 			OptType:     types.Int,
 			ConfigKey:   &submitterOpts.MaxBaseFee,
-			FlagDefault: txnbuild.MinBaseFee,
+			FlagDefault: 100 * txnbuild.MinBaseFee,
 			Required:    true,
 		},
 		{

--- a/cmd/transaction_submitter_test.go
+++ b/cmd/transaction_submitter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve"
@@ -77,7 +78,7 @@ func Test_tss(t *testing.T) {
 		HorizonURL:           "https://horizon-testnet.stellar.org",
 		DistributionSeed:     "SBQ3ZNC2SE3FV43HZ2KW3FCXQMMIQ33LZB745KTMCHDS6PNQOVXMV5NC",
 		NetworkPassphrase:    "Test SDF Network ; September 2015",
-		MaxBaseFee:           100,
+		MaxBaseFee:           100 * txnbuild.MinBaseFee,
 		NumChannelAccounts:   2,
 		QueuePollingInterval: 6,
 		MonitorService:       &mMonitorService,

--- a/helmchart/sdp/values.yaml
+++ b/helmchart/sdp/values.yaml
@@ -308,7 +308,7 @@ tss:
 
     data:
       NUM_CHANNEL_ACCOUNTS: "1"
-      MAX_BASE_FEE: "100"
+      MAX_BASE_FEE: "100000"
       MOCK: "false"
       TSS_METRICS_TYPE: "TSS_PROMETHEUS"
 


### PR DESCRIPTION
### What

Increase base fee

### Why

During tests with the demo instance, we noticed some payments failing or taking too long to succeed.

A higher (default) fee will be more resilient.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
