### PR TITLE
SDP-892: prevent users from deactivating themselves

### DIFF
--- a/internal/serve/httphandler/user_handler.go
+++ b/internal/serve/httphandler/user_handler.go
@@ -113,12 +113,12 @@ func (h UserHandler) UserActivation(rw http.ResponseWriter, req *http.Request) {
 		httperror.BadRequest("", err, nil).Render(rw)
 		return
 	}
-
 	if err := reqBody.validate(); err != nil {
 		err.Render(rw)
 		return
 	}
 
+	// Check if the users are trying to update their own activation
 	userID, err := h.AuthManager.GetUserID(ctx, token)
 	if err != nil {
 		if errors.Is(err, auth.ErrInvalidToken) {
@@ -146,15 +146,11 @@ func (h UserHandler) UserActivation(rw http.ResponseWriter, req *http.Request) {
 	if activationErr != nil {
 		if errors.Is(activationErr, auth.ErrInvalidToken) {
 			httperror.Unauthorized("", activationErr, nil).Render(rw)
-			return
-		}
-
-		if errors.Is(activationErr, auth.ErrNoRowsAffected) {
+		} else if errors.Is(activationErr, auth.ErrNoRowsAffected) {
 			httperror.BadRequest("", activationErr, map[string]interface{}{"user_id": "user_id is invalid"}).Render(rw)
-			return
+		} else {
+			httperror.InternalError(ctx, "", activationErr, nil).Render(rw)
 		}
-
-		httperror.InternalError(ctx, "", activationErr, nil).Render(rw)
 		return
 	}
 

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -36,6 +36,9 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 		auth.WithCustomJWTManagerOption(jwtManagerMock),
 		auth.WithCustomRoleManagerOption(roleManagerMock),
 	)
+	defer authenticatorMock.AssertExpectations(t)
+	defer jwtManagerMock.AssertExpectations(t)
+	defer roleManagerMock.AssertExpectations(t)
 
 	handler := &UserHandler{AuthManager: authManager}
 
@@ -46,11 +49,8 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 	t.Run("returns Unauthorized when no token is in the request context", func(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPatch, url, nil)
 		require.NoError(t, err)
-
 		w := httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp := w.Result()
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
@@ -62,15 +62,12 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 	t.Run("returns error when request body is invalid", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, "mytoken")
 
+		// is_active and user_id are required
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(`{}`))
 		require.NoError(t, err)
-
 		w := httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp := w.Result()
-
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -83,19 +80,15 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 				}
 			}
 		`
-
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
 
+		// is_active is required
 		req, err = http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(`{"user_id": "user-id"}`))
 		require.NoError(t, err)
-
 		w = httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp = w.Result()
-
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -110,15 +103,12 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
 
+		// user_id is required
 		req, err = http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(`{"is_active": true}`))
 		require.NoError(t, err)
-
 		w = httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp = w.Result()
-
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -133,18 +123,14 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
 
+		// invalid body format:
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
-
 		req, err = http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(`"invalid"`))
 		require.NoError(t, err)
-
 		w = httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp = w.Result()
-
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -177,13 +163,9 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 		`
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
-
 		w := httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp := w.Result()
-
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -199,13 +181,9 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 		`
 		req, err = http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
-
 		w = httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp = w.Result()
-
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -240,13 +218,9 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 		`
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
-
 		w := httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp := w.Result()
-
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -262,13 +236,9 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 			`
 		req, err = http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
-
 		w = httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp = w.Result()
-
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -297,13 +267,9 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 		`
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
-
 		w := httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp := w.Result()
-
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -343,13 +309,9 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 		`
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
-
 		w := httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp := w.Result()
-
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
@@ -365,13 +327,9 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 			`
 		req, err = http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
-
 		w = httptest.NewRecorder()
-
 		r.ServeHTTP(w, req)
-
 		resp = w.Result()
-
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -336,8 +336,6 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 	})
 }
 
-// 399
-
 func Test_CreateUserRequest_validate(t *testing.T) {
 	cur := CreateUserRequest{
 		FirstName: "",


### PR DESCRIPTION
### What

Prevent users from deactivating themselves

### Why

If you deactivate your own user, you'll get locked out and the product may end up without any user having access to it.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
