### PR TITLE
[SDP-913] stellar-multitenant: add-tenants cmd

### DIFF
--- a/stellar-multitenant/pkg/cli/add_tenants.go
+++ b/stellar-multitenant/pkg/cli/add_tenants.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+)
+
+var validTenantName *regexp.Regexp = regexp.MustCompile(`^[a-z-]+$`)
+
+func AddTenantsCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:     "add-tenants",
+		Short:   "Add a new tenant.",
+		Example: "add-tenants [name]",
+		Long:    "Add a new tenant. The tenant name should no contain spaces or symbols.",
+		Args: cobra.MatchAll(
+			cobra.ExactArgs(1),
+			validateTenantNameArg,
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			if err := executeAddTenant(ctx, globalOptions.multitenantDbURL, args[0]); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	return &cmd
+}
+
+func validateTenantNameArg(cmd *cobra.Command, args []string) error {
+	if !validTenantName.MatchString(args[0]) {
+		return fmt.Errorf("invalid tenant name %q. It should only contains lower case letters and dash (-)", args[0])
+	}
+	return nil
+}
+
+func executeAddTenant(ctx context.Context, dbURL, name string) error {
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbURL)
+	if err != nil {
+		return fmt.Errorf("opening database connection pool: %w", err)
+	}
+	defer dbConnectionPool.Close()
+
+	m := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
+	t, err := m.AddTenant(ctx, name)
+	if err != nil {
+		return fmt.Errorf("adding tenant with name %s: %w", name, err)
+	}
+
+	log.Ctx(ctx).Infof("tenant %s added successfully", name)
+	log.Ctx(ctx).Infof("tenant ID: %s", t.ID)
+
+	return nil
+}

