### PR TITLE
SDP-915 Improve error messages during receiver registration process

### DIFF
--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -36,7 +36,7 @@ func (e *ErrorVerificationAttemptsExceeded) Error() string {
 }
 
 const (
-	InformationNotFoundOnServer = "the information you provided could not be found in our server"
+	InformationNotFoundOnServer = "the information you provided could not be found"
 )
 
 type VerifyReceiverRegistrationHandler struct {
@@ -125,7 +125,7 @@ func (v VerifyReceiverRegistrationHandler) processReceiverVerificationPII(
 	// STEP 2: check if the number of attempts to confirm the verification value has already exceeded the max value
 	if v.Models.ReceiverVerification.ExceededAttempts(receiverVerification.Attempts) {
 		// TODO: the application currently can't recover from a max attempts exceeded error.
-		err = fmt.Errorf("the number of attempts to confirm the verification value exceededs the max attempts limit of %d", data.MaxAttemptsAllowed)
+		err = fmt.Errorf("the number of attempts to confirm the verification value exceededs the max attempts")
 		return &ErrorVerificationAttemptsExceeded{cause: err}
 	}
 

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -250,7 +250,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 				VerificationType:  data.VerificationFieldDateOfBirth,
 				VerificationValue: "1990-01-01",
 			},
-			wantErrContains: fmt.Sprintf("the number of attempts to confirm the verification value exceededs the max attempts limit of %d", data.MaxAttemptsAllowed),
+			wantErrContains: "the number of attempts to confirm the verification value exceededs the max attempts",
 		},
 		{
 			name:     "returns an error if the varification value provided in the payload is different from the DB one",
@@ -701,7 +701,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		expectedError := fmt.Sprintf("the number of attempts to confirm the verification value exceededs the max attempts limit of %d", data.MaxAttemptsAllowed)
+		expectedError := "the number of attempts to confirm the verification value exceededs the max attempts"
 		wantBody := fmt.Sprintf(`{"error": "%s"}`, expectedError)
 		assert.JSONEq(t, wantBody, string(respBody))
 

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -225,6 +225,10 @@ async function submitOtp(event) {
             location.reload();
             clearTimeout(t);
           }, 2000);
+        } else if (response.status === 400) {
+          const data = await response.json();
+          const errorMessage = data.error || "Something went wrong, please try again later.";
+          throw new Error(errorMessage);
         } else {
           throw new Error("Something went wrong, please try again later.");
         }


### PR DESCRIPTION
### What
Return better error messages during receiver registration. 

### Why
Help the receiver troubleshoot registration issues. 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [ ] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
