### PR TITLE
[SDP-905] data/httphandler: serve SMS templates

### DIFF
--- a/internal/data/organizations.go
+++ b/internal/data/organizations.go
@@ -21,6 +21,11 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 )
 
+const (
+	DefaultSMSRegistrationMessageTemplate = "You have a payment waiting for you from the {{.OrganizationName}}. Click {{.RegistrationLink}} to register."
+	DefaultOTPMessageTemplate             = "{{.OTP}} is your {{.OrganizationName}} phone verification code."
+)
+
 type Organization struct {
 	ID                             string `json:"id" db:"id"`
 	Name                           string `json:"name" db:"name"`

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -354,13 +354,23 @@ func (h ProfileHandler) GetOrganizationInfo(rw http.ResponseWriter, req *http.Re
 		return
 	}
 
-	httpjson.RenderStatus(rw, http.StatusOK, map[string]interface{}{
+	resp := map[string]interface{}{
 		"name":                            org.Name,
 		"logo_url":                        lu.String(),
 		"distribution_account_public_key": h.DistributionPublicKey,
 		"timezone_utc_offset":             org.TimezoneUTCOffset,
 		"is_approval_required":            org.IsApprovalRequired,
-	}, httpjson.JSON)
+	}
+
+	if org.SMSRegistrationMessageTemplate != data.DefaultSMSRegistrationMessageTemplate {
+		resp["sms_registration_message_template"] = org.SMSRegistrationMessageTemplate
+	}
+
+	if org.OTPMessageTemplate != data.DefaultOTPMessageTemplate {
+		resp["otp_message_template"] = org.OTPMessageTemplate
+	}
+
+	httpjson.RenderStatus(rw, http.StatusOK, resp, httpjson.JSON)
 }
 
 // GetOrganizationLogo renders the stored organization logo. The image is rendered inline (not attached - the attached option downloads the content)


### PR DESCRIPTION
### What

This PR adds the attributes `sms_registration_message_template` and `otp_message_template` to the response body of `GET /organizations` endpoint. These attributes will only be returned when they aren't the default values.

### Why

These messages will be displayed by the client on the settings screen.

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
