### PR TITLE
SDP-465: Update PATCH {AP}/transaction body with the appropriate fields

### DIFF
--- a/internal/anchorplatform/object_schemas.go
+++ b/internal/anchorplatform/object_schemas.go
@@ -48,9 +48,7 @@ type APSep24TransactionWrapper struct {
 
 // APSep24Transaction is the transaction object used in the `{PlatformAPIBaseURL}/transactions` requests.
 type APSep24Transaction struct {
-	ID          string `json:"id"`
-	KYCVerified bool   `json:"kyc_verified,omitempty"`
-
+	APSep24TransactionPatch
 	// Kind can be "deposit" or "withdrawal". It's a read-only field.
 	Kind           string    `json:"kind,omitempty"`
 	AmountExpected *APAmount `json:"amount_expected,omitempty"`
@@ -64,8 +62,26 @@ type APSep24Transaction struct {
 	Memo      string     `json:"memo,omitempty"`
 	MemoType  string     `json:"memo_type,omitempty"`
 	AmountIn  *APAmount  `json:"amount_in,omitempty"`
+}
 
-	// These fields are patchable:
+func NewAPSep24TransactionRecordsFromPatches(patches ...APSep24TransactionPatch) APSep24TransactionRecords {
+	var records APSep24TransactionRecords
+	for _, patch := range patches {
+		newEntry := APSep24TransactionWrapper{
+			APSep24Transaction: APSep24Transaction{
+				APSep24TransactionPatch: patch,
+			},
+		}
+		records.Records = append(records.Records, newEntry)
+	}
+
+	return records
+}
+
+// APSep24TransactionPatch is the transaction object used in the `PATCH {PlatformAPIBaseURL}/transactions` request. It's be used to update the transaction data.
+type APSep24TransactionPatch struct {
+	// Identifiers:
+	ID                    string `json:"id"`
 	ExternalTransactionID string `json:"external_transaction_id,omitempty"`
 
 	// Status
@@ -83,19 +99,18 @@ type APSep24Transaction struct {
 	TransferReceivedAt *time.Time `json:"transfer_received_at,omitempty"`
 }
 
-func NewAPSep24TransactionRecordsFromPatches(patches ...APSep24Transaction) APSep24TransactionRecords {
-	var records APSep24TransactionRecords
-	for _, patch := range patches {
-		newEntry := APSep24TransactionWrapper{
-			APSep24Transaction: patch,
-		}
-		records.Records = append(records.Records, newEntry)
-	}
-
-	return records
+// APSep24TransactionPatchPostRegistration is a subset of APSep24TransactionPatch that can be used to update the
+// transaction data after the registration.
+type APSep24TransactionPatchPostRegistration struct {
+	ID                    string              `json:"id"`
+	ExternalTransactionID string              `json:"external_transaction_id,omitempty"`
+	SEP                   string              `json:"sep,omitempty"`
+	Status                APTransactionStatus `json:"status,omitempty"`
+	Message               string              `json:"message,omitempty"`
+	TransferReceivedAt    *time.Time          `json:"transfer_received_at,omitempty"`
 }
 
-// type APSep24TransactionPostSuccess struct {
+// type APSep24TransactionPatchPostSuccess struct {
 // 	ID                  string                 `json:"id"`
 // 	SEP                 string                 `json:"sep,omitempty"`
 // 	Status              APTransactionStatus    `json:"status,omitempty"` // Success
@@ -105,7 +120,7 @@ func NewAPSep24TransactionRecordsFromPatches(patches ...APSep24Transaction) APSe
 // 	AmountOut           APAmount               `json:"amount_out,omitempty"`
 // }
 
-// type APSep24TransactionPostError struct {
+// type APSep24TransactionPatchPostError struct {
 // 	ID                  string                 `json:"id"`
 // 	SEP                 string                 `json:"sep,omitempty"`
 // 	Status              APTransactionStatus    `json:"status,omitempty"` // Error

--- a/internal/anchorplatform/object_schemas.go
+++ b/internal/anchorplatform/object_schemas.go
@@ -116,19 +116,21 @@ type APSep24TransactionPatchPostRegistration struct {
 // 	SEP                 string                 `json:"sep,omitempty"`
 // 	Status              APTransactionStatus    `json:"status,omitempty"` // Success
 // 	StellarTransactions []APStellarTransaction `json:"stellar_transactions,omitempty"`
-// 	SourceAccount       string                 `json:"source_account,omitempty"`
 // 	Message             string                 `json:"message,omitempty"`
 // 	CompletedAt         *time.Time             `json:"completed_at,omitempty"`
 // 	AmountOut           APAmount               `json:"amount_out,omitempty"`
+// 	// TODO: update the AP version when source_account becomes patchable
+// 	SourceAccount string `json:"source_account,omitempty"`
 // }
 
 // type APSep24TransactionPatchPostError struct {
 // 	ID                  string                 `json:"id"`
 // 	SEP                 string                 `json:"sep,omitempty"`
-// 	Status              APTransactionStatus    `json:"status,omitempty"` // Error
-// 	SourceAccount       string                 `json:"source_account,omitempty"`
 // 	StellarTransactions []APStellarTransaction `json:"stellar_transactions,omitempty"`
 // 	Message             string                 `json:"message,omitempty"` // Error message
+// 	Status              APTransactionStatus    `json:"status,omitempty"`  // Error
+// 	// TODO: update the AP version when source_account becomes patchable
+// 	SourceAccount string `json:"source_account,omitempty"`
 // }
 
 // APTransactionStatus is the body of the Stellar transaction stored in the Anchor Platform.

--- a/internal/anchorplatform/object_schemas.go
+++ b/internal/anchorplatform/object_schemas.go
@@ -53,9 +53,6 @@ type APSep24Transaction struct {
 	Kind           string    `json:"kind,omitempty"`
 	AmountExpected *APAmount `json:"amount_expected,omitempty"`
 
-	SourceAccount      string `json:"source_account,omitempty"`
-	DestinationAccount string `json:"destination_account,omitempty"`
-
 	// These fields are patchable but they are already set by the AP, so I'm leaving them out of the patch:
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 	StartedAt *time.Time `json:"started_at,omitempty"`
@@ -94,6 +91,10 @@ type APSep24TransactionPatch struct {
 	AmountOut *APAmount `json:"amount_out,omitempty"`
 	AmountFee *APAmount `json:"amount_fee,omitempty"`
 
+	// Accounts
+	SourceAccount      string `json:"source_account,omitempty"`
+	DestinationAccount string `json:"destination_account,omitempty"`
+
 	// Dates
 	CompletedAt        *time.Time `json:"completed_at,omitempty"`
 	TransferReceivedAt *time.Time `json:"transfer_received_at,omitempty"`
@@ -115,6 +116,7 @@ type APSep24TransactionPatchPostRegistration struct {
 // 	SEP                 string                 `json:"sep,omitempty"`
 // 	Status              APTransactionStatus    `json:"status,omitempty"` // Success
 // 	StellarTransactions []APStellarTransaction `json:"stellar_transactions,omitempty"`
+// 	SourceAccount       string                 `json:"source_account,omitempty"`
 // 	Message             string                 `json:"message,omitempty"`
 // 	CompletedAt         *time.Time             `json:"completed_at,omitempty"`
 // 	AmountOut           APAmount               `json:"amount_out,omitempty"`
@@ -124,6 +126,7 @@ type APSep24TransactionPatchPostRegistration struct {
 // 	ID                  string                 `json:"id"`
 // 	SEP                 string                 `json:"sep,omitempty"`
 // 	Status              APTransactionStatus    `json:"status,omitempty"` // Error
+// 	SourceAccount       string                 `json:"source_account,omitempty"`
 // 	StellarTransactions []APStellarTransaction `json:"stellar_transactions,omitempty"`
 // 	Message             string                 `json:"message,omitempty"` // Error message
 // }

--- a/internal/anchorplatform/platform_api_service.go
+++ b/internal/anchorplatform/platform_api_service.go
@@ -30,7 +30,7 @@ const (
 )
 
 type AnchorPlatformAPIServiceInterface interface {
-	PatchAnchorTransactionsPostRegistration(ctx context.Context, apTxPatch ...APSep24Transaction) error
+	PatchAnchorTransactionsPostRegistration(ctx context.Context, apTxPatch ...APSep24TransactionPatchPostRegistration) error
 	IsAnchorProtectedByAuth(ctx context.Context) (bool, error)
 }
 
@@ -65,20 +65,20 @@ func NewAnchorPlatformAPIService(httpClient httpclient.HttpClientInterface, anch
 	}, nil
 }
 
-func (a *AnchorPlatformAPIService) PatchAnchorTransactionsPostRegistration(ctx context.Context, apTxPostRegistrationPatch ...APSep24Transaction) error {
-	var apTxPatches []APSep24Transaction
+func (a *AnchorPlatformAPIService) PatchAnchorTransactionsPostRegistration(ctx context.Context, apTxPostRegistrationPatch ...APSep24TransactionPatchPostRegistration) error {
+	var apTxPatches []APSep24TransactionPatch
 	for _, patch := range apTxPostRegistrationPatch {
-		apTxPatch, err := utils.ConvertType[APSep24Transaction, APSep24Transaction](patch)
+		apTxPatch, err := utils.ConvertType[APSep24TransactionPatchPostRegistration, APSep24TransactionPatch](patch)
 		if err != nil {
 			return fmt.Errorf("converting apTxPostRegistrationPatch into apTxPatch: %w", err)
 		}
-		apTxPatches = append(apTxPatches, APSep24Transaction(apTxPatch))
+		apTxPatches = append(apTxPatches, APSep24TransactionPatch(apTxPatch))
 	}
 
 	return a.updateAnchorTransactions(ctx, apTxPatches...)
 }
 
-func (a *AnchorPlatformAPIService) updateAnchorTransactions(ctx context.Context, apTxPatch ...APSep24Transaction) error {
+func (a *AnchorPlatformAPIService) updateAnchorTransactions(ctx context.Context, apTxPatch ...APSep24TransactionPatch) error {
 	records := NewAPSep24TransactionRecordsFromPatches(apTxPatch...)
 
 	recordsJSON, err := json.Marshal(records)
@@ -177,7 +177,7 @@ func (a *AnchorPlatformAPIService) IsAnchorProtectedByAuth(ctx context.Context) 
 }
 
 // GetJWTToken will generate a JWT token if the service is configured with an outgoing JWT secret.
-func (a *AnchorPlatformAPIService) GetJWTToken(apTx ...APSep24Transaction) (string, error) {
+func (a *AnchorPlatformAPIService) GetJWTToken(apTx ...APSep24TransactionPatch) (string, error) {
 	if a.jwtManager == nil {
 		return "", ErrJWTManagerNotSet
 	}

--- a/internal/anchorplatform/platform_api_service_mock.go
+++ b/internal/anchorplatform/platform_api_service_mock.go
@@ -11,7 +11,11 @@ type AnchorPlatformAPIServiceMock struct {
 }
 
 func (a *AnchorPlatformAPIServiceMock) PatchAnchorTransactionsPostRegistration(ctx context.Context, apTxPatch ...APSep24TransactionPatchPostRegistration) error {
-	args := a.Called(ctx, apTxPatch)
+	inputArgs := []interface{}{ctx}
+	for _, patch := range apTxPatch {
+		inputArgs = append(inputArgs, patch)
+	}
+	args := a.Called(inputArgs...)
 	return args.Error(0)
 }
 

--- a/internal/anchorplatform/platform_api_service_mock.go
+++ b/internal/anchorplatform/platform_api_service_mock.go
@@ -10,7 +10,7 @@ type AnchorPlatformAPIServiceMock struct {
 	mock.Mock
 }
 
-func (a *AnchorPlatformAPIServiceMock) PatchAnchorTransactionsPostRegistration(ctx context.Context, apTxPatch ...APSep24Transaction) error {
+func (a *AnchorPlatformAPIServiceMock) PatchAnchorTransactionsPostRegistration(ctx context.Context, apTxPatch ...APSep24TransactionPatchPostRegistration) error {
 	args := a.Called(ctx, apTxPatch)
 	return args.Error(0)
 }

--- a/internal/anchorplatform/platform_api_service_test.go
+++ b/internal/anchorplatform/platform_api_service_test.go
@@ -77,7 +77,7 @@ func Test_updateAnchorTransactions(t *testing.T) {
 	require.NoError(t, err)
 	ctx := context.Background()
 
-	apTxPatch := APSep24Transaction{
+	apTxPatch := APSep24TransactionPatch{
 		ID:     "test-transaction-id",
 		Status: "pending_anchor",
 		SEP:    "24",
@@ -206,14 +206,14 @@ func Test_PatchAnchorTransactionsPostRegistration(t *testing.T) {
 		})).Return(response, nil).Twice()
 
 		// PatchAnchorTransactionsPostRegistration and updateAnchorTransactions should result in the same request:
-		err := anchorPlatformAPIService.PatchAnchorTransactionsPostRegistration(ctx, APSep24Transaction{
+		err := anchorPlatformAPIService.PatchAnchorTransactionsPostRegistration(ctx, APSep24TransactionPatchPostRegistration{
 			ID:     "test-transaction-id",
 			Status: "pending_anchor",
 			SEP:    "24",
 		})
 		require.NoError(t, err)
 
-		err = anchorPlatformAPIService.updateAnchorTransactions(ctx, APSep24Transaction{
+		err = anchorPlatformAPIService.updateAnchorTransactions(ctx, APSep24TransactionPatch{
 			ID:     "test-transaction-id",
 			Status: "pending_anchor",
 			SEP:    "24",
@@ -403,7 +403,7 @@ func Test_IsAnchorProtectedByAuth(t *testing.T) {
 func Test_GetJWTToken(t *testing.T) {
 	t.Run("returns ErrJWTSecretNotSet when a JWT secret is not set", func(t *testing.T) {
 		apService := AnchorPlatformAPIService{}
-		transactions := []APSep24Transaction{{ID: "1"}, {ID: "2"}}
+		transactions := []APSep24TransactionPatch{{ID: "1"}, {ID: "2"}}
 		token, err := apService.GetJWTToken(transactions...)
 		require.ErrorIs(t, err, ErrJWTManagerNotSet)
 		require.Empty(t, token)
@@ -414,7 +414,7 @@ func Test_GetJWTToken(t *testing.T) {
 		require.NoError(t, err)
 
 		apService := AnchorPlatformAPIService{jwtManager: jwtManager}
-		transactions := []APSep24Transaction{{ID: "1"}, {ID: "2"}}
+		transactions := []APSep24TransactionPatch{{ID: "1"}, {ID: "2"}}
 		token, err := apService.GetJWTToken(transactions...)
 		require.NoError(t, err)
 		require.NotEmpty(t, token)

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -194,14 +194,10 @@ func (v VerifyReceiverRegistrationHandler) processReceiverWalletOTP(ctx context.
 
 // processAnchorPlatformID PATCHes the transaction on the AnchorPlatform with the status "pending_anchor" and updates the local database accordingly.
 func (v VerifyReceiverRegistrationHandler) processAnchorPlatformID(ctx context.Context, sep24Claims *anchorplatform.SEP24JWTClaims) error {
-	apTxPatch := anchorplatform.APSep24Transaction{
-		ID:                 sep24Claims.TransactionID(),
-		SEP:                "24",
-		Status:             anchorplatform.APTransactionStatusPendingAnchor,
-		Kind:               "deposit",
-		DestinationAccount: sep24Claims.SEP10StellarAccount(),
-		Memo:               sep24Claims.SEP10StellarMemo(),
-		KYCVerified:        true,
+	apTxPatch := anchorplatform.APSep24TransactionPatchPostRegistration{
+		ID:     sep24Claims.TransactionID(),
+		SEP:    "24",
+		Status: anchorplatform.APTransactionStatusPendingAnchor,
 	}
 
 	err := v.AnchorPlatformAPIService.PatchAnchorTransactionsPostRegistration(ctx, apTxPatch)

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -474,11 +474,11 @@ func Test_VerifyReceiverRegistrationHandler_processAnchorPlatformID(t *testing.T
 	}
 
 	// mocks
-	apTxPatches := []anchorplatform.APSep24TransactionPatchPostRegistration{{
+	apTxPatch := anchorplatform.APSep24TransactionPatchPostRegistration{
 		ID:     "test-transaction-id",
 		Status: "pending_anchor",
 		SEP:    "24",
-	}}
+	}
 
 	testCases := []struct {
 		name            string
@@ -502,7 +502,7 @@ func Test_VerifyReceiverRegistrationHandler_processAnchorPlatformID(t *testing.T
 			defer mockAnchorPlatformService.AssertExpectations(t)
 			handler.AnchorPlatformAPIService = &mockAnchorPlatformService
 			mockAnchorPlatformService.
-				On("PatchAnchorTransactionsPostRegistration", mock.Anything, apTxPatches).
+				On("PatchAnchorTransactionsPostRegistration", mock.Anything, apTxPatch).
 				Return(tc.mockReturnError).Once()
 
 			// assertions
@@ -689,16 +689,16 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		handler.ReCAPTCHAValidator = reCAPTCHAValidator
 		reCAPTCHAValidator.On("IsTokenValid", mock.Anything, "token").Return(true, nil).Once()
 
-		apTxPatches := []anchorplatform.APSep24TransactionPatchPostRegistration{{
+		apTxPatche := anchorplatform.APSep24TransactionPatchPostRegistration{
 			ID:     "test-transaction-id",
 			Status: "pending_anchor",
 			SEP:    "24",
-		}}
+		}
 		mockAnchorPlatformService := anchorplatform.AnchorPlatformAPIServiceMock{}
 		defer mockAnchorPlatformService.AssertExpectations(t)
 		handler.AnchorPlatformAPIService = &mockAnchorPlatformService
 		mockAnchorPlatformService.
-			On("PatchAnchorTransactionsPostRegistration", mock.Anything, apTxPatches).
+			On("PatchAnchorTransactionsPostRegistration", mock.Anything, apTxPatche).
 			Return(fmt.Errorf("error updating transaction on anchor platform")).Once()
 
 		// update database with the entries needed
@@ -766,15 +766,15 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 				handler.ReCAPTCHAValidator = reCAPTCHAValidator
 				reCAPTCHAValidator.On("IsTokenValid", mock.Anything, "token").Return(true, nil).Once()
 
-				apTxPatches := []anchorplatform.APSep24TransactionPatchPostRegistration{{
+				apTxPatch := anchorplatform.APSep24TransactionPatchPostRegistration{
 					ID:     "test-transaction-id",
 					Status: "pending_anchor",
 					SEP:    "24",
-				}}
+				}
 				mockAnchorPlatformService := anchorplatform.AnchorPlatformAPIServiceMock{}
 				defer mockAnchorPlatformService.AssertExpectations(t)
 				handler.AnchorPlatformAPIService = &mockAnchorPlatformService
-				mockAnchorPlatformService.On("PatchAnchorTransactionsPostRegistration", mock.Anything, apTxPatches).Return(nil).Once()
+				mockAnchorPlatformService.On("PatchAnchorTransactionsPostRegistration", mock.Anything, apTxPatch).Return(nil).Once()
 
 				// update database with the entries needed
 				defer data.DeleteAllReceiversFixtures(t, ctx, dbConnectionPool)

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -474,14 +474,10 @@ func Test_VerifyReceiverRegistrationHandler_processAnchorPlatformID(t *testing.T
 	}
 
 	// mocks
-	apTxPatches := []anchorplatform.APSep24Transaction{{
-		ID:                 "test-transaction-id",
-		Status:             "pending_anchor",
-		SEP:                "24",
-		Kind:               "deposit",
-		DestinationAccount: sep24Claims.SEP10StellarAccount(),
-		Memo:               sep24Claims.SEP10StellarMemo(),
-		KYCVerified:        true,
+	apTxPatches := []anchorplatform.APSep24TransactionPatchPostRegistration{{
+		ID:     "test-transaction-id",
+		Status: "pending_anchor",
+		SEP:    "24",
 	}}
 
 	testCases := []struct {
@@ -693,14 +689,10 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		handler.ReCAPTCHAValidator = reCAPTCHAValidator
 		reCAPTCHAValidator.On("IsTokenValid", mock.Anything, "token").Return(true, nil).Once()
 
-		apTxPatches := []anchorplatform.APSep24Transaction{{
-			ID:                 "test-transaction-id",
-			Status:             "pending_anchor",
-			SEP:                "24",
-			Kind:               "deposit",
-			DestinationAccount: validClaims.SEP10StellarAccount(),
-			Memo:               validClaims.SEP10StellarMemo(),
-			KYCVerified:        true,
+		apTxPatches := []anchorplatform.APSep24TransactionPatchPostRegistration{{
+			ID:     "test-transaction-id",
+			Status: "pending_anchor",
+			SEP:    "24",
 		}}
 		mockAnchorPlatformService := anchorplatform.AnchorPlatformAPIServiceMock{}
 		defer mockAnchorPlatformService.AssertExpectations(t)
@@ -774,14 +766,10 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 				handler.ReCAPTCHAValidator = reCAPTCHAValidator
 				reCAPTCHAValidator.On("IsTokenValid", mock.Anything, "token").Return(true, nil).Once()
 
-				apTxPatches := []anchorplatform.APSep24Transaction{{
-					ID:                 "test-transaction-id",
-					Status:             "pending_anchor",
-					SEP:                "24",
-					Kind:               "deposit",
-					DestinationAccount: sep24Claims.SEP10StellarAccount(),
-					Memo:               sep24Claims.SEP10StellarMemo(),
-					KYCVerified:        true,
+				apTxPatches := []anchorplatform.APSep24TransactionPatchPostRegistration{{
+					ID:     "test-transaction-id",
+					Status: "pending_anchor",
+					SEP:    "24",
 				}}
 				mockAnchorPlatformService := anchorplatform.AnchorPlatformAPIServiceMock{}
 				defer mockAnchorPlatformService.AssertExpectations(t)

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -689,7 +689,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		handler.ReCAPTCHAValidator = reCAPTCHAValidator
 		reCAPTCHAValidator.On("IsTokenValid", mock.Anything, "token").Return(true, nil).Once()
 
-		apTxPatche := anchorplatform.APSep24TransactionPatchPostRegistration{
+		apTxPatch := anchorplatform.APSep24TransactionPatchPostRegistration{
 			ID:     "test-transaction-id",
 			Status: "pending_anchor",
 			SEP:    "24",
@@ -698,7 +698,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		defer mockAnchorPlatformService.AssertExpectations(t)
 		handler.AnchorPlatformAPIService = &mockAnchorPlatformService
 		mockAnchorPlatformService.
-			On("PatchAnchorTransactionsPostRegistration", mock.Anything, apTxPatche).
+			On("PatchAnchorTransactionsPostRegistration", mock.Anything, apTxPatch).
 			Return(fmt.Errorf("error updating transaction on anchor platform")).Once()
 
 		// update database with the entries needed


### PR DESCRIPTION
### What

Update PATCH {AP}/transaction body with the appropriate fields.

### Why

We had a task to review if we were PATCHING the correct fields, and it turns out we were sending no-op fields that were being ignored by the AP.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
