### PR TITLE
[SDP-759] stellar-multitenant: provision new tenant

### DIFF
--- a/db/migrations/tenant-migrations/2023-10-16.0.add-tenants-table.sql
+++ b/db/migrations/tenant-migrations/2023-10-16.0.add-tenants-table.sql
@@ -15,6 +15,7 @@ $$ language 'plpgsql';
 
 CREATE TYPE public.email_sender_type AS ENUM ('AWS_EMAIL', 'DRY_RUN');
 CREATE TYPE public.sms_sender_type AS ENUM ('TWILIO_SMS', 'AWS_SMS', 'DRY_RUN');
+CREATE TYPE public.tenant_status AS ENUM ('TENANT_CREATED', 'TENANT_PROVISIONED', 'TENANT_ACTIVATED', 'TENANT_DEACTIVATED');
 
 CREATE TABLE public.tenants
 (
@@ -29,6 +30,7 @@ CREATE TABLE public.tenants
     cors_allowed_origins text[] NULL,
     base_url text NULL,
     sdp_ui_base_url text NULL,
+    status tenant_status DEFAULT 'TENANT_CREATED',
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
@@ -46,5 +48,7 @@ DROP TABLE public.tenants;
 DROP TYPE public.email_sender_type;
 
 DROP TYPE public.sms_sender_type;
+
+DROP TYPE public.tenant_status;
 
 DROP FUNCTION update_at_refresh;

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -59,6 +59,7 @@ func (s *DisbursementManagementService) GetDisbursementsWithCount(ctx context.Co
 
 			return utils.NewResultWithTotal(totalDisbursements, disbursements), nil
 		})
+
 }
 
 func (s *DisbursementManagementService) GetDisbursementReceiversWithCount(ctx context.Context, disbursementID string, queryParams *data.QueryParams) (*utils.ResultWithTotal, error) {

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -59,7 +59,6 @@ func (s *DisbursementManagementService) GetDisbursementsWithCount(ctx context.Co
 
 			return utils.NewResultWithTotal(totalDisbursements, disbursements), nil
 		})
-
 }
 
 func (s *DisbursementManagementService) GetDisbursementReceiversWithCount(ctx context.Context, disbursementID string, queryParams *data.QueryParams) (*utils.ResultWithTotal, error) {

--- a/internal/utils/network_type.go
+++ b/internal/utils/network_type.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/stellar/go/network"
 )
@@ -21,5 +22,16 @@ func GetNetworkTypeFromNetworkPassphrase(networkPassphrase string) (NetworkType,
 		return TestnetNetworkType, nil
 	default:
 		return "", fmt.Errorf("invalid network passphrase provided")
+	}
+}
+
+func GetNetworkTypeFromString(networkType string) (NetworkType, error) {
+	switch NetworkType(strings.ToLower(networkType)) {
+	case PubnetNetworkType:
+		return PubnetNetworkType, nil
+	case TestnetNetworkType:
+		return TestnetNetworkType, nil
+	default:
+		return "", fmt.Errorf("invalid network type provided")
 	}
 }

