### PR TITLE
[SDP-933] services: truncate error messages before patching to anchor platform

### DIFF
--- a/internal/services/patch_anchor_platform_transactions_completion.go
+++ b/internal/services/patch_anchor_platform_transactions_completion.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 )
 
+const MaxErrorMessageLength = 255
+
 type PatchAnchorPlatformTransactionCompletionService struct {
 	apAPISvc  anchorplatform.AnchorPlatformAPIServiceInterface
 	sdpModels *data.Models
@@ -103,10 +105,15 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchTransactionsCompl
 				}
 			}
 
+			messageLength := len(status.StatusMessage)
+			if messageLength > MaxErrorMessageLength {
+				messageLength = MaxErrorMessageLength - 1
+			}
+
 			err = s.apAPISvc.PatchAnchorTransactionsPostErrorCompletion(ctx, anchorplatform.APSep24TransactionPatchPostError{
 				ID:      payment.ReceiverWallet.AnchorPlatformTransactionID,
 				SEP:     "24",
-				Message: status.StatusMessage,
+				Message: status.StatusMessage[:messageLength],
 				Status:  anchorplatform.APTransactionStatusError,
 			})
 			if err != nil {


### PR DESCRIPTION
### What

Truncate error messages before patching transactions on the anchor platform.

### Why

We were sending an error message with more than 255 characters which causes an error on the Anchor Platform.

Closes #70 

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
