### PR TITLE
SDP-930 add wallets filtering by enabled flag

### DIFF
--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -212,6 +212,20 @@ func ClearAndCreateWalletFixtures(t *testing.T, ctx context.Context, sqlExec db.
 	return expected
 }
 
+func EnableOrDisableWalletFixtures(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, enabled bool, walletIDs ...string) {
+	const query = `
+		UPDATE
+			wallets
+		SET
+			enabled = $1
+		WHERE
+			id = ANY($2)
+	`
+
+	_, err := sqlExec.ExecContext(ctx, query, enabled, pq.Array(walletIDs))
+	require.NoError(t, err)
+}
+
 func GetCountryFixture(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, code string) *Country {
 	const query = `
 		SELECT

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -71,6 +71,10 @@ func (d DisbursementHandler) PostDisbursement(w http.ResponseWriter, r *http.Req
 		httperror.BadRequest("wallet ID is invalid", err, nil).Render(w)
 		return
 	}
+	if !wallet.Enabled {
+		httperror.BadRequest("wallet is not enabled", errors.New("wallet is not enabled"), nil).Render(w)
+		return
+	}
 	asset, err := d.Models.Assets.Get(ctx, disbursementRequest.AssetID)
 	if err != nil {
 		httperror.BadRequest("asset ID is invalid", err, nil).Render(w)
@@ -353,6 +357,8 @@ func (d DisbursementHandler) PatchDisbursementStatus(w http.ResponseWriter, r *h
 			httperror.BadRequest(services.ErrDisbursementStatusCantBeChanged.Error(), err, nil).Render(w)
 		case errors.Is(err, services.ErrDisbursementStartedByCreator):
 			httperror.Forbidden("Disbursement can't be started by its creator. Approval by another user is required.", err, nil).Render(w)
+		case errors.Is(err, services.ErrDisbursementWalletDisabled):
+			httperror.BadRequest(services.ErrDisbursementWalletDisabled.Error(), err, nil).Render(w)
 		default:
 			msg := fmt.Sprintf("Cannot update disbursement ID %s with status: %s", disbursementID, toStatus)
 			httperror.InternalError(ctx, msg, err, nil).Render(w)

--- a/internal/serve/httphandler/wallets_handler.go
+++ b/internal/serve/httphandler/wallets_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stellar/go/support/http/httpdecode"
@@ -19,9 +20,22 @@ type WalletsHandler struct {
 
 // GetWallets returns a list of wallets
 func (h WalletsHandler) GetWallets(w http.ResponseWriter, r *http.Request) {
-	wallets, err := h.Models.Wallets.GetAll(r.Context())
+	context := r.Context()
+
+	enabledParam := r.URL.Query().Get("enabled")
+	var enabledFilter *bool
+	if enabledParam != "" {
+		enabledValue, err := strconv.ParseBool(enabledParam)
+		if err != nil {
+			httperror.BadRequest("Invalid enabled parameter value", nil, nil).Render(w)
+			return
+		}
+		enabledFilter = &enabledValue
+	}
+
+	wallets, err := h.Models.Wallets.FindWallets(context, enabledFilter)
 	if err != nil {
-		httperror.InternalError(r.Context(), "Cannot retrieve list of wallets", err, nil).Render(w)
+		httperror.InternalError(context, "Cannot retrieve list of wallets", err, nil).Render(w)
 		return
 	}
 	httpjson.Render(w, wallets, httpjson.JSON)

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -201,6 +201,13 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		require.ErrorIs(t, err, ErrDisbursementNotFound)
 	})
 
+	t.Run("disbursement wallet is disabled", func(t *testing.T) {
+		data.EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, false, wallet.ID)
+		defer data.EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, true, wallet.ID)
+		err = service.StartDisbursement(context.Background(), draftDisbursement.ID)
+		require.ErrorIs(t, err, ErrDisbursementWalletDisabled)
+	})
+
 	t.Run("disbursement not ready to start", func(t *testing.T) {
 		err = service.StartDisbursement(context.Background(), draftDisbursement.ID)
 		require.ErrorIs(t, err, ErrDisbursementNotReadyToStart)


### PR DESCRIPTION
### What
* Add `enabled` flag for `GET /wallets` to return only enabled wallets. 
* Change `POST /disbursements` to fail when using a disabled wallet.
* Change **StartDisbursement** to fail when using a disabled wallet. 

### Why
This feature complements the `Wallet Providers Configuration` feature. 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [ ] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