--- a/stellar-multitenant/pkg/cli/add_tenants.go
+++ b/stellar-multitenant/pkg/cli/add_tenants.go
@@ -3,32 +3,60 @@ package cli
 import (
 	"context"
 	"fmt"
+	"go/types"
 	"regexp"
 
 	"github.com/spf13/cobra"
+	"github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/cli/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 var validTenantName *regexp.Regexp = regexp.MustCompile(`^[a-z-]+$`)
 
 func AddTenantsCmd() *cobra.Command {
+	var networkType string
+	configOptions := config.ConfigOptions{
+		{
+			Name:           "network-type",
+			Usage:          "",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionNetworkType,
+			ConfigKey:      &networkType,
+			FlagDefault:    "testnet",
+			Required:       false,
+		},
+	}
+
 	cmd := cobra.Command{
 		Use:     "add-tenants",
 		Short:   "Add a new tenant.",
-		Example: "add-tenants [name]",
+		Example: "add-tenants [tenant name] [user first name] [user last name] [user email]",
 		Long:    "Add a new tenant. The tenant name should only contain lower case characters and dash (-)",
 		Args: cobra.MatchAll(
-			cobra.ExactArgs(1),
+			cobra.ExactArgs(4),
 			validateTenantNameArg,
 		),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			configOptions.Require()
+			err := configOptions.SetValues()
+			if err != nil {
+				log.Fatalf("Error setting values of config options: %s", err.Error())
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
-			if err := executeAddTenant(ctx, globalOptions.multitenantDbURL, args[0]); err != nil {
+			if err := executeAddTenant(ctx, globalOptions.multitenantDbURL, args[0], args[1], args[2], args[3], networkType); err != nil {
 				log.Fatal(err)
 			}
 		},
+	}
+
+	if err := configOptions.Init(&cmd); err != nil {
+		log.Fatalf("initializing config options: %v", err)
 	}
 
 	return &cmd
@@ -41,7 +69,7 @@ func validateTenantNameArg(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func executeAddTenant(ctx context.Context, dbURL, name string) error {
+func executeAddTenant(ctx context.Context, dbURL, tenantName, userFirstName, userLastName, userEmail, networkType string) error {
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbURL)
 	if err != nil {
 		return fmt.Errorf("opening database connection pool: %w", err)
@@ -49,12 +77,12 @@ func executeAddTenant(ctx context.Context, dbURL, name string) error {
 	defer dbConnectionPool.Close()
 
 	m := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
-	t, err := m.AddTenant(ctx, name)
+	t, err := m.ProvisionNewTenant(ctx, tenantName, userFirstName, userLastName, userEmail, networkType)
 	if err != nil {
-		return fmt.Errorf("adding tenant with name %s: %w", name, err)
+		return fmt.Errorf("adding tenant with name %s: %w", tenantName, err)
 	}
 
-	log.Ctx(ctx).Infof("tenant %s added successfully", name)
+	log.Ctx(ctx).Infof("tenant %s added successfully", tenantName)
 	log.Ctx(ctx).Infof("tenant ID: %s", t.ID)
 
 	return nil

--- a/stellar-multitenant/pkg/cli/add_tenants_test.go
+++ b/stellar-multitenant/pkg/cli/add_tenants_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
@@ -17,9 +19,20 @@ import (
 )
 
 func DeleteAllTenantsFixture(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool) {
-	const q = "DELETE FROM tenants"
+	q := "DELETE FROM tenants"
 	_, err := dbConnectionPool.ExecContext(ctx, q)
 	require.NoError(t, err)
+
+	var schemasToDrop []string
+	q = "SELECT schema_name FROM information_schema.schemata WHERE schema_name ILIKE 'sdp_%'"
+	err = dbConnectionPool.SelectContext(ctx, &schemasToDrop, q)
+	require.NoError(t, err)
+
+	for _, schema := range schemasToDrop {
+		q = fmt.Sprintf("DROP SCHEMA %s CASCADE", pq.QuoteIdentifier(schema))
+		_, err = dbConnectionPool.ExecContext(ctx, q)
+		require.NoError(t, err)
+	}
 }
 
 func Test_validateTenantNameArg(t *testing.T) {
@@ -81,7 +94,7 @@ func Test_executeAddTenant(t *testing.T) {
 
 		getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
 
-		err := executeAddTenant(ctx, dbt.DSN, "myorg")
+		err := executeAddTenant(ctx, dbt.DSN, "myorg", "first", "last", "email@email.com", "testnet")
 		assert.Nil(t, err)
 
 		const q = "SELECT id FROM tenants WHERE name = $1"
@@ -90,9 +103,9 @@ func Test_executeAddTenant(t *testing.T) {
 		require.NoError(t, err)
 
 		entries := getEntries()
-		require.Len(t, entries, 2)
-		assert.Equal(t, "tenant myorg added successfully", entries[0].Message)
-		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[1].Message)
+		require.Len(t, entries, 15)
+		assert.Equal(t, "tenant myorg added successfully", entries[13].Message)
+		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[14].Message)
 	})
 
 	t.Run("duplicated tenant name", func(t *testing.T) {
@@ -100,10 +113,10 @@ func Test_executeAddTenant(t *testing.T) {
 
 		getEntries := log.DefaultLogger.StartTest(log.DebugLevel)
 
-		err := executeAddTenant(ctx, dbt.DSN, "myorg")
+		err := executeAddTenant(ctx, dbt.DSN, "myorg", "first", "last", "email@email.com", "testnet")
 		assert.Nil(t, err)
 
-		err = executeAddTenant(ctx, dbt.DSN, "MyOrg")
+		err = executeAddTenant(ctx, dbt.DSN, "myorg", "first", "last", "email@email.com", "testnet")
 		assert.ErrorIs(t, err, tenant.ErrDuplicatedTenantName)
 
 		const q = "SELECT id FROM tenants WHERE name = $1"
@@ -112,9 +125,9 @@ func Test_executeAddTenant(t *testing.T) {
 		require.NoError(t, err)
 
 		entries := getEntries()
-		require.Len(t, entries, 2)
-		assert.Equal(t, "tenant myorg added successfully", entries[0].Message)
-		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[1].Message)
+		require.Len(t, entries, 16)
+		assert.Equal(t, "tenant myorg added successfully", entries[13].Message)
+		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[14].Message)
 	})
 }
 
@@ -135,17 +148,18 @@ func Test_AddTenantsCmd(t *testing.T) {
 		mockCmd.SetErr(out)
 		mockCmd.SetArgs([]string{"add-tenants"})
 		err := mockCmd.ExecuteContext(ctx)
-		assert.EqualError(t, err, "accepts 1 arg(s), received 0")
+		assert.EqualError(t, err, "accepts 4 arg(s), received 0")
 
-		expectUsageMessage := `Error: accepts 1 arg(s), received 0
+		expectUsageMessage := `Error: accepts 4 arg(s), received 0
 Usage:
    add-tenants [flags]
 
 Examples:
-add-tenants [name]
+add-tenants [tenant name] [user first name] [user last name] [user email]
 
 Flags:
-  -h, --help   help for add-tenants
+  -h, --help                  help for add-tenants
+      --network-type string    (NETWORK_TYPE) (default "testnet")
 
 `
 		assert.Equal(t, expectUsageMessage, out.String())
@@ -161,21 +175,27 @@ Usage:
    add-tenants [flags]
 
 Examples:
-add-tenants [name]
+add-tenants [tenant name] [user first name] [user last name] [user email]
 
 Flags:
-  -h, --help   help for add-tenants
+  -h, --help                  help for add-tenants
+      --network-type string    (NETWORK_TYPE) (default "testnet")
 `
 		assert.Equal(t, expectUsageMessage, out.String())
 	})
 
-	t.Run("adds new tenant successfully", func(t *testing.T) {
+	t.Run("adds new tenant successfully testnet", func(t *testing.T) {
+		tenantName := "unhcr"
+		userFirstName := "First"
+		userLastName := "Last"
+		userEmail := "email@email.com"
+
 		out := new(strings.Builder)
 		rootCmd := rootCmd()
 		rootCmd.AddCommand(AddTenantsCmd())
 		rootCmd.SetOut(out)
 		rootCmd.SetErr(out)
-		rootCmd.SetArgs([]string{"add-tenants", "unhcr", "--multitenant-db-url", dbt.DSN})
+		rootCmd.SetArgs([]string{"add-tenants", tenantName, userFirstName, userLastName, userEmail, "--network-type", "testnet", "--multitenant-db-url", dbt.DSN})
 		getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
 
 		err := rootCmd.ExecuteContext(ctx)
@@ -184,12 +204,117 @@ Flags:
 
 		const q = "SELECT id FROM tenants WHERE name = $1"
 		var tenantID string
-		err = dbConnectionPool.GetContext(ctx, &tenantID, q, "unhcr")
+		err = dbConnectionPool.GetContext(ctx, &tenantID, q, tenantName)
 		require.NoError(t, err)
 
 		entries := getEntries()
-		require.Len(t, entries, 4)
-		assert.Equal(t, "tenant unhcr added successfully", entries[2].Message)
-		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[3].Message)
+		require.Len(t, entries, 17)
+		assert.Equal(t, "tenant unhcr added successfully", entries[15].Message)
+		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[16].Message)
+
+		// Connecting to the new schema
+		schemaName := fmt.Sprintf("sdp_%s", tenantName)
+		dataSourceName := dbConnectionPool.DSN()
+		u, err := url.Parse(dataSourceName)
+		require.NoError(t, err)
+		uq := u.Query()
+		uq.Set("search_path", schemaName)
+		u.RawQuery = uq.Encode()
+
+		tenantSchemaConnectionPool, err := db.OpenDBConnectionPool(u.String())
+		require.NoError(t, err)
+		defer tenantSchemaConnectionPool.Close()
+
+		expectedTablesAfterMigrationsApplied := []string{
+			"assets",
+			"auth_migrations",
+			"auth_user_mfa_codes",
+			"auth_user_password_reset",
+			"auth_users",
+			"channel_accounts",
+			"countries",
+			"disbursements",
+			"gorp_migrations",
+			"messages",
+			"organizations",
+			"payments",
+			"receiver_verifications",
+			"receiver_wallets",
+			"receivers",
+			"submitter_transactions",
+			"wallets",
+			"wallets_assets",
+		}
+		tenant.TenantSchemaHasTablesFixture(t, ctx, tenantSchemaConnectionPool, schemaName, expectedTablesAfterMigrationsApplied)
+		tenant.AssertRegisteredAssets(t, ctx, tenantSchemaConnectionPool, []string{"USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", "XLM:"})
+		tenant.AssertRegisteredWallets(t, ctx, tenantSchemaConnectionPool, []string{"Demo Wallet", "Vibrant Assist"})
+		tenant.AssertRegisteredUser(t, ctx, tenantSchemaConnectionPool, userFirstName, userLastName, userEmail)
+	})
+
+	t.Run("adds new tenant successfully pubnet", func(t *testing.T) {
+		tenantName := "irc"
+		userFirstName := "First"
+		userLastName := "Last"
+		userEmail := "email@email.com"
+
+		out := new(strings.Builder)
+		rootCmd := rootCmd()
+		rootCmd.AddCommand(AddTenantsCmd())
+		rootCmd.SetOut(out)
+		rootCmd.SetErr(out)
+		rootCmd.SetArgs([]string{"add-tenants", tenantName, userFirstName, userLastName, userEmail, "--network-type", "pubnet", "--multitenant-db-url", dbt.DSN})
+		getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
+
+		err := rootCmd.ExecuteContext(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, out.String())
+
+		const q = "SELECT id FROM tenants WHERE name = $1"
+		var tenantID string
+		err = dbConnectionPool.GetContext(ctx, &tenantID, q, tenantName)
+		require.NoError(t, err)
+
+		entries := getEntries()
+		require.Len(t, entries, 17)
+		assert.Equal(t, "tenant irc added successfully", entries[15].Message)
+		assert.Contains(t, fmt.Sprintf("tenant ID: %s", tenantID), entries[16].Message)
+
+		// Connecting to the new schema
+		schemaName := fmt.Sprintf("sdp_%s", tenantName)
+		dataSourceName := dbConnectionPool.DSN()
+		u, err := url.Parse(dataSourceName)
+		require.NoError(t, err)
+		uq := u.Query()
+		uq.Set("search_path", schemaName)
+		u.RawQuery = uq.Encode()
+
+		tenantSchemaConnectionPool, err := db.OpenDBConnectionPool(u.String())
+		require.NoError(t, err)
+		defer tenantSchemaConnectionPool.Close()
+
+		expectedTablesAfterMigrationsApplied := []string{
+			"assets",
+			"auth_migrations",
+			"auth_user_mfa_codes",
+			"auth_user_password_reset",
+			"auth_users",
+			"channel_accounts",
+			"countries",
+			"disbursements",
+			"gorp_migrations",
+			"messages",
+			"organizations",
+			"payments",
+			"receiver_verifications",
+			"receiver_wallets",
+			"receivers",
+			"submitter_transactions",
+			"wallets",
+			"wallets_assets",
+		}
+		tenant.TenantSchemaHasTablesFixture(t, ctx, tenantSchemaConnectionPool, schemaName, expectedTablesAfterMigrationsApplied)
+		tenant.AssertRegisteredAssets(t, ctx, tenantSchemaConnectionPool, []string{"USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN", "XLM:"})
+		tenant.AssertRegisteredWallets(t, ctx, tenantSchemaConnectionPool, []string{"Vibrant Assist RC", "Vibrant Assist"})
+		tenant.AssertRegisteredUser(t, ctx, tenantSchemaConnectionPool, userFirstName, userLastName, userEmail)
 	})
 }

--- a/stellar-multitenant/pkg/cli/utils/custom_set_value.go
+++ b/stellar-multitenant/pkg/cli/utils/custom_set_value.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/log"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
@@ -128,5 +129,20 @@ func SetConfigOptionOptionalBoolean(co *config.ConfigOption) error {
 		return fmt.Errorf("the expected type for this config key is a boolean, but got a %T instead", co.ConfigKey)
 	}
 	*key = &value
+	return nil
+}
+
+func SetConfigOptionNetworkType(co *config.ConfigOption) error {
+	networkType := viper.GetString(co.Name)
+	value, err := utils.GetNetworkTypeFromString(networkType)
+	if err != nil {
+		return fmt.Errorf("getting network type from string: %w", err)
+	}
+
+	key, ok := co.ConfigKey.(*string)
+	if !ok {
+		return fmt.Errorf("the expected type for this config key is a string, but got a %T instead", co.ConfigKey)
+	}
+	*key = string(value)
 	return nil
 }

--- a/stellar-multitenant/pkg/tenant/fixtures.go
+++ b/stellar-multitenant/pkg/tenant/fixtures.go
@@ -1,0 +1,103 @@
+package tenant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ResetTenantConfigFixture(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, tenantID string) *Tenant {
+	t.Helper()
+
+	const q = `
+		UPDATE tenants
+		SET
+			email_sender_type = DEFAULT, sms_sender_type = DEFAULT, sep10_signing_public_key = NULL,
+			distribution_public_key = NULL, enable_mfa = DEFAULT, enable_recaptcha = DEFAULT,
+			cors_allowed_origins = NULL, base_url = NULL, sdp_ui_base_url = NULL
+		WHERE
+			id = $1
+		RETURNING *
+	`
+
+	var tnt Tenant
+	err := dbConnectionPool.GetContext(ctx, &tnt, q, tenantID)
+	require.NoError(t, err)
+
+	return &tnt
+}
+
+func CheckSchemaExistsFixture(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, schemaName string) bool {
+	t.Helper()
+
+	const q = `
+		SELECT EXISTS(
+			SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1
+		)
+	`
+
+	var exists bool
+	err := dbConnectionPool.GetContext(ctx, &exists, q, schemaName)
+	require.NoError(t, err)
+
+	return exists
+}
+
+// TenantSchemaHasTablesFixture asserts if the new tenant database schema has the tables passed by parameter.
+func TenantSchemaHasTablesFixture(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, schemaName string, tableNames []string) {
+	t.Helper()
+
+	const q = `
+		SELECT table_name FROM information_schema.tables WHERE table_schema = $1 ORDER BY table_name
+	`
+
+	var schemaTables []string
+	err := dbConnectionPool.SelectContext(ctx, &schemaTables, q, schemaName)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, tableNames, schemaTables)
+}
+
+func AssertRegisteredAssets(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, expectedAssets []string) {
+	var registeredAssets []string
+	queryRegisteredAssets := `
+		SELECT CONCAT(code, ':', issuer) FROM assets
+	`
+	err := dbConnectionPool.SelectContext(ctx, &registeredAssets, queryRegisteredAssets)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, expectedAssets, registeredAssets)
+}
+
+func AssertRegisteredWallets(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, expectedWallets []string) {
+	var registeredWallets []string
+	queryRegisteredWallets := `
+		SELECT name FROM wallets
+	`
+	err := dbConnectionPool.SelectContext(ctx, &registeredWallets, queryRegisteredWallets)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, expectedWallets, registeredWallets)
+}
+
+func AssertRegisteredUser(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, userFirstName, userLastName, userEmail string) {
+	var user struct {
+		FirstName string         `db:"first_name"`
+		LastName  string         `db:"last_name"`
+		Email     string         `db:"email"`
+		Roles     pq.StringArray `db:"roles"`
+		IsOwner   bool           `db:"is_owner"`
+	}
+	queryRegisteredUser := `
+		SELECT first_name, last_name, email, roles, is_owner FROM auth_users WHERE email = $1
+	`
+	err := dbConnectionPool.GetContext(ctx, &user, queryRegisteredUser, userEmail)
+	require.NoError(t, err)
+	assert.Equal(t, userFirstName, user.FirstName)
+	assert.Equal(t, userLastName, user.LastName)
+	assert.Equal(t, userEmail, user.Email)
+	assert.Equal(t, pq.StringArray{"owner"}, user.Roles)
+	assert.True(t, user.IsOwner)
+}

