### PR TITLE
SDP-884: solve intermittent test failure due to timestamp comparison

### DIFF
--- a/internal/serve/httphandler/assets_handler.go
+++ b/internal/serve/httphandler/assets_handler.go
@@ -34,10 +34,10 @@ const (
 var errCouldNotRemoveTrustline = errors.New("could not remove trustline")
 
 type AssetsHandler struct {
-	Models           *data.Models
-	HorizonClient    horizonclient.ClientInterface
-	SignatureService engine.SignatureService
-	GetPreconditions func() txnbuild.Preconditions
+	Models             *data.Models
+	HorizonClient      horizonclient.ClientInterface
+	SignatureService   engine.SignatureService
+	GetPreconditionsFn func() txnbuild.Preconditions
 }
 
 type AssetRequest struct {
@@ -271,8 +271,8 @@ func (c AssetsHandler) submitChangeTrustTransaction(ctx context.Context, acc *ho
 	}
 
 	preconditions := txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)}
-	if c.GetPreconditions != nil {
-		preconditions = c.GetPreconditions()
+	if c.GetPreconditionsFn != nil {
+		preconditions = c.GetPreconditionsFn()
 	}
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -21,13 +21,14 @@ import (
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/txnbuild"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 var preconditions = txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)}

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -30,10 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var preconditions = txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)}
+
 func Test_AssetsHandlerGetAssets(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
-
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
@@ -88,7 +89,7 @@ func Test_AssetsHandlerGetAssets(t *testing.T) {
 	})
 }
 
-func Test_AssetHandlerAddAsset(t *testing.T) {
+func Test_AssetHandler_CreateAsset(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 
@@ -107,6 +108,7 @@ func Test_AssetHandlerAddAsset(t *testing.T) {
 		Models:           model,
 		SignatureService: signatureService,
 		HorizonClient:    horizonClientMock,
+		GetPreconditions: func() txnbuild.Preconditions { return preconditions },
 	}
 
 	code := "USDT"
@@ -142,7 +144,7 @@ func Test_AssetHandlerAddAsset(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)},
+				Preconditions: preconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -328,7 +330,7 @@ func Test_AssetHandlerAddAsset(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)},
+				Preconditions: preconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -414,7 +416,7 @@ func Test_AssetHandlerAddAsset(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)},
+				Preconditions: preconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -477,7 +479,7 @@ func Test_AssetHandlerAddAsset(t *testing.T) {
 	signatureService.AssertExpectations(t)
 }
 
-func Test_AssetHandlerDeleteAsset(t *testing.T) {
+func Test_AssetHandler_DeleteAsset(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 
@@ -497,6 +499,7 @@ func Test_AssetHandlerDeleteAsset(t *testing.T) {
 		Models:           model,
 		SignatureService: signatureService,
 		HorizonClient:    horizonClientMock,
+		GetPreconditions: func() txnbuild.Preconditions { return preconditions },
 	}
 
 	r := chi.NewRouter()
@@ -533,7 +536,7 @@ func Test_AssetHandlerDeleteAsset(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)},
+				Preconditions: preconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -700,6 +703,7 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 	handler := &AssetsHandler{
 		SignatureService: signatureService,
 		HorizonClient:    horizonClientMock,
+		GetPreconditions: func() txnbuild.Preconditions { return preconditions },
 	}
 
 	assetToAddTrustline := &txnbuild.CreditAsset{
@@ -780,7 +784,7 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)},
+				Preconditions: preconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -871,7 +875,7 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)},
+				Preconditions: preconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -1083,6 +1087,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 	handler := &AssetsHandler{
 		SignatureService: signatureService,
 		HorizonClient:    horizonClientMock,
+		GetPreconditions: func() txnbuild.Preconditions { return preconditions },
 	}
 
 	code := "USDC"
@@ -1143,7 +1148,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)},
+				Preconditions: preconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -1189,7 +1194,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)},
+				Preconditions: preconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -1256,7 +1261,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)},
+				Preconditions: preconditions,
 			},
 		)
 		require.NoError(t, err)

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/mocks"
 )
 
