### PR TITLE
[SDP-774] Update tx worker to use crash tracker on failed tx's

### DIFF
--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -175,7 +175,10 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 				}
 
 				txJob.Transaction = *updatedTx
-				tw.crashTrackerClient.LogAndReportErrors(ctx, hErrWrapper, "transaction error - cannot be retried")
+				// report any terminal errors, excluding those caused by the external account not being valid
+				if !hErrWrapper.IsDestinationAccountNotReady() {
+					tw.crashTrackerClient.LogAndReportErrors(ctx, hErrWrapper, "transaction error - cannot be retried")
+				}
 			}
 		}
 	}

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -228,10 +228,6 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 	return nil
 }
 
-func (tw *TransactionWorker) handleAuthorizationError() error {
-	return nil
-}
-
 // TODO: add tests
 // unlockJob will unlock the channel account and transaction instantaneously, so they can be made available ASAP. If
 // this method is not called, the algorithm will fall back to get these resources qutomatically unlocked when their

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -166,39 +166,8 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 
 		if hErrWrapper.ResultCodes != nil {
 			isHorizonErr = true
-			// TODO: move this logic inside the HorizonErrorWrapper
-			// ref: https://developers.stellar.org/api/horizon/errors/result-codes/
-			failedTxErrCodes := []string{
-				"tx_bad_auth",
-				"tx_bad_auth_extra",
-				"tx_insufficient_balance",
-			}
-			if slices.Contains(failedTxErrCodes, hErrWrapper.ResultCodes.TransactionCode) || slices.Contains(failedTxErrCodes, hErrWrapper.ResultCodes.InnerTransactionCode) {
-				shouldMarkAsError = true
-			}
 
-			// TODO: move this logic inside the HorizonErrorWrapper
-			// ref: https://developers.stellar.org/api/horizon/errors/result-codes/
-			failedOpCodes := []string{
-				"op_bad_auth",
-				"op_underfunded",
-				"op_src_not_authorized",
-				"op_no_destination",
-				"op_no_trust",
-				"op_line_full",
-				"op_not_authorized",
-				"op_no_issuer",
-			}
-			if !shouldMarkAsError {
-				for _, opResult := range hErrWrapper.ResultCodes.OperationCodes {
-					if slices.Contains(failedOpCodes, opResult) {
-						shouldMarkAsError = true
-						break
-					}
-				}
-			}
-
-			if shouldMarkAsError {
+			if hErrWrapper.ShouldMarkAsError() {
 				var updatedTx *store.Transaction
 				updatedTx, err = tw.txModel.UpdateStatusToError(ctx, txJob.Transaction, hErrWrapper.Error())
 				if err != nil {
@@ -206,6 +175,7 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 				}
 
 				txJob.Transaction = *updatedTx
+				tw.crashTrackerClient.LogAndReportErrors(ctx, hErrWrapper, "transaction error - cannot be retried")
 			}
 		}
 	}
@@ -255,6 +225,10 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 		return fmt.Errorf("unlocking job: %w", err)
 	}
 
+	return nil
+}
+
+func (tw *TransactionWorker) handleAuthorizationError() error {
 	return nil
 }
 

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -183,8 +183,6 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 		}
 	}
 
-	// TODO: call MonitorService if needed
-	// TODO: call crashTrackerClient if needed
 	// TODO: op_bad_auth, tx_bad_auth, tx_bad_auth_extra are big problems that need to be reported accordingly
 	// TODO: tx_bad_seq is a big problem that needs to be reported accordingly
 

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -880,7 +880,7 @@ func Test_TransactionWorker_submit(t *testing.T) {
 					Extras: map[string]interface{}{
 						"result_codes": map[string]interface{}{
 							"transaction": "tx_failed",
-							"operations":  []string{"op_no_trust"}, // <--- this should make the transaction be marked as ERROR
+							"operations":  []string{"op_underfunded"}, // <--- this should make the transaction be marked as ERROR
 						},
 					},
 				},

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -908,7 +908,7 @@ func Test_TransactionWorker_submit(t *testing.T) {
 			mockHorizonClient := &horizonclient.MockClient{}
 			mockCrashTrackerClient := &crashtracker.MockCrashTrackerClient{}
 			if tc.txMarkAsError {
-				mockCrashTrackerClient.On("LogAndReportErrors", ctx, utils.NewHorizonErrorWrapper(tc.horizonError), "transaction error - cannot be retried")
+				mockCrashTrackerClient.On("LogAndReportErrors", ctx, utils.NewHorizonErrorWrapper(tc.horizonError), "transaction error - cannot be retried").Once()
 			}
 
 			txProcessingLimiter := engine.NewTransactionProcessingLimiter(15)
@@ -957,6 +957,7 @@ func Test_TransactionWorker_submit(t *testing.T) {
 			assert.False(t, refreshedChAcc.IsLocked(int32(txJob.LockedUntilLedgerNumber)))
 
 			mockHorizonClient.AssertExpectations(t)
+			mockCrashTrackerClient.AssertExpectations(t)
 		})
 	}
 }


### PR DESCRIPTION
### What
- Moved horizon tx error parsing logic to utils file
- Call crash tracker when tx should be marked as an error

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