--- a/stellar-multitenant/pkg/cli/add_tenants.go
+++ b/stellar-multitenant/pkg/cli/add_tenants.go
@@ -18,7 +18,7 @@ func AddTenantsCmd() *cobra.Command {
 		Use:     "add-tenants",
 		Short:   "Add a new tenant.",
 		Example: "add-tenants [name]",
-		Long:    "Add a new tenant. The tenant name should no contain spaces or symbols.",
+		Long:    "Add a new tenant. The tenant name should only contain lower case characters and dash (-)",
 		Args: cobra.MatchAll(
 			cobra.ExactArgs(1),
 			validateTenantNameArg,

--- a/stellar-multitenant/pkg/cli/add_tenants_test.go
+++ b/stellar-multitenant/pkg/cli/add_tenants_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func DeleteAllTenantsFixture(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool) {
+	const q = "DELETE FROM tenants"
+	_, err := dbConnectionPool.ExecContext(ctx, q)
+	require.NoError(t, err)
+}
+
+func Test_validateTenantNameArg(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "orgname",
+			err:  nil,
+		},
+		{
+			name: "orgname-ukraine",
+			err:  nil,
+		},
+		{
+			name: "ORGNAME",
+			err:  errors.New(`invalid tenant name "ORGNAME". It should only contains lower case letters and dash (-)`),
+		},
+		{
+			name: "orgname org",
+			err:  errors.New(`invalid tenant name "orgname org". It should only contains lower case letters and dash (-)`),
+		},
+		{
+			name: "orgname126",
+			err:  errors.New(`invalid tenant name "orgname126". It should only contains lower case letters and dash (-)`),
+		},
+		{
+			name: "@rgn#ame$",
+			err:  errors.New(`invalid tenant name "@rgn#ame$". It should only contains lower case letters and dash (-)`),
+		},
+		{
+			name: "orgname_ukraine",
+			err:  errors.New(`invalid tenant name "orgname_ukraine". It should only contains lower case letters and dash (-)`),
+		},
+	}
+
+	for _, tc := range testCases {
+		err := validateTenantNameArg(&cobra.Command{}, []string{tc.name})
+		if tc.err != nil {
+			assert.Equal(t, tc.err, err)
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+}
+
+func Test_executeAddTenant(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+
+	t.Run("adds a new tenant successfully", func(t *testing.T) {
+		DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
+
+		getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
+
+		err := executeAddTenant(ctx, dbt.DSN, "myorg")
+		assert.Nil(t, err)
+
+		const q = "SELECT id FROM tenants WHERE name = $1"
+		var tenantID string
+		err = dbConnectionPool.GetContext(ctx, &tenantID, q, "myorg")
+		require.NoError(t, err)
+
+		entries := getEntries()
+		require.Len(t, entries, 2)
+		assert.Equal(t, "tenant myorg added successfully", entries[0].Message)
+		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[1].Message)
+	})
+
+	t.Run("duplicated tenant name", func(t *testing.T) {
+		DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
+
+		getEntries := log.DefaultLogger.StartTest(log.DebugLevel)
+
+		err := executeAddTenant(ctx, dbt.DSN, "myorg")
+		assert.Nil(t, err)
+
+		err = executeAddTenant(ctx, dbt.DSN, "MyOrg")
+		assert.ErrorIs(t, err, tenant.ErrDuplicatedTenantName)
+
+		const q = "SELECT id FROM tenants WHERE name = $1"
+		var tenantID string
+		err = dbConnectionPool.GetContext(ctx, &tenantID, q, "myorg")
+		require.NoError(t, err)
+
+		entries := getEntries()
+		require.Len(t, entries, 2)
+		assert.Equal(t, "tenant myorg added successfully", entries[0].Message)
+		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[1].Message)
+	})
+}
+
+func Test_AddTenantsCmd(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+
+	t.Run("shows usage", func(t *testing.T) {
+		out := new(strings.Builder)
+		mockCmd := cobra.Command{}
+		mockCmd.AddCommand(AddTenantsCmd())
+		mockCmd.SetOut(out)
+		mockCmd.SetErr(out)
+		mockCmd.SetArgs([]string{"add-tenants"})
+		err := mockCmd.ExecuteContext(ctx)
+		assert.EqualError(t, err, "accepts 1 arg(s), received 0")
+
+		expectUsageMessage := `Error: accepts 1 arg(s), received 0
+Usage:
+   add-tenants [flags]
+
+Examples:
+add-tenants [name]
+
+Flags:
+  -h, --help   help for add-tenants
+
+`
+		assert.Equal(t, expectUsageMessage, out.String())
+
+		out.Reset()
+		mockCmd.SetArgs([]string{"add-tenants", "--help"})
+		err = mockCmd.ExecuteContext(ctx)
+		require.NoError(t, err)
+
+		expectUsageMessage = `Add a new tenant. The tenant name should no contain spaces or symbols.
+
+Usage:
+   add-tenants [flags]
+
+Examples:
+add-tenants [name]
+
+Flags:
+  -h, --help   help for add-tenants
+`
+		assert.Equal(t, expectUsageMessage, out.String())
+	})
+
+	t.Run("adds new tenant successfully", func(t *testing.T) {
+		out := new(strings.Builder)
+		rootCmd := rootCmd()
+		rootCmd.AddCommand(AddTenantsCmd())
+		rootCmd.SetOut(out)
+		rootCmd.SetErr(out)
+		rootCmd.SetArgs([]string{"add-tenants", "unhcr", "--multitenant-db-url", dbt.DSN})
+		getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
+
+		err := rootCmd.ExecuteContext(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, out.String())
+
+		const q = "SELECT id FROM tenants WHERE name = $1"
+		var tenantID string
+		err = dbConnectionPool.GetContext(ctx, &tenantID, q, "unhcr")
+		require.NoError(t, err)
+
+		entries := getEntries()
+		require.Len(t, entries, 4)
+		assert.Equal(t, "tenant unhcr added successfully", entries[2].Message)
+		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[3].Message)
+	})
+}

--- a/stellar-multitenant/pkg/cli/add_tenants_test.go
+++ b/stellar-multitenant/pkg/cli/add_tenants_test.go
@@ -155,7 +155,7 @@ Flags:
 		err = mockCmd.ExecuteContext(ctx)
 		require.NoError(t, err)
 
-		expectUsageMessage = `Add a new tenant. The tenant name should no contain spaces or symbols.
+		expectUsageMessage = `Add a new tenant. The tenant name should only contain lower case characters and dash (-)
 
 Usage:
    add-tenants [flags]

