### PR TITLE
[SDP-913] stellar-multitenant: add config-tenant command

### DIFF
--- a/stellar-multitenant/internal/db/migrations/2023-10-16.0.add-tenants-table.sql
+++ b/stellar-multitenant/internal/db/migrations/2023-10-16.0.add-tenants-table.sql
@@ -18,21 +18,25 @@ CREATE TYPE public.sms_sender_type AS ENUM ('TWILIO_SMS', 'AWS_SMS', 'DRY_RUN');
 CREATE TABLE public.tenants
 (
     id VARCHAR(36) PRIMARY KEY DEFAULT uuid_generate_v4(),
-    name text NULL,
-    email_sender_type email_sender_type NULL,
-    sms_sender_type sms_sender_type   NULL,
+    name text NOT NULL,
+    email_sender_type email_sender_type DEFAULT 'DRY_RUN'::email_sender_type,
+    sms_sender_type sms_sender_type DEFAULT 'DRY_RUN'::sms_sender_type,
     sep10_signing_public_key text NULL,
     distribution_public_key text NULL,
-    enable_mfa boolean NULL,
-    enable_recaptcha boolean NULL,
-    cors_allowed_origins text NULL,
+    enable_mfa boolean DEFAULT true,
+    enable_recaptcha boolean DEFAULT true,
+    cors_allowed_origins text[] NULL,
     base_url text NULL,
+    sdp_ui_base_url text NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
 CREATE UNIQUE INDEX idx_unique_name ON public.tenants (LOWER(name));
 CREATE TRIGGER refresh_tenants_updated_at BEFORE UPDATE ON public.tenants FOR EACH ROW EXECUTE PROCEDURE update_at_refresh();
+
+COMMENT ON COLUMN tenants.base_url IS 'The SDP backend server''s base URL';
+COMMENT ON COLUMN tenants.sdp_ui_base_url IS 'The SDP UI/dashboard Base URL.';
 
 -- +migrate Down
 

--- a/stellar-multitenant/pkg/cli/config_tenant.go
+++ b/stellar-multitenant/pkg/cli/config_tenant.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"go/types"
+
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/support/config"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/cli/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+)
+
+type tenantOptions struct {
+	ID                    string
+	EmailSenderType       *tenant.EmailSenderType
+	SMSSenderType         *tenant.SMSSenderType
+	SEP10SigningPublicKey *string
+	DistributionPublicKey *string
+	EnableMFA             *bool
+	EnableReCAPTCHA       *bool
+	CORSAllowedOrigins    []string
+	BaseURL               *string
+	SDPUIBaseURL          *string
+}
+
+func ConfigTenantCmd() *cobra.Command {
+	to := tenantOptions{}
+	configOptions := config.ConfigOptions{
+		{
+			Name:      "tenant-id",
+			Usage:     "The ID of the Tenant to configure.",
+			OptType:   types.String,
+			ConfigKey: &to.ID,
+			Required:  true,
+		},
+		{
+			Name:           "email-sender-type",
+			Usage:          `The messenger type used to send invitations to new dashboard users. Options: "AWS_EMAIL", "DRY_RUN"`,
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionEmailSenderType,
+			ConfigKey:      &to.EmailSenderType,
+			Required:       false,
+		},
+		{
+			Name:           "sms-sender-type",
+			Usage:          `SMS Sender Type. Options: "TWILIO_SMS", "AWS_SMS", "DRY_RUN"`,
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionSMSSenderType,
+			ConfigKey:      &to.SMSSenderType,
+			Required:       false,
+		},
+		{
+			Name:           "sep10-signing-public-key",
+			Usage:          "The public key of the Stellar account that signs the SEP-10 transactions. It's also used to sign URLs.",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionStellarPublicKey,
+			ConfigKey:      &to.SEP10SigningPublicKey,
+			Required:       false,
+		},
+		{
+			Name:           "distribution-public-key",
+			Usage:          "The public key of the Stellar distribution account that sends the Stellar payments.",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionStellarPublicKey,
+			ConfigKey:      &to.DistributionPublicKey,
+			Required:       false,
+		},
+		{
+			Name:           "enable-mfa",
+			Usage:          "Enable MFA using email.",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionOptionalBoolean,
+			ConfigKey:      &to.EnableMFA,
+			Required:       false,
+		},
+		{
+			Name:           "enable-recaptcha",
+			Usage:          "Enable ReCAPTCHA for login and forgot password.",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionOptionalBoolean,
+			ConfigKey:      &to.EnableReCAPTCHA,
+			Required:       false,
+		},
+		{
+			Name:           "cors-allowed-origins",
+			Usage:          `Cors URLs that are allowed to access the endpoints, separated by ","`,
+			OptType:        types.String,
+			CustomSetValue: utils.SetCORSAllowedOrigins,
+			ConfigKey:      &to.CORSAllowedOrigins,
+			Required:       false,
+		},
+		{
+			Name:           "base-url",
+			Usage:          "The SDP backend server's base URL.",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionURLString,
+			ConfigKey:      &to.BaseURL,
+			Required:       false,
+		},
+		{
+			Name:           "sdp-ui-base-url",
+			Usage:          "The SDP UI/dashboard Base URL.",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionURLString,
+			ConfigKey:      &to.SDPUIBaseURL,
+			Required:       false,
+		},
+	}
+
+	cmd := cobra.Command{
+		Use:     "config-tenant",
+		Short:   "",
+		Aliases: []string{"ct"},
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			configOptions.Require()
+			err := configOptions.SetValues()
+			if err != nil {
+				log.Fatalf("Error setting values of config options: %s", err.Error())
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			if err := executeConfigTenant(ctx, &to, globalOptions.multitenantDbURL); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	if err := configOptions.Init(&cmd); err != nil {
+		log.Fatalf("initializing ConfigTenantCmd config options: %v", err)
+	}
+
+	return &cmd
+}
+
+func executeConfigTenant(ctx context.Context, to *tenantOptions, dbURL string) error {
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbURL)
+	if err != nil {
+		return fmt.Errorf("opening database connection pool: %w", err)
+	}
+	defer dbConnectionPool.Close()
+
+	m := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
+	_, err = m.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
+		ID:                    to.ID,
+		EmailSenderType:       to.EmailSenderType,
+		SMSSenderType:         to.SMSSenderType,
+		SEP10SigningPublicKey: to.SEP10SigningPublicKey,
+		DistributionPublicKey: to.DistributionPublicKey,
+		EnableMFA:             to.EnableMFA,
+		EnableReCAPTCHA:       to.EnableReCAPTCHA,
+		CORSAllowedOrigins:    to.CORSAllowedOrigins,
+		BaseURL:               to.BaseURL,
+		SDPUIBaseURL:          to.SDPUIBaseURL,
+	})
+	if err != nil {
+		return fmt.Errorf("updating tenant config: %w", err)
+	}
+
+	log.Infof("tenant ID %s configuration updated successfully", to.ID)
+
+	return nil
+}

