### PR TITLE
[SDP-815] data/httphandler: add sms_resend_interval to organizations table

### DIFF
--- a/internal/data/organizations_test.go
+++ b/internal/data/organizations_test.go
@@ -79,7 +79,7 @@ func Test_Organizations_Get(t *testing.T) {
 func Test_OrganizationUpdate_validate(t *testing.T) {
 	ou := &OrganizationUpdate{}
 	err := ou.validate()
-	assert.EqualError(t, err, "name, timezone UTC offset, approval workflow flag, SMS invite template, OTP message template or logo is required")
+	assert.EqualError(t, err, "name, timezone UTC offset, approval workflow flag, SMS Resend Interval, SMS invite template, OTP message template or logo is required")
 
 	ou.Name = "My Org Name"
 	err = ou.validate()
@@ -198,7 +198,7 @@ func Test_Organizations_Update(t *testing.T) {
 	t.Run("returns error with invalid OrganizationUpdate", func(t *testing.T) {
 		ou := &OrganizationUpdate{}
 		err := organizationModel.Update(ctx, ou)
-		assert.EqualError(t, err, "invalid organization update: name, timezone UTC offset, approval workflow flag, SMS invite template, OTP message template or logo is required")
+		assert.EqualError(t, err, "invalid organization update: name, timezone UTC offset, approval workflow flag, SMS Resend Interval, SMS invite template, OTP message template or logo is required")
 	})
 
 	t.Run("updates only organization's name successfully", func(t *testing.T) {
@@ -391,5 +391,30 @@ func Test_Organizations_Update(t *testing.T) {
 		o, err = organizationModel.Get(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, defaultMessage, o.OTPMessageTemplate)
+	})
+
+	t.Run("updates the organization's SMSResendInterval", func(t *testing.T) {
+		resetOrganizationInfo(t, ctx)
+
+		o, err := organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, o.SMSResendInterval)
+
+		var smsResendInterval int64 = 2
+		err = organizationModel.Update(ctx, &OrganizationUpdate{SMSResendInterval: &smsResendInterval})
+		require.NoError(t, err)
+
+		o, err = organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, smsResendInterval, *o.SMSResendInterval)
+
+		// Set it as null
+		smsResendInterval = 0
+		err = organizationModel.Update(ctx, &OrganizationUpdate{SMSResendInterval: &smsResendInterval})
+		require.NoError(t, err)
+
+		o, err = organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, o.SMSResendInterval)
 	})
 }

--- a/internal/db/migrations/2023-10-12.0.alter-organizations-table-add-sms-resend-interval.sql
+++ b/internal/db/migrations/2023-10-12.0.alter-organizations-table-add-sms-resend-interval.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+
+ALTER TABLE public.organizations
+    ADD COLUMN sms_resend_interval INTEGER NULL,
+    ADD CONSTRAINT organization_sms_resend_interval_valid_value_check CHECK ((sms_resend_interval IS NOT NULL AND sms_resend_interval > 0) OR sms_resend_interval IS NULL);
+
+-- +migrate Down
+
+ALTER TABLE public.organizations
+    DROP CONSTRAINT organization_sms_resend_interval_valid_value_check,
+    DROP COLUMN sms_resend_interval;

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -48,6 +48,7 @@ type PatchOrganizationProfileRequest struct {
 	OrganizationName               string  `json:"organization_name"`
 	TimezoneUTCOffset              string  `json:"timezone_utc_offset"`
 	IsApprovalRequired             *bool   `json:"is_approval_required"`
+	SMSResendInterval              *int64  `json:"sms_resend_interval"`
 	SMSRegistrationMessageTemplate *string `json:"sms_registration_message_template"`
 	OTPMessageTemplate             *string `json:"otp_message_template"`
 }
@@ -57,7 +58,8 @@ func (r *PatchOrganizationProfileRequest) AreAllFieldsEmpty() bool {
 		r.TimezoneUTCOffset == "" &&
 		r.IsApprovalRequired == nil &&
 		r.SMSRegistrationMessageTemplate == nil &&
-		r.OTPMessageTemplate == nil)
+		r.OTPMessageTemplate == nil &&
+		r.SMSResendInterval == nil)
 }
 
 type PatchUserProfileRequest struct {
@@ -156,13 +158,14 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 		IsApprovalRequired:             reqBody.IsApprovalRequired,
 		SMSRegistrationMessageTemplate: reqBody.SMSRegistrationMessageTemplate,
 		OTPMessageTemplate:             reqBody.OTPMessageTemplate,
+		SMSResendInterval:              reqBody.SMSResendInterval,
 	})
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot update organization", err, nil).Render(rw)
 		return
 	}
 
