### PR TITLE
SDP-800 add application activity Logs

### DIFF
--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -309,6 +309,10 @@ func Test_LoginHandler(t *testing.T) {
 	})
 
 	t.Run("returns the token correctly", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		user := &auth.User{
 			ID:    "user-ID",
 			Email: "email",
@@ -318,20 +322,33 @@ func Test_LoginHandler(t *testing.T) {
 			On("ValidateCredentials", mock.Anything, "testuser", "pass1234").
 			Return(user, nil).
 			Once()
-
 		roleManagerMock.
 			On("GetUserRoles", mock.Anything, user).
 			Return([]string{"role1"}, nil).
 			Once()
-
 		jwtManagerMock.
 			On("GenerateToken", mock.Anything, user, mock.AnythingOfType("time.Time")).
 			Return("token123", nil).
 			Once()
-
 		reCAPTCHAValidator.
 			On("IsTokenValid", mock.Anything, "XyZ").
 			Return(true, nil).
+			Once()
+		jwtManagerMock.
+			On("ValidateToken", mock.Anything, "token123").
+			Return(true, nil).
+			Once()
+		jwtManagerMock.
+			On("GetUserFromToken", mock.Anything, "token123").
+			Return(user, nil).
+			Once()
+		authenticatorMock.
+			On("GetUser", mock.Anything, "user-ID").
+			Return(user, nil).
+			Once()
+		roleManagerMock.
+			On("GetUserRoles", mock.Anything, user).
+			Return([]string{"role1"}, nil).
 			Once()
 
 		r.Post(url, handler.ServeHTTP)
@@ -358,6 +375,9 @@ func Test_LoginHandler(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.JSONEq(t, `{"token": "token123"}`, string(respBody))
+
+		// validate logs
+		require.Contains(t, buf.String(), "[UserLogin] - Logged in user with account ID user-ID")
 	})
 
 	authenticatorMock.AssertExpectations(t)

--- a/internal/serve/httphandler/mfa_handler.go
+++ b/internal/serve/httphandler/mfa_handler.go
@@ -79,5 +79,12 @@ func (h MFAHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		httperror.InternalError(ctx, "Cannot authenticate user", err, nil).Render(rw)
 		return
 	}
+
+	userID, err := h.AuthManager.GetUserID(ctx, token)
+	if err != nil {
+		httperror.InternalError(ctx, "Cannot get user ID", err, nil).Render(rw)
+		return
+	}
+	log.Ctx(ctx).Infof("[UserLogin] - Logged in user with account ID %s", userID)
 	httpjson.RenderStatus(rw, http.StatusOK, MFAResponse{Token: token}, httpjson.JSON)
 }

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -258,6 +258,13 @@ func (h ProfileHandler) PatchUserPassword(rw http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	userID, err := h.AuthManager.GetUserID(ctx, token)
+	if err != nil {
+		httperror.InternalError(ctx, "Cannot get user ID", err, nil).Render(rw)
+		return
+	}
+	log.Ctx(ctx).Infof("[UpdateUserPassword] - Updated password for user with account ID %s", userID)
+
 	httpjson.RenderStatus(rw, http.StatusOK, map[string]string{"message": "user password updated successfully"}, httpjson.JSON)
 }
 

--- a/internal/serve/httphandler/reset_password_handler.go
+++ b/internal/serve/httphandler/reset_password_handler.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
@@ -70,5 +72,7 @@ func (h ResetPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	log.Infof("[ResetUserPassword] - Reset password for user with token %s",
+		utils.TruncateString(resetPasswordRequest.ResetToken, len(resetPasswordRequest.ResetToken)/4))
 	httpjson.RenderStatus(w, http.StatusOK, nil, httpjson.JSON)
 }

--- a/internal/serve/httphandler/reset_password_handler_test.go
+++ b/internal/serve/httphandler/reset_password_handler_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stellar/go/support/log"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +28,10 @@ func Test_ResetPasswordHandlerPost(t *testing.T) {
 	}
 
 	t.Run("Should return http status 200 on a valid request", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		requestBody := `{ "password": "!1Az?2By.3Cx", "reset_token": "goodtoken" }`
 
 		rr := httptest.NewRecorder()
@@ -41,6 +47,9 @@ func Test_ResetPasswordHandlerPost(t *testing.T) {
 
 		resp := rr.Result()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[ResetUserPassword] - Reset password for user with token go...en")
 	})
 
 	t.Run("Should return an error with an invalid token", func(t *testing.T) {

--- a/internal/serve/httphandler/user_handler.go
+++ b/internal/serve/httphandler/user_handler.go
@@ -121,8 +121,10 @@ func (h UserHandler) UserActivation(rw http.ResponseWriter, req *http.Request) {
 
 	var activationErr error
 	if *reqBody.IsActive {
+		log.Ctx(ctx).Infof("[ActivateUserAccount] - Activating user with account ID %s", reqBody.UserID)
 		activationErr = h.AuthManager.ActivateUser(ctx, token, reqBody.UserID)
 	} else {
+		log.Ctx(ctx).Infof("[DeactivateUserAccount] - Deactivating user with account ID %s", reqBody.UserID)
 		activationErr = h.AuthManager.DeactivateUser(ctx, token, reqBody.UserID)
 	}
 
@@ -215,6 +217,7 @@ func (h UserHandler) CreateUser(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	log.Ctx(ctx).Infof("[CreateUserAccount] - Created user with account ID %s", u.ID)
 	httpjson.RenderStatus(rw, http.StatusCreated, u, httpjson.JSON)
 }
 

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -313,6 +313,10 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 	})
 
 	t.Run("updates the user activation correctly", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		token := "mytoken"
 
 		jwtManagerMock.
@@ -373,6 +377,9 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.JSONEq(t, `{"message": "user activation was updated successfully"}`, string(respBody))
+
+		// validate logs
+		require.Contains(t, buf.String(), "[ActivateUserAccount] - Activating user with account ID user-id")
 	})
 }
 
@@ -776,6 +783,10 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 	})
 
 	t.Run("creates user successfully", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		u := &auth.User{
 			FirstName: "First",
 			LastName:  "Last",
@@ -851,6 +862,9 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
+
+		// validate logs
+		require.Contains(t, buf.String(), "[CreateUserAccount] - Created user with account ID user-id")
 	})
 
 	authenticatorMock.AssertExpectations(t)

--- a/stellar-auth/pkg/auth/mocks.go
+++ b/stellar-auth/pkg/auth/mocks.go
@@ -250,6 +250,11 @@ func (am *AuthManagerMock) GetUser(ctx context.Context, tokenString string) (*Us
 	return args.Get(0).(*User), args.Error(1)
 }
 
+func (am *AuthManagerMock) GetUserID(ctx context.Context, tokenString string) (string, error) {
+	args := am.Called(ctx, tokenString)
+	return args.Get(0).(string), args.Error(1)
+}
+
 func (am *AuthManagerMock) GetAllUsers(ctx context.Context, tokenString string) ([]User, error) {
 	args := am.Called(ctx, tokenString)
 	if args.Get(0) == nil {


### PR DESCRIPTION
### What
Adding the following logs 
* Account Lifecycle Logging: Must log creation and deletion of user accounts.
* Password Management Logging: Must log all changes to user passwords.
* User Access Pattern Logging: Must log new login instances of user logins.

### Why
To have a comprehensive application security log system that includes tracking of account lifecycle events, password management actions, and user access patterns, with timestamps and user associations in order to effectively monitor, detect, and respond to unauthorized access or malicious activities within the system, ensuring transparency, accountability, and compliance with security standards.

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [ ] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
