### PR TITLE
SDP-761 - Multitenant Connection Pool & DataSource Router

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -30,8 +30,8 @@ type DBConnectionPool interface {
 	BeginTxx(ctx context.Context, opts *sql.TxOptions) (DBTransaction, error)
 	Close() error
 	Ping(ctx context.Context) error
-	SqlDB(ctx context.Context) *sql.DB
-	SqlxDB(ctx context.Context) *sqlx.DB
+	SqlDB(ctx context.Context) (*sql.DB, error)
+	SqlxDB(ctx context.Context) (*sqlx.DB, error)
 	DSN(ctx context.Context) (string, error)
 }
 
@@ -49,12 +49,18 @@ func (db *DBConnectionPoolImplementation) Ping(ctx context.Context) error {
 	return db.DB.PingContext(ctx)
 }
 
-func (db *DBConnectionPoolImplementation) SqlDB(ctx context.Context) *sql.DB {
-	return db.DB.DB
+func (db *DBConnectionPoolImplementation) SqlDB(ctx context.Context) (*sql.DB, error) {
+	if db.DB.DB == nil {
+		return nil, fmt.Errorf("sql.DB is not initialized")
+	}
+	return db.DB.DB, nil
 }
 
-func (db *DBConnectionPoolImplementation) SqlxDB(ctx context.Context) *sqlx.DB {
-	return db.DB
+func (db *DBConnectionPoolImplementation) SqlxDB(ctx context.Context) (*sqlx.DB, error) {
+	if db.DB == nil {
+		return nil, fmt.Errorf("sqlx.DB is not initialized")
+	}
+	return db.DB, nil
 }
 
 func (db *DBConnectionPoolImplementation) DSN(ctx context.Context) (string, error) {

--- a/db/db.go
+++ b/db/db.go
@@ -32,7 +32,7 @@ type DBConnectionPool interface {
 	Ping() error
 	SqlDB() *sql.DB
 	SqlxDB() *sqlx.DB
-	DSN() string
+	DSN(ctx context.Context) (string, error)
 }
 
 // DBConnectionPoolImplementation is a wrapper around sqlx.DB that implements DBConnectionPool.
@@ -53,8 +53,8 @@ func (db *DBConnectionPoolImplementation) SqlxDB() *sqlx.DB {
 	return db.DB
 }
 
-func (db *DBConnectionPoolImplementation) DSN() string {
-	return db.dataSourceName
+func (db *DBConnectionPoolImplementation) DSN(ctx context.Context) (string, error) {
+	return db.dataSourceName, nil
 }
 
 // RunInTransactionWithResult runs the given atomic function in an atomic database transaction and returns a result and

--- a/db/db.go
+++ b/db/db.go
@@ -31,7 +31,6 @@ type DBConnectionPool interface {
 	Close() error
 	Ping() error
 	SqlDB() *sql.DB
-	SqlxDB() *sqlx.DB
 	DSN(ctx context.Context) (string, error)
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -50,7 +50,7 @@ func (db *DBConnectionPoolImplementation) Ping(ctx context.Context) error {
 }
 
 func (db *DBConnectionPoolImplementation) SqlDB(ctx context.Context) (*sql.DB, error) {
-	if db.DB.DB == nil {
+	if db.DB == nil || db.DB.DB == nil {
 		return nil, fmt.Errorf("sql.DB is not initialized")
 	}
 	return db.DB.DB, nil

--- a/db/db.go
+++ b/db/db.go
@@ -29,8 +29,9 @@ type DBConnectionPool interface {
 	SQLExecuter
 	BeginTxx(ctx context.Context, opts *sql.TxOptions) (DBTransaction, error)
 	Close() error
-	Ping() error
-	SqlDB() *sql.DB
+	Ping(ctx context.Context) error
+	SqlDB(ctx context.Context) *sql.DB
+	SqlxDB(ctx context.Context) *sqlx.DB
 	DSN(ctx context.Context) (string, error)
 }
 
@@ -44,11 +45,15 @@ func (db *DBConnectionPoolImplementation) BeginTxx(ctx context.Context, opts *sq
 	return db.DB.BeginTxx(ctx, opts)
 }
 
-func (db *DBConnectionPoolImplementation) SqlDB() *sql.DB {
+func (db *DBConnectionPoolImplementation) Ping(ctx context.Context) error {
+	return db.DB.PingContext(ctx)
+}
+
+func (db *DBConnectionPoolImplementation) SqlDB(ctx context.Context) *sql.DB {
 	return db.DB.DB
 }
 
-func (db *DBConnectionPoolImplementation) SqlxDB() *sqlx.DB {
+func (db *DBConnectionPoolImplementation) SqlxDB(ctx context.Context) *sqlx.DB {
 	return db.DB
 }
 

--- a/db/db_connection_pool_with_metrics.go
+++ b/db/db_connection_pool_with_metrics.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 )
 
@@ -42,12 +44,16 @@ func (dbc *DBConnectionPoolWithMetrics) Close() error {
 	return dbc.dbConnectionPool.Close()
 }
 
-func (dbc *DBConnectionPoolWithMetrics) Ping() error {
-	return dbc.dbConnectionPool.Ping()
+func (dbc *DBConnectionPoolWithMetrics) Ping(ctx context.Context) error {
+	return dbc.dbConnectionPool.Ping(ctx)
 }
 
-func (dbc *DBConnectionPoolWithMetrics) SqlDB() *sql.DB {
-	return dbc.dbConnectionPool.SqlDB()
+func (dbc *DBConnectionPoolWithMetrics) SqlDB(ctx context.Context) *sql.DB {
+	return dbc.dbConnectionPool.SqlDB(ctx)
+}
+
+func (dbc *DBConnectionPoolWithMetrics) SqlxDB(ctx context.Context) *sqlx.DB {
+	return dbc.dbConnectionPool.SqlxDB(ctx)
 }
 
 func (dbc *DBConnectionPoolWithMetrics) DSN(ctx context.Context) (string, error) {

--- a/db/db_connection_pool_with_metrics.go
+++ b/db/db_connection_pool_with_metrics.go
@@ -55,6 +55,6 @@ func (dbc *DBConnectionPoolWithMetrics) SqlxDB() *sqlx.DB {
 	return dbc.dbConnectionPool.SqlxDB()
 }
 
-func (dbc *DBConnectionPoolWithMetrics) DSN() string {
-	return dbc.dbConnectionPool.DSN()
+func (dbc *DBConnectionPoolWithMetrics) DSN(ctx context.Context) (string, error) {
+	return dbc.dbConnectionPool.DSN(ctx)
 }

--- a/db/db_connection_pool_with_metrics.go
+++ b/db/db_connection_pool_with_metrics.go
@@ -48,11 +48,11 @@ func (dbc *DBConnectionPoolWithMetrics) Ping(ctx context.Context) error {
 	return dbc.dbConnectionPool.Ping(ctx)
 }
 
-func (dbc *DBConnectionPoolWithMetrics) SqlDB(ctx context.Context) *sql.DB {
+func (dbc *DBConnectionPoolWithMetrics) SqlDB(ctx context.Context) (*sql.DB, error) {
 	return dbc.dbConnectionPool.SqlDB(ctx)
 }
 
-func (dbc *DBConnectionPoolWithMetrics) SqlxDB(ctx context.Context) *sqlx.DB {
+func (dbc *DBConnectionPoolWithMetrics) SqlxDB(ctx context.Context) (*sqlx.DB, error) {
 	return dbc.dbConnectionPool.SqlxDB(ctx)
 }
 

--- a/db/db_connection_pool_with_metrics.go
+++ b/db/db_connection_pool_with_metrics.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 )
 
@@ -49,10 +48,6 @@ func (dbc *DBConnectionPoolWithMetrics) Ping() error {
 
 func (dbc *DBConnectionPoolWithMetrics) SqlDB() *sql.DB {
 	return dbc.dbConnectionPool.SqlDB()
-}
-
-func (dbc *DBConnectionPoolWithMetrics) SqlxDB() *sqlx.DB {
-	return dbc.dbConnectionPool.SqlxDB()
 }
 
 func (dbc *DBConnectionPoolWithMetrics) DSN(ctx context.Context) (string, error) {

--- a/db/db_connection_pool_with_metrics_test.go
+++ b/db/db_connection_pool_with_metrics_test.go
@@ -5,29 +5,11 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestDBConnectionPoolWithMetrics_SqlxDB(t *testing.T) {
-	dbt := dbtest.Open(t)
-	defer dbt.Close()
-	dbConnectionPool, err := OpenDBConnectionPool(dbt.DSN)
-	require.NoError(t, err)
-	defer dbConnectionPool.Close()
-
-	mMonitorService := &monitor.MockMonitorService{}
-
-	dbConnectionPoolWithMetrics, err := NewDBConnectionPoolWithMetrics(dbConnectionPool, mMonitorService)
-	require.NoError(t, err)
-
-	sqlxDB := dbConnectionPoolWithMetrics.SqlxDB()
-
-	assert.IsType(t, &sqlx.DB{}, sqlxDB)
-}
 
 func TestDBConnectionPoolWithMetrics_SqlDB(t *testing.T) {
 	dbt := dbtest.Open(t)

--- a/db/db_connection_pool_with_metrics_test.go
+++ b/db/db_connection_pool_with_metrics_test.go
@@ -26,7 +26,8 @@ func TestDBConnectionPoolWithMetrics_SqlxDB(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	sqlxDB := dbConnectionPoolWithMetrics.SqlxDB(ctx)
+	sqlxDB, err := dbConnectionPoolWithMetrics.SqlxDB(ctx)
+	require.NoError(t, err)
 
 	assert.IsType(t, &sqlx.DB{}, sqlxDB)
 }
@@ -44,7 +45,8 @@ func TestDBConnectionPoolWithMetrics_SqlDB(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	sqlDB := dbConnectionPoolWithMetrics.SqlDB(ctx)
+	sqlDB, err := dbConnectionPoolWithMetrics.SqlDB(ctx)
+	require.NoError(t, err)
 
 	assert.IsType(t, &sql.DB{}, sqlDB)
 }

--- a/db/db_connection_pool_with_router.go
+++ b/db/db_connection_pool_with_router.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// ConnectionPoolWithRouter implements the DBConnectionPool interface
+type ConnectionPoolWithRouter struct {
+	SQLExecutorWithRouter
+}
+
+// NewConnectionPoolWithRouter creates a new ConnectionPoolWithRouter
+func NewConnectionPoolWithRouter(dataSourceRouter DataSourceRouter) (*ConnectionPoolWithRouter, error) {
+	sqlExecutor, err := NewSQLExecutorWithRouter(dataSourceRouter)
+	if err != nil {
+		return nil, fmt.Errorf("creating new sqlExecutor for connection pool with router: %w", err)
+	}
+	return &ConnectionPoolWithRouter{
+		SQLExecutorWithRouter: *sqlExecutor,
+	}, nil
+}
+
+func (m ConnectionPoolWithRouter) BeginTxx(ctx context.Context, opts *sql.TxOptions) (DBTransaction, error) {
+	dbcpl, err := m.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting data source from context in BeginTxx: %w", err)
+	}
+	return dbcpl.BeginTxx(ctx, opts)
+}
+
+func (m ConnectionPoolWithRouter) Close() error {
+	dbcpls, err := m.dataSourceRouter.GetAllDataSources()
+	if err != nil {
+		return fmt.Errorf("getting all data sources in Close: %w", err)
+	}
+	if len(dbcpls) == 0 {
+		return fmt.Errorf("no data sources found in Close")
+	}
+	for _, dbcpl := range dbcpls {
+		err = dbcpl.Close()
+		if err != nil {
+			return fmt.Errorf("closing data source in Close: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m ConnectionPoolWithRouter) Ping(ctx context.Context) error {
+	dbcpl, err := m.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return fmt.Errorf("getting data source from context in Ping: %w", err)
+	}
+	return dbcpl.Ping(ctx)
+}
+
+func (m ConnectionPoolWithRouter) SqlDB(ctx context.Context) (*sql.DB, error) {
+	dbcpl, err := m.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting data source from context in SqlDB: %w", err)
+	}
+	return dbcpl.SqlDB(ctx)
+}
+
+func (m ConnectionPoolWithRouter) SqlxDB(ctx context.Context) (*sqlx.DB, error) {
+	dbcpl, err := m.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting data source from context in SqlxDB: %w", err)
+	}
+	return dbcpl.SqlxDB(ctx)
+}
+
+func (m ConnectionPoolWithRouter) DSN(ctx context.Context) (string, error) {
+	dbcpl, err := m.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return "", fmt.Errorf("getting data source from context in DSN: %w", err)
+	}
+	return dbcpl.DSN(ctx)
+}
+
+// make sure *ConnectionPoolWithRouter implements DBConnectionPool:
+var _ DBConnectionPool = (*ConnectionPoolWithRouter)(nil)

--- a/db/db_connection_pool_with_router_test.go
+++ b/db/db_connection_pool_with_router_test.go
@@ -1,0 +1,260 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionPoolWithRouter_BeginTxx(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	connectionPoolWithRouter, outerErr := NewConnectionPoolWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+	ctx := context.Background()
+
+	t.Run("BeginTxx successful", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		dbTx, err := connectionPoolWithRouter.BeginTxx(ctx, nil)
+
+		// Defer a rollback in case anything fails.
+		defer func() {
+			err = dbTx.Rollback()
+			require.Error(t, err, "not in transaction")
+		}()
+		require.NoError(t, err)
+
+		assert.IsType(t, &sqlx.Tx{}, dbTx)
+
+		err = dbTx.Commit()
+		require.NoError(t, err)
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(nil, assert.AnError).
+			Once()
+
+		dbTx, err := connectionPoolWithRouter.BeginTxx(ctx, nil)
+		require.Error(t, err)
+		assert.Nil(t, dbTx)
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestConnectionPoolWithRouter_Close(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	connectionPoolWithRouter, outerErr := NewConnectionPoolWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	t.Run("Close successful", func(t *testing.T) {
+		mockRouter.
+			On("GetAllDataSources").
+			Return([]DBConnectionPool{dbConnectionPool}, nil).
+			Once()
+
+		err := connectionPoolWithRouter.Close()
+		require.NoError(t, err)
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting all data sources", func(t *testing.T) {
+		mockRouter.
+			On("GetAllDataSources").
+			Return(nil, assert.AnError).
+			Once()
+
+		err := connectionPoolWithRouter.Close()
+		require.Error(t, err)
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestConnectionPoolWithRouter_Ping(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	connectionPoolWithRouter, outerErr := NewConnectionPoolWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+	ctx := context.Background()
+
+	t.Run("Ping successful", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		err := connectionPoolWithRouter.Ping(ctx)
+		require.NoError(t, err)
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(nil, assert.AnError).
+			Once()
+
+		err := connectionPoolWithRouter.Ping(ctx)
+		require.Error(t, err)
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestConnectionPoolWithRouter_SqlDB(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	connectionPoolWithRouter, outerErr := NewConnectionPoolWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+	ctx := context.Background()
+
+	t.Run("SqlDB successful", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		db, err := connectionPoolWithRouter.SqlDB(ctx)
+		require.NoError(t, err)
+
+		assert.IsType(t, &sql.DB{}, db)
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(nil, assert.AnError).
+			Once()
+
+		db, err := connectionPoolWithRouter.SqlDB(ctx)
+		require.Error(t, err)
+		assert.Nil(t, db)
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestConnectionPoolWithRouter_SqlxDB(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	connectionPoolWithRouter, outerErr := NewConnectionPoolWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+	ctx := context.Background()
+
+	t.Run("SqlDB successful", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		db, err := connectionPoolWithRouter.SqlxDB(ctx)
+		require.NoError(t, err)
+
+		assert.IsType(t, &sqlx.DB{}, db)
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(nil, assert.AnError).
+			Once()
+
+		db, err := connectionPoolWithRouter.SqlxDB(ctx)
+		require.Error(t, err)
+		assert.Nil(t, db)
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestConnectionPoolWithRouter_DSN(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	connectionPoolWithRouter, outerErr := NewConnectionPoolWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+	ctx := context.Background()
+
+	t.Run("DSN successful", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		dsn, err := connectionPoolWithRouter.DSN(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, dbt.DSN, dsn)
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(nil, assert.AnError).
+			Once()
+
+		dsn, err := connectionPoolWithRouter.DSN(ctx)
+		require.Error(t, err)
+		assert.Equal(t, "", dsn)
+
+		mockRouter.AssertExpectations(t)
+	})
+}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/support/db/dbtest"
@@ -18,6 +19,7 @@ func TestOpen_OpenDBConnectionPool(t *testing.T) {
 
 	assert.Equal(t, "postgres", dbConnectionPool.DriverName())
 
-	err = dbConnectionPool.Ping()
+	ctx := context.Background()
+	err = dbConnectionPool.Ping(ctx)
 	require.NoError(t, err)
 }

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"net/http"
@@ -29,5 +30,6 @@ func Migrate(dbURL string, dir migrate.MigrationDirection, count int, migrationF
 	}
 
 	m := migrate.HttpFileSystemMigrationSource{FileSystem: http.FS(migrationFiles)}
-	return ms.ExecMax(dbConnectionPool.SqlDB(), dbConnectionPool.DriverName(), m, dir, count)
+	ctx := context.Background()
+	return ms.ExecMax(dbConnectionPool.SqlDB(ctx), dbConnectionPool.DriverName(), m, dir, count)
 }

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -31,5 +31,9 @@ func Migrate(dbURL string, dir migrate.MigrationDirection, count int, migrationF
 
 	m := migrate.HttpFileSystemMigrationSource{FileSystem: http.FS(migrationFiles)}
 	ctx := context.Background()
-	return ms.ExecMax(dbConnectionPool.SqlDB(ctx), dbConnectionPool.DriverName(), m, dir, count)
+	db, err := dbConnectionPool.SqlDB(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("fetching sql.DB: %w", err)
+	}
+	return ms.ExecMax(db, dbConnectionPool.DriverName(), m, dir, count)
 }

--- a/db/migrations/sdp-migrations/2023-10-25.0-update-payments-status-type-and-organizations-table.sql
+++ b/db/migrations/sdp-migrations/2023-10-25.0-update-payments-status-type-and-organizations-table.sql
@@ -4,7 +4,7 @@ ADD
     VALUE 'CANCELED';
 
 ALTER TABLE
-    public.organizations
+    organizations
 ADD
     COLUMN payment_cancellation_period_days INTEGER;
 
@@ -47,4 +47,4 @@ ALTER TABLE payments DROP COLUMN status_old;
 DROP TYPE old_payment_status CASCADE;
 
 ALTER TABLE
-    public.organizations DROP COLUMN payment_cancellation_period_days;
+    organizations DROP COLUMN payment_cancellation_period_days;

--- a/db/sql_exec_with_metrics_test.go
+++ b/db/sql_exec_with_metrics_test.go
@@ -33,7 +33,7 @@ func TestSQLExecWithMetrics_GetContext(t *testing.T) {
 		VALUES
 			($1, $2)
 	`
-	_, err = dbConnectionPool.SqlDB().ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
+	_, err = dbConnectionPool.ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
 	require.NoError(t, err)
 
 	t.Run("query successful in GetContext", func(t *testing.T) {
@@ -94,10 +94,10 @@ func TestSQLExecWithMetrics_SelectContext(t *testing.T) {
 		VALUES
 			($1, $2)
 	`
-	_, err = dbConnectionPool.SqlDB().ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
+	_, err = dbConnectionPool.ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
 	require.NoError(t, err)
 
-	_, err = dbConnectionPool.SqlDB().ExecContext(ctx, query, "EURT", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
+	_, err = dbConnectionPool.ExecContext(ctx, query, "EURT", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
 	require.NoError(t, err)
 
 	t.Run("query successful in SelectContext", func(t *testing.T) {
@@ -157,10 +157,10 @@ func TestSQLExecWithMetrics_QueryContext(t *testing.T) {
 		VALUES
 			($1, $2)
 	`
-	_, err = dbConnectionPool.SqlDB().ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
+	_, err = dbConnectionPool.ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
 	require.NoError(t, err)
 
-	_, err = dbConnectionPool.SqlDB().ExecContext(ctx, query, "EURT", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
+	_, err = dbConnectionPool.ExecContext(ctx, query, "EURT", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
 	require.NoError(t, err)
 
 	t.Run("query successful in QueryContext", func(t *testing.T) {
@@ -229,10 +229,10 @@ func TestSQLExecWithMetrics_QueryxContext(t *testing.T) {
 		VALUES
 			($1, $2)
 	`
-	_, err = dbConnectionPool.SqlDB().ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
+	_, err = dbConnectionPool.ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
 	require.NoError(t, err)
 
-	_, err = dbConnectionPool.SqlDB().ExecContext(ctx, query, "EURT", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
+	_, err = dbConnectionPool.ExecContext(ctx, query, "EURT", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
 	require.NoError(t, err)
 
 	t.Run("query successful in QueryxContext", func(t *testing.T) {
@@ -301,7 +301,7 @@ func TestSQLExecWithMetrics_QueryRowxContext(t *testing.T) {
 		VALUES
 			($1, $2)
 	`
-	_, err = dbConnectionPool.SqlDB().ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
+	_, err = dbConnectionPool.ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
 	require.NoError(t, err)
 
 	t.Run("query successful in QueryRowxContext", func(t *testing.T) {
@@ -362,7 +362,7 @@ func TestSQLExecWithMetrics_ExecContext(t *testing.T) {
 		VALUES
 			($1, $2)
 	`
-	_, err = dbConnectionPool.SqlDB().ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
+	_, err = dbConnectionPool.ExecContext(ctx, query, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZCC")
 	require.NoError(t, err)
 
 	t.Run("query successful in ExecContext", func(t *testing.T) {

--- a/db/sql_exec_with_router.go
+++ b/db/sql_exec_with_router.go
@@ -1,0 +1,109 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type DataSourceRouter interface {
+	GetDataSource(ctx context.Context) (DBConnectionPool, error)
+	GetAllDataSources() ([]DBConnectionPool, error)
+	AnyDataSource() (DBConnectionPool, error)
+}
+
+type SQLExecutorWithRouter struct {
+	dataSourceRouter DataSourceRouter
+}
+
+func NewSQLExecutorWithRouter(router DataSourceRouter) (*SQLExecutorWithRouter, error) {
+	if router == nil {
+		return nil, fmt.Errorf("router is nil in NewSQLExecutorWithRouter")
+	}
+	return &SQLExecutorWithRouter{
+		dataSourceRouter: router,
+	}, nil
+}
+
+func (s SQLExecutorWithRouter) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	dbcpl, err := s.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return fmt.Errorf("getting data source from context in GetContext: %w", err)
+	}
+	return dbcpl.GetContext(ctx, dest, query, args...)
+}
+
+func (s SQLExecutorWithRouter) SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	dbcpl, err := s.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return fmt.Errorf("getting data source from context in SelectContext: %w", err)
+	}
+
+	return dbcpl.SelectContext(ctx, dest, query, args...)
+}
+
+func (s SQLExecutorWithRouter) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	dbcpl, err := s.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting data source from context in ExecContext: %w", err)
+	}
+
+	return dbcpl.ExecContext(ctx, query, args...)
+}
+
+func (s SQLExecutorWithRouter) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	dbcpl, err := s.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting data source from context in QueryContext: %w", err)
+	}
+
+	return dbcpl.QueryContext(ctx, query, args...)
+}
+
+func (s SQLExecutorWithRouter) QueryxContext(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error) {
+	dbcpl, err := s.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting data source from context in QueryxContext: %w", err)
+	}
+
+	return dbcpl.QueryxContext(ctx, query, args...)
+}
+
+func (s SQLExecutorWithRouter) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	dbcpl, err := s.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting data source from context in PrepareContext: %w", err)
+	}
+
+	return dbcpl.PrepareContext(ctx, query)
+}
+
+func (s SQLExecutorWithRouter) QueryRowxContext(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
+	dbcpl, err := s.dataSourceRouter.GetDataSource(ctx)
+	if err != nil {
+		return nil
+	}
+
+	return dbcpl.QueryRowxContext(ctx, query, args...)
+}
+
+func (s SQLExecutorWithRouter) Rebind(query string) string {
+	dbcp, err := s.dataSourceRouter.AnyDataSource()
+	if err != nil {
+		return sqlx.Rebind(sqlx.DOLLAR, query)
+	}
+	return dbcp.Rebind(query)
+}
+
+func (m SQLExecutorWithRouter) DriverName() string {
+	dbcp, err := m.dataSourceRouter.AnyDataSource()
+	if err != nil {
+		return ""
+	}
+	return dbcp.DriverName()
+}
+
+// make sure *SQLExecutorWithRouter implements SQLExecuter:
+var _ SQLExecuter = (*SQLExecutorWithRouter)(nil)

--- a/db/sql_exec_with_router.go
+++ b/db/sql_exec_with_router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/stellar/go/support/log"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -100,6 +101,7 @@ func (s SQLExecutorWithRouter) Rebind(query string) string {
 func (m SQLExecutorWithRouter) DriverName() string {
 	dbcp, err := m.dataSourceRouter.AnyDataSource()
 	if err != nil {
+		log.Errorf("Error getting driver name: %s", err.Error())
 		return ""
 	}
 	return dbcp.DriverName()

--- a/db/sql_exec_with_router.go
+++ b/db/sql_exec_with_router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/stellar/go/support/log"
 
 	"github.com/jmoiron/sqlx"

--- a/db/sql_exec_with_router_test.go
+++ b/db/sql_exec_with_router_test.go
@@ -1,0 +1,430 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type MockDataSourceRouter struct {
+	mock.Mock
+}
+
+func (m *MockDataSourceRouter) GetAllDataSources() ([]DBConnectionPool, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]DBConnectionPool), args.Error(1)
+}
+
+func (m *MockDataSourceRouter) AnyDataSource() (DBConnectionPool, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(DBConnectionPool), args.Error(1)
+}
+
+func (m *MockDataSourceRouter) GetDataSource(ctx context.Context) (DBConnectionPool, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(DBConnectionPool), args.Error(1)
+}
+
+func TestSQLExecutorWithRouter_GetContext(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	sqlExecWithRouter, outerErr := NewSQLExecutorWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	ctx := context.Background()
+	query := "SELECT o.name FROM organizations o"
+	var dest string
+
+	t.Run("query successful in GetContext", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		err := sqlExecWithRouter.GetContext(ctx, &dest, query)
+		require.NoError(t, err)
+		require.Equal(t, "MyCustomAid", dest)
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source in GetContext", func(t *testing.T) {
+		mockRouter.On("GetDataSource", ctx).
+			Return(nil, fmt.Errorf("data source error")).
+			Once()
+
+		err := sqlExecWithRouter.GetContext(ctx, &dest, query)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "getting data source from context in GetContext")
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestSQLExecutorWithRouter_SelectContext(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	sqlExecWithRouter, outerErr := NewSQLExecutorWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	ctx := context.Background()
+	query := "SELECT o.name FROM organizations o"
+	var dest []string
+	t.Run("query successful in SelectContext", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		err := sqlExecWithRouter.SelectContext(ctx, &dest, query)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(dest))
+		require.Equal(t, "MyCustomAid", dest[0])
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source in SelectContext", func(t *testing.T) {
+		mockRouter.On("GetDataSource", ctx).
+			Return(nil, fmt.Errorf("data source error")).
+			Once()
+
+		err := sqlExecWithRouter.SelectContext(ctx, &dest, query)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "getting data source from context in SelectContext")
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestSQLExecutorWithRouter_ExecContext(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	sqlExecWithRouter, outerErr := NewSQLExecutorWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	ctx := context.Background()
+	query := "INSERT INTO assets (code, issuer) VALUES ('BTC', 'GCNSGHUCG5VMGLT5RIYYZSO7VQULQKAJ62QA33DBC5PPBSO57LFWVV6P')"
+	t.Run("query successful in ExecContext", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		result, err := sqlExecWithRouter.ExecContext(ctx, query)
+		require.NoError(t, err)
+
+		rowsAffected, err := result.RowsAffected()
+		require.NoError(t, err)
+
+		assert.Equal(t, rowsAffected, int64(1))
+		require.NoError(t, err)
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source in ExecContext", func(t *testing.T) {
+		mockRouter.On("GetDataSource", ctx).
+			Return(nil, fmt.Errorf("data source error")).
+			Once()
+
+		_, err := sqlExecWithRouter.ExecContext(ctx, query)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "getting data source from context in ExecContext")
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestSQLExecutorWithRouter_QueryContext(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	sqlExecWithRouter, outerErr := NewSQLExecutorWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	ctx := context.Background()
+	query := "SELECT o.name FROM organizations o"
+	t.Run("query successful in QueryContext", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		rows, err := sqlExecWithRouter.QueryContext(ctx, query)
+		require.NoError(t, err)
+
+		var dest []string
+		for rows.Next() {
+			var name string
+			err = rows.Scan(&name)
+			require.NoError(t, err)
+			dest = append(dest, name)
+		}
+
+		require.Equal(t, 1, len(dest))
+		require.Equal(t, "MyCustomAid", dest[0])
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source in QueryContext", func(t *testing.T) {
+		mockRouter.On("GetDataSource", ctx).
+			Return(nil, fmt.Errorf("data source error")).
+			Once()
+
+		_, err := sqlExecWithRouter.QueryContext(ctx, query)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "getting data source from context in QueryContext")
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestSQLExecutorWithRouter_QueryxContext(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	sqlExecWithRouter, outerErr := NewSQLExecutorWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	ctx := context.Background()
+	query := "SELECT o.name FROM organizations o"
+	t.Run("query successful in QueryxContext", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		rows, err := sqlExecWithRouter.QueryxContext(ctx, query)
+		require.NoError(t, err)
+
+		var dest []string
+		for rows.Next() {
+			var name string
+			err = rows.Scan(&name)
+			require.NoError(t, err)
+			dest = append(dest, name)
+		}
+
+		require.Equal(t, 1, len(dest))
+		require.Equal(t, "MyCustomAid", dest[0])
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source in QueryxContext", func(t *testing.T) {
+		mockRouter.On("GetDataSource", ctx).
+			Return(nil, fmt.Errorf("data source error")).
+			Once()
+
+		_, err := sqlExecWithRouter.QueryxContext(ctx, query)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "getting data source from context in QueryxContext")
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestSQLExecutorWithRouter_PrepareContext(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	sqlExecWithRouter, outerErr := NewSQLExecutorWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	ctx := context.Background()
+	query := "SELECT o.name FROM organizations o"
+	t.Run("query successful in PrepareContext", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		stmt, err := sqlExecWithRouter.PrepareContext(ctx, query)
+		require.NoError(t, err)
+
+		rows, err := stmt.Query()
+		require.NoError(t, err)
+
+		var dest []string
+		for rows.Next() {
+			var name string
+			err = rows.Scan(&name)
+			require.NoError(t, err)
+			dest = append(dest, name)
+		}
+
+		require.Equal(t, 1, len(dest))
+		require.Equal(t, "MyCustomAid", dest[0])
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source in PrepareContext", func(t *testing.T) {
+		mockRouter.On("GetDataSource", ctx).
+			Return(nil, fmt.Errorf("data source error")).
+			Once()
+
+		_, err := sqlExecWithRouter.PrepareContext(ctx, query)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "getting data source from context in PrepareContext")
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestSQLExecutorWithRouter_QueryRowxContext(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	sqlExecWithRouter, outerErr := NewSQLExecutorWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	ctx := context.Background()
+	query := "SELECT o.name FROM organizations o"
+	t.Run("query successful in QueryRowxContext", func(t *testing.T) {
+		mockRouter.
+			On("GetDataSource", ctx).
+			Return(dbConnectionPool, nil).
+			Once()
+
+		row := sqlExecWithRouter.QueryRowxContext(ctx, query)
+
+		var dest string
+		err := row.Scan(&dest)
+		require.NoError(t, err)
+
+		require.Equal(t, "MyCustomAid", dest)
+
+		mockRouter.AssertExpectations(t)
+	})
+
+	t.Run("error getting data source in QueryRowxContext", func(t *testing.T) {
+		mockRouter.On("GetDataSource", ctx).
+			Return(nil, fmt.Errorf("data source error")).
+			Once()
+
+		row := sqlExecWithRouter.QueryRowxContext(ctx, query)
+		require.Nil(t, row)
+
+		mockRouter.AssertExpectations(t)
+	})
+}
+
+func TestSQLExecutorWithRouter_Rebind(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	sqlExecWithRouter, outerErr := NewSQLExecutorWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	query := "SELECT * FROM organizations o WHERE o.name = ?"
+	expected := "SELECT * FROM organizations o WHERE o.name = $1"
+	t.Run("query successful in Rebind", func(t *testing.T) {
+		mockRouter.
+			On("AnyDataSource").
+			Return(dbConnectionPool, nil).
+			Once()
+		reboundQuery := sqlExecWithRouter.Rebind(query)
+		require.Equal(t, expected, reboundQuery)
+	})
+
+	t.Run("query successful in Rebind when there is no connectionPool", func(t *testing.T) {
+		mockRouter.
+			On("AnyDataSource").
+			Return(nil, fmt.Errorf("data source error")).
+			Once()
+		reboundQuery := sqlExecWithRouter.Rebind(query)
+		require.Equal(t, expected, reboundQuery)
+	})
+}
+
+func TestSQLExecutorWithRouter_DriverName(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	mockRouter := new(MockDataSourceRouter)
+
+	sqlExecWithRouter, outerErr := NewSQLExecutorWithRouter(mockRouter)
+	require.NoError(t, outerErr)
+
+	expected := "postgres"
+	t.Run("query successful in DriverName", func(t *testing.T) {
+		mockRouter.
+			On("AnyDataSource").
+			Return(dbConnectionPool, nil).
+			Once()
+		driverName := sqlExecWithRouter.DriverName()
+		require.Equal(t, expected, driverName)
+	})
+
+	t.Run("empty when there is no connection pool", func(t *testing.T) {
+		mockRouter.
+			On("AnyDataSource").
+			Return(nil, fmt.Errorf("data source error")).
+			Once()
+		driverName := sqlExecWithRouter.DriverName()
+		require.Empty(t, driverName)
+	})
+}

--- a/internal/data/assets_test.go
+++ b/internal/data/assets_test.go
@@ -31,7 +31,7 @@ func Test_AssetModelGet(t *testing.T) {
 	})
 
 	t.Run("returns asset successfully", func(t *testing.T) {
-		expected := CreateAssetFixture(t, ctx, dbConnectionPool.SqlxDB(), "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+		expected := CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
 		actual, err := assetModel.Get(ctx, expected.ID)
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
@@ -57,7 +57,7 @@ func Test_AssetModelGetByCodeAndIssuer(t *testing.T) {
 	})
 
 	t.Run("returns asset successfully", func(t *testing.T) {
-		expected := CreateAssetFixture(t, ctx, dbConnectionPool.SqlxDB(), "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+		expected := CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
 		actual, err := assetModel.GetByCodeAndIssuer(ctx, expected.Code, expected.Issuer)
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
@@ -77,7 +77,7 @@ func Test_AssetModelGetAll(t *testing.T) {
 	assetModel := &AssetModel{dbConnectionPool: dbConnectionPool}
 
 	t.Run("returns all assets successfully", func(t *testing.T) {
-		expected := ClearAndCreateAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		expected := ClearAndCreateAssetFixtures(t, ctx, dbConnectionPool)
 		actual, err := assetModel.GetAll(ctx)
 		require.NoError(t, err)
 
@@ -85,7 +85,7 @@ func Test_AssetModelGetAll(t *testing.T) {
 	})
 
 	t.Run("returns empty array when no assets", func(t *testing.T) {
-		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 		actual, err := assetModel.GetAll(ctx)
 		require.NoError(t, err)
 
@@ -145,7 +145,7 @@ func Test_AssetModelInsert(t *testing.T) {
 	assetModel := &AssetModel{dbConnectionPool: dbConnectionPool}
 
 	t.Run("inserts asset successfully", func(t *testing.T) {
-		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
 
@@ -159,7 +159,7 @@ func Test_AssetModelInsert(t *testing.T) {
 	})
 
 	t.Run("re-create a deleted asset", func(t *testing.T) {
-		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
 
@@ -204,7 +204,7 @@ func Test_AssetModelInsert(t *testing.T) {
 	})
 
 	t.Run("does not insert the same asset again", func(t *testing.T) {
-		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
 
@@ -218,7 +218,7 @@ func Test_AssetModelInsert(t *testing.T) {
 	})
 
 	t.Run("creates the stellar native asset successfully", func(t *testing.T) {
-		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 
 		asset, err := assetModel.Insert(ctx, dbConnectionPool, "XLM", "")
 		require.NoError(t, err)
@@ -229,7 +229,7 @@ func Test_AssetModelInsert(t *testing.T) {
 	})
 
 	t.Run("does not create an asset with empty issuer", func(t *testing.T) {
-		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 
 		asset, err := assetModel.Insert(ctx, dbConnectionPool, "USDC", "")
 		assert.EqualError(t, err, `error inserting asset: pq: new row for relation "assets" violates check constraint "asset_issuer_length_check"`)
@@ -237,7 +237,7 @@ func Test_AssetModelInsert(t *testing.T) {
 	})
 
 	t.Run("does not create an asset with a invalid issuer", func(t *testing.T) {
-		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 
 		asset, err := assetModel.Insert(ctx, dbConnectionPool, "USDC", "INVALID")
 		assert.EqualError(t, err, `error inserting asset: pq: new row for relation "assets" violates check constraint "asset_issuer_length_check"`)
@@ -275,7 +275,7 @@ func Test_AssetModelGetOrCreate(t *testing.T) {
 	})
 
 	t.Run("returns asset successfully", func(t *testing.T) {
-		expected := CreateAssetFixture(t, ctx, dbConnectionPool.SqlxDB(), "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+		expected := CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
 		asset, err := assetModel.GetOrCreate(ctx, expected.Code, expected.Issuer)
 		require.NoError(t, err)
 		assert.Equal(t, expected.ID, asset.ID)
@@ -295,8 +295,8 @@ func Test_AssetModelSoftDelete(t *testing.T) {
 	assetModel := &AssetModel{dbConnectionPool: dbConnectionPool}
 
 	t.Run("delete successful", func(t *testing.T) {
-		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
-		expected := CreateAssetFixture(t, ctx, dbConnectionPool.SqlxDB(), "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+		DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
+		expected := CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
 
 		asset, err := assetModel.SoftDelete(ctx, dbConnectionPool, expected.ID)
 		require.NoError(t, err)
@@ -311,7 +311,7 @@ func Test_AssetModelSoftDelete(t *testing.T) {
 	})
 
 	t.Run("delete unsuccessful, cannot find asset", func(t *testing.T) {
-		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 
 		_, err := assetModel.SoftDelete(ctx, dbConnectionPool, "non-existant")
 		require.Error(t, err)

--- a/internal/data/countries_test.go
+++ b/internal/data/countries_test.go
@@ -28,7 +28,7 @@ func Test_CountryModelGet(t *testing.T) {
 	})
 
 	t.Run("returns asset successfully", func(t *testing.T) {
-		expected := CreateCountryFixture(t, ctx, dbConnectionPool.SqlxDB(), "FRA", "France")
+		expected := CreateCountryFixture(t, ctx, dbConnectionPool, "FRA", "France")
 		actual, err := countryModel.Get(ctx, "FRA")
 		require.NoError(t, err)
 
@@ -48,7 +48,7 @@ func Test_CountryModelGetAll(t *testing.T) {
 	countryModel := &CountryModel{dbConnectionPool: dbConnectionPool}
 
 	t.Run("returns all countries successfully", func(t *testing.T) {
-		expected := ClearAndCreateCountryFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		expected := ClearAndCreateCountryFixtures(t, ctx, dbConnectionPool)
 		actual, err := countryModel.GetAll(ctx)
 		require.NoError(t, err)
 
@@ -56,7 +56,7 @@ func Test_CountryModelGetAll(t *testing.T) {
 	})
 
 	t.Run("returns empty array when no countries", func(t *testing.T) {
-		DeleteAllCountryFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllCountryFixtures(t, ctx, dbConnectionPool)
 		actual, err := countryModel.GetAll(ctx)
 		require.NoError(t, err)
 

--- a/internal/data/wallets_test.go
+++ b/internal/data/wallets_test.go
@@ -28,7 +28,7 @@ func Test_WalletModelGet(t *testing.T) {
 	})
 
 	t.Run("returns wallet successfully", func(t *testing.T) {
-		expected := CreateWalletFixture(t, ctx, dbConnectionPool.SqlxDB(),
+		expected := CreateWalletFixture(t, ctx, dbConnectionPool,
 			"NewWallet",
 			"https://newwallet.com",
 			"newwallet.com",
@@ -63,7 +63,7 @@ func Test_WalletModelGetByWalletName(t *testing.T) {
 	})
 
 	t.Run("returns wallet successfully", func(t *testing.T) {
-		expected := CreateWalletFixture(t, ctx, dbConnectionPool.SqlxDB(),
+		expected := CreateWalletFixture(t, ctx, dbConnectionPool,
 			"NewWallet",
 			"https://newwallet.com",
 			"newwallet.com",
@@ -95,7 +95,7 @@ func Test_WalletModelGetAll(t *testing.T) {
 	xlm := CreateAssetFixture(t, ctx, dbConnectionPool, "XLM", "")
 
 	t.Run("returns all wallets successfully", func(t *testing.T) {
-		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)
 
 		wallet1 := wallets[0]
 		wallet2 := wallets[1]
@@ -129,7 +129,7 @@ func Test_WalletModelGetAll(t *testing.T) {
 	})
 
 	t.Run("returns empty array when no wallets", func(t *testing.T) {
-		DeleteAllWalletFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllWalletFixtures(t, ctx, dbConnectionPool)
 		actual, err := walletModel.GetAll(ctx)
 		require.NoError(t, err)
 
@@ -148,10 +148,10 @@ func Test_WalletModelFindWallets(t *testing.T) {
 	walletModel := &WalletModel{dbConnectionPool: dbConnectionPool}
 
 	t.Run("returns only enabled wallets", func(t *testing.T) {
-		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)
 
-		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool.SqlxDB(), false, wallets[0].ID)
-		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool.SqlxDB(), true, wallets[1].ID)
+		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, false, wallets[0].ID)
+		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, true, wallets[1].ID)
 
 		findEnabled := true
 		actual, err := walletModel.FindWallets(ctx, &findEnabled)
@@ -162,10 +162,10 @@ func Test_WalletModelFindWallets(t *testing.T) {
 	})
 
 	t.Run("returns only disabled wallets", func(t *testing.T) {
-		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)
 
-		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool.SqlxDB(), false, wallets[0].ID)
-		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool.SqlxDB(), true, wallets[1].ID)
+		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, false, wallets[0].ID)
+		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, true, wallets[1].ID)
 
 		findDisabled := false
 		actual, err := walletModel.FindWallets(ctx, &findDisabled)
@@ -176,7 +176,7 @@ func Test_WalletModelFindWallets(t *testing.T) {
 	})
 
 	t.Run("returns empty array when no wallets", func(t *testing.T) {
-		DeleteAllWalletFixtures(t, ctx, dbConnectionPool.SqlxDB())
+		DeleteAllWalletFixtures(t, ctx, dbConnectionPool)
 		actual, err := walletModel.FindWallets(ctx, nil)
 		require.NoError(t, err)
 
@@ -396,7 +396,7 @@ func Test_WalletModelGetOrCreate(t *testing.T) {
 
 	t.Run("returns error wallet name already been used", func(t *testing.T) {
 		DeleteAllWalletFixtures(t, ctx, dbConnectionPool)
-		CreateWalletFixture(t, ctx, dbConnectionPool.SqlxDB(),
+		CreateWalletFixture(t, ctx, dbConnectionPool,
 			"test_wallet",
 			"https://www.new_wallet.com",
 			"www.new_wallet.com",
@@ -429,7 +429,7 @@ func Test_WalletModelGetOrCreate(t *testing.T) {
 
 	t.Run("returns wallet successfully", func(t *testing.T) {
 		DeleteAllWalletFixtures(t, ctx, dbConnectionPool)
-		expected := CreateWalletFixture(t, ctx, dbConnectionPool.SqlxDB(),
+		expected := CreateWalletFixture(t, ctx, dbConnectionPool,
 			"test_wallet",
 			"https://www.test_wallet.com",
 			"www.test_wallet.com",
@@ -463,7 +463,7 @@ func Test_WalletModelGetAssets(t *testing.T) {
 
 	t.Run("return empty when wallet doesn't have assets", func(t *testing.T) {
 		DeleteAllWalletFixtures(t, ctx, dbConnectionPool)
-		wallet := CreateWalletFixture(t, ctx, dbConnectionPool.SqlxDB(),
+		wallet := CreateWalletFixture(t, ctx, dbConnectionPool,
 			"NewWallet",
 			"https://newwallet.com",
 			"newwallet.com",
@@ -476,7 +476,7 @@ func Test_WalletModelGetAssets(t *testing.T) {
 
 	t.Run("return wallet's assets", func(t *testing.T) {
 		DeleteAllWalletFixtures(t, ctx, dbConnectionPool)
-		wallet := CreateWalletFixture(t, ctx, dbConnectionPool.SqlxDB(),
+		wallet := CreateWalletFixture(t, ctx, dbConnectionPool,
 			"NewWallet",
 			"https://newwallet.com",
 			"newwallet.com",
@@ -572,7 +572,7 @@ func Test_WalletModelUpdate(t *testing.T) {
 	_, err = walletModel.Update(ctx, "unknown", true)
 	assert.Equal(t, ErrRecordNotFound, err)
 
-	wallet := CreateWalletFixture(t, ctx, dbConnectionPool.SqlxDB(),
+	wallet := CreateWalletFixture(t, ctx, dbConnectionPool,
 		"NewWallet",
 		"https://newwallet.com",
 		"newwallet.com",

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -1379,34 +1379,6 @@ func Test_AssetHandler_submitChangeTrustTransaction_makeSurePreconditionsAreSetA
 		BaseFee: txnbuild.MinBaseFee * feeMultiplierInStroops,
 	}
 
-	t.Run("makes sure a non-empty precondition is used if none is explicitly set", func(t *testing.T) {
-		mocks := newAssetTestMock(t, distributionKP.Address())
-		mocks.Handler.GetPreconditionsFn = nil
-
-		txParams := txParamsWithoutPreconditions
-		txParams.Preconditions = defaultPreconditions
-		tx, err := txnbuild.NewTransaction(txParams)
-		require.NoError(t, err)
-
-		signedTx, err := tx.Sign(network.TestNetworkPassphrase, distributionKP)
-		require.NoError(t, err)
-
-		mocks.SignatureService.
-			On("SignStellarTransaction", ctx, mock.MatchedBy(matchPreconditionsTimeboundsFn(defaultPreconditions)), distributionKP.Address()).
-			Return(signedTx, nil).
-			Once()
-		defer mocks.SignatureService.AssertExpectations(t)
-
-		mocks.HorizonClientMock.
-			On("SubmitTransactionWithOptions", mock.MatchedBy(matchPreconditionsTimeboundsFn(defaultPreconditions)), horizonclient.SubmitTxOpts{SkipMemoRequiredCheck: true}).
-			Return(horizon.Transaction{}, nil).
-			Once()
-		defer mocks.HorizonClientMock.AssertExpectations(t)
-
-		err = mocks.Handler.submitChangeTrustTransaction(ctx, acc, []*txnbuild.ChangeTrust{changeTrustOp})
-		assert.NoError(t, err)
-	})
-
 	t.Run("makes sure a the precondition that was set is used", func(t *testing.T) {
 		mocks := newAssetTestMock(t, distributionKP.Address())
 		newPreconditions := txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(int64(rand.Intn(999999999)))}

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -43,7 +43,7 @@ func (r *RetryPaymentsRequest) validate() *httperror.HTTPError {
 func (p PaymentsHandler) GetPayment(w http.ResponseWriter, r *http.Request) {
 	payment_id := chi.URLParam(r, "id")
 
-	payment, err := p.Models.Payment.Get(r.Context(), payment_id, p.DBConnectionPool.SqlxDB())
+	payment, err := p.Models.Payment.Get(r.Context(), payment_id, p.DBConnectionPool)
 	if err != nil {
 		if errors.Is(data.ErrRecordNotFound, err) {
 			errorResponse := fmt.Sprintf("Cannot retrieve payment with ID: %s", payment_id)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1,7 +1,6 @@
 package serve
 
 import (
-	"context"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -420,17 +419,11 @@ func createAuthManager(dbConnectionPool db.DBConnectionPool, ec256PublicKey, ec2
 
 	passwordEncrypter := auth.NewDefaultPasswordEncrypter()
 
-	ctx := context.Background()
-	dbcp, err := dbConnectionPool.SqlDB(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting sql db from db connection pool: %w", err)
-	}
-	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbcp, dbConnectionPool.DriverName())
 	authManager := auth.NewAuthManager(
-		auth.WithDefaultAuthenticatorOption(authDBConnectionPool, passwordEncrypter, time.Hour*time.Duration(resetTokenExpirationHours)),
+		auth.WithDefaultAuthenticatorOption(dbConnectionPool, passwordEncrypter, time.Hour*time.Duration(resetTokenExpirationHours)),
 		auth.WithDefaultJWTManagerOption(ec256PublicKey, ec256PrivateKey),
-		auth.WithDefaultRoleManagerOption(authDBConnectionPool, data.OwnerUserRole.String()),
-		auth.WithDefaultMFAManagerOption(authDBConnectionPool),
+		auth.WithDefaultRoleManagerOption(dbConnectionPool, data.OwnerUserRole.String()),
+		auth.WithDefaultMFAManagerOption(dbConnectionPool),
 	)
 
 	return authManager, nil

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -419,7 +420,8 @@ func createAuthManager(dbConnectionPool db.DBConnectionPool, ec256PublicKey, ec2
 
 	passwordEncrypter := auth.NewDefaultPasswordEncrypter()
 
-	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbConnectionPool.SqlDB(), dbConnectionPool.DriverName())
+	ctx := context.Background()
+	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbConnectionPool.SqlDB(ctx), dbConnectionPool.DriverName())
 	authManager := auth.NewAuthManager(
 		auth.WithDefaultAuthenticatorOption(authDBConnectionPool, passwordEncrypter, time.Hour*time.Duration(resetTokenExpirationHours)),
 		auth.WithDefaultJWTManagerOption(ec256PublicKey, ec256PrivateKey),

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -421,7 +421,11 @@ func createAuthManager(dbConnectionPool db.DBConnectionPool, ec256PublicKey, ec2
 	passwordEncrypter := auth.NewDefaultPasswordEncrypter()
 
 	ctx := context.Background()
-	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbConnectionPool.SqlDB(ctx), dbConnectionPool.DriverName())
+	dbcp, err := dbConnectionPool.SqlDB(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting sql db from db connection pool: %w", err)
+	}
+	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbcp, dbConnectionPool.DriverName())
 	authManager := auth.NewAuthManager(
 		auth.WithDefaultAuthenticatorOption(authDBConnectionPool, passwordEncrypter, time.Hour*time.Duration(resetTokenExpirationHours)),
 		auth.WithDefaultJWTManagerOption(ec256PublicKey, ec256PrivateKey),

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -338,7 +338,9 @@ func Test_createAuthManager(t *testing.T) {
 
 	// creates the expected auth manager
 	passwordEncrypter := auth.NewDefaultPasswordEncrypter()
-	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbConnectionPool.SqlDB(context.Background()), dbConnectionPool.DriverName())
+	dbcp, err := dbConnectionPool.SqlDB(context.Background())
+	require.NoError(t, err)
+	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbcp, dbConnectionPool.DriverName())
 	wantAuthManager := auth.NewAuthManager(
 		auth.WithDefaultAuthenticatorOption(authDBConnectionPool, passwordEncrypter, time.Hour*time.Duration(1)),
 		auth.WithDefaultJWTManagerOption(publicKeyStr, privateKeyStr),

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -337,7 +338,7 @@ func Test_createAuthManager(t *testing.T) {
 
 	// creates the expected auth manager
 	passwordEncrypter := auth.NewDefaultPasswordEncrypter()
-	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbConnectionPool.SqlDB(), dbConnectionPool.DriverName())
+	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbConnectionPool.SqlDB(context.Background()), dbConnectionPool.DriverName())
 	wantAuthManager := auth.NewAuthManager(
 		auth.WithDefaultAuthenticatorOption(authDBConnectionPool, passwordEncrypter, time.Hour*time.Duration(1)),
 		auth.WithDefaultJWTManagerOption(publicKeyStr, privateKeyStr),

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -1,7 +1,6 @@
 package serve
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -338,14 +337,11 @@ func Test_createAuthManager(t *testing.T) {
 
 	// creates the expected auth manager
 	passwordEncrypter := auth.NewDefaultPasswordEncrypter()
-	dbcp, err := dbConnectionPool.SqlDB(context.Background())
-	require.NoError(t, err)
-	authDBConnectionPool := auth.DBConnectionPoolFromSqlDB(dbcp, dbConnectionPool.DriverName())
 	wantAuthManager := auth.NewAuthManager(
-		auth.WithDefaultAuthenticatorOption(authDBConnectionPool, passwordEncrypter, time.Hour*time.Duration(1)),
+		auth.WithDefaultAuthenticatorOption(dbConnectionPool, passwordEncrypter, time.Hour*time.Duration(1)),
 		auth.WithDefaultJWTManagerOption(publicKeyStr, privateKeyStr),
-		auth.WithDefaultRoleManagerOption(authDBConnectionPool, data.OwnerUserRole.String()),
-		auth.WithDefaultMFAManagerOption(authDBConnectionPool),
+		auth.WithDefaultRoleManagerOption(dbConnectionPool, data.OwnerUserRole.String()),
+		auth.WithDefaultMFAManagerOption(dbConnectionPool),
 	)
 
 	testCases := []struct {

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -2,12 +2,9 @@ package auth
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"time"
-
-	"github.com/stellar/stellar-disbursement-platform-backend/db"
 )
 
 var ErrInvalidToken = errors.New("invalid token")
@@ -33,13 +30,6 @@ type AuthManager interface {
 	MFADeviceRemembered(ctx context.Context, deviceID, userID string) (bool, error)
 	GetMFACode(ctx context.Context, deviceID, userID string) (string, error)
 	AuthenticateMFA(ctx context.Context, deviceID, code string, rememberMe bool) (string, error)
-}
-
-// DBConnectionPoolFromSqlDB returns a new DBConnectionPool wrapper for a PRE-EXISTING *sql.DB. The driverName of the
-// original database is required for named query support. ATTENTION: this will not start a new connection pool, just
-// create a wrap aroung the pre-existing connection pool.
-func DBConnectionPoolFromSqlDB(sqlDB *sql.DB, driverName string) db.DBConnectionPool {
-	return db.DBConnectionPoolFromSqlDB(sqlDB, driverName)
 }
 
 func (am *defaultAuthManager) Authenticate(ctx context.Context, email, pass string) (string, error) {

--- a/stellar-multitenant/pkg/cli/add_tenants.go
+++ b/stellar-multitenant/pkg/cli/add_tenants.go
@@ -124,7 +124,8 @@ func validateTenantNameArg(cmd *cobra.Command, args []string) error {
 
 func executeAddTenant(
 	ctx context.Context, dbURL, tenantName, userFirstName, userLastName, userEmail,
-	organizationName, uiBaseURL, networkType string, messengerClient message.MessengerClient) error {
+	organizationName, uiBaseURL, networkType string, messengerClient message.MessengerClient,
+) error {
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbURL)
 	if err != nil {
 		return fmt.Errorf("opening database connection pool: %w", err)

--- a/stellar-multitenant/pkg/cli/add_tenants_test.go
+++ b/stellar-multitenant/pkg/cli/add_tenants_test.go
@@ -242,7 +242,9 @@ Flags:
 
 		// Connecting to the new schema
 		schemaName := fmt.Sprintf("sdp_%s", tenantName)
-		u, err := url.Parse(dbConnectionPool.DSN())
+		dataSourceName, err := dbConnectionPool.DSN(ctx)
+		require.NoError(t, err)
+		u, err := url.Parse(dataSourceName)
 		require.NoError(t, err)
 		uq := u.Query()
 		uq.Set("search_path", schemaName)
@@ -309,7 +311,9 @@ Flags:
 
 		// Connecting to the new schema
 		schemaName := fmt.Sprintf("sdp_%s", tenantName)
-		u, err := url.Parse(dbConnectionPool.DSN())
+		dataSourceName, err := dbConnectionPool.DSN(ctx)
+		require.NoError(t, err)
+		u, err := url.Parse(dataSourceName)
 		require.NoError(t, err)
 		uq := u.Query()
 		uq.Set("search_path", schemaName)

--- a/stellar-multitenant/pkg/router/multitenant_data_source_router.go
+++ b/stellar-multitenant/pkg/router/multitenant_data_source_router.go
@@ -1,0 +1,104 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+)
+
+var (
+	ErrTenantNotFoundInContext = errors.New("tenant not found in context")
+	ErrNoDataSourcesAvailable  = errors.New("no data sources are available")
+)
+
+type tenantContextKey struct{}
+
+type MultiTenantDataSourceRouter struct {
+	dataSources   sync.Map
+	tenantManager *tenant.Manager
+}
+
+func NewMultiTenantDataSourceRouter(tenantManager *tenant.Manager) *MultiTenantDataSourceRouter {
+	return &MultiTenantDataSourceRouter{
+		tenantManager: tenantManager,
+	}
+}
+
+func (m *MultiTenantDataSourceRouter) GetDataSource(ctx context.Context) (db.DBConnectionPool, error) {
+	tenant, ok := GetTenantFromContext(ctx)
+	if !ok {
+		return nil, ErrTenantNotFoundInContext
+	}
+
+	return m.GetDataSourceForTenant(ctx, *tenant)
+}
+
+// GetDataSourceForTenant returns the database connection pool for the given tenant if it exists, otherwise create a new one.
+func (m *MultiTenantDataSourceRouter) GetDataSourceForTenant(ctx context.Context, tenant tenant.Tenant) (db.DBConnectionPool, error) {
+	value, exists := m.dataSources.Load(tenant.ID)
+	if exists {
+		return value.(db.DBConnectionPool), nil
+	}
+
+	u, err := m.tenantManager.GetDSNForTenant(ctx, tenant.Name)
+	if err != nil || u == "" {
+		return nil, fmt.Errorf("getting database DSN for tenant %s: %w", tenant.ID, err)
+	}
+
+	dbcp, err := db.OpenDBConnectionPool(u)
+	if err != nil {
+		return nil, fmt.Errorf("opening database connection pool for tenant %s: %w", tenant.ID, err)
+	}
+
+	// Store the new pool, but if another goroutine already stored a pool for this tenant,
+	// then use the existing one and close the newly created one.
+	actualValue, loaded := m.dataSources.LoadOrStore(tenant.ID, dbcp)
+	if loaded {
+		dbcp.Close() // Close the newly created pool if we're not using it
+		return actualValue.(db.DBConnectionPool), nil
+	}
+
+	return dbcp, nil
+}
+
+// GetAllDataSources returns all the database connection pools.
+func (m *MultiTenantDataSourceRouter) GetAllDataSources() ([]db.DBConnectionPool, error) {
+	var pools []db.DBConnectionPool
+	m.dataSources.Range(func(_, value interface{}) bool {
+		pools = append(pools, value.(db.DBConnectionPool))
+		return true
+	})
+	return pools, nil
+}
+
+func (m *MultiTenantDataSourceRouter) AnyDataSource() (db.DBConnectionPool, error) {
+	var anyDBCP db.DBConnectionPool
+	var found bool
+	m.dataSources.Range(func(_, value interface{}) bool {
+		anyDBCP = value.(db.DBConnectionPool)
+		found = true
+		return false
+	})
+	if !found {
+		return nil, ErrNoDataSourcesAvailable
+	}
+	return anyDBCP, nil
+}
+
+// SetTenantInContext stores the tenant information in the context.
+func SetTenantInContext(ctx context.Context, tenant *tenant.Tenant) context.Context {
+	return context.WithValue(ctx, tenantContextKey{}, tenant)
+}
+
+// GetTenantFromContext retrieves the tenant information from the context.
+func GetTenantFromContext(ctx context.Context) (*tenant.Tenant, bool) {
+	tenant, ok := ctx.Value(tenantContextKey{}).(*tenant.Tenant)
+	return tenant, ok
+}
+
+// make sure *MultiTenantDataSourceRouter implements DataSourceRouter:
+var _ db.DataSourceRouter = (*MultiTenantDataSourceRouter)(nil)

--- a/stellar-multitenant/pkg/router/multitenant_data_source_router_test.go
+++ b/stellar-multitenant/pkg/router/multitenant_data_source_router_test.go
@@ -1,0 +1,127 @@
+package router
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiTenantDataSourceRouter_GetDataSource(t *testing.T) {
+	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	defer dbt.Close()
+
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	tenantManager := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
+
+	router := NewMultiTenantDataSourceRouter(tenantManager)
+
+	ctx := context.Background()
+
+	t.Run("error tenant not found in context", func(t *testing.T) {
+		dbcp, err := router.GetDataSource(ctx)
+		require.Nil(t, dbcp)
+		require.EqualError(t, err, ErrTenantNotFoundInContext.Error())
+	})
+
+	t.Run("successfully getting data source", func(t *testing.T) {
+		// Create a new context with tenant information
+		tenantInfo := &tenant.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "aid-org-1"}
+		ctx = SetTenantInContext(context.Background(), tenantInfo)
+
+		dbcp, err := router.GetDataSource(ctx)
+		require.NotNil(t, dbcp)
+		require.NoError(t, err)
+		defer dbcp.Close()
+
+		dsn, err := dbcp.DSN(ctx)
+		require.NoError(t, err)
+		require.Contains(t, dsn, tenantInfo.Name)
+	})
+}
+
+func TestMultiTenantDataSourceRouter_GetAllDataSources(t *testing.T) {
+	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	defer dbt.Close()
+
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	tenantManager := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
+
+	router := NewMultiTenantDataSourceRouter(tenantManager)
+
+	t.Run("empty data sources", func(t *testing.T) {
+		dbcps, err := router.GetAllDataSources()
+		require.NoError(t, err)
+		require.Nil(t, dbcps)
+		require.Empty(t, dbcps)
+	})
+
+	t.Run("successfully getting data sources", func(t *testing.T) {
+		// Store DB Connection Pool for aid-org-1
+		tenantInfo := &tenant.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "aid-org-1"}
+		ctx := SetTenantInContext(context.Background(), tenantInfo)
+		dbcp1, err := router.GetDataSource(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, dbcp1)
+		defer dbcp1.Close()
+
+		// Store DB Connection Pool for aid-org-2
+		tenantInfo = &tenant.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e45", Name: "aid-org-2"}
+		ctx = SetTenantInContext(context.Background(), tenantInfo)
+		dbcp2, err := router.GetDataSource(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, dbcp2)
+		defer dbcp2.Close()
+
+		dbcps, err := router.GetAllDataSources()
+		require.NotNil(t, dbcps)
+		require.NoError(t, err)
+
+		require.Equal(t, 2, len(dbcps))
+		require.Contains(t, dbcps, dbcp1)
+		require.Contains(t, dbcps, dbcp2)
+	})
+}
+
+func TestMultiTenantDataSourceRouter_AnyDataSource(t *testing.T) {
+	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	defer dbt.Close()
+
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	tenantManager := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
+
+	router := NewMultiTenantDataSourceRouter(tenantManager)
+
+	t.Run("no data sources available", func(t *testing.T) {
+		dbcp, err := router.AnyDataSource()
+		require.Nil(t, dbcp)
+		require.EqualError(t, err, ErrNoDataSourcesAvailable.Error())
+	})
+
+	t.Run("successfully getting data source", func(t *testing.T) {
+		// Store DB Connection Pool for aid-org-1
+		tenantInfo := &tenant.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "aid-org-1"}
+		ctx := SetTenantInContext(context.Background(), tenantInfo)
+		dbcp1, err := router.GetDataSource(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, dbcp1)
+		defer dbcp1.Close()
+
+		dbcp, err := router.AnyDataSource()
+		require.NotNil(t, dbcp)
+		require.NoError(t, err)
+		require.Equal(t, dbcp1, dbcp)
+	})
+}

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -50,33 +50,26 @@ func (m *Manager) ProvisionNewTenant(
 		return nil, fmt.Errorf("creating a new database schema: %w", err)
 	}
 
-	dataSourceName, err := m.db.DSN(ctx)
+	u, err := m.GetDSNForTenant(ctx, t.Name)
 	if err != nil {
-		return nil, fmt.Errorf("getting database DSN: %w", err)
+		return nil, fmt.Errorf("getting database DSN for tenant %s: %w", t.Name, err)
 	}
-	u, err := url.Parse(dataSourceName)
-	if err != nil {
-		return nil, fmt.Errorf("parsing database DSN: %w", err)
-	}
-	q := u.Query()
-	q.Set("search_path", schemaName)
-	u.RawQuery = q.Encode()
 
 	// Applying migrations
 	log.Infof("applying SDP migrations on the tenant %s schema", t.Name)
-	err = m.RunMigrationsForTenant(ctx, t, u.String(), migrate.Up, 0, sdpmigrations.FS, db.StellarSDPMigrationsTableName)
+	err = m.RunMigrationsForTenant(ctx, t, u, migrate.Up, 0, sdpmigrations.FS, db.StellarSDPMigrationsTableName)
 	if err != nil {
 		return nil, fmt.Errorf("applying SDP migrations: %w", err)
 	}
 
 	log.Infof("applying stellar-auth migrations on the tenant %s schema", t.Name)
-	err = m.RunMigrationsForTenant(ctx, t, u.String(), migrate.Up, 0, authmigrations.FS, db.StellarAuthMigrationsTableName)
+	err = m.RunMigrationsForTenant(ctx, t, u, migrate.Up, 0, authmigrations.FS, db.StellarAuthMigrationsTableName)
 	if err != nil {
 		return nil, fmt.Errorf("applying stellar-auth migrations: %w", err)
 	}
 
 	// Connecting to the tenant database schema
-	tenantSchemaConnectionPool, err := db.OpenDBConnectionPool(u.String())
+	tenantSchemaConnectionPool, err := db.OpenDBConnectionPool(u)
 	if err != nil {
 		return nil, fmt.Errorf("opening database connection on tenant schema: %w", err)
 	}
@@ -126,6 +119,34 @@ func (m *Manager) ProvisionNewTenant(
 	}
 
 	return t, nil
+}
+
+func (m *Manager) GetDSNForTenant(ctx context.Context, tenantName string) (string, error) {
+	dataSourceName, err := m.db.DSN(ctx)
+	if err != nil {
+		return "", fmt.Errorf("getting database DSN: %w", err)
+	}
+	u, err := url.Parse(dataSourceName)
+	if err != nil {
+		return "", fmt.Errorf("parsing database DSN: %w", err)
+	}
+	q := u.Query()
+	schemaName := fmt.Sprintf("sdp_%s", tenantName)
+	q.Set("search_path", schemaName)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func (m *Manager) GetTenantByName(ctx context.Context, name string) (*Tenant, error) {
+	const q = "SELECT * FROM tenants WHERE name = $1"
+	var t Tenant
+	if err := m.db.GetContext(ctx, &t, q, name); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrTenantDoesNotExist
+		}
+		return nil, fmt.Errorf("getting tenant %s: %w", name, err)
+	}
+	return &t, nil
 }
 
 func (m *Manager) AddTenant(ctx context.Context, name string) (*Tenant, error) {

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -50,7 +50,10 @@ func (m *Manager) ProvisionNewTenant(
 		return nil, fmt.Errorf("creating a new database schema: %w", err)
 	}
 
-	dataSourceName := m.db.DSN()
+	dataSourceName, err := m.db.DSN(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting database DSN: %w", err)
+	}
 	u, err := url.Parse(dataSourceName)
 	if err != nil {
 		return nil, fmt.Errorf("parsing database DSN: %w", err)


### PR DESCRIPTION
### What

#### ➕ Additions
* Additions are separated from refactors and done in this commit 7eb0cc54182886f535946501c2292cc4748d0dbb
* Changes to `db` package
   * add `DataSourceRouter` interface that will be used for routing users to the correct datasource using the context
   * add `SQLExecutorWithRouter` a SQLExecutor that leverages the router to direct users to the correct connection pool
   * add `ConnectionPoolWithRouter` a ConnectionPool that uses routing. 

* Changes to `stellar-multitenant` 
   * add `MultiTenantDataSourceRouter` an implementation of `DataSourceRouter` that uses tenant information to perform routing to the correct datasource. 

#### 🔨 Refactors
* Added `ctx` to interfaces and implementations in the `db` package to prepare the ground for multi-tenancy. These changes are done in separate commits to help with reviews 👀
    * d6dfcc8a4f6bc2673c1703d905cd698e693fa123
    * 22e1be8f35cd13eb0e27312c5a8d801196158f2a
    * 0cc8bbab9c21c3901048fe760e88af86c3e40cfb

 

### Why
This prepares the ground work for making the SDP database connections tenant-aware. 