-	httpjson.RenderStatus(rw, http.StatusOK, map[string]string{"message": "organization profile updated successfully"}, httpjson.JSON)
+	httpjson.RenderStatus(rw, http.StatusOK, map[string]string{"message": "updated successfully"}, httpjson.JSON)
 }
 
 func (h ProfileHandler) PatchUserProfile(rw http.ResponseWriter, req *http.Request) {

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -62,7 +62,8 @@ func resetOrganizationInfo(t *testing.T, ctx context.Context, dbConnectionPool d
 			organizations
 		SET
 			name = 'MyCustomAid', logo = NULL, timezone_utc_offset = '+00:00',
-			sms_registration_message_template = DEFAULT, otp_message_template = DEFAULT`
+			sms_registration_message_template = DEFAULT, otp_message_template = DEFAULT,
+			sms_resend_interval = NULL`
 	_, err := dbConnectionPool.ExecContext(ctx, q)
 	require.NoError(t, err)
 }
@@ -255,7 +256,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -290,7 +291,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -323,7 +324,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -361,7 +362,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -402,7 +403,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -447,7 +448,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -484,7 +485,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		defer resp.Body.Close()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -503,7 +504,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		defer resp.Body.Close()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -522,7 +523,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		defer resp.Body.Close()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -553,7 +554,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		defer resp.Body.Close()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -572,7 +573,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		defer resp.Body.Close()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
@@ -591,11 +592,77 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		defer resp.Body.Close()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.JSONEq(t, `{"message": "organization profile updated successfully"}`, string(respBody))
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
 
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, defaultMessage, org.OTPMessageTemplate)
+	})
+
+	t.Run("updates organization's SMS Resend Interval", func(t *testing.T) {
+		resetOrganizationInfo(t, ctx, dbConnectionPool)
+		ctx = context.WithValue(ctx, middleware.TokenContextKey, "token")
+
+		org, err := models.Organizations.Get(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, org.SMSResendInterval)
+
+		// Custom interval
+		w := httptest.NewRecorder()
+		req, err := createOrganizationProfileMultipartRequest(t, url, "", "", `{"sms_resend_interval": 2}`, new(bytes.Buffer))
+		require.NoError(t, err)
+		req = req.WithContext(ctx)
+		http.HandlerFunc(handler.PatchOrganizationProfile).ServeHTTP(w, req)
+
+		resp := w.Result()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
+
+		org, err = models.Organizations.Get(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), *org.SMSResendInterval)
+
+		// Don't update the interval
+		w = httptest.NewRecorder()
+		req, err = createOrganizationProfileMultipartRequest(t, url, "", "", `{"organization_name": "MyOrg"}`, new(bytes.Buffer))
+		require.NoError(t, err)
+		req = req.WithContext(ctx)
+		http.HandlerFunc(handler.PatchOrganizationProfile).ServeHTTP(w, req)
+
+		resp = w.Result()
+		respBody, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
+
+		org, err = models.Organizations.Get(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), *org.SMSResendInterval)
+
+		// Back to default interval
+		w = httptest.NewRecorder()
+		req, err = createOrganizationProfileMultipartRequest(t, url, "", "", `{"sms_resend_interval": 0}`, new(bytes.Buffer))
+		require.NoError(t, err)
+		req = req.WithContext(ctx)
+		http.HandlerFunc(handler.PatchOrganizationProfile).ServeHTTP(w, req)
+
+		resp = w.Result()
+		respBody, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.JSONEq(t, `{"message": "updated successfully"}`, string(respBody))
+
+		org, err = models.Organizations.Get(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, org.SMSResendInterval)
 	})
 }
 


### PR DESCRIPTION
### What

This PR adds a new column on the `organizations` table - `sms_resend_interval`. Also, adds this field in the `PATCH /organizations` endpoint.

### Why

This new column will control the interval of resending the Invitation SMS to the receivers when they don't get registered after receiving the first invitation. The value of this column can be `null` or an integer greater than `0 (zero)`. `Null` means that the organization doesn't want to automatically resend the invitation SMS. To set this field as null a request with the number 0 (zero) should be sent.

### Known limitations

- This new column will be used in the next [PR](https://github.com/stellar/stellar-disbursement-platform-backend/pull/66). 
- Create a pull request in the stellar-docs adding this new attribute.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
