### PR TITLE
[statistics] fix: include canceled payment status

### DIFF
--- a/internal/statistics/calculate_statistics.go
+++ b/internal/statistics/calculate_statistics.go
@@ -15,24 +15,26 @@ import (
 var ErrResourcesNotFound = errors.New("resources not found")
 
 type PaymentCounters struct {
-	Draft   int64 `json:"draft"`
-	Ready   int64 `json:"ready"`
-	Pending int64 `json:"pending"`
-	Paused  int64 `json:"paused"`
-	Success int64 `json:"success"`
-	Failed  int64 `json:"failed"`
-	Total   int64 `json:"total"`
+	Draft    int64 `json:"draft"`
+	Ready    int64 `json:"ready"`
+	Pending  int64 `json:"pending"`
+	Paused   int64 `json:"paused"`
+	Success  int64 `json:"success"`
+	Failed   int64 `json:"failed"`
+	Canceled int64 `json:"canceled"`
+	Total    int64 `json:"total"`
 }
 
 type PaymentAmounts struct {
-	Draft   string `json:"draft"`
-	Ready   string `json:"ready"`
-	Pending string `json:"pending"`
-	Paused  string `json:"paused"`
-	Success string `json:"success"`
-	Failed  string `json:"failed"`
-	Average string `json:"average"`
-	Total   string `json:"total"`
+	Draft    string `json:"draft"`
+	Ready    string `json:"ready"`
+	Pending  string `json:"pending"`
+	Paused   string `json:"paused"`
+	Success  string `json:"success"`
+	Failed   string `json:"failed"`
+	Canceled string `json:"canceled"`
+	Average  string `json:"average"`
+	Total    string `json:"total"`
 }
 
 type PaymentAmountsByAsset struct {
@@ -151,6 +153,10 @@ func getPaymentsStats(ctx context.Context, sqlExec db.SQLExecuter, disbursementI
 		case data.PausedPaymentStatus:
 			paymentCounters.Paused += count
 			paymentAmounts.Paused = amount
+
+		case data.CanceledPaymentStatus:
+			paymentCounters.Canceled += count
+			paymentAmounts.Canceled = amount
 		default:
 			return nil, nil, fmt.Errorf("status %v is not a valid payment status", status)
 		}


### PR DESCRIPTION
### What

Include CANCELED payment status to statistics

### Why

Sentry alerts: status CANCELED is not a valid payment status

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
