### PR TITLE
SDP-488: store the Anchor Platform's tx ID when registering a receiver's wallet

### DIFF
--- a/internal/anchorplatform/platform_api_service.go
+++ b/internal/anchorplatform/platform_api_service.go
@@ -78,6 +78,8 @@ func (a *AnchorPlatformAPIService) PatchAnchorTransactionsPostRegistration(ctx c
 	return a.updateAnchorTransactions(ctx, apTxPatches...)
 }
 
+// updateAnchorTransactions will update the transactions on the anchor platform, according with the API documentation in
+// https://developers.stellar.org/api/anchor-platform/resources/patch-transactions.
 func (a *AnchorPlatformAPIService) updateAnchorTransactions(ctx context.Context, apTxPatch ...APSep24TransactionPatch) error {
 	records := NewAPSep24TransactionRecordsFromPatches(apTxPatch...)
 

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -385,7 +385,6 @@ func CreateReceiverWalletFixture(t *testing.T, ctx context.Context, sqlExec db.S
 			JOIN wallets AS w ON rw.wallet_id = w.id
 	`
 
-	var statusHistoryJSON pq.ByteaArray
 	var receiverWallet ReceiverWallet
 	err = sqlExec.QueryRowxContext(ctx, query, receiverID, walletID, stellarAddress, stellarMemo, stellarMemoType, status).Scan(
 		&receiverWallet.ID,
@@ -393,7 +392,7 @@ func CreateReceiverWalletFixture(t *testing.T, ctx context.Context, sqlExec db.S
 		&receiverWallet.StellarMemo,
 		&receiverWallet.StellarMemoType,
 		&receiverWallet.Status,
-		&statusHistoryJSON,
+		&receiverWallet.StatusHistory,
 		&receiverWallet.CreatedAt,
 		&receiverWallet.UpdatedAt,
 		&receiverWallet.Receiver.ID,
@@ -409,9 +408,6 @@ func CreateReceiverWalletFixture(t *testing.T, ctx context.Context, sqlExec db.S
 		&receiverWallet.Wallet.CreatedAt,
 		&receiverWallet.Wallet.UpdatedAt,
 	)
-	require.NoError(t, err)
-
-	err = receiverWallet.statusHistoryFromByteArray(statusHistoryJSON)
 	require.NoError(t, err)
 
 	return &receiverWallet

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -414,9 +414,7 @@ func CreateReceiverWalletFixture(t *testing.T, ctx context.Context, sqlExec db.S
 }
 
 func DeleteAllReceiverWalletsFixtures(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter) {
-	const query = `
-		DELETE FROM receiver_wallets
-	`
+	const query = "DELETE FROM receiver_wallets"
 	_, err := sqlExec.ExecContext(ctx, query)
 	require.NoError(t, err)
 }
@@ -720,4 +718,16 @@ func CreateMockImage(t *testing.T, width, height int, size ImageSize) image.Imag
 	}
 
 	return img
+}
+
+func DeleteAllFixtures(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter) {
+	DeleteAllMessagesFixtures(t, ctx, sqlExec)
+	DeleteAllPaymentsFixtures(t, ctx, sqlExec)
+	DeleteAllReceiverVerificationFixtures(t, ctx, sqlExec)
+	DeleteAllReceiverWalletsFixtures(t, ctx, sqlExec)
+	DeleteAllReceiversFixtures(t, ctx, sqlExec)
+	DeleteAllDisbursementFixtures(t, ctx, sqlExec)
+	DeleteAllWalletFixtures(t, ctx, sqlExec)
+	DeleteAllAssetFixtures(t, ctx, sqlExec)
+	DeleteAllCountryFixtures(t, ctx, sqlExec)
 }

--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -79,6 +79,8 @@ func (psh PaymentStatusHistory) Value() (driver.Value, error) {
 	return pq.Array(statusHistoryJSON).Value()
 }
 
+var _ driver.Valuer = (*PaymentStatusHistory)(nil)
+
 // Scan implements the sql.Scanner interface.
 func (psh *PaymentStatusHistory) Scan(src interface{}) error {
 	var statusHistoryJSON []string
@@ -97,6 +99,8 @@ func (psh *PaymentStatusHistory) Scan(src interface{}) error {
 
 	return nil
 }
+
+var _ sql.Scanner = (*PaymentStatusHistory)(nil)
 
 func (p *PaymentInsert) Validate() error {
 	if strings.TrimSpace(p.ReceiverID) == "" {

--- a/internal/data/receivers_wallet.go
+++ b/internal/data/receivers_wallet.go
@@ -349,7 +349,7 @@ func (rw *ReceiverWalletModel) GetByReceiverIDAndWalletDomain(ctx context.Contex
 	return &receiverWallet, nil
 }
 
-// UpdateReceiverWallet updates informations from the receiver wallet.
+// UpdateReceiverWallet updates the status, address and OTP confirmation date of a receiver wallet.
 func (rw *ReceiverWalletModel) UpdateReceiverWallet(ctx context.Context, receiverWallet ReceiverWallet, sqlExec db.SQLExecuter) error {
 	query := `
 		UPDATE 
@@ -368,7 +368,7 @@ func (rw *ReceiverWalletModel) UpdateReceiverWallet(ctx context.Context, receive
 		receiverWallet.StellarAddress,
 		sql.NullString{String: receiverWallet.StellarMemo, Valid: receiverWallet.StellarMemo != ""},
 		sql.NullString{String: receiverWallet.StellarMemoType, Valid: receiverWallet.StellarMemoType != ""},
-		time.Now(),
+		receiverWallet.OTPConfirmedAt,
 		receiverWallet.ID)
 	if err != nil {
 		return fmt.Errorf("error updating receiver wallet: %w", err)

--- a/internal/data/receivers_wallet.go
+++ b/internal/data/receivers_wallet.go
@@ -326,8 +326,12 @@ func (rw *ReceiverWalletModel) GetByReceiverIDAndWalletDomain(ctx context.Contex
 			rw.id,
 			rw.receiver_id as "receiver.id",
 			rw.status,
+			COALESCE(rw.stellar_address, '') as stellar_address,
+			COALESCE(rw.stellar_memo, '') as stellar_memo,
+			COALESCE(rw.stellar_memo_type, '') as stellar_memo_type,
 			COALESCE(rw.otp, '') as otp,
 			rw.otp_created_at,
+			rw.otp_confirmed_at,
 			w.id as "wallet.id",
 			w.name as "wallet.name",
 			w.sep_10_client_domain as "wallet.sep_10_client_domain"

--- a/internal/data/receivers_wallet.go
+++ b/internal/data/receivers_wallet.go
@@ -363,7 +363,7 @@ func (rw *ReceiverWalletModel) UpdateReceiverWallet(ctx context.Context, receive
 		WHERE rw.id = $6
 	`
 
-	_, err := sqlExec.ExecContext(ctx, query,
+	result, err := sqlExec.ExecContext(ctx, query,
 		receiverWallet.Status,
 		receiverWallet.StellarAddress,
 		sql.NullString{String: receiverWallet.StellarMemo, Valid: receiverWallet.StellarMemo != ""},
@@ -371,7 +371,16 @@ func (rw *ReceiverWalletModel) UpdateReceiverWallet(ctx context.Context, receive
 		receiverWallet.OTPConfirmedAt,
 		receiverWallet.ID)
 	if err != nil {
-		return fmt.Errorf("error updating receiver wallet: %w", err)
+		return fmt.Errorf("updating receiver wallet: %w", err)
+	}
+
+	numRowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("getting number of rows affected: %w", err)
+	}
+
+	if numRowsAffected == 0 {
+		return fmt.Errorf("no receiver wallet could be found in UpdateReceiverWallet: %w", ErrRecordNotFound)
 	}
 
 	return nil

--- a/internal/data/receivers_wallet.go
+++ b/internal/data/receivers_wallet.go
@@ -358,7 +358,8 @@ func (rw *ReceiverWalletModel) GetByReceiverIDAndWalletDomain(ctx context.Contex
 	return &receiverWallet, nil
 }
 
-// UpdateReceiverWallet updates the status, address and OTP confirmation date of a receiver wallet.
+// UpdateReceiverWallet updates the status, address, OTP confirmation time, and anchor platform transaction ID of a
+// receiver wallet.
 func (rw *ReceiverWalletModel) UpdateReceiverWallet(ctx context.Context, receiverWallet ReceiverWallet, sqlExec db.SQLExecuter) error {
 	query := `
 		UPDATE 

--- a/internal/data/receivers_wallet_test.go
+++ b/internal/data/receivers_wallet_test.go
@@ -529,6 +529,7 @@ func Test_UpdateReceiverWallet(t *testing.T) {
 	})
 
 	t.Run("successfuly update receiver wallet", func(t *testing.T) {
+		receiverWallet.AnchorPlatformTransactionID = "test-anchor-tx-platform-id"
 		receiverWallet.StellarAddress = "GBLTXF46JTCGMWFJASQLVXMMA36IPYTDCN4EN73HRXCGDCGYBZM3A444"
 		receiverWallet.StellarMemo = "123456"
 		receiverWallet.StellarMemoType = "id"
@@ -543,6 +544,7 @@ func Test_UpdateReceiverWallet(t *testing.T) {
 		query := `
 			SELECT
 				rw.status,
+				rw.anchor_platform_transaction_id,
 				rw.stellar_address,
 				rw.stellar_memo,
 				rw.stellar_memo_type,
@@ -557,6 +559,7 @@ func Test_UpdateReceiverWallet(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, RegisteredReceiversWalletStatus, receiverWalletUpdated.Status)
+		assert.Equal(t, "test-anchor-tx-platform-id", receiverWalletUpdated.AnchorPlatformTransactionID)
 		assert.Equal(t, "GBLTXF46JTCGMWFJASQLVXMMA36IPYTDCN4EN73HRXCGDCGYBZM3A444", receiverWalletUpdated.StellarAddress)
 		assert.Equal(t, "123456", receiverWalletUpdated.StellarMemo)
 		assert.Equal(t, "id", receiverWalletUpdated.StellarMemoType)

--- a/internal/data/receivers_wallet_test.go
+++ b/internal/data/receivers_wallet_test.go
@@ -490,9 +490,13 @@ func Test_GetByReceiverIDAndWalletDomain(t *testing.T) {
 				Name:              wallet.Name,
 				SEP10ClientDomain: wallet.SEP10ClientDomain,
 			},
-			Status:       receiverWallet.Status,
-			OTP:          "123456",
-			OTPCreatedAt: receiverWallet.OTPCreatedAt,
+			Status:          receiverWallet.Status,
+			StellarAddress:  receiverWallet.StellarAddress,
+			StellarMemo:     receiverWallet.StellarMemo,
+			StellarMemoType: receiverWallet.StellarMemoType,
+			OTP:             "123456",
+			OTPCreatedAt:    receiverWallet.OTPCreatedAt,
+			OTPConfirmedAt:  nil,
 		}
 
 		assert.Equal(t, expected, *actual)

--- a/internal/data/receivers_wallet_test.go
+++ b/internal/data/receivers_wallet_test.go
@@ -531,6 +531,8 @@ func Test_UpdateReceiverWallet(t *testing.T) {
 		receiverWallet.StellarMemo = "123456"
 		receiverWallet.StellarMemoType = "id"
 		receiverWallet.Status = RegisteredReceiversWalletStatus
+		now := time.Now()
+		receiverWallet.OTPConfirmedAt = &now
 
 		err := receiverWalletModel.UpdateReceiverWallet(ctx, *receiverWallet, dbConnectionPool)
 		require.NoError(t, err)
@@ -556,7 +558,7 @@ func Test_UpdateReceiverWallet(t *testing.T) {
 		assert.Equal(t, "GBLTXF46JTCGMWFJASQLVXMMA36IPYTDCN4EN73HRXCGDCGYBZM3A444", receiverWalletUpdated.StellarAddress)
 		assert.Equal(t, "123456", receiverWalletUpdated.StellarMemo)
 		assert.Equal(t, "id", receiverWalletUpdated.StellarMemoType)
-		require.NotEmpty(t, receiverWalletUpdated.OTPConfirmedAt)
+		assert.WithinDuration(t, now, *receiverWalletUpdated.OTPConfirmedAt, 100*time.Millisecond)
 	})
 }
 

--- a/internal/data/receivers_wallet_test.go
+++ b/internal/data/receivers_wallet_test.go
@@ -502,18 +502,16 @@ func Test_GetByReceiverIDAndWalletDomain(t *testing.T) {
 func Test_UpdateReceiverWallet(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
-
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
 
 	ctx := context.Background()
-
 	receiverWalletModel := ReceiverWalletModel{dbConnectionPool: dbConnectionPool}
 
 	t.Run("returns error when receiver wallet does not exist", func(t *testing.T) {
 		err := receiverWalletModel.UpdateReceiverWallet(ctx, ReceiverWallet{ID: "invalid_id", Status: DraftReceiversWalletStatus}, dbConnectionPool)
-		require.NoError(t, err)
+		require.ErrorIs(t, err, ErrRecordNotFound)
 	})
 
 	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{})
@@ -523,7 +521,7 @@ func Test_UpdateReceiverWallet(t *testing.T) {
 	t.Run("returns error when status is not valid", func(t *testing.T) {
 		receiverWallet.Status = "invalid_status"
 		err := receiverWalletModel.UpdateReceiverWallet(ctx, *receiverWallet, dbConnectionPool)
-		require.Error(t, err, "error querying receiver wallet: sql: no rows in result set")
+		require.Error(t, err, "querying receiver wallet: sql: no rows in result set")
 	})
 
 	t.Run("successfuly update receiver wallet", func(t *testing.T) {

--- a/internal/db/migrations/2023-07-17.2-add-status-history-column-submitter-transactions-table.sql
+++ b/internal/db/migrations/2023-07-17.2-add-status-history-column-submitter-transactions-table.sql
@@ -1,4 +1,4 @@
--- This migration updates the submitter_transactions table by addring the status_history table, for increased debuggability.
+-- This migration updates the submitter_transactions table by adding the status_history column, for increased debuggability.
 
 -- +migrate Up
 

--- a/internal/db/migrations/2023-09-17.0-add-anchor-platform-tx-id.sql
+++ b/internal/db/migrations/2023-09-17.0-add-anchor-platform-tx-id.sql
@@ -1,4 +1,4 @@
--- This migration updates the submitter_transactions table by addring the status_history table, for increased debuggability.
+-- This migration updates the receiver_wallets table by adding the anchor_platform_transaction_id column, for increased debuggability.
 
 -- +migrate Up
 

--- a/internal/db/migrations/2023-09-17.0-add-anchor-platform-tx-id.sql
+++ b/internal/db/migrations/2023-09-17.0-add-anchor-platform-tx-id.sql
@@ -1,0 +1,12 @@
+-- This migration updates the submitter_transactions table by addring the status_history table, for increased debuggability.
+
+-- +migrate Up
+
+ALTER TABLE public.receiver_wallets
+    ADD COLUMN anchor_platform_transaction_id text;
+
+
+-- +migrate Down
+
+ALTER TABLE public.receiver_wallets
+    DROP COLUMN anchor_platform_transaction_id;

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -183,6 +183,8 @@ func (v VerifyReceiverRegistrationHandler) processReceiverWalletOTP(ctx context.
 		receiverWallet.StellarMemoType = "id"
 	}
 	receiverWallet.Status = data.RegisteredReceiversWalletStatus
+	now := time.Now()
+	receiverWallet.OTPConfirmedAt = &now
 	err = v.Models.ReceiverWallet.UpdateReceiverWallet(ctx, *receiverWallet, dbTx)
 	if err != nil {
 		err = fmt.Errorf("completing receiver wallet registration: %w", err)

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -192,10 +192,9 @@ func (v VerifyReceiverRegistrationHandler) processReceiverWalletOTP(
 	rw.Status = data.RegisteredReceiversWalletStatus
 	rw.StellarAddress = sep24Claims.SEP10StellarAccount()
 	rw.StellarMemo = sep24Claims.SEP10StellarMemo()
+	rw.StellarMemoType = ""
 	if sep24Claims.SEP10StellarMemo() != "" {
 		rw.StellarMemoType = "id"
-	} else {
-		rw.StellarMemoType = ""
 	}
 	err = v.Models.ReceiverWallet.UpdateReceiverWallet(ctx, *rw, dbTx)
 	if err != nil {
@@ -276,7 +275,7 @@ func (v VerifyReceiverRegistrationHandler) VerifyReceiverRegistration(w http.Res
 			return nil
 		}
 
-		// STEP 5: PATCH transaction on the AnchorPlatform
+		// STEP 5: PATCH transaction on the AnchorPlatform and update the receiver wallet with the anchor platform tx ID
 		err = v.processAnchorPlatformID(ctx, dbTx, *sep24Claims, receiverWallet)
 		if err != nil {
 			return fmt.Errorf("processing anchor platform transaction ID: %w", err)

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -206,7 +206,8 @@ func (v VerifyReceiverRegistrationHandler) processReceiverWalletOTP(
 	return *rw, false, nil
 }
 
-// processAnchorPlatformID PATCHes the transaction on the AnchorPlatform with the status "pending_anchor".
+// processAnchorPlatformID PATCHes the transaction on the AnchorPlatform with the "pending_anchor" status, and updates
+// the receiver wallet with the anchor platform transaction ID.
 func (v VerifyReceiverRegistrationHandler) processAnchorPlatformID(ctx context.Context, dbTx db.DBTransaction, sep24Claims anchorplatform.SEP24JWTClaims, receiverWallet data.ReceiverWallet) error {
 	// STEP 1: update receiver wallet with the anchor platform transaction ID.
 	receiverWallet.AnchorPlatformTransactionID = sep24Claims.TransactionID()

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -151,7 +151,7 @@ func (v VerifyReceiverRegistrationHandler) processReceiverVerificationPII(ctx co
 func (v VerifyReceiverRegistrationHandler) processReceiverWalletOTP(
 	ctx context.Context,
 	dbTx db.DBTransaction,
-	sep24Claims *anchorplatform.SEP24JWTClaims,
+	sep24Claims anchorplatform.SEP24JWTClaims,
 	receiver data.Receiver, otp string,
 ) (receiverWallet data.ReceiverWallet, wasAlreadyRegistered bool, err error) {
 	// STEP 1: find the receiver wallet for the given [receiverID, clientDomain]
@@ -202,7 +202,7 @@ func (v VerifyReceiverRegistrationHandler) processReceiverWalletOTP(
 }
 
 // processAnchorPlatformID PATCHes the transaction on the AnchorPlatform with the status "pending_anchor" and updates the local database accordingly.
-func (v VerifyReceiverRegistrationHandler) processAnchorPlatformID(ctx context.Context, sep24Claims *anchorplatform.SEP24JWTClaims) error {
+func (v VerifyReceiverRegistrationHandler) processAnchorPlatformID(ctx context.Context, sep24Claims anchorplatform.SEP24JWTClaims) error {
 	apTxPatch := anchorplatform.APSep24TransactionPatchPostRegistration{
 		ID:     sep24Claims.TransactionID(),
 		SEP:    "24",
@@ -253,7 +253,7 @@ func (v VerifyReceiverRegistrationHandler) VerifyReceiverRegistration(w http.Res
 		}
 
 		// STEP 4: process OTP
-		_, wasAlreadyRegistered, err := v.processReceiverWalletOTP(ctx, dbTx, sep24Claims, *receiver, receiverRegistrationRequest.OTP)
+		_, wasAlreadyRegistered, err := v.processReceiverWalletOTP(ctx, dbTx, *sep24Claims, *receiver, receiverRegistrationRequest.OTP)
 		if err != nil {
 			return fmt.Errorf("processing OTP for receiver with phone number %s: %w", truncatedPhoneNumber, err)
 		}
@@ -262,7 +262,7 @@ func (v VerifyReceiverRegistrationHandler) VerifyReceiverRegistration(w http.Res
 		}
 
 		// STEP 5: PATCH transaction on the AnchorPlatform
-		err = v.processAnchorPlatformID(ctx, sep24Claims)
+		err = v.processAnchorPlatformID(ctx, *sep24Claims)
 		if err != nil {
 			return fmt.Errorf("processing anchor platform transaction ID: %w", err)
 		}

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -209,8 +209,8 @@ func (v VerifyReceiverRegistrationHandler) processReceiverWalletOTP(
 // processAnchorPlatformID PATCHes the transaction on the AnchorPlatform with the status "pending_anchor" and updates
 // the local database accordingly.
 func (v VerifyReceiverRegistrationHandler) processAnchorPlatformID(ctx context.Context, dbTx db.DBTransaction, sep24Claims anchorplatform.SEP24JWTClaims, receiverWallet data.ReceiverWallet) error {
-	// STEP 1: update receiver wallet with the anchor platform transaction ID
-	// TODO: implement
+	// STEP 1: update receiver wallet with the anchor platform transaction ID.
+	// receiverWallet.AnchorPlatformTransactionID = sep24Claims.TransactionID()
 
 	// STEP 2: PATCH transaction on the AnchorPlatform, signaling that it is pending anchor
 	apTxPatch := anchorplatform.APSep24TransactionPatchPostRegistration{

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -536,6 +536,12 @@ func Test_VerifyReceiverRegistrationHandler_processAnchorPlatformID(t *testing.T
 			err = handler.processAnchorPlatformID(ctx, dbTx, *sep24Claims, *receiverWallet)
 			if tc.wantErrContains == "" {
 				require.NoError(t, err)
+
+				// make sure the receiverWallet was updated in the DB with the anchor platform transaction ID
+				var rw data.ReceiverWallet
+				err = dbTx.GetContext(ctx, &rw, "SELECT id, anchor_platform_transaction_id FROM receiver_wallets WHERE id = $1", receiverWallet.ID)
+				require.NoError(t, err)
+				assert.Equal(t, "test-transaction-id", rw.AnchorPlatformTransactionID)
 			} else {
 				require.ErrorContains(t, err, tc.wantErrContains)
 			}

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -469,17 +469,9 @@ func Test_VerifyReceiverRegistrationHandler_processAnchorPlatformID(t *testing.T
 
 	// creeate fixtures
 	const phoneNumber = "+380445555555"
-	defer data.DeleteAllWalletFixtures(t, ctx, dbConnectionPool)
-	defer data.DeleteAllReceiversFixtures(t, ctx, dbConnectionPool)
-	defer data.DeleteAllReceiverVerificationFixtures(t, ctx, dbConnectionPool)
-	defer data.DeleteAllReceiverWalletsFixtures(t, ctx, dbConnectionPool)
+	defer data.DeleteAllFixtures(t, ctx, dbConnectionPool)
 	wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "testWallet", "https://home.page", "home.page", "wallet123://")
 	receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: phoneNumber})
-	_ = data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
-		ReceiverID:        receiver.ID,
-		VerificationField: data.VerificationFieldDateOfBirth,
-		VerificationValue: "1990-01-01",
-	})
 	receiverWallet := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
 
 	// create valid sep24 token
@@ -520,8 +512,7 @@ func Test_VerifyReceiverRegistrationHandler_processAnchorPlatformID(t *testing.T
 			dbTx, err := dbConnectionPool.BeginTxx(ctx, nil)
 			require.NoError(t, err)
 			defer func() {
-				err = dbTx.Rollback()
-				require.NoError(t, err)
+				require.NoError(t, dbTx.Rollback())
 			}()
 
 			// mocks

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -428,7 +428,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverWalletOTP(t *testing.
 			}
 
 			// assertions
-			rwUpdated, wasAlreadyRegistered, err := handler.processReceiverWalletOTP(ctx, dbTx, tc.sep24Claims, *receiver, otp)
+			rwUpdated, wasAlreadyRegistered, err := handler.processReceiverWalletOTP(ctx, dbTx, *tc.sep24Claims, *receiver, otp)
 			if tc.wantErrContains == nil {
 				require.NoError(t, err)
 				assert.Equal(t, tc.wantWasAlreadyRegistered, wasAlreadyRegistered)
@@ -511,7 +511,7 @@ func Test_VerifyReceiverRegistrationHandler_processAnchorPlatformID(t *testing.T
 				Return(tc.mockReturnError).Once()
 
 			// assertions
-			err := handler.processAnchorPlatformID(ctx, sep24Claims)
+			err := handler.processAnchorPlatformID(ctx, *sep24Claims)
 			if tc.wantErrContains == "" {
 				require.NoError(t, err)
 			} else {

--- a/internal/transactionsubmission/utils/utils_test.go
+++ b/internal/transactionsubmission/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
@@ -16,7 +17,8 @@ func TestAdvisoryLockAndRelease(t *testing.T) {
 	defer dbt.Close()
 
 	// Creates a database pool
-	lockKey := 123
+	lockKey := rand.Intn(100000)
+
 	dbConnectionPool1, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
 	lockAcquired, err := AcquireAdvisoryLock(ctx, dbConnectionPool1, lockKey)


### PR DESCRIPTION
### What

Store the Anchor Platform's tx ID when registering a receiver's wallet

### Why

So we can PATCH the AP with the success/error states later.

### Further discussion

I'm storing the AP ID in the receiver wallet entry, because this is the DB row that gets updated when we complete the SEP24 registration.

We don't know exactly the amount that will be updated there, but we can update the amount when we PATCH the success/failure responses.

Alternatively, we could store the AnchorPlatform ID in a payment row, but since that is not used in the registration flow, it seemed inconsistent to rely on that table for this part of the flow while the registration does not rely on payments.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
