### PR TITLE
[httphandler/data] get canceled payment status for disbursement and receivers metrics

### DIFF
--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -37,6 +37,7 @@ type DisbursementStats struct {
 	TotalPayments      int    `json:"total_payments" db:"total_payments"`
 	SuccessfulPayments int    `json:"total_payments_sent" db:"total_payments_sent"`
 	FailedPayments     int    `json:"total_payments_failed" db:"total_payments_failed"`
+	CanceledPayments   int    `json:"total_payments_canceled" db:"total_payments_canceled"`
 	RemainingPayments  int    `json:"total_payments_remaining" db:"total_payments_remaining"`
 	AmountDisbursed    string `json:"amount_disbursed" db:"amount_disbursed"`
 	TotalAmount        string `json:"total_amount" db:"total_amount"`
@@ -232,6 +233,7 @@ func (d *DisbursementModel) populateStatistics(ctx context.Context, disbursement
 			count(*) as total_payments,
 			sum(case when status = 'SUCCESS' then 1 else 0 end) as total_payments_sent,
 			sum(case when status = 'FAILED' then 1 else 0 end) as total_payments_failed,
+			sum(case when status = 'CANCELED' then 1 else 0 end) as total_payments_canceled,
 			sum(case when status IN ('DRAFT', 'READY', 'PENDING', 'PAUSED')  then 1 else 0 end) as total_payments_remaining,
 			ROUND(SUM(CASE WHEN status = 'SUCCESS' THEN amount ELSE 0 END), 2) as amount_disbursed,
 			ROUND(SUM(amount), 2) as total_amount,
@@ -259,6 +261,7 @@ func (d *DisbursementModel) populateStatistics(ctx context.Context, disbursement
 			&stats.TotalPayments,
 			&stats.SuccessfulPayments,
 			&stats.FailedPayments,
+			&stats.CanceledPayments,
 			&stats.RemainingPayments,
 			&stats.AmountDisbursed,
 			&stats.TotalAmount,

--- a/internal/data/disbursements_test.go
+++ b/internal/data/disbursements_test.go
@@ -391,15 +391,23 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 			Amount:         "020.50",
 			Status:         FailedPaymentStatus,
 		})
+		CreatePaymentFixture(t, ctx, dbConnectionPool, &paymentModel, &Payment{
+			ReceiverWallet: receiverWallet,
+			Disbursement:   expectedDisbursement,
+			Asset:          *asset,
+			Amount:         "020.50",
+			Status:         CanceledPaymentStatus,
+		})
 
 		expectedStats := &DisbursementStats{}
-		expectedStats.TotalPayments = 3
+		expectedStats.TotalPayments = 4
 		expectedStats.SuccessfulPayments = 1
 		expectedStats.FailedPayments = 1
+		expectedStats.CanceledPayments = 1
 		expectedStats.RemainingPayments = 1
-		expectedStats.TotalAmount = "270.55"
+		expectedStats.TotalAmount = "291.05"
 		expectedStats.AmountDisbursed = "100.00"
-		expectedStats.AverageAmount = "90.18"
+		expectedStats.AverageAmount = "72.76"
 
 		expectedDisbursement.DisbursementStats = expectedStats
 

--- a/internal/data/receivers.go
+++ b/internal/data/receivers.go
@@ -37,6 +37,7 @@ type ReceiverStats struct {
 	TotalPayments      string          `json:"total_payments,omitempty" db:"total_payments"`
 	SuccessfulPayments string          `json:"successful_payments,omitempty" db:"successful_payments"`
 	FailedPayments     string          `json:"failed_payments,omitempty" db:"failed_payments"`
+	CanceledPayments   string          `json:"canceled_payments,omitempty" db:"canceled_payments"`
 	RemainingPayments  string          `json:"remaining_payments,omitempty" db:"remaining_payments"`
 	RegisteredWallets  string          `json:"registered_wallets,omitempty" db:"registered_wallets"`
 	ReceivedAmounts    ReceivedAmounts `json:"received_amounts,omitempty" db:"received_amounts"`
@@ -117,6 +118,7 @@ func (r *ReceiverModel) Get(ctx context.Context, sqlExec db.SQLExecuter, id stri
 			COUNT(p) as total_payments,
 			COUNT(p) FILTER(WHERE p.status = 'SUCCESS') as successful_payments,
 			COUNT(p) FILTER(WHERE p.status = 'FAILED') as failed_payments,
+			COUNT(p) FILTER(WHERE p.status = 'CANCELED') as canceled_payments,
 			COUNT(p) FILTER(WHERE p.status IN ('DRAFT', 'READY', 'PENDING', 'PAUSED')) as remaining_payments,
 			a.code as asset_code,
 			a.issuer as asset_issuer,
@@ -132,6 +134,7 @@ func (r *ReceiverModel) Get(ctx context.Context, sqlExec db.SQLExecuter, id stri
 			SUM(rs.total_payments) as total_payments,
 			SUM(rs.successful_payments) as successful_payments,
 			SUM(rs.failed_payments) as failed_payments,
+			SUM(rs.canceled_payments) as canceled_payments,
 			SUM(rs.remaining_payments) as remaining_payments,
 			jsonb_agg(jsonb_build_object('asset_code', rs.asset_code, 'asset_issuer', rs.asset_issuer, 'received_amount', rs.received_amount::text)) as received_amounts
 		FROM receiver_stats rs
@@ -147,6 +150,7 @@ func (r *ReceiverModel) Get(ctx context.Context, sqlExec db.SQLExecuter, id stri
 		COALESCE(total_payments, 0) as total_payments,
 		COALESCE(successful_payments, 0) as successful_payments,
 		COALESCE(rs.failed_payments, '0') as failed_payments,
+		COALESCE(rs.canceled_payments, '0') as canceled_payments,
 		COALESCE(rs.remaining_payments, '0') as remaining_payments,
 		rs.received_amounts,
 		COALESCE(rw.registered_wallets, 0) as registered_wallets
@@ -206,6 +210,7 @@ func (r *ReceiverModel) GetAll(ctx context.Context, sqlExec db.SQLExecuter, quer
 				COUNT(p) as total_payments,
 				COUNT(p) FILTER(WHERE p.status = 'SUCCESS') as successful_payments,
 				COUNT(p) FILTER(WHERE p.status = 'FAILED') as failed_payments,
+				COUNT(p) FILTER(WHERE p.status = 'CANCELED') as canceled_payments,
 				COUNT(p) FILTER(WHERE p.status IN ('DRAFT', 'READY', 'PENDING', 'PAUSED')) as remaining_payments,
 				a.code as asset_code,
 				a.issuer as asset_issuer,
@@ -221,6 +226,7 @@ func (r *ReceiverModel) GetAll(ctx context.Context, sqlExec db.SQLExecuter, quer
 				SUM(rs.total_payments) as total_payments,
 				SUM(rs.successful_payments) as successful_payments,
 				SUM(rs.failed_payments) as failed_payments,
+				SUM(rs.canceled_payments) as canceled_payments,
 				SUM(rs.remaining_payments) as remaining_payments,
 				jsonb_agg(jsonb_build_object('asset_code', rs.asset_code, 'asset_issuer', rs.asset_issuer, 'received_amount', rs.received_amount::text)) as received_amounts
 			FROM receiver_stats rs
@@ -236,6 +242,7 @@ func (r *ReceiverModel) GetAll(ctx context.Context, sqlExec db.SQLExecuter, quer
 			COALESCE(total_payments, 0) as total_payments,
 			COALESCE(successful_payments, 0) as successful_payments,
 			COALESCE(rs.failed_payments, '0') as failed_payments,
+			COALESCE(rs.canceled_payments, '0') as canceled_payments,
 			COALESCE(rs.remaining_payments, '0') as remaining_payments,
 			rs.received_amounts,
 			COALESCE(rrwc.registered_wallets, 0) as registered_wallets

--- a/internal/data/receivers_test.go
+++ b/internal/data/receivers_test.go
@@ -99,6 +99,7 @@ func Test_ReceiversModelGet(t *testing.T) {
 				TotalPayments:      "0",
 				SuccessfulPayments: "0",
 				FailedPayments:     "0",
+				CanceledPayments:   "0",
 				RemainingPayments:  "0",
 				RegisteredWallets:  "0",
 				ReceivedAmounts:    nil,
@@ -139,6 +140,7 @@ func Test_ReceiversModelGet(t *testing.T) {
 				TotalPayments:      "1",
 				SuccessfulPayments: "0",
 				FailedPayments:     "0",
+				CanceledPayments:   "0",
 				RemainingPayments:  "1",
 				RegisteredWallets:  "0",
 				ReceivedAmounts: []Amount{
@@ -195,6 +197,7 @@ func Test_ReceiversModelGet(t *testing.T) {
 				TotalPayments:      "2",
 				SuccessfulPayments: "1",
 				FailedPayments:     "0",
+				CanceledPayments:   "0",
 				RemainingPayments:  "1",
 				RegisteredWallets:  "0",
 				ReceivedAmounts: []Amount{
@@ -254,6 +257,7 @@ func Test_ReceiversModelGet(t *testing.T) {
 				TotalPayments:      "2",
 				SuccessfulPayments: "1",
 				FailedPayments:     "0",
+				CanceledPayments:   "0",
 				RemainingPayments:  "1",
 				RegisteredWallets:  "0",
 				ReceivedAmounts: []Amount{
@@ -312,6 +316,7 @@ func Test_ReceiversModelGet(t *testing.T) {
 				TotalPayments:      "1",
 				SuccessfulPayments: "0",
 				FailedPayments:     "0",
+				CanceledPayments:   "0",
 				RemainingPayments:  "1",
 				RegisteredWallets:  "0",
 				ReceivedAmounts: []Amount{
@@ -503,6 +508,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 					"total_payments": "0",
 					"successful_payments": "0",
 					"failed_payments": "0",
+					"canceled_payments": "0",
 					"remaining_payments": "0",
 					"registered_wallets":"0"
 				},
@@ -516,6 +522,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 					"total_payments": "0",
 					"successful_payments": "0",
 					"failed_payments": "0",
+					"canceled_payments": "0",
 					"remaining_payments": "0",
 					"registered_wallets":"1"
 				}
@@ -559,6 +566,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 				"total_payments": "0",
 				"successful_payments": "0",
 				"failed_payments": "0",
+				"canceled_payments": "0",
 				"remaining_payments": "0",
 				"registered_wallets":"0"
 			}
@@ -601,6 +609,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 				"total_payments": "0",
 				"successful_payments": "0",
 				"failed_payments": "0",
+				"canceled_payments": "0",
 				"remaining_payments": "0",
 				"registered_wallets":"1"
 			}
@@ -643,6 +652,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 				"total_payments": "0",
 				"successful_payments": "0",
 				"failed_payments": "0",
+				"canceled_payments": "0",
 				"remaining_payments": "0",
 				"registered_wallets":"0"
 			}
@@ -680,6 +690,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 				"total_payments": "0",
 				"successful_payments": "0",
 				"failed_payments": "0",
+				"canceled_payments": "0",
 				"remaining_payments": "0",
 				"registered_wallets":"0"	
 			}
@@ -717,6 +728,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 				"total_payments": "0",
 				"successful_payments": "0",
 				"failed_payments": "0",
+				"canceled_payments": "0",
 				"remaining_payments": "0",
 				"registered_wallets":"1"
 			}
@@ -758,6 +770,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 				"total_payments": "0",
 				"successful_payments": "0",
 				"failed_payments": "0",
+				"canceled_payments": "0",
 				"remaining_payments": "0",
 				"registered_wallets":"0"
 			}
@@ -795,6 +808,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 					"total_payments": "0",
 					"successful_payments": "0",
 					"failed_payments": "0",
+					"canceled_payments": "0",
 					"remaining_payments": "0",
 					"registered_wallets":"0"
 				},
@@ -808,6 +822,7 @@ func Test_ReceiversModelGetAll(t *testing.T) {
 					"total_payments": "0",
 					"successful_payments": "0",
 					"failed_payments": "0",
+					"canceled_payments": "0",
 					"remaining_payments": "0",
 					"registered_wallets":"1"
 				}

--- a/internal/data/receivers_wallet.go
+++ b/internal/data/receivers_wallet.go
@@ -89,6 +89,7 @@ type ReceiverWalletStats struct {
 	TotalPayments     string          `json:"total_payments,omitempty" db:"total_payments"`
 	PaymentsReceived  string          `json:"payments_received,omitempty" db:"payments_received"`
 	FailedPayments    string          `json:"failed_payments,omitempty" db:"failed_payments"`
+	CanceledPayments  string          `json:"canceled_payments,omitempty" db:"canceled_payments"`
 	RemainingPayments string          `json:"remaining_payments,omitempty" db:"remaining_payments"`
 	ReceivedAmounts   ReceivedAmounts `json:"received_amounts,omitempty" db:"received_amounts"`
 	// TotalInvitationSMSResentAttempts holds how many times were resent the Invitation SMS to the receiver
@@ -133,6 +134,7 @@ func (rw *ReceiverWalletModel) GetWithReceiverIds(ctx context.Context, sqlExec d
 			COUNT(p) as total_payments,
 			COUNT(p) FILTER(WHERE p.status = 'SUCCESS') as payments_received,
 			COUNT(p) FILTER(WHERE p.status = 'FAILED') as failed_payments,
+			COUNT(p) FILTER(WHERE p.status = 'CANCELED') as canceled_payments,
 			COUNT(p) FILTER(WHERE p.status IN ('DRAFT', 'READY', 'PENDING', 'PAUSED')) as remaining_payments,
 			a.code as asset_code,
 			a.issuer as asset_issuer,
@@ -148,6 +150,7 @@ func (rw *ReceiverWalletModel) GetWithReceiverIds(ctx context.Context, sqlExec d
 			SUM(rws.total_payments) as total_payments,
 			SUM(rws.payments_received) as payments_received,
 			SUM(rws.failed_payments) as failed_payments,
+			SUM(rws.canceled_payments) as canceled_payments,
 			SUM(rws.remaining_payments) as remaining_payments,
 			jsonb_agg(jsonb_build_object('asset_code', rws.asset_code, 'asset_issuer', rws.asset_issuer, 'received_amount', rws.received_amount::text)) as received_amounts
 		FROM receiver_wallets_stats rws
@@ -180,6 +183,7 @@ func (rw *ReceiverWalletModel) GetWithReceiverIds(ctx context.Context, sqlExec d
 		COALESCE(rws.total_payments, '0') as total_payments,
 		COALESCE(rws.payments_received, '0') as payments_received,
 		COALESCE(rws.failed_payments, '0') as failed_payments,
+		COALESCE(rws.canceled_payments, '0') as canceled_payments,
 		COALESCE(rws.remaining_payments, '0') as remaining_payments,
 		rws.received_amounts,
 		rwm.invited_at as invited_at,

--- a/internal/data/receivers_wallet_test.go
+++ b/internal/data/receivers_wallet_test.go
@@ -143,6 +143,7 @@ func Test_ReceiversWalletModelGetWithReceiverId(t *testing.T) {
 					TotalPayments:     "0",
 					PaymentsReceived:  "0",
 					FailedPayments:    "0",
+					CanceledPayments:  "0",
 					RemainingPayments: "0",
 					ReceivedAmounts:   nil,
 				},
@@ -207,6 +208,7 @@ func Test_ReceiversWalletModelGetWithReceiverId(t *testing.T) {
 					TotalPayments:     "2",
 					PaymentsReceived:  "1",
 					FailedPayments:    "0",
+					CanceledPayments:  "0",
 					RemainingPayments: "1",
 					ReceivedAmounts: []Amount{
 						{
@@ -312,6 +314,7 @@ func Test_ReceiversWalletModelGetWithReceiverId(t *testing.T) {
 					TotalPayments:     "2",
 					PaymentsReceived:  "1",
 					FailedPayments:    "0",
+					CanceledPayments:  "0",
 					RemainingPayments: "1",
 					ReceivedAmounts: []Amount{
 						{
@@ -345,6 +348,7 @@ func Test_ReceiversWalletModelGetWithReceiverId(t *testing.T) {
 					TotalPayments:     "1",
 					PaymentsReceived:  "0",
 					FailedPayments:    "0",
+					CanceledPayments:  "0",
 					RemainingPayments: "1",
 					ReceivedAmounts: []Amount{
 						{
@@ -425,6 +429,7 @@ func Test_ReceiversWalletModelGetWithReceiverId(t *testing.T) {
 					TotalPayments:     "0",
 					PaymentsReceived:  "0",
 					FailedPayments:    "0",
+					CanceledPayments:  "0",
 					RemainingPayments: "0",
 					ReceivedAmounts:   nil,
 				},

--- a/internal/serve/httphandler/receiver_handler_test.go
+++ b/internal/serve/httphandler/receiver_handler_test.go
@@ -87,6 +87,7 @@ func Test_ReceiverHandlerGet(t *testing.T) {
 			"total_payments": "0",
 			"successful_payments": "0",
 			"failed_payments": "0",
+			"canceled_payments": "0",
     		"remaining_payments": "0",
 			"registered_wallets": "0",
 			"wallets": []
@@ -147,6 +148,7 @@ func Test_ReceiverHandlerGet(t *testing.T) {
 			"total_payments": "1",
 			"successful_payments": "1",
 			"failed_payments": "0",
+			"canceled_payments": "0",
 			"remaining_payments": "0",
             "registered_wallets": "0",
 			"received_amounts":	[
@@ -181,6 +183,7 @@ func Test_ReceiverHandlerGet(t *testing.T) {
 					"total_payments": "1",
 					"payments_received": "1",
 					"failed_payments": "0",
+					"canceled_payments": "0",
 					"remaining_payments": "0",
 					"received_amounts":  [
 						{
@@ -254,6 +257,7 @@ func Test_ReceiverHandlerGet(t *testing.T) {
 			"total_payments": "2",
 			"successful_payments": "1",
 			"failed_payments": "0",
+			"canceled_payments": "0",
 			"remaining_payments": "1",
 			"registered_wallets": "1",
 			"received_amounts":  [
@@ -288,6 +292,7 @@ func Test_ReceiverHandlerGet(t *testing.T) {
 					"total_payments": "1",
 					"payments_received": "1",
 					"failed_payments": "0",
+					"canceled_payments": "0",
 					"remaining_payments": "0",
 					"received_amounts":  [
 						{
@@ -322,6 +327,7 @@ func Test_ReceiverHandlerGet(t *testing.T) {
 					"total_payments": "1",
 					"payments_received": "0",
 					"failed_payments": "0",
+					"canceled_payments": "0",
 					"remaining_payments": "1",
 					"received_amounts":  [
 						{
@@ -664,6 +670,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "0",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"registered_wallets":"0",
 						"wallets": [
@@ -691,6 +698,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 								"total_payments": "0",
 								"payments_received": "0",
 								"failed_payments": "0",
+								"canceled_payments": "0",
 								"remaining_payments": "0",
 								"anchor_platform_transaction_id": %q
 							}
@@ -706,6 +714,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "1",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "1",
 						"received_amounts":  [
 							{
@@ -740,6 +749,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 								"total_payments": "1",
 								"payments_received": "0",
 								"failed_payments": "0",
+								"canceled_payments": "0",
 								"remaining_payments": "1",
 								"received_amounts":  [
 									{
@@ -762,6 +772,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "1",
 						"successful_payments": "1",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"received_amounts":  [
 							{
@@ -796,6 +807,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 								"total_payments": "1",
 								"payments_received": "1",
 								"failed_payments": "0",
+								"canceled_payments": "0",
 								"remaining_payments": "0",
 								"received_amounts":  [
 									{
@@ -818,6 +830,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "0",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"registered_wallets":"0",
 						"wallets": []
@@ -867,6 +880,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "0",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"registered_wallets":"0",
 						"wallets": []
@@ -901,6 +915,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "1",
 						"successful_payments": "1",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"received_amounts":  [
 							{
@@ -935,6 +950,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 								"total_payments": "1",
 								"payments_received": "1",
 								"failed_payments": "0",
+								"canceled_payments": "0",
 								"remaining_payments": "0",
 								"received_amounts":  [
 									{
@@ -980,6 +996,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "0",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"registered_wallets":"0",
 						"wallets": [
@@ -1007,6 +1024,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 								"total_payments": "0",
 								"payments_received": "0",
 								"failed_payments": "0",
+								"canceled_payments": "0",
 								"remaining_payments": "0",
 								"anchor_platform_transaction_id": %q
 							}
@@ -1041,6 +1059,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "0",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"registered_wallets":"0",
 						"wallets": [
@@ -1068,6 +1087,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 								"total_payments": "0",
 								"payments_received": "0",
 								"failed_payments": "0",
+								"canceled_payments": "0",
 								"remaining_payments": "0",
 								"anchor_platform_transaction_id": %q
 							}
@@ -1102,6 +1122,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "0",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"registered_wallets":"0",
 						"wallets": []
@@ -1131,6 +1152,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "0",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"registered_wallets":"0",
 						"wallets": [
@@ -1158,6 +1180,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 								"total_payments": "0",
 								"payments_received": "0",
 								"failed_payments": "0",
+								"canceled_payments": "0",
 								"remaining_payments": "0",
 								"anchor_platform_transaction_id": %q
 							}
@@ -1196,6 +1219,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"successful_payments": "0",
 						"received_amounts":  "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "1",
 						"received_amounts":  [
 							{
@@ -1230,6 +1254,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 								"total_payments": "1",
 								"payments_received": "0",
 								"failed_payments": "0",
+								"canceled_payments": "0",
 								"remaining_payments": "1",
 								"received_amounts":  [
 									{
@@ -1252,6 +1277,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "1",
 						"successful_payments": "1",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"received_amounts":  [
 							{
@@ -1286,6 +1312,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 								"total_payments": "1",
 								"payments_received": "1",
 								"failed_payments": "0",
+								"canceled_payments": "0",
 								"remaining_payments": "0",
 								"received_amounts":  [
 									{
@@ -1332,6 +1359,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "0",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"registered_wallets":"0",
 						"wallets": []
@@ -1361,6 +1389,7 @@ func Test_ReceiverHandler_GetReceivers_Success(t *testing.T) {
 						"total_payments": "0",
 						"successful_payments": "0",
 						"failed_payments": "0",
+						"canceled_payments": "0",
 						"remaining_payments": "0",
 						"registered_wallets":"0",
 						"wallets": []
@@ -1493,6 +1522,7 @@ func Test_ReceiverHandler_BuildReceiversResponse(t *testing.T) {
 			"total_payments": "0",
 			"successful_payments": "0",
 			"failed_payments": "0",
+			"canceled_payments": "0",
 			"remaining_payments": "0",
 			"registered_wallets":"0",
 			"wallets": [
@@ -1520,6 +1550,7 @@ func Test_ReceiverHandler_BuildReceiversResponse(t *testing.T) {
 					"total_payments": "0",
 					"payments_received": "0",
 					"failed_payments": "0",
+					"canceled_payments": "0",
 					"remaining_payments": "0",
 					"anchor_platform_transaction_id": %q
 				}
@@ -1535,6 +1566,7 @@ func Test_ReceiverHandler_BuildReceiversResponse(t *testing.T) {
 			"total_payments": "0",
 			"successful_payments": "0",
 			"failed_payments": "0",
+			"canceled_payments": "0",
 			"remaining_payments": "0",
 			"registered_wallets":"0",
 			"wallets": [
@@ -1562,6 +1594,7 @@ func Test_ReceiverHandler_BuildReceiversResponse(t *testing.T) {
 					"total_payments": "0",
 					"payments_received": "0",
 					"failed_payments": "0",
+					"canceled_payments": "0",
 					"remaining_payments": "0",
 					"anchor_platform_transaction_id": %q
 				}


### PR DESCRIPTION
### What

Get canceled payments for disbursement and receiver metrics

### Why

statistics metrics on FE

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