-var preconditions = txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)}
+var defaultPreconditions = txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)}
 
 func Test_AssetsHandlerGetAssets(t *testing.T) {
 	dbt := dbtest.Open(t)
@@ -108,10 +108,10 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 	signatureService := mocks.NewMockSignatureService(t)
 
 	handler := &AssetsHandler{
-		Models:           model,
-		SignatureService: signatureService,
-		HorizonClient:    horizonClientMock,
-		GetPreconditions: func() txnbuild.Preconditions { return preconditions },
+		Models:             model,
+		SignatureService:   signatureService,
+		HorizonClient:      horizonClientMock,
+		GetPreconditionsFn: func() txnbuild.Preconditions { return defaultPreconditions },
 	}
 
 	code := "USDT"
@@ -147,7 +147,7 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: preconditions,
+				Preconditions: defaultPreconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -333,7 +333,7 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: preconditions,
+				Preconditions: defaultPreconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -419,7 +419,7 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: preconditions,
+				Preconditions: defaultPreconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -499,10 +499,10 @@ func Test_AssetHandler_DeleteAsset(t *testing.T) {
 	signatureService := mocks.NewMockSignatureService(t)
 
 	handler := &AssetsHandler{
-		Models:           model,
-		SignatureService: signatureService,
-		HorizonClient:    horizonClientMock,
-		GetPreconditions: func() txnbuild.Preconditions { return preconditions },
+		Models:             model,
+		SignatureService:   signatureService,
+		HorizonClient:      horizonClientMock,
+		GetPreconditionsFn: func() txnbuild.Preconditions { return defaultPreconditions },
 	}
 
 	r := chi.NewRouter()
@@ -539,7 +539,7 @@ func Test_AssetHandler_DeleteAsset(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: preconditions,
+				Preconditions: defaultPreconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -704,9 +704,9 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 	signatureService := mocks.NewMockSignatureService(t)
 
 	handler := &AssetsHandler{
-		SignatureService: signatureService,
-		HorizonClient:    horizonClientMock,
-		GetPreconditions: func() txnbuild.Preconditions { return preconditions },
+		SignatureService:   signatureService,
+		HorizonClient:      horizonClientMock,
+		GetPreconditionsFn: func() txnbuild.Preconditions { return defaultPreconditions },
 	}
 
 	assetToAddTrustline := &txnbuild.CreditAsset{
@@ -787,7 +787,7 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: preconditions,
+				Preconditions: defaultPreconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -878,7 +878,7 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: preconditions,
+				Preconditions: defaultPreconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -1088,9 +1088,9 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 	signatureService := mocks.NewMockSignatureService(t)
 
 	handler := &AssetsHandler{
-		SignatureService: signatureService,
-		HorizonClient:    horizonClientMock,
-		GetPreconditions: func() txnbuild.Preconditions { return preconditions },
+		SignatureService:   signatureService,
+		HorizonClient:      horizonClientMock,
+		GetPreconditionsFn: func() txnbuild.Preconditions { return defaultPreconditions },
 	}
 
 	code := "USDC"
@@ -1151,7 +1151,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: preconditions,
+				Preconditions: defaultPreconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -1197,7 +1197,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: preconditions,
+				Preconditions: defaultPreconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -1264,7 +1264,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 					},
 				},
 				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
-				Preconditions: preconditions,
+				Preconditions: defaultPreconditions,
 			},
 		)
 		require.NoError(t, err)
@@ -1381,10 +1381,10 @@ func Test_AssetHandler_submitChangeTrustTransaction_makeSurePreconditionsAreSetA
 
 	t.Run("makes sure a non-empty precondition is used if none is explicitly set", func(t *testing.T) {
 		mocks := newAssetTestMock(t, distributionKP.Address())
-		mocks.Handler.GetPreconditions = nil
+		mocks.Handler.GetPreconditionsFn = nil
 
 		txParams := txParamsWithoutPreconditions
-		txParams.Preconditions = preconditions
+		txParams.Preconditions = defaultPreconditions
 		tx, err := txnbuild.NewTransaction(txParams)
 		require.NoError(t, err)
 
@@ -1392,13 +1392,13 @@ func Test_AssetHandler_submitChangeTrustTransaction_makeSurePreconditionsAreSetA
 		require.NoError(t, err)
 
 		mocks.SignatureService.
-			On("SignStellarTransaction", ctx, mock.MatchedBy(matchPreconditionsTimeboundsFn(preconditions)), distributionKP.Address()).
+			On("SignStellarTransaction", ctx, mock.MatchedBy(matchPreconditionsTimeboundsFn(defaultPreconditions)), distributionKP.Address()).
 			Return(signedTx, nil).
 			Once()
 		defer mocks.SignatureService.AssertExpectations(t)
 
 		mocks.HorizonClientMock.
-			On("SubmitTransactionWithOptions", mock.MatchedBy(matchPreconditionsTimeboundsFn(preconditions)), horizonclient.SubmitTxOpts{SkipMemoRequiredCheck: true}).
+			On("SubmitTransactionWithOptions", mock.MatchedBy(matchPreconditionsTimeboundsFn(defaultPreconditions)), horizonclient.SubmitTxOpts{SkipMemoRequiredCheck: true}).
 			Return(horizon.Transaction{}, nil).
 			Once()
 		defer mocks.HorizonClientMock.AssertExpectations(t)
@@ -1410,7 +1410,7 @@ func Test_AssetHandler_submitChangeTrustTransaction_makeSurePreconditionsAreSetA
 	t.Run("makes sure a the precondition that was set is used", func(t *testing.T) {
 		mocks := newAssetTestMock(t, distributionKP.Address())
 		newPreconditions := txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(int64(rand.Intn(999999999)))}
-		mocks.Handler.GetPreconditions = func() txnbuild.Preconditions { return newPreconditions }
+		mocks.Handler.GetPreconditionsFn = func() txnbuild.Preconditions { return newPreconditions }
 
 		txParams := txParamsWithoutPreconditions
 		txParams.Preconditions = newPreconditions


### PR DESCRIPTION
### What

Add an option to specify a custom `GetPreconditionsFn` parameter in the AssetsHandler object.

### Why

To address the intermittent test failure ([example](https://github.com/stellar/stellar-disbursement-platform-backend/actions/runs/6200706140/job/16835930483?pr=40)) where the test assertion would fail because the time.Now() call generated in the test would differ from the one generated in the code by a second.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