--- a/stellar-multitenant/pkg/cli/root.go
+++ b/stellar-multitenant/pkg/cli/root.go
@@ -63,6 +63,7 @@ func SetupCLI(version, gitCommit string) *cobra.Command {
 
 	cmd.AddCommand(MigrateCmd(""))
 	cmd.AddCommand(AddTenantsCmd())
+	cmd.AddCommand(ConfigTenantCmd())
 
 	return cmd
 }

--- a/stellar-multitenant/pkg/cli/utils/custom_set_value.go
+++ b/stellar-multitenant/pkg/cli/utils/custom_set_value.go
@@ -67,7 +67,6 @@ func SetConfigOptionStellarPublicKey(co *config.ConfigOption) error {
 func SetCORSAllowedOrigins(co *config.ConfigOption) error {
 	corsAllowedOriginsOptions := viper.GetString(co.Name)
 	if corsAllowedOriginsOptions == "" {
-
 		return nil
 	}
 

--- a/stellar-multitenant/pkg/cli/utils/custom_set_value.go
+++ b/stellar-multitenant/pkg/cli/utils/custom_set_value.go
@@ -1,0 +1,133 @@
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/viper"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/support/config"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+)
+
+func SetConfigOptionEmailSenderType(co *config.ConfigOption) error {
+	senderType := viper.GetString(co.Name)
+	if senderType == "" {
+		return nil
+	}
+
+	esType, err := tenant.ParseEmailSenderType(senderType)
+	if err != nil {
+		return fmt.Errorf("couldn't parse messenger type: %w", err)
+	}
+
+	*(co.ConfigKey.(**tenant.EmailSenderType)) = &esType
+	return nil
+}
+
+func SetConfigOptionSMSSenderType(co *config.ConfigOption) error {
+	senderType := viper.GetString(co.Name)
+	if senderType == "" {
+		return nil
+	}
+
+	smsSenderType, err := tenant.ParseSMSSenderType(senderType)
+	if err != nil {
+		return fmt.Errorf("couldn't parse messenger type: %w", err)
+	}
+
+	*(co.ConfigKey.(**tenant.SMSSenderType)) = &smsSenderType
+	return nil
+}
+
+func SetConfigOptionStellarPublicKey(co *config.ConfigOption) error {
+	publicKey := viper.GetString(co.Name)
+	if publicKey == "" {
+		return nil
+	}
+
+	kp, err := keypair.ParseAddress(publicKey)
+	if err != nil {
+		return fmt.Errorf("error validating public key: %w", err)
+	}
+
+	key, ok := co.ConfigKey.(**string)
+	if !ok {
+		return fmt.Errorf("the expected type for this config key is a string, but got a %T instead", co.ConfigKey)
+	}
+	addr := kp.Address()
+	*key = &addr
+
+	return nil
+}
+
+func SetCORSAllowedOrigins(co *config.ConfigOption) error {
+	corsAllowedOriginsOptions := viper.GetString(co.Name)
+	if corsAllowedOriginsOptions == "" {
+
+		return nil
+	}
+
+	corsAllowedOrigins := strings.Split(corsAllowedOriginsOptions, ",")
+
+	// validate addresses
+	for _, address := range corsAllowedOrigins {
+		_, err := url.ParseRequestURI(address)
+		if err != nil {
+			return fmt.Errorf("error parsing cors addresses: %w", err)
+		}
+		if address == "*" {
+			log.Warn(`The value "*" for the CORS Allowed Origins is too permissive and not recommended.`)
+		}
+	}
+
+	key, ok := co.ConfigKey.(*[]string)
+	if !ok {
+		return fmt.Errorf("the expected type for this config key is a string slice, but got a %T instead", co.ConfigKey)
+	}
+	*key = corsAllowedOrigins
+
+	return nil
+}
+
+func SetConfigOptionURLString(co *config.ConfigOption) error {
+	u := viper.GetString(co.Name)
+	if u == "" {
+		return nil
+	}
+
+	_, err := url.ParseRequestURI(u)
+	if err != nil {
+		return fmt.Errorf("error parsing ui base url: %w", err)
+	}
+
+	key, ok := co.ConfigKey.(**string)
+	if !ok {
+		return fmt.Errorf("the expected type for this config key is a string, but got a %T instead", co.ConfigKey)
+	}
+	*key = &u
+
+	return nil
+}
+
+func SetConfigOptionOptionalBoolean(co *config.ConfigOption) error {
+	b := viper.GetString(co.Name)
+	if b == "" {
+		return nil
+	}
+
+	value, err := strconv.ParseBool(b)
+	if err != nil {
+		return fmt.Errorf("parsing %q as a boolean value: %w", b, err)
+	}
+
+	key, ok := co.ConfigKey.(**bool)
+	if !ok {
+		return fmt.Errorf("the expected type for this config key is a boolean, but got a %T instead", co.ConfigKey)
+	}
+	*key = &value
+	return nil
+}

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -2,14 +2,17 @@ package tenant
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/lib/pq"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db"
 )
 
 var (
+	ErrTenantDoesNotExist   = errors.New("tenant does not exist")
 	ErrDuplicatedTenantName = errors.New("duplicated tenant name")
 	ErrEmptyTenantName      = errors.New("tenant name cannot be empty")
 )