--- a/stellar-multitenant/pkg/tenant/tenant_test.go
+++ b/stellar-multitenant/pkg/tenant/tenant_test.go
@@ -54,6 +54,12 @@ func Test_TenantUpdate_Validate(t *testing.T) {
 		tu.CORSAllowedOrigins = []string{"inv@lid$"}
 		err = tu.Validate()
 		assert.EqualError(t, err, `invalid CORS allowed origin url: "inv@lid$"`)
+
+		tu.CORSAllowedOrigins = nil
+		tenantStatus := TenantStatus("invalid")
+		tu.Status = &tenantStatus
+		err = tu.Validate()
+		assert.EqualError(t, err, `invalid tenant status: "invalid"`)
 	})
 
 	t.Run("valid values", func(t *testing.T) {
@@ -68,6 +74,7 @@ func Test_TenantUpdate_Validate(t *testing.T) {
 			CORSAllowedOrigins:    []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"},
 			BaseURL:               &[]string{"https://myorg.backend.io"}[0],
 			SDPUIBaseURL:          &[]string{"https://myorg.frontend.io"}[0],
+			Status:                &[]TenantStatus{ProvisionedTenantStatus}[0],
 		}
 		err := tu.Validate()
 		assert.NoError(t, err)
@@ -107,4 +114,36 @@ func Test_ParseSMSSenderType(t *testing.T) {
 	sst, err = ParseSMSSenderType("TWILIO_SMS")
 	assert.NoError(t, err)
 	assert.Equal(t, TwilioSMSSenderType, sst)
+}
+
+func Test_TenantStatus_IsValid(t *testing.T) {
+	testCases := []struct {
+		status TenantStatus
+		expect bool
+	}{
+		{
+			status: CreatedTenantStatus,
+			expect: true,
+		},
+		{
+			status: ProvisionedTenantStatus,
+			expect: true,
+		},
+		{
+			status: ActivatedTenantStatus,
+			expect: true,
+		},
+		{
+			status: DeactivatedTenantStatus,
+			expect: true,
+		},
+		{
+			status: TenantStatus("invalid"),
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expect, tc.status.IsValid())
+	}
 }


### PR DESCRIPTION
### What

This PR adds a new method to the `Multitenant Manager` called `ProvisionNewTenant` which adds a new tenant to the `tenants` table, creates a new database schema for this new tenant, runs the database migrations on this new schema, and finally register a user on the `auth_users` table on that schema.

The `add-tenants` CLI command was changed to use this new method.

### Why

We should be able to provision a new tenant without caring about the transport layer that was used (API call, CLI, etc...).

### Known limitations

We should send the invitation email to the user registered in the database. We're going to do this in another PR.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