--- a/stellar-multitenant/pkg/cli/root.go
+++ b/stellar-multitenant/pkg/cli/root.go
@@ -61,7 +61,7 @@ func SetupCLI(version, gitCommit string) *cobra.Command {
 
 	cmd := rootCmd()
 
-	cmd.AddCommand(MigrateCmd("multitenant-db-url"))
+	cmd.AddCommand(MigrateCmd(""))
 
 	return cmd
 }

--- a/stellar-multitenant/pkg/cli/root.go
+++ b/stellar-multitenant/pkg/cli/root.go
@@ -62,6 +62,7 @@ func SetupCLI(version, gitCommit string) *cobra.Command {
 	cmd := rootCmd()
 
 	cmd.AddCommand(MigrateCmd(""))
+	cmd.AddCommand(AddTenantsCmd())
 
 	return cmd
 }

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -1,0 +1,51 @@
+package tenant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/lib/pq"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db"
+)
+
+var (
+	ErrDuplicatedTenantName = errors.New("duplicated tenant name")
+	ErrEmptyTenantName      = errors.New("tenant name cannot be empty")
+)
+
+type Manager struct {
+	db db.DBConnectionPool
+}
+
+func (m *Manager) AddTenant(ctx context.Context, name string) (*Tenant, error) {
+	if name == "" {
+		return nil, ErrEmptyTenantName
+	}
+
+	const q = "INSERT INTO tenants (name) VALUES ($1) RETURNING id, name"
+	var t Tenant
+	if err := m.db.GetContext(ctx, &t, q, name); err != nil {
+		if pqError, ok := err.(*pq.Error); ok && pqError.Constraint == "idx_unique_name" {
+			return nil, ErrDuplicatedTenantName
+		}
+		return nil, fmt.Errorf("inserting tenant %s: %w", name, err)
+	}
+	return &t, nil
+}
+
+type Option func(m *Manager)
+
+func NewManager(opts ...Option) *Manager {
+	m := Manager{}
+	for _, opt := range opts {
+		opt(&m)
+	}
+	return &m
+}
+
+func WithDatabase(dbConnectionPool db.DBConnectionPool) Option {
+	return func(m *Manager) {
+		m.db = dbConnectionPool
+	}
+}

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -1,0 +1,49 @@
+package tenant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Manager_AddTenant(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+
+	m := NewManager(WithDatabase(dbConnectionPool))
+
+	t.Run("returns error when tenant name is empty", func(t *testing.T) {
+		tnt, err := m.AddTenant(ctx, "")
+		assert.Equal(t, ErrEmptyTenantName, err)
+		assert.Nil(t, tnt)
+	})
+
+	t.Run("inserts a new tenant successfully", func(t *testing.T) {
+		tnt, err := m.AddTenant(ctx, "myorg-ukraine")
+		require.NoError(t, err)
+		assert.NotNil(t, tnt)
+		assert.NotEmpty(t, tnt.ID)
+		assert.Equal(t, "myorg-ukraine", tnt.Name)
+	})
+
+	t.Run("returns error when tenant name is duplicated", func(t *testing.T) {
+		tnt, err := m.AddTenant(ctx, "myorg")
+		require.NoError(t, err)
+		assert.NotNil(t, tnt)
+		assert.NotEmpty(t, tnt.ID)
+		assert.Equal(t, "myorg", tnt.Name)
+
+		tnt, err = m.AddTenant(ctx, "MyOrg")
+		assert.Equal(t, ErrDuplicatedTenantName, err)
+		assert.Nil(t, tnt)
+	})
+}

--- a/stellar-multitenant/pkg/tenant/tenant.go
+++ b/stellar-multitenant/pkg/tenant/tenant.go
@@ -1,0 +1,6 @@
+package tenant
+
+type Tenant struct {
+	ID   string `db:"id"`
+	Name string `db:"name"`
+}


### PR DESCRIPTION
### What

This PR adds a new CLI command in the `stellar-multitenant` package. This CLI is responsible for registering new `tenants` on the main database schema. The `tenant name` is unique.

```sh
mtn add-tenants myorg
``` 

### Why

We should be able to register new `tenants`.

### Known limitations

This process only registers the new `tenant` in the main database schema but we are missing creating the database schema and configuring the basics for it.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
