### PR TITLE
[SDP-952] stellar-multitenant/services: send invitation email

### DIFF
--- a/internal/serve/httphandler/user_handler.go
+++ b/internal/serve/httphandler/user_handler.go
@@ -4,21 +4,18 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/stellar/go/support/http/httpdecode"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
-
-const invitationMessageTitle = "Welcome to Stellar Disbursement Platform"
 
 type UserHandler struct {
 	AuthManager     auth.AuthManager
@@ -173,15 +170,15 @@ func (h UserHandler) CreateUser(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	newUser := &auth.User{
+	newUser := auth.User{
 		FirstName: reqBody.FirstName,
 		LastName:  reqBody.LastName,
 		Email:     reqBody.Email,
 		Roles:     data.FromUserRoleArrayToStringArray(reqBody.Roles),
 	}
 
-	// The password is empty so the AuthManager will generate one automatically.
-	u, err := h.AuthManager.CreateUser(ctx, newUser, "")
+	s := services.NewCreateUserService(h.Models, h.Models.DBConnectionPool, h.AuthManager, h.MessengerClient)
+	u, err := s.CreateUser(ctx, newUser, h.UIBaseURL)
 	if err != nil {
 		if errors.Is(err, auth.ErrUserEmailAlreadyExists) {
 			httperror.BadRequest(auth.ErrUserEmailAlreadyExists.Error(), err, nil).Render(rw)
@@ -189,42 +186,6 @@ func (h UserHandler) CreateUser(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		httperror.InternalError(ctx, "Cannot create user", err, nil).Render(rw)
-		return
-	}
-
-	organization, err := h.Models.Organizations.Get(ctx)
-	if err != nil {
-		httperror.InternalError(ctx, "Cannot get organization data", err, nil).Render(rw)
-		return
-	}
-
-	forgotPasswordLink, err := url.JoinPath(h.UIBaseURL, "forgot-password")
-	if err != nil {
-		httperror.InternalError(ctx, "Cannot get forgot password link", err, nil).Render(rw)
-		return
-	}
-
-	invitationMsgData := htmltemplate.InvitationMessageTemplate{
-		FirstName:          u.FirstName,
-		Role:               u.Roles[0],
-		ForgotPasswordLink: forgotPasswordLink,
-		OrganizationName:   organization.Name,
-	}
-	messageContent, err := htmltemplate.ExecuteHTMLTemplateForInvitationMessage(invitationMsgData)
-	if err != nil {
-		httperror.InternalError(ctx, "Cannot execute invitation message template", err, nil).Render(rw)
-		return
-	}
-
-	msg := message.Message{
-		ToEmail: u.Email,
-		Message: messageContent,
-		Title:   invitationMessageTitle,
-	}
-	err = h.MessengerClient.SendMessage(msg)
-	if err != nil {
-		msg := fmt.Sprintf("Cannot send invitation email for user %s", u.ID)
-		httperror.InternalError(ctx, msg, err, nil).Render(rw)
 		return
 	}
 

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -641,7 +641,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 		msg := message.Message{
 			ToEmail: u.Email,
-			Title:   invitationMessageTitle,
+			Title:   "Welcome to Stellar Disbursement Platform",
 			Message: content,
 		}
 		messengerClientMock.
@@ -671,7 +671,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 		wantsBody := `
 			{
-				"error": "Cannot send invitation email for user user-id"
+				"error": "Cannot create user"
 			}
 		`
 
@@ -727,7 +727,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 		wantsBody := `
 			{
-				"error": "Cannot get forgot password link"
+				"error": "Cannot create user"
 			}
 		`
 
@@ -774,7 +774,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 		msg := message.Message{
 			ToEmail: u.Email,
-			Title:   invitationMessageTitle,
+			Title:   "Welcome to Stellar Disbursement Platform",
 			Message: content,
 		}
 		messengerClientMock.

--- a/internal/services/create_auth_user.go
+++ b/internal/services/create_auth_user.go
@@ -1,0 +1,72 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+)
+
+const invitationMessageTitle = "Welcome to Stellar Disbursement Platform"
+
+type CreateAuthUserService struct {
+	models           *data.Models
+	dbConnectionPool db.DBConnectionPool
+	authManager      auth.AuthManager
+	messengerClient  message.MessengerClient
+}
+
+func NewCreateUserService(models *data.Models, dbConnectionPool db.DBConnectionPool, authManager auth.AuthManager, messengerClient message.MessengerClient) *CreateAuthUserService {
+	return &CreateAuthUserService{
+		models:           models,
+		dbConnectionPool: dbConnectionPool,
+		authManager:      authManager,
+		messengerClient:  messengerClient,
+	}
+}
+
+func (s *CreateAuthUserService) CreateUser(ctx context.Context, newUser auth.User, uiBaseURL string) (*auth.User, error) {
+	// The password is empty so the AuthManager will generate one automatically.
+	u, err := s.authManager.CreateUser(ctx, &newUser, "")
+	if err != nil {
+		return nil, fmt.Errorf("creating new user: %w", err)
+	}
+
+	organization, err := s.models.Organizations.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting organization: %w", err)
+	}
+
+	forgotPasswordLink, err := url.JoinPath(uiBaseURL, "forgot-password")
+	if err != nil {
+		return nil, fmt.Errorf("getting forgot password link: %w", err)
+	}
+
+	invitationMsgData := htmltemplate.InvitationMessageTemplate{
+		FirstName:          u.FirstName,
+		Role:               u.Roles[0],
+		ForgotPasswordLink: forgotPasswordLink,
+		OrganizationName:   organization.Name,
+	}
+	messageContent, err := htmltemplate.ExecuteHTMLTemplateForInvitationMessage(invitationMsgData)
+	if err != nil {
+		return nil, fmt.Errorf("executing invitation message HTML template: %w", err)
+	}
+
+	msg := message.Message{
+		ToEmail: u.Email,
+		Message: messageContent,
+		Title:   invitationMessageTitle,
+	}
+	err = s.messengerClient.SendMessage(msg)
+	if err != nil {
+		return nil, fmt.Errorf("sending invitation email for user %s: %w", u.ID, err)
+	}
+
+	return u, nil
+}

--- a/internal/services/create_auth_user_test.go
+++ b/internal/services/create_auth_user_test.go
@@ -1,0 +1,172 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CreateAuthUserService_CreateUser(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	authManagerMock := auth.AuthManagerMock{}
+	messengerClientMock := message.MessengerClientMock{}
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	s := NewCreateUserService(models, dbConnectionPool, &authManagerMock, &messengerClientMock)
+
+	t.Run("returns error when can't create user", func(t *testing.T) {
+		newUser := auth.User{
+			FirstName: "First",
+			LastName:  "Last",
+			Email:     "email@email.com",
+			IsOwner:   true,
+			Roles:     []string{"owner"},
+		}
+
+		authManagerMock.
+			On("CreateUser", ctx, &newUser, "").
+			Return(nil, errors.New("unexpected error")).
+			Once()
+
+		u, err := s.CreateUser(ctx, newUser, "http://localhost:3000")
+		assert.EqualError(t, err, "creating new user: unexpected error")
+		assert.Nil(t, u)
+	})
+
+	t.Run("returns error when can't get the forgot password link", func(t *testing.T) {
+		newUser := auth.User{
+			FirstName: "First",
+			LastName:  "Last",
+			Email:     "email@email.com",
+			IsOwner:   true,
+			Roles:     []string{"owner"},
+		}
+
+		authManagerMock.
+			On("CreateUser", ctx, &newUser, "").
+			Return(&auth.User{}, nil).
+			Once()
+
+		u, err := s.CreateUser(ctx, newUser, "%invalid$%")
+		assert.EqualError(t, err, `getting forgot password link: parse "%invalid$%": invalid URL escape "%in"`)
+		assert.Nil(t, u)
+	})
+
+	t.Run("returns error when fails sending message", func(t *testing.T) {
+		newUser := auth.User{
+			FirstName: "First",
+			LastName:  "Last",
+			Email:     "email@email.com",
+			IsOwner:   true,
+			Roles:     []string{"owner"},
+		}
+
+		authManagerMock.
+			On("CreateUser", ctx, &newUser, "").
+			Return(&auth.User{
+				ID:        "user-id",
+				FirstName: newUser.FirstName,
+				LastName:  newUser.LastName,
+				Email:     newUser.Email,
+				IsOwner:   true,
+				Roles:     newUser.Roles,
+			}, nil).
+			Once()
+
+		uiBaseURL := "http://localhost:3000"
+		forgotPasswordLink, err := url.JoinPath(uiBaseURL, "forgot-password")
+		require.NoError(t, err)
+
+		content, err := htmltemplate.ExecuteHTMLTemplateForInvitationMessage(htmltemplate.InvitationMessageTemplate{
+			FirstName:          newUser.FirstName,
+			Role:               newUser.Roles[0],
+			ForgotPasswordLink: forgotPasswordLink,
+			OrganizationName:   "MyCustomAid",
+		})
+		require.NoError(t, err)
+
+		messengerClientMock.
+			On("SendMessage", message.Message{
+				ToEmail: newUser.Email,
+				Title:   invitationMessageTitle,
+				Message: content,
+			}).
+			Return(errors.New("unexpected error")).
+			Once()
+
+		u, err := s.CreateUser(ctx, newUser, uiBaseURL)
+		assert.EqualError(t, err, `sending invitation email for user user-id: unexpected error`)
+		assert.Nil(t, u)
+	})
+
+	t.Run("creates user and sends invitation message successfully", func(t *testing.T) {
+		newUser := auth.User{
+			FirstName: "First",
+			LastName:  "Last",
+			Email:     "email@email.com",
+			IsOwner:   true,
+			Roles:     []string{"owner"},
+		}
+
+		authManagerMock.
+			On("CreateUser", ctx, &newUser, "").
+			Return(&auth.User{
+				ID:        "user-id",
+				FirstName: newUser.FirstName,
+				LastName:  newUser.LastName,
+				Email:     newUser.Email,
+				IsOwner:   true,
+				Roles:     newUser.Roles,
+			}, nil).
+			Once()
+
+		uiBaseURL := "http://localhost:3000"
+		forgotPasswordLink, err := url.JoinPath(uiBaseURL, "forgot-password")
+		require.NoError(t, err)
+
+		content, err := htmltemplate.ExecuteHTMLTemplateForInvitationMessage(htmltemplate.InvitationMessageTemplate{
+			FirstName:          newUser.FirstName,
+			Role:               newUser.Roles[0],
+			ForgotPasswordLink: forgotPasswordLink,
+			OrganizationName:   "MyCustomAid",
+		})
+		require.NoError(t, err)
+
+		messengerClientMock.
+			On("SendMessage", message.Message{
+				ToEmail: newUser.Email,
+				Title:   invitationMessageTitle,
+				Message: content,
+			}).
+			Return(nil).
+			Once()
+
+		u, err := s.CreateUser(ctx, newUser, uiBaseURL)
+		require.NoError(t, err)
+
+		assert.Equal(t, "user-id", u.ID)
+		assert.Equal(t, newUser.FirstName, u.FirstName)
+		assert.Equal(t, newUser.LastName, u.LastName)
+		assert.Equal(t, newUser.Email, u.Email)
+		assert.Equal(t, newUser.Roles, u.Roles)
+		assert.Equal(t, newUser.IsOwner, u.IsOwner)
+	})
+}

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -59,6 +59,7 @@ func (s *DisbursementManagementService) GetDisbursementsWithCount(ctx context.Co
 
 			return utils.NewResultWithTotal(totalDisbursements, disbursements), nil
 		})
+
 }
 
 func (s *DisbursementManagementService) GetDisbursementReceiversWithCount(ctx context.Context, disbursementID string, queryParams *data.QueryParams) (*utils.ResultWithTotal, error) {

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -59,7 +59,6 @@ func (s *DisbursementManagementService) GetDisbursementsWithCount(ctx context.Co
 
 			return utils.NewResultWithTotal(totalDisbursements, disbursements), nil
 		})
-
 }
 
 func (s *DisbursementManagementService) GetDisbursementReceiversWithCount(ctx context.Context, disbursementID string, queryParams *data.QueryParams) (*utils.ResultWithTotal, error) {

--- a/stellar-multitenant/pkg/cli/add_tenants.go
+++ b/stellar-multitenant/pkg/cli/add_tenants.go
@@ -10,33 +10,79 @@ import (
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/cli/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 var validTenantName *regexp.Regexp = regexp.MustCompile(`^[a-z-]+$`)
 
+type AddTenantsCommandOptions struct {
+	SDPUIBaseURL     *string
+	NetworkType      string
+	MessengerOptions message.MessengerOptions
+}
+
 func AddTenantsCmd() *cobra.Command {
-	var networkType string
+	opts := AddTenantsCommandOptions{}
+
 	configOptions := config.ConfigOptions{
 		{
 			Name:           "network-type",
-			Usage:          "",
+			Usage:          "The Stellar Network type",
 			OptType:        types.String,
 			CustomSetValue: utils.SetConfigOptionNetworkType,
-			ConfigKey:      &networkType,
+			ConfigKey:      &opts.NetworkType,
 			FlagDefault:    "testnet",
-			Required:       false,
+			Required:       true,
+		},
+		{
+			Name:           "sdp-ui-base-url",
+			Usage:          "The Tenant SDP UI/dashboard Base URL.",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionURLString,
+			ConfigKey:      &opts.SDPUIBaseURL,
+			FlagDefault:    "http://localhost:3000",
+			Required:       true,
+		},
+		{
+			Name:           "email-sender-type",
+			Usage:          fmt.Sprintf("The messenger type used to send invitations to new dashboard users. Options: %+v", message.MessengerType("").ValidEmailTypes()),
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionMessengerType,
+			ConfigKey:      &opts.MessengerOptions.MessengerType,
+			Required:       true,
+		},
+		{
+			Name:      "aws-access-key-id",
+			Usage:     "The AWS access key ID",
+			OptType:   types.String,
+			ConfigKey: &opts.MessengerOptions.AWSAccessKeyID,
+			Required:  false,
+		},
+		{
+			Name:      "aws-secret-access-key",
+			Usage:     "The AWS secret access key",
+			OptType:   types.String,
+			ConfigKey: &opts.MessengerOptions.AWSSecretAccessKey,
+			Required:  false,
+		},
+		{
+			Name:      "aws-region",
+			Usage:     "The AWS region",
+			OptType:   types.String,
+			ConfigKey: &opts.MessengerOptions.AWSRegion,
+			Required:  false,
 		},
 	}
 
 	cmd := cobra.Command{
 		Use:     "add-tenants",
 		Short:   "Add a new tenant.",
-		Example: "add-tenants [tenant name] [user first name] [user last name] [user email]",
+		Example: "add-tenants [tenant name] [user first name] [user last name] [user email] [organization name]",
 		Long:    "Add a new tenant. The tenant name should only contain lower case characters and dash (-)",
 		Args: cobra.MatchAll(
-			cobra.ExactArgs(4),
+			cobra.ExactArgs(5),
 			validateTenantNameArg,
 		),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -48,8 +94,15 @@ func AddTenantsCmd() *cobra.Command {
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			messengerClient, err := message.GetClient(opts.MessengerOptions)
+			if err != nil {
+				log.Fatalf("creating email client: %v", err)
+			}
+
 			ctx := cmd.Context()
-			if err := executeAddTenant(ctx, globalOptions.multitenantDbURL, args[0], args[1], args[2], args[3], networkType); err != nil {
+			if err := executeAddTenant(
+				ctx, globalOptions.multitenantDbURL, args[0], args[1], args[2], args[3], args[4],
+				*opts.SDPUIBaseURL, opts.NetworkType, messengerClient); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -69,15 +122,17 @@ func validateTenantNameArg(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func executeAddTenant(ctx context.Context, dbURL, tenantName, userFirstName, userLastName, userEmail, networkType string) error {
+func executeAddTenant(
+	ctx context.Context, dbURL, tenantName, userFirstName, userLastName, userEmail,
+	organizationName, uiBaseURL, networkType string, messengerClient message.MessengerClient) error {
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbURL)
 	if err != nil {
 		return fmt.Errorf("opening database connection pool: %w", err)
 	}
 	defer dbConnectionPool.Close()
 
-	m := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
-	t, err := m.ProvisionNewTenant(ctx, tenantName, userFirstName, userLastName, userEmail, networkType)
+	m := tenant.NewManager(tenant.WithDatabase(dbConnectionPool), tenant.WithMessengerClient(messengerClient))
+	t, err := m.ProvisionNewTenant(ctx, tenantName, userFirstName, userLastName, userEmail, organizationName, uiBaseURL, networkType)
 	if err != nil {
 		return fmt.Errorf("adding tenant with name %s: %w", tenantName, err)
 	}

--- a/stellar-multitenant/pkg/cli/utils/custom_set_value.go
+++ b/stellar-multitenant/pkg/cli/utils/custom_set_value.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/log"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -144,5 +145,17 @@ func SetConfigOptionNetworkType(co *config.ConfigOption) error {
 		return fmt.Errorf("the expected type for this config key is a string, but got a %T instead", co.ConfigKey)
 	}
 	*key = string(value)
+	return nil
+}
+
+func SetConfigOptionMessengerType(co *config.ConfigOption) error {
+	senderType := viper.GetString(co.Name)
+
+	messengerType, err := message.ParseMessengerType(senderType)
+	if err != nil {
+		return fmt.Errorf("couldn't parse messenger type: %w", err)
+	}
+
+	*(co.ConfigKey.(*message.MessengerType)) = messengerType
 	return nil
 }


### PR DESCRIPTION
### What

This PR creates a new service that creates a new user and sends the invitation email. We refactor to use this service when creating a new user on the user HTTP handler and provisioning a new tenant.

### Why

We should send an invitation email when provisioning a new tenant.

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