@@ -23,7 +26,7 @@ func (m *Manager) AddTenant(ctx context.Context, name string) (*Tenant, error) {
 		return nil, ErrEmptyTenantName
 	}
 
-	const q = "INSERT INTO tenants (name) VALUES ($1) RETURNING id, name"
+	const q = "INSERT INTO tenants (name) VALUES ($1) RETURNING *"
 	var t Tenant
 	if err := m.db.GetContext(ctx, &t, q, name); err != nil {
 		if pqError, ok := err.(*pq.Error); ok && pqError.Constraint == "idx_unique_name" {
@@ -31,6 +34,86 @@ func (m *Manager) AddTenant(ctx context.Context, name string) (*Tenant, error) {
 		}
 		return nil, fmt.Errorf("inserting tenant %s: %w", name, err)
 	}
+	return &t, nil
+}
+
+func (m *Manager) UpdateTenantConfig(ctx context.Context, tu *TenantUpdate) (*Tenant, error) {
+	if tu == nil {
+		return nil, fmt.Errorf("tenant update cannot be nil")
+	}
+
+	if err := tu.Validate(); err != nil {
+		return nil, err
+	}
+
+	q := `
+		UPDATE tenants
+		SET
+			%s
+		WHERE
+			id = ?
+		RETURNING *
+	`
+
+	fields := make([]string, 0)
+	args := make([]interface{}, 0)
+	if tu.EmailSenderType != nil {
+		fields = append(fields, "email_sender_type = ?")
+		args = append(args, *tu.EmailSenderType)
+	}
+
+	if tu.SMSSenderType != nil {
+		fields = append(fields, "sms_sender_type = ?")
+		args = append(args, *tu.SMSSenderType)
+	}
+
+	if tu.SEP10SigningPublicKey != nil {
+		fields = append(fields, "sep10_signing_public_key = ?")
+		args = append(args, *tu.SEP10SigningPublicKey)
+	}
+
+	if tu.DistributionPublicKey != nil {
+		fields = append(fields, "distribution_public_key = ?")
+		args = append(args, *tu.DistributionPublicKey)
+	}
+
+	if tu.EnableMFA != nil {
+		fields = append(fields, "enable_mfa = ?")
+		args = append(args, *tu.EnableMFA)
+	}
+
+	if tu.EnableReCAPTCHA != nil {
+		fields = append(fields, "enable_recaptcha = ?")
+		args = append(args, *tu.EnableReCAPTCHA)
+	}
+
+	if tu.BaseURL != nil {
+		fields = append(fields, "base_url = ?")
+		args = append(args, *tu.BaseURL)
+	}
+
+	if tu.SDPUIBaseURL != nil {
+		fields = append(fields, "sdp_ui_base_url = ?")
+		args = append(args, *tu.SDPUIBaseURL)
+	}
+
+	if tu.CORSAllowedOrigins != nil && len(tu.CORSAllowedOrigins) > 0 {
+		fields = append(fields, "cors_allowed_origins = ?")
+		args = append(args, pq.Array(tu.CORSAllowedOrigins))
+	}
+
+	args = append(args, tu.ID)
+	q = fmt.Sprintf(q, strings.Join(fields, ",\n"))
+	q = m.db.Rebind(q)
+
+	var t Tenant
+	if err := m.db.GetContext(ctx, &t, q, args...); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrTenantDoesNotExist
+		}
+		return nil, fmt.Errorf("updating tenant ID %s: %w", tu.ID, err)
+	}
+
 	return &t, nil
 }
 

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -4,11 +4,33 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stellar/go/keypair"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/internal/db/dbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func resetTenantConfigFixture(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, tenantID string) *Tenant {
+	t.Helper()
+
+	const q = `
+		UPDATE tenants
+		SET
+			email_sender_type = DEFAULT, sms_sender_type = DEFAULT, sep10_signing_public_key = NULL,
+			distribution_public_key = NULL, enable_mfa = DEFAULT, enable_recaptcha = DEFAULT,
+			cors_allowed_origins = NULL, base_url = NULL, sdp_ui_base_url = NULL
+		WHERE
+			id = $1
+		RETURNING *
+	`
+
+	var tnt Tenant
+	err := dbConnectionPool.GetContext(ctx, &tnt, q, tenantID)
+	require.NoError(t, err)
+
+	return &tnt
+}
 
 func Test_Manager_AddTenant(t *testing.T) {
 	dbt := dbtest.Open(t)
@@ -45,5 +67,91 @@ func Test_Manager_AddTenant(t *testing.T) {
 		tnt, err = m.AddTenant(ctx, "MyOrg")
 		assert.Equal(t, ErrDuplicatedTenantName, err)
 		assert.Nil(t, tnt)
+	})
+}
+
+func Test_Manager_UpdateTenantConfig(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+
+	m := NewManager(WithDatabase(dbConnectionPool))
+	tntDB, err := m.AddTenant(ctx, "myorg")
+	require.NoError(t, err)
+
+	t.Run("returns error when tenant update is nil", func(t *testing.T) {
+		tnt, err := m.UpdateTenantConfig(ctx, nil)
+		assert.EqualError(t, err, "tenant update cannot be nil")
+		assert.Nil(t, tnt)
+	})
+
+	t.Run("returns error when no field has changed", func(t *testing.T) {
+		tnt, err := m.UpdateTenantConfig(ctx, &TenantUpdate{ID: tntDB.ID})
+		assert.EqualError(t, err, "provide at least one field to be updated")
+		assert.Nil(t, tnt)
+	})
+
+	t.Run("returns error when the tenant ID does not exist", func(t *testing.T) {
+		tnt, err := m.UpdateTenantConfig(ctx, &TenantUpdate{ID: "abc", EmailSenderType: &AWSEmailSenderType})
+		assert.Equal(t, ErrTenantDoesNotExist, err)
+		assert.Nil(t, tnt)
+	})
+
+	t.Run("updates tenant config successfully", func(t *testing.T) {
+		tntDB = resetTenantConfigFixture(t, ctx, dbConnectionPool, tntDB.ID)
+		assert.Equal(t, tntDB.EmailSenderType, DryRunEmailSenderType)
+		assert.Equal(t, tntDB.SMSSenderType, DryRunSMSSenderType)
+		assert.Nil(t, tntDB.SEP10SigningPublicKey)
+		assert.Nil(t, tntDB.DistributionPublicKey)
+		assert.True(t, tntDB.EnableMFA)
+		assert.True(t, tntDB.EnableReCAPTCHA)
+		assert.Nil(t, tntDB.BaseURL)
+		assert.Nil(t, tntDB.SDPUIBaseURL)
+		assert.Empty(t, tntDB.CORSAllowedOrigins)
+
+		// Partial Update
+		addr := keypair.MustRandom().Address()
+		tnt, err := m.UpdateTenantConfig(ctx, &TenantUpdate{
+			ID:                    tntDB.ID,
+			EmailSenderType:       &AWSEmailSenderType,
+			SEP10SigningPublicKey: &addr,
+			EnableMFA:             &[]bool{false}[0],
+			CORSAllowedOrigins:    []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"},
+			SDPUIBaseURL:          &[]string{"https://myorg.frontend.io"}[0],
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, tnt.EmailSenderType, AWSEmailSenderType)
+		assert.Equal(t, tnt.SMSSenderType, DryRunSMSSenderType)
+		assert.Equal(t, addr, *tnt.SEP10SigningPublicKey)
+		assert.Nil(t, tnt.DistributionPublicKey)
+		assert.False(t, tnt.EnableMFA)
+		assert.True(t, tnt.EnableReCAPTCHA)
+		assert.Nil(t, tnt.BaseURL)
+		assert.Equal(t, "https://myorg.frontend.io", *tnt.SDPUIBaseURL)
+		assert.ElementsMatch(t, []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"}, tnt.CORSAllowedOrigins)
+
+		tnt, err = m.UpdateTenantConfig(ctx, &TenantUpdate{
+			ID:                    tntDB.ID,
+			SMSSenderType:         &TwilioSMSSenderType,
+			DistributionPublicKey: &addr,
+			EnableReCAPTCHA:       &[]bool{false}[0],
+			BaseURL:               &[]string{"https://myorg.backend.io"}[0],
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, tnt.EmailSenderType, AWSEmailSenderType)
+		assert.Equal(t, tnt.SMSSenderType, TwilioSMSSenderType)
+		assert.Equal(t, addr, *tnt.SEP10SigningPublicKey)
+		assert.Equal(t, addr, *tnt.DistributionPublicKey)
+		assert.False(t, tnt.EnableMFA)
+		assert.False(t, tnt.EnableReCAPTCHA)
+		assert.Equal(t, "https://myorg.backend.io", *tnt.BaseURL)
+		assert.Equal(t, "https://myorg.frontend.io", *tnt.SDPUIBaseURL)
+		assert.ElementsMatch(t, []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"}, tnt.CORSAllowedOrigins)
 	})
 }

--- a/stellar-multitenant/pkg/tenant/tenant.go
+++ b/stellar-multitenant/pkg/tenant/tenant.go
@@ -1,6 +1,136 @@
 package tenant
 
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/stellar/go/strkey"
+	"golang.org/x/exp/slices"
+)
+
+type EmailSenderType string
+
+var (
+	AWSEmailSenderType    EmailSenderType = "AWS_EMAIL"
+	DryRunEmailSenderType EmailSenderType = "DRY_RUN"
+)
+
+func ParseEmailSenderType(emailSenderTypeStr string) (EmailSenderType, error) {
+	validTypes := []EmailSenderType{AWSEmailSenderType, DryRunEmailSenderType}
+	esType := EmailSenderType(emailSenderTypeStr)
+	if slices.Contains(validTypes, esType) {
+		return esType, nil
+	}
+	return "", fmt.Errorf("invalid email sender type %q", emailSenderTypeStr)
+}
+
+type SMSSenderType string
+
+var (
+	TwilioSMSSenderType SMSSenderType = "TWILIO_SMS"
+	AWSSMSSenderType    SMSSenderType = "AWS_SMS"
+	DryRunSMSSenderType SMSSenderType = "DRY_RUN"
+)
+
+func ParseSMSSenderType(smsSenderTypeStr string) (SMSSenderType, error) {
+	validTypes := []SMSSenderType{TwilioSMSSenderType, AWSSMSSenderType, DryRunSMSSenderType}
+	smsSenderType := SMSSenderType(smsSenderTypeStr)
+	if slices.Contains(validTypes, smsSenderType) {
+		return smsSenderType, nil
+	}
+	return "", fmt.Errorf("invalid sms sender type %q", smsSenderTypeStr)
+}
+
 type Tenant struct {
-	ID   string `db:"id"`
-	Name string `db:"name"`
+	ID                    string          `db:"id"`
+	Name                  string          `db:"name"`
+	EmailSenderType       EmailSenderType `db:"email_sender_type"`
+	SMSSenderType         SMSSenderType   `db:"sms_sender_type"`
+	SEP10SigningPublicKey *string         `db:"sep10_signing_public_key"`
+	DistributionPublicKey *string         `db:"distribution_public_key"`
+	EnableMFA             bool            `db:"enable_mfa"`
+	EnableReCAPTCHA       bool            `db:"enable_recaptcha"`
+	CORSAllowedOrigins    pq.StringArray  `db:"cors_allowed_origins"`
+	BaseURL               *string         `db:"base_url"`
+	SDPUIBaseURL          *string         `db:"sdp_ui_base_url"`
+	CreatedAt             time.Time       `db:"created_at"`
+	UpdatedAt             time.Time       `db:"updated_at"`
+}
+
+type TenantUpdate struct {
+	ID                    string           `db:"id"`
+	EmailSenderType       *EmailSenderType `db:"email_sender_type"`
+	SMSSenderType         *SMSSenderType   `db:"sms_sender_type"`
+	SEP10SigningPublicKey *string          `db:"sep10_signing_public_key"`
+	DistributionPublicKey *string          `db:"distribution_public_key"`
+	EnableMFA             *bool            `db:"enable_mfa"`
+	EnableReCAPTCHA       *bool            `db:"enable_recaptcha"`
+	CORSAllowedOrigins    []string         `db:"cors_allowed_origins"`
+	BaseURL               *string          `db:"base_url"`
+	SDPUIBaseURL          *string          `db:"sdp_ui_base_url"`
+}
+
+func (tu *TenantUpdate) Validate() error {
+	if tu.ID == "" {
+		return fmt.Errorf("tenant ID is required")
+	}
+
+	if tu.areAllFieldsEmpty() {
+		return fmt.Errorf("provide at least one field to be updated")
+	}
+
+	if tu.EmailSenderType != nil {
+		if _, err := ParseEmailSenderType(string(*tu.EmailSenderType)); err != nil {
+			return fmt.Errorf("invalid email sender type: %w", err)
+		}
+	}
+
+	if tu.SMSSenderType != nil {
+		if _, err := ParseSMSSenderType(string(*tu.SMSSenderType)); err != nil {
+			return fmt.Errorf("invalid SMS sender type: %w", err)
+		}
+	}
+
+	if tu.SEP10SigningPublicKey != nil && !strkey.IsValidEd25519PublicKey(*tu.SEP10SigningPublicKey) {
+		return fmt.Errorf("invalid SEP-10 signing public key")
+	}
+
+	if tu.DistributionPublicKey != nil && !strkey.IsValidEd25519PublicKey(*tu.DistributionPublicKey) {
+		return fmt.Errorf("invalid distribution public key")
+	}
+
+	if tu.BaseURL != nil && !isValidURL(*tu.BaseURL) {
+		return fmt.Errorf("invalid base URL")
+	}
+
+	if tu.SDPUIBaseURL != nil && !isValidURL(*tu.SDPUIBaseURL) {
+		return fmt.Errorf("invalid SDP UI base URL")
+	}
+
+	for _, u := range tu.CORSAllowedOrigins {
+		if !isValidURL(u) {
+			return fmt.Errorf("invalid CORS allowed origin url: %q", u)
+		}
+	}
+
+	return nil
+}
+
+func (tu *TenantUpdate) areAllFieldsEmpty() bool {
+	return (tu.EmailSenderType == nil &&
+		tu.SMSSenderType == nil &&
+		tu.SEP10SigningPublicKey == nil &&
+		tu.DistributionPublicKey == nil &&
+		tu.EnableMFA == nil &&
+		tu.EnableReCAPTCHA == nil &&
+		tu.CORSAllowedOrigins == nil &&
+		tu.BaseURL == nil &&
+		tu.SDPUIBaseURL == nil)
+}
+
+func isValidURL(u string) bool {
+	_, err := url.ParseRequestURI(u)
+	return err == nil
 }

--- a/stellar-multitenant/pkg/tenant/tenant_test.go
+++ b/stellar-multitenant/pkg/tenant/tenant_test.go
@@ -1,0 +1,110 @@
+package tenant
+
+import (
+	"testing"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_TenantUpdate_Validate(t *testing.T) {
+	t.Run("invalid values", func(t *testing.T) {
+		tu := TenantUpdate{}
+		err := tu.Validate()
+		assert.EqualError(t, err, "tenant ID is required")
+
+		tu.ID = "abc"
+		err = tu.Validate()
+		assert.EqualError(t, err, "provide at least one field to be updated")
+
+		esType := EmailSenderType("invalid")
+		tu.EmailSenderType = &esType
+		err = tu.Validate()
+		assert.EqualError(t, err, `invalid email sender type: invalid email sender type "invalid"`)
+
+		tu.EmailSenderType = nil
+		smsSenderType := SMSSenderType("invalid")
+		tu.SMSSenderType = &smsSenderType
+		err = tu.Validate()
+		assert.EqualError(t, err, `invalid SMS sender type: invalid sms sender type "invalid"`)
+
+		tu.SMSSenderType = nil
+		addr := "invalid"
+		tu.SEP10SigningPublicKey = &addr
+		err = tu.Validate()
+		assert.EqualError(t, err, "invalid SEP-10 signing public key")
+
+		tu.SEP10SigningPublicKey = nil
+		tu.DistributionPublicKey = &addr
+		err = tu.Validate()
+		assert.EqualError(t, err, "invalid distribution public key")
+
+		tu.DistributionPublicKey = nil
+		u := "inv@lid$"
+		tu.BaseURL = &u
+		err = tu.Validate()
+		assert.EqualError(t, err, "invalid base URL")
+
+		tu.BaseURL = nil
+		tu.SDPUIBaseURL = &u
+		err = tu.Validate()
+		assert.EqualError(t, err, "invalid SDP UI base URL")
+
+		tu.SDPUIBaseURL = nil
+		tu.CORSAllowedOrigins = []string{"inv@lid$"}
+		err = tu.Validate()
+		assert.EqualError(t, err, `invalid CORS allowed origin url: "inv@lid$"`)
+	})
+
+	t.Run("valid values", func(t *testing.T) {
+		tu := TenantUpdate{
+			ID:                    "abc",
+			EmailSenderType:       &AWSEmailSenderType,
+			SMSSenderType:         &TwilioSMSSenderType,
+			SEP10SigningPublicKey: &[]string{keypair.MustRandom().Address()}[0],
+			DistributionPublicKey: &[]string{keypair.MustRandom().Address()}[0],
+			EnableMFA:             &[]bool{true}[0],
+			EnableReCAPTCHA:       &[]bool{true}[0],
+			CORSAllowedOrigins:    []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"},
+			BaseURL:               &[]string{"https://myorg.backend.io"}[0],
+			SDPUIBaseURL:          &[]string{"https://myorg.frontend.io"}[0],
+		}
+		err := tu.Validate()
+		assert.NoError(t, err)
+	})
+}
+
+func Test_TenantUpdate_areAllFieldsEmpty(t *testing.T) {
+	tu := TenantUpdate{}
+	assert.True(t, tu.areAllFieldsEmpty())
+	tu.SDPUIBaseURL = &[]string{"https://myorg.backend.io"}[0]
+	assert.False(t, tu.areAllFieldsEmpty())
+}
+
+func Test_ParseEmailSenderType(t *testing.T) {
+	est, err := ParseEmailSenderType("invalid")
+	assert.EqualError(t, err, `invalid email sender type "invalid"`)
+	assert.Empty(t, est)
+
+	est, err = ParseEmailSenderType("aws_email")
+	assert.EqualError(t, err, `invalid email sender type "aws_email"`)
+	assert.Empty(t, est)
+
+	est, err = ParseEmailSenderType("AWS_EMAIL")
+	assert.NoError(t, err)
+	assert.Equal(t, AWSEmailSenderType, est)
+}
+
+func Test_ParseSMSSenderType(t *testing.T) {
+	sst, err := ParseSMSSenderType("invalid")
+	assert.EqualError(t, err, `invalid sms sender type "invalid"`)
+	assert.Empty(t, sst)
+
+	sst, err = ParseSMSSenderType("twilio_sms")
+	assert.EqualError(t, err, `invalid sms sender type "twilio_sms"`)
+	assert.Empty(t, sst)
+
+	sst, err = ParseSMSSenderType("TWILIO_SMS")
+	assert.NoError(t, err)
+	assert.Equal(t, TwilioSMSSenderType, sst)
+}


### PR DESCRIPTION
### What

This PR adds the `config-tenant` CLI command in the `stellar-multitenant` package. This command sets the basic environment variables for the tenants individually. Each flag of the command is optional, but at least one should be provided when running it. When a flag is not provided the corresponding value in the database will not be changed. To change a value it should be explicitly passed when running the CLI. 

The `tenant-id` is required to run the CLI.


```sh
mtn config-tenant --tenant-id abc --enable-mfa "false" --distribution-public-key "GBDYRFO3ZJ74UQ6V36D2PHXRXBYW52HKUYRYCWSFIGWQSPJMN4ARBGIF"
```

### Why

We should be able to configure the tenants' environment variables.

### Known limitations

We are still not able to set up `secrets`.
Missing tests for the CLI.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
