### PR TITLE
SDP-795 Remove TSS configs that could allow unencrypted ChannelAccount private keys to be saved in the database

### DIFF
--- a/cmd/channel_accounts.go
+++ b/cmd/channel_accounts.go
@@ -121,23 +121,6 @@ func (c *ChannelAccountsCommand) CreateCommand(toolOpts *txSubSvc.ChannelAccount
 			FlagDefault: 100 * txnbuild.MinBaseFee,
 			Required:    true,
 		},
-		{
-			Name:        "encrypt-key",
-			Usage:       "Whether or not to encrypt the private key for storage",
-			OptType:     types.Bool,
-			ConfigKey:   &toolOpts.EncryptKey,
-			FlagDefault: true,
-			Required:    true,
-		},
-		// { // TODO - actually use this  - not needed for SDP's TSS
-		// 	Name:           "output",
-		// 	Usage:          "where to output the channel accounts (database or csv file)",
-		// 	OptType:        types.String,
-		// 	CustomSetValue: ?,
-		// 	ConfigKey:      &submitterOpts.DistributionPublicKey,
-		// 	FlagDefault:    "database",
-		// 	Required:       false,
-		// },
 	}
 	createCmd := &cobra.Command{
 		Use:   "create",
@@ -236,14 +219,6 @@ func (c *ChannelAccountsCommand) EnsureCommand(toolOpts *txSubSvc.ChannelAccount
 			OptType:     types.Int,
 			ConfigKey:   &toolOpts.MaxBaseFee,
 			FlagDefault: 100 * txnbuild.MinBaseFee,
-			Required:    true,
-		},
-		{
-			Name:        "encrypt-key",
-			Usage:       "Whether or not to encrypt the private key for storage",
-			OptType:     types.Bool,
-			ConfigKey:   &toolOpts.EncryptKey,
-			FlagDefault: true,
 			Required:    true,
 		},
 	}

--- a/cmd/channel_accounts_test.go
+++ b/cmd/channel_accounts_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strconv"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -55,7 +54,6 @@ func Test_ChannelAccountsCommand_CreateCommand(t *testing.T) {
 	parentCmdMock.AddCommand(cmd)
 
 	distributionSeed := keypair.MustRandom().Seed()
