### PR TITLE
[SDP-898] data: increase max attempts to the receiver validate the PII

### DIFF
--- a/internal/data/receiver_verification.go
+++ b/internal/data/receiver_verification.go
@@ -32,7 +32,7 @@ type ReceiverVerificationInsert struct {
 	VerificationValue string            `db:"hashed_value"`
 }
 
-const MaxAttemptsAllowed = 6
+const MaxAttemptsAllowed = 15
 
 func (rvi *ReceiverVerificationInsert) Validate() error {
 	if strings.TrimSpace(rvi.ReceiverID) == "" {

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -246,7 +246,7 @@ func Test_ReceiverVerificationModel_CheckTotalAttempts(t *testing.T) {
 	receiverVerificationModel := &ReceiverVerificationModel{}
 
 	t.Run("attempts exceeded the max value", func(t *testing.T) {
-		attempts := 6
+		attempts := 15
 		e := receiverVerificationModel.ExceededAttempts(attempts)
 		assert.True(t, e)
 	})

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -250,7 +250,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 				VerificationType:  data.VerificationFieldDateOfBirth,
 				VerificationValue: "1990-01-01",
 			},
-			wantErrContains: "the number of attempts to confirm the verification value exceededs the max attempts limit of 6",
+			wantErrContains: fmt.Sprintf("the number of attempts to confirm the verification value exceededs the max attempts limit of %d", data.MaxAttemptsAllowed),
 		},
 		{
 			name:     "returns an error if the varification value provided in the payload is different from the DB one",


### PR DESCRIPTION
### What

This PR increases the maximum attempts for the receiver validate its PII.

### Why

Avoid blocking the receiver forever from receiving the payment.

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
