### PR TITLE
[SDP-565] Inform user if they have exceeded the maximum attempts at verification

### DIFF
--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -35,10 +35,6 @@ func (e *ErrorVerificationAttemptsExceeded) Error() string {
 	return e.cause.Error()
 }
 
-func (e *ErrorVerificationAttemptsExceeded) Unwrap() error {
-	return e.cause
-}
-
 const (
 	InformationNotFoundOnServer = "the information you provided could not be found in our server"
 )

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -302,6 +302,8 @@ func (v VerifyReceiverRegistrationHandler) VerifyReceiverRegistration(w http.Res
 			httperror.BadRequest(InformationNotFoundOnServer, atomicFnErr, nil).Render(w)
 			return
 		}
+		// if error is due to verification attempts being exceeded, we want to display the message with what that limit is clearly
+		// to the user
 		var errorVerficationAttemptsExceeded *ErrorVerificationAttemptsExceeded
 		if errors.As(atomicFnErr, &errorVerficationAttemptsExceeded) {
 			log.Ctx(ctx).Error(errorVerficationAttemptsExceeded.cause)

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -582,15 +582,15 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 
 		// setup router and execute request
 		r.Post("/wallet-registration/verification", handler.VerifyReceiverRegistration)
-		req, err := http.NewRequest("POST", "/wallet-registration/verification", nil)
-		require.NoError(t, err)
+		req, reqErr := http.NewRequest("POST", "/wallet-registration/verification", nil)
+		require.NoError(t, reqErr)
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
 
 		// execute and validate response
 		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
+		respBody, readRespErr := io.ReadAll(resp.Body)
+		require.NoError(t, readRespErr)
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 		assert.JSONEq(t, `{"error": "Not authorized."}`, string(respBody))
 
@@ -611,16 +611,16 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 
 		// setup router and execute request
 		r.Post("/wallet-registration/verification", handler.VerifyReceiverRegistration)
-		req, err := http.NewRequest("POST", "/wallet-registration/verification", strings.NewReader(string(reqBody)))
-		require.NoError(t, err)
+		req, reqErr := http.NewRequest("POST", "/wallet-registration/verification", strings.NewReader(string(reqBody)))
+		require.NoError(t, reqErr)
 		req = req.WithContext(context.WithValue(req.Context(), anchorplatform.SEP24ClaimsContextKey, validClaims))
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
 
 		// execute and validate response
 		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
+		respBody, readRespErr := io.ReadAll(resp.Body)
+		require.NoError(t, readRespErr)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		wantBody := fmt.Sprintf(`{"error": "%s"}`, InformationNotFoundOnServer)
 		assert.JSONEq(t, wantBody, string(respBody))
@@ -646,16 +646,16 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 
 		// setup router and execute request
 		r.Post("/wallet-registration/verification", handler.VerifyReceiverRegistration)
-		req, err := http.NewRequest("POST", "/wallet-registration/verification", strings.NewReader(string(reqBody)))
-		require.NoError(t, err)
+		req, reqErr := http.NewRequest("POST", "/wallet-registration/verification", strings.NewReader(string(reqBody)))
+		require.NoError(t, reqErr)
 		req = req.WithContext(context.WithValue(req.Context(), anchorplatform.SEP24ClaimsContextKey, validClaims))
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
 
 		// execute and validate response
 		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
+		respBody, readRespErr := io.ReadAll(resp.Body)
+		require.NoError(t, readRespErr)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		wantBody := fmt.Sprintf(`{"error": "%s"}`, InformationNotFoundOnServer)
 		assert.JSONEq(t, wantBody, string(respBody))


### PR DESCRIPTION
### What
Rather than just specifying a generic error message in the response, we want to show some message to the users about exceeding the verification limit.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [ ] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