-	encryptKey := true
 
 	parentCmdMock.SetArgs([]string{
 		"create",
@@ -63,8 +61,6 @@ func Test_ChannelAccountsCommand_CreateCommand(t *testing.T) {
 		distributionSeed,
 		"--num-channel-accounts-create",
 		"2",
-		"--encrypt-key",
-		strconv.FormatBool(encryptKey),
 	})
 
 	t.Run("exit with status 1 when ChannelAccountsService fails", func(t *testing.T) {
@@ -75,7 +71,6 @@ func Test_ChannelAccountsCommand_CreateCommand(t *testing.T) {
 					NumChannelAccounts: 2,
 					MaxBaseFee:         txnbuild.MinBaseFee,
 					RootSeed:           distributionSeed,
-					EncryptKey:         encryptKey,
 				}).
 				Return(customErr)
 			crashTrackerMock.On("LogAndReportErrors", context.Background(), customErr, "Cmd channel-accounts create crash")
@@ -105,7 +100,6 @@ func Test_ChannelAccountsCommand_CreateCommand(t *testing.T) {
 				NumChannelAccounts: 2,
 				MaxBaseFee:         100 * txnbuild.MinBaseFee,
 				RootSeed:           distributionSeed,
-				EncryptKey:         encryptKey,
 			}).
 			Return(nil)
 
@@ -187,7 +181,6 @@ func Test_ChannelAccountsCommand_EnsureCommand(t *testing.T) {
 	parentCmdMock.AddCommand(cmd)
 
 	distributionSeed := keypair.MustRandom().Seed()
-	encryptKey := true
 
 	parentCmdMock.SetArgs([]string{
 		"ensure",
@@ -195,8 +188,6 @@ func Test_ChannelAccountsCommand_EnsureCommand(t *testing.T) {
 		distributionSeed,
 		"--num-channel-accounts-ensure",
 		"2",
-		"--encrypt-key",
-		strconv.FormatBool(encryptKey),
 	})
 
 	t.Run("exit with status 1 when ChannelAccountsService fails", func(t *testing.T) {
@@ -207,7 +198,6 @@ func Test_ChannelAccountsCommand_EnsureCommand(t *testing.T) {
 					MaxBaseFee:         txnbuild.MinBaseFee,
 					NumChannelAccounts: 2,
 					RootSeed:           distributionSeed,
-					EncryptKey:         encryptKey,
 				}).
 				Return(customErr)
 			crashTrackerMock.On("LogAndReportErrors", context.Background(), customErr, "Cmd channel-accounts ensure crash")
@@ -238,7 +228,6 @@ func Test_ChannelAccountsCommand_EnsureCommand(t *testing.T) {
 				MaxBaseFee:         100 * txnbuild.MinBaseFee,
 				NumChannelAccounts: 2,
 				RootSeed:           distributionSeed,
-				EncryptKey:         encryptKey,
 			}).
 			Return(nil)
 

--- a/internal/transactionsubmission/README.md
+++ b/internal/transactionsubmission/README.md
@@ -77,7 +77,6 @@ Usage:
 
 Flags:
       --distribution-seed string          The private key of the Stellar account that will be used to sponsor the channel accounts (DISTRIBUTION_SEED)
-      --encrypt-key                       Whether or not to encrypt the private key for storage (ENCRYPT_KEY) (default true)
   -h, --help                              help for create
       --max-base-fee int                  The max base fee for submitting a stellar transaction (MAX_BASE_FEE) (default 100)
       --num-channel-accounts-create int   The desired number of channel accounts to be created (NUM_CHANNEL_ACCOUNTS_CREATE) (default 1)
@@ -91,7 +90,6 @@ Usage:
 
 Flags:
       --distribution-seed string          The private key of the Stellar account used to sponsor existing channel accounts (DISTRIBUTION_SEED)
-      --encrypt-key                       Whether or not to encrypt the private key for storage (ENCRYPT_KEY) (default true)
   -h, --help                              help for ensure
       --max-base-fee int                  The max base fee for submitting a stellar transaction (MAX_BASE_FEE) (default 100)
       --num-channel-accounts-ensure int   The desired number of channel accounts to manage (NUM_CHANNEL_ACCOUNTS_ENSURE) (default 1)

--- a/internal/transactionsubmission/horizon.go
+++ b/internal/transactionsubmission/horizon.go
@@ -35,7 +35,7 @@ const DefaultRevokeSponsorshipReserveAmount = "1.5"
 // CreateChannelAccountsOnChain will create up to 19 accounts per Transaction due to the 20 signatures per tx limit This
 // is also a good opportunity to periodically write the generated accounts to persistent storage if generating large
 // amounts of channel accounts.
-func CreateChannelAccountsOnChain(ctx context.Context, horizonClient horizonclient.ClientInterface, numOfChanAccToCreate int, maxBaseFee int, shouldEncryptSeed bool, sigService engine.SignatureService, currLedgerNumber int) (newAccountAddresses []string, err error) {
+func CreateChannelAccountsOnChain(ctx context.Context, horizonClient horizonclient.ClientInterface, numOfChanAccToCreate int, maxBaseFee int, sigService engine.SignatureService, currLedgerNumber int) (newAccountAddresses []string, err error) {
 	defer func() {
 		// If we failed to create the accounts, we should delete the accounts that were added to the signature service.
 		if err != nil && sigService != nil {
@@ -103,7 +103,7 @@ func CreateChannelAccountsOnChain(ctx context.Context, horizonClient horizonclie
 		newAccountAddresses = append(newAccountAddresses, channelAccountKP.Address())
 	}
 
-	err = sigService.BatchInsert(ctx, kpsToCreate, shouldEncryptSeed, currLedgerNumber)
+	err = sigService.BatchInsert(ctx, kpsToCreate, true, currLedgerNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert channel accounts into signature service: %w", err)
 	}

--- a/internal/transactionsubmission/horizon_test.go
+++ b/internal/transactionsubmission/horizon_test.go
@@ -47,7 +47,6 @@ func Test_CreateChannelAccountsOnChain(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		numOfChanAccToCreate int
-		shouldEncryptSeed    bool
 		prepareMocksFn       func()
 		wantErrContains      string
 	}{
@@ -82,7 +81,6 @@ func Test_CreateChannelAccountsOnChain(t *testing.T) {
 		{
 			name:                 "returns error when fails encrypting private key",
 			numOfChanAccToCreate: 2,
-			shouldEncryptSeed:    true,
 			prepareMocksFn: func() {
 				horizonClientMock.
 					On("AccountDetail", horizonclient.AccountRequest{AccountID: sigService.DistributionAccount()}).
@@ -120,30 +118,16 @@ func Test_CreateChannelAccountsOnChain(t *testing.T) {
 						},
 					}).
 					Once()
+
+				privateKeyEncrypterMock.
+					On("Encrypt", mock.AnythingOfType("string"), encrypterPass).Return("encryptedkey", nil).Twice().
+					On("Decrypt", mock.AnythingOfType("string"), encrypterPass).Return(keypair.MustRandom().Seed(), nil).Twice()
 			},
 			wantErrContains: "creating sponsored channel accounts: horizon response error: StatusCode=408, Type=https://stellar.org/horizon-errors/timeout, Title=Timeout, Detail=Foo bar detail",
 		},
 		{
-			name:                 "🎉 successfully creates channel accounts on-chain (UNENCRYPTED)",
-			numOfChanAccToCreate: 2,
-			shouldEncryptSeed:    false,
-			prepareMocksFn: func() {
-				horizonClientMock.
-					On("AccountDetail", horizonclient.AccountRequest{AccountID: distributionKP.Address()}).
-					Return(horizon.Account{
-						AccountID: distributionKP.Address(),
-						Sequence:  1,
-					}, nil).
-					Once().
-					On("SubmitTransactionWithOptions", mock.AnythingOfType("*txnbuild.Transaction"), horizonclient.SubmitTxOpts{SkipMemoRequiredCheck: true}).
-					Return(horizon.Transaction{}, nil).
-					Once()
-			},
-		},
-		{
 			name:                 "🎉 successfully creates channel accounts on-chain (ENCRYPTED)",
 			numOfChanAccToCreate: 3,
-			shouldEncryptSeed:    true,
 			prepareMocksFn: func() {
 				horizonClientMock.
 					On("AccountDetail", horizonclient.AccountRequest{AccountID: distributionKP.Address()}).
@@ -172,7 +156,7 @@ func Test_CreateChannelAccountsOnChain(t *testing.T) {
 				tc.prepareMocksFn()
 			}
 
-			channelAccountAddresses, err := CreateChannelAccountsOnChain(ctx, horizonClientMock, tc.numOfChanAccToCreate, txnbuild.MinBaseFee, tc.shouldEncryptSeed, sigService, currLedgerNumber)
+			channelAccountAddresses, err := CreateChannelAccountsOnChain(ctx, horizonClientMock, tc.numOfChanAccToCreate, txnbuild.MinBaseFee, sigService, currLedgerNumber)
 			if tc.wantErrContains != "" {
 				require.Error(t, err)
 				assert.Empty(t, channelAccountAddresses)
@@ -193,14 +177,8 @@ func Test_CreateChannelAccountsOnChain(t *testing.T) {
 				require.NoError(t, err)
 				assert.Len(t, allChAcc, tc.numOfChanAccToCreate)
 
-				if !tc.shouldEncryptSeed {
-					for _, chAcc := range allChAcc {
-						assert.True(t, strkey.IsValidEd25519SecretSeed(chAcc.PrivateKey))
-					}
-				} else {
-					for _, chAcc := range allChAcc {
-						assert.False(t, strkey.IsValidEd25519SecretSeed(chAcc.PrivateKey))
-					}
+				for _, chAcc := range allChAcc {
+					assert.False(t, strkey.IsValidEd25519SecretSeed(chAcc.PrivateKey))
 				}
 			}
 

--- a/internal/transactionsubmission/services/channel_account_service.go
+++ b/internal/transactionsubmission/services/channel_account_service.go
@@ -40,7 +40,6 @@ type ChannelAccountServiceOptions struct {
 	DatabaseDSN            string
 	DeleteAllAccounts      bool
 	DeleteInvalidAcccounts bool
-	EncryptKey             bool
 	HorizonUrl             string
 	MaxBaseFee             int
 	NetworkPassphrase      string
@@ -80,7 +79,7 @@ func NewChannelAccountService(ctx context.Context, opts ChannelAccountServiceOpt
 
 // CreateChannelAccountsOnChain creates a specified count of sponsored channel accounts onchain and internally in the database.
 func (s *ChannelAccountsService) CreateChannelAccountsOnChain(ctx context.Context, opts ChannelAccountServiceOptions) error {
-	log.Ctx(ctx).Infof("NumChannelAccounts: %d, Horizon: %s, Passphrase: %s, EncryptKey?: %t", opts.NumChannelAccounts, opts.HorizonUrl, opts.NetworkPassphrase, opts.EncryptKey)
+	log.Ctx(ctx).Infof("NumChannelAccounts: %d, Horizon: %s, Passphrase: %s", opts.NumChannelAccounts, opts.HorizonUrl, opts.NetworkPassphrase)
 	// createAccountsInBatch creates count number of channel accounts in batches of MaxBatchSize or less per loop
 	err := createAccountsInBatch(ctx, s.dbConnectionPool, opts, s.horizonClient, s.caStore, s.ledgerNumberTracker)
 	if err != nil {
@@ -121,7 +120,6 @@ func createAccountsInBatch(
 			horizonClient,
 			batchSize,
 			opts.MaxBaseFee,
-			opts.EncryptKey,
 			sigService,
 			currLedgerNumber,
 		)

--- a/internal/transactionsubmission/services/channel_accounts_service_test.go
+++ b/internal/transactionsubmission/services/channel_accounts_service_test.go
@@ -48,7 +48,6 @@ func Test_ChannelAccounts_CreateAccount_Success(t *testing.T) {
 		MaxBaseFee:         100,
 		NetworkPassphrase:  "Test SDF Network ; September 2015",
 		RootSeed:           "SBMW2WDSVTGT2N2PCBF3PV7WBOIKVTGGIEBUUYMDX3CKTDD5HY3UIHV4",
-		EncryptKey:         true,
 	}
 
 	rootAccount := keypair.MustParseFull(opts.RootSeed)
@@ -107,7 +106,6 @@ func Test_ChannelAccounts_CreateAccount_CannotFindRootAccount_Failure(t *testing
 		MaxBaseFee:         100,
 		NetworkPassphrase:  "Test SDF Network ; September 2015",
 		RootSeed:           "SDL4E4RF6BHX77DBKE63QC4H4LQG7S7D2PB4TSF64LTHDIHP7UUJHH2V",
-		EncryptKey:         true,
 	}
 
 	rootAccount := keypair.MustParseFull(opts.RootSeed)
@@ -151,7 +149,6 @@ func Test_ChannelAccounts_CreateAccount_Insert_Failure(t *testing.T) {
 		MaxBaseFee:         100,
 		NetworkPassphrase:  "Test SDF Network ; September 2015",
 		RootSeed:           "SBMW2WDSVTGT2N2PCBF3PV7WBOIKVTGGIEBUUYMDX3CKTDD5HY3UIHV4",
-		EncryptKey:         true,
 	}
 
 	rootAccount := keypair.MustParseFull(opts.RootSeed)


### PR DESCRIPTION
### What

SDP-795 Remove TSS configs that could allow unencrypted ChannelAccount private keys to be saved in the database

### Why

Security improvement to prevent someone from misconfigure this in production.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
