### PR TITLE
[SDP-953] cmd: change the migrate CLI to be tenant aware

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -16,6 +16,7 @@ import (
 	sdpmigrations "github.com/stellar/stellar-disbursement-platform-backend/db/migrations/sdp-migrations"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	tenantcli "github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/cli"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
@@ -125,8 +126,27 @@ func (c *DatabaseCommand) Command() *cobra.Command {
 	}
 	stellarAuthMigrateCmd.AddCommand(authMigrateCmd)
 
+	tenantMigrateCmd := &cobra.Command{
+		Use:   "tenant",
+		Short: "Stellar Multi-Tenant migration helpers",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cmd.Parent().PersistentPreRun != nil {
+				cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cmd.Help(); err != nil {
+				log.Fatalf("Error calling help command: %s", err.Error())
+			}
+		},
+	}
+	tenantMigrateCmd.AddCommand(tenantcli.MigrateCmd(dbConfigOptionFlagName))
+
 	// Add `auth` as a sub-command to `db`. Usage: db auth migrate up
 	cmd.AddCommand(stellarAuthMigrateCmd)
+
+	// Add `tenant` as a sub-command to `db`. Usage: db tenant migrate up
+	cmd.AddCommand(tenantMigrateCmd)
 
 	if err := configOptions.Init(cmd); err != nil {
 		log.Fatalf("initializing config options: %v", err)

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -1,25 +1,64 @@
 package cmd
 
 import (
+	"context"
+	"embed"
 	"fmt"
+	"go/types"
 	"strconv"
 
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/spf13/cobra"
+	"github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
-	migrations "github.com/stellar/stellar-disbursement-platform-backend/db/migrations/sdp-migrations"
+	authmigrations "github.com/stellar/stellar-disbursement-platform-backend/db/migrations/auth-migrations"
+	sdpmigrations "github.com/stellar/stellar-disbursement-platform-backend/db/migrations/sdp-migrations"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/cli"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
+
+type databaseCommandConfigOptions struct {
+	All      bool
+	TenantID string
+}
 
 type DatabaseCommand struct{}
 
 func (c *DatabaseCommand) Command() *cobra.Command {
+	opts := databaseCommandConfigOptions{}
+
+	configOptions := config.ConfigOptions{
+		{
+			Name:        "all",
+			Usage:       "Apply the migrations to all tenants.",
+			OptType:     types.Bool,
+			FlagDefault: false,
+			ConfigKey:   &opts.All,
+			Required:    false,
+		},
+		{
+			Name:      "tenant-id",
+			Usage:     "The tenant ID where the migrations will be applied.",
+			OptType:   types.String,
+			ConfigKey: &opts.TenantID,
+			Required:  false,
+		},
+	}
+
 	cmd := &cobra.Command{
 		Use:   "db",
 		Short: "Database related commands",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cmd.Parent().PersistentPreRun != nil {
+				cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			}
+			configOptions.Require()
+			if err := configOptions.SetValues(); err != nil {
+				log.Fatalf("Error setting values of config options: %s", err.Error())
+			}
+		},
 		Run: func(cmd *cobra.Command, _ []string) {
 			err := cmd.Help()
 			if err != nil {
@@ -28,57 +67,18 @@ func (c *DatabaseCommand) Command() *cobra.Command {
 		},
 	}
 
-	migrateCmd := &cobra.Command{
-		Use:   "migrate",
-		Short: "Schema migration helpers",
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				log.Fatalf("Error calling help command: %s", err.Error())
-			}
-		},
-	}
-	cmd.AddCommand(migrateCmd)
+	// migrate CMD
+	sdpMigrateCmd := c.migrateCmd()
+	authMigrateCmd := c.migrateCmd()
+	cmd.AddCommand(sdpMigrateCmd)
 
-	migrateUp := &cobra.Command{
-		Use:   "up",
-		Short: "Migrates database up [count]",
-		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			var count int
-			if len(args) > 0 {
-				var err error
-				count, err = strconv.Atoi(args[0])
-				if err != nil {
-					log.Fatalf("Invalid [count] argument: %s", args[0])
-				}
-			}
+	// migrate Up CMD
+	sdpMigrateCmd.AddCommand(c.migrateUpCmd(&opts))
+	authMigrateCmd.AddCommand(c.migrateUpCmd(&opts))
 
-			err := c.migrate(migrate.Up, count)
-			if err != nil {
-				log.Fatalf("Error migrating database Up: %s", err.Error())
-			}
-		},
-	}
-	migrateCmd.AddCommand(migrateUp)
-
-	migrateDown := &cobra.Command{
-		Use:   "down [count]",
-		Short: "Migrates database down [count] migrations",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			count, err := strconv.Atoi(args[0])
-			if err != nil {
-				log.Fatalf("Invalid [count] argument: %s", args[0])
-			}
-
-			err = c.migrate(migrate.Down, count)
-			if err != nil {
-				log.Fatalf("Error migrating database Down: %s", err.Error())
-			}
-		},
-	}
-	migrateCmd.AddCommand(migrateDown)
+	// migrate Down CMD
+	sdpMigrateCmd.AddCommand(c.migrateDownCmd(&opts))
+	authMigrateCmd.AddCommand(c.migrateDownCmd(&opts))
 
 	setupForNetwork := &cobra.Command{
 		Use:   "setup-for-network",
@@ -110,25 +110,148 @@ func (c *DatabaseCommand) Command() *cobra.Command {
 	cmd.AddCommand(setupForNetwork)
 
 	stellarAuthMigrateCmd := &cobra.Command{
-		Use:     "auth",
-		Short:   "Stellar Auth schema migration helpers",
-		Example: "stellarauth migrate [direction] [count]",
+		Use:   "auth",
+		Short: "Stellar Auth schema migration helpers",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cmd.Parent().PersistentPreRun != nil {
+				cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {
 				log.Fatalf("Error calling help command: %s", err.Error())
 			}
 		},
 	}
-	stellarAuthMigrateCmd.AddCommand(cli.MigrateCmd(dbConfigOptionFlagName))
+	stellarAuthMigrateCmd.AddCommand(authMigrateCmd)
 
 	// Add `auth` as a sub-command to `db`. Usage: db auth migrate up
 	cmd.AddCommand(stellarAuthMigrateCmd)
 
+	if err := configOptions.Init(cmd); err != nil {
+		log.Fatalf("initializing config options: %v", err)
+	}
+
 	return cmd
 }
 
-func (c *DatabaseCommand) migrate(dir migrate.MigrationDirection, count int) error {
-	numMigrationsRun, err := db.Migrate(globalOptions.databaseURL, dir, count, migrations.FS, db.StellarSDPMigrationsTableName)
+func (c *DatabaseCommand) migrateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "migrate",
+		Short: "Schema migration helpers",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cmd.Parent().PersistentPreRun != nil {
+				cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			}
+		},
+		Run: func(cmd *cobra.Command, _ []string) {
+			err := cmd.Help()
+			if err != nil {
+				log.Fatalf("Error calling help command: %s", err.Error())
+			}
+		},
+	}
+}
+
+func (c *DatabaseCommand) migrateUpCmd(opts *databaseCommandConfigOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "up",
+		Short: "Migrates database up [count]",
+		Args:  cobra.MaximumNArgs(1),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cmd.Parent().PersistentPreRun != nil {
+				cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			var count int
+			if len(args) > 0 {
+				var err error
+				count, err = strconv.Atoi(args[0])
+				if err != nil {
+					log.Fatalf("Invalid [count] argument: %s", args[0])
+				}
+			}
+
+			migrationFiles := sdpmigrations.FS
+			migrationTableName := db.StellarSDPMigrationsTableName
+
+			migrateCmd := cmd.Parent()
+			if migrateCmd.Parent().Name() == "auth" {
+				migrationFiles = authmigrations.FS
+				migrationTableName = db.StellarAuthMigrationsTableName
+			}
+
+			if err := c.executeMigrate(cmd.Context(), opts, migrate.Up, count, migrationFiles, migrationTableName); err != nil {
+				log.Fatalf("Error executing migrate up: %v", err)
+			}
+		},
+	}
+}
+
+func (c *DatabaseCommand) migrateDownCmd(opts *databaseCommandConfigOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "down [count]",
+		Short: "Migrates database down [count] migrations",
+		Args:  cobra.ExactArgs(1),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cmd.Parent().PersistentPreRun != nil {
+				cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			count, err := strconv.Atoi(args[0])
+			if err != nil {
+				log.Fatalf("Invalid [count] argument: %s", args[0])
+			}
+
+			migrationFiles := sdpmigrations.FS
+			migrationTableName := db.StellarSDPMigrationsTableName
+
+			migrateCmd := cmd.Parent()
+			if migrateCmd.Parent().Name() == "auth" {
+				migrationFiles = authmigrations.FS
+				migrationTableName = db.StellarAuthMigrationsTableName
+			}
+
+			if err := c.executeMigrate(cmd.Context(), opts, migrate.Down, count, migrationFiles, migrationTableName); err != nil {
+				log.Fatalf("Error executing migrate down: %v", err)
+			}
+		},
+	}
+}
+
+func (c *DatabaseCommand) executeMigrate(ctx context.Context, opts *databaseCommandConfigOptions, dir migrate.MigrationDirection, count int, migrationFiles embed.FS, tableName db.MigrationTableName) error {
+	if err := c.validateFlags(opts); err != nil {
+		log.Fatal(err.Error())
+	}
+
+	tenantsDSNMap, err := c.getTenantsDSN(ctx, globalOptions.databaseURL)
+	if err != nil {
+		return fmt.Errorf("getting tenants schemas: %w", err)
+	}
+
+	if opts.TenantID != "" {
+		if dsn, ok := tenantsDSNMap[opts.TenantID]; ok {
+			tenantsDSNMap = map[string]string{opts.TenantID: dsn}
+		} else {
+			log.Fatalf("tenant ID %s does not exist", opts.TenantID)
+		}
+	}
+
+	for tenantID, dsn := range tenantsDSNMap {
+		log.Infof("applying migrations on tenant ID %s", tenantID)
+		err = c.applyMigrations(dsn, dir, count, migrationFiles, tableName)
+		if err != nil {
+			log.Fatalf("Error migrating database Up: %s", err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (c *DatabaseCommand) applyMigrations(dbURL string, dir migrate.MigrationDirection, count int, migrationFiles embed.FS, tableName db.MigrationTableName) error {
+	numMigrationsRun, err := db.Migrate(dbURL, dir, count, migrationFiles, tableName)
 	if err != nil {
 		return fmt.Errorf("migrating database: %w", err)
 	}
@@ -139,4 +262,39 @@ func (c *DatabaseCommand) migrate(dir migrate.MigrationDirection, count int) err
 		log.Infof("Successfully applied %d migrations.", numMigrationsRun)
 	}
 	return nil
+}
+
+func (c *DatabaseCommand) validateFlags(opts *databaseCommandConfigOptions) error {
+	if !opts.All && opts.TenantID == "" {
+		return fmt.Errorf(
+			"invalid config. Please specify --all to run the migrations for all tenants " +
+				"or specify --tenant-id to run the migrations to a specific tenant",
+		)
+	}
+	return nil
+}
+
+func (c *DatabaseCommand) getTenantsDSN(ctx context.Context, dbURL string) (map[string]string, error) {
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbURL)
+	if err != nil {
+		return nil, fmt.Errorf("opening database connection pool: %w", err)
+	}
+	defer dbConnectionPool.Close()
+
+	m := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
+	tenants, err := m.GetAllTenants(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting all tenants: %w", err)
+	}
+
+	tenantsDSNMap := make(map[string]string, len(tenants))
+	for _, tnt := range tenants {
+		dsn, err := m.GetDSNForTenant(ctx, tnt.Name)
+		if err != nil {
+			return nil, fmt.Errorf("getting DSN for tenant %s: %w", tnt.Name, err)
+		}
+		tenantsDSNMap[tnt.ID] = dsn
+	}
+
+	return tenantsDSNMap, nil
 }

--- a/cmd/db_test.go
+++ b/cmd/db_test.go
@@ -453,8 +453,8 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 
 	testnetUSDCIssuer := keypair.MustRandom().Address()
 	clearTenantTables := func(t *testing.T, ctx context.Context, tenantSchemaConnectionPool db.DBConnectionPool) {
-		models, err := data.NewModels(tenantSchemaConnectionPool)
-		require.NoError(t, err)
+		models, mErr := data.NewModels(tenantSchemaConnectionPool)
+		require.NoError(t, mErr)
 
 		// Assets
 		data.DeleteAllWalletFixtures(t, ctx, tenantSchemaConnectionPool)
@@ -462,8 +462,8 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 
 		data.CreateAssetFixture(t, ctx, tenantSchemaConnectionPool, "USDC", testnetUSDCIssuer)
 
-		assets, err := models.Assets.GetAll(ctx)
-		require.NoError(t, err)
+		assets, aErr := models.Assets.GetAll(ctx)
+		require.NoError(t, aErr)
 
 		assert.Len(t, assets, 1)
 		assert.Equal(t, "USDC", assets[0].Code)
@@ -472,8 +472,8 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 		// Wallets
 		data.CreateWalletFixture(t, ctx, tenantSchemaConnectionPool, "Vibrant Assist", "https://vibrantapp.com", "api-dev.vibrantapp.com", "https://vibrantapp.com/sdp-dev")
 
-		wallets, err := models.Wallets.GetAll(ctx)
-		require.NoError(t, err)
+		wallets, wErr := models.Wallets.GetAll(ctx)
+		require.NoError(t, wErr)
 
 		assert.Len(t, wallets, 1)
 		assert.Equal(t, "Vibrant Assist", wallets[0].Name)
@@ -506,12 +506,12 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 		require.NoError(t, err)
 
 		// Tenant 1
-		models, err := data.NewModels(tenant1SchemaConnectionPool)
-		require.NoError(t, err)
+		models, mErr := data.NewModels(tenant1SchemaConnectionPool)
+		require.NoError(t, mErr)
 
 		// Validating assets
-		assets, err := models.Assets.GetAll(ctx)
-		require.NoError(t, err)
+		assets, aErr := models.Assets.GetAll(ctx)
+		require.NoError(t, aErr)
 
 		assert.Len(t, assets, 2)
 		assert.Equal(t, "USDC", assets[0].Code)
@@ -521,8 +521,8 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 		assert.Empty(t, assets[1].Issuer)
 
 		// Validating wallets
-		wallets, err := models.Wallets.GetAll(ctx)
-		require.NoError(t, err)
+		wallets, wErr := models.Wallets.GetAll(ctx)
+		require.NoError(t, wErr)
 
 		assert.Len(t, wallets, 2)
 		// assert.Equal(t, "Beans App", wallets[0].Name)

--- a/cmd/db_test.go
+++ b/cmd/db_test.go
@@ -14,12 +14,36 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func getMigrationsApplied(t *testing.T, ctx context.Context, db db.DBConnectionPool) []string {
+func getSDPMigrationsApplied(t *testing.T, ctx context.Context, db db.DBConnectionPool) []string {
+	t.Helper()
+
 	rows, err := db.QueryContext(ctx, "SELECT id FROM gorp_migrations")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	ids := []string{}
+	for rows.Next() {
+		var id string
+		err := rows.Scan(&id)
+		require.NoError(t, err)
+
+		ids = append(ids, id)
+	}
+
+	require.NoError(t, rows.Err())
+
+	return ids
+}
+
+func getAuthMigrationsApplied(t *testing.T, ctx context.Context, db db.DBConnectionPool) []string {
+	t.Helper()
+
+	rows, err := db.QueryContext(ctx, "SELECT id FROM auth_migrations")
 	require.NoError(t, err)
 	defer rows.Close()
 
@@ -53,7 +77,9 @@ func Test_DatabaseCommand_db_help(t *testing.T) {
 		"auth              Stellar Auth schema migration helpers",
 		"migrate           Schema migration helpers",
 		"setup-for-network Set up the assets and wallets registered in the database based on the network passphrase.",
-		"-h, --help   help for db",
+		"--all                Apply the migrations to all tenants. (ALL)",
+		"-h, --help               help for db",
+		"--tenant-id string   The tenant ID where the migrations will be applied. (TENANT_ID)",
 		`--base-url string             The SDP backend server's base URL. (BASE_URL) (default "http://localhost:8000")`,
 		`--database-url string         Postgres DB URL (DATABASE_URL) (default "postgres://localhost:5432/sdp?sslmode=disable")`,
 		`--environment string          The environment where the application is running. Example: "development", "staging", "production". (ENVIRONMENT) (default "development")`,
@@ -79,63 +105,310 @@ func Test_DatabaseCommand_db_help(t *testing.T) {
 }
 
 func Test_DatabaseCommand_db_migrate(t *testing.T) {
-	dbt := dbtest.OpenWithoutMigrations(t)
+	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
 
+	ctx := context.Background()
+	m := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
 	buf := new(strings.Builder)
 
-	rootCmd := SetupCLI("x.y.z", "1234567890abcdef")
-	rootCmd.SetArgs([]string{"db", "migrate"})
-	rootCmd.SetOut(buf)
-	err = rootCmd.Execute()
-	require.NoError(t, err)
+	t.Run("migrate usage", func(t *testing.T) {
+		rootCmd := SetupCLI("x.y.z", "1234567890abcdef")
+		rootCmd.SetArgs([]string{"db", "migrate"})
+		rootCmd.SetOut(buf)
+		err = rootCmd.Execute()
+		require.NoError(t, err)
 
-	expectedContains := []string{
-		"Schema migration helpers",
-		"stellar-disbursement-platform db migrate [flags]",
-		"stellar-disbursement-platform db migrate [command]",
-		"down        Migrates database down [count] migrations",
-		"up          Migrates database up [count]",
-		"-h, --help   help for migrate",
-		`--base-url string             The SDP backend server's base URL. (BASE_URL) (default "http://localhost:8000")`,
-		`--database-url string         Postgres DB URL (DATABASE_URL) (default "postgres://localhost:5432/sdp?sslmode=disable")`,
-		`--environment string          The environment where the application is running. Example: "development", "staging", "production". (ENVIRONMENT) (default "development")`,
-		`--log-level string            The log level used in this project. Options: "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", or "PANIC". (LOG_LEVEL) (default "TRACE")`,
-		`--network-passphrase string   The Stellar network passphrase (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")`,
-		`--sentry-dsn string           The DSN (client key) of the Sentry project. If not provided, Sentry will not be used. (SENTRY_DSN)`,
-	}
+		expectedContains := []string{
+			"Schema migration helpers",
+			"stellar-disbursement-platform db migrate [flags]",
+			"stellar-disbursement-platform db migrate [command]",
+			"down        Migrates database down [count] migrations",
+			"up          Migrates database up [count]",
+			"-h, --help   help for migrate",
+			`--all                         Apply the migrations to all tenants. (ALL)`,
+			`--base-url string             The SDP backend server's base URL. (BASE_URL) (default "http://localhost:8000")`,
+			`--database-url string         Postgres DB URL (DATABASE_URL) (default "postgres://localhost:5432/sdp?sslmode=disable")`,
+			`--environment string          The environment where the application is running. Example: "development", "staging", "production". (ENVIRONMENT) (default "development")`,
+			`--log-level string            The log level used in this project. Options: "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", or "PANIC". (LOG_LEVEL) (default "TRACE")`,
+			`--network-passphrase string   The Stellar network passphrase (NETWORK_PASSPHRASE) (default "Test SDF Network ; September 2015")`,
+			`--sentry-dsn string           The DSN (client key) of the Sentry project. If not provided, Sentry will not be used. (SENTRY_DSN)`,
+			`--tenant-id string            The tenant ID where the migrations will be applied. (TENANT_ID)`,
+		}
 
-	output := buf.String()
-	for _, expected := range expectedContains {
-		assert.Contains(t, output, expected)
-	}
+		output := buf.String()
+		for _, expected := range expectedContains {
+			assert.Contains(t, output, expected)
+		}
+	})
 
-	buf.Reset()
-	log.DefaultLogger.SetOutput(buf)
-	rootCmd = SetupCLI("x.y.z", "1234567890abcdef")
-	rootCmd.SetArgs([]string{"db", "migrate", "up", "1", "--database-url", dbt.DSN, "--log-level", "TRACE"})
-	err = rootCmd.Execute()
-	require.NoError(t, err)
+	t.Run("migrate up and down --all", func(t *testing.T) {
+		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
 
-	ids := getMigrationsApplied(t, context.Background(), dbConnectionPool)
-	assert.Equal(t, []string{"2023-01-20.0-initial.sql"}, ids)
+		// Creating Tenants
+		tnt1, err := m.AddTenant(ctx, "myorg1")
+		require.NoError(t, err)
 
-	assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tnt2, err := m.AddTenant(ctx, "myorg2")
+		require.NoError(t, err)
 
-	buf.Reset()
-	rootCmd = SetupCLI("x.y.z", "1234567890abcdef")
-	rootCmd.SetArgs([]string{"db", "migrate", "down", "1", "--database-url", dbt.DSN, "--log-level", "TRACE"})
-	err = rootCmd.Execute()
-	require.NoError(t, err)
+		_, err = dbConnectionPool.ExecContext(ctx, "CREATE SCHEMA sdp_myorg1")
+		require.NoError(t, err)
+		_, err = dbConnectionPool.ExecContext(ctx, "CREATE SCHEMA sdp_myorg2")
+		require.NoError(t, err)
 
-	ids = getMigrationsApplied(t, context.Background(), dbConnectionPool)
-	assert.Equal(t, []string{}, ids)
+		buf.Reset()
+		log.DefaultLogger.SetOutput(buf)
+		rootCmd := SetupCLI("x.y.z", "1234567890abcdef")
+		rootCmd.SetArgs([]string{"db", "migrate", "up", "1", "--database-url", dbt.DSN, "--log-level", "TRACE", "--all"})
+		err = rootCmd.Execute()
+		require.NoError(t, err)
 
-	assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tnt1DSN, err := m.GetDSNForTenant(ctx, tnt1.Name)
+		require.NoError(t, err)
+
+		tnt2DSN, err := m.GetDSNForTenant(ctx, tnt2.Name)
+		require.NoError(t, err)
+
+		tenant1SchemaConnectionPool, err := db.OpenDBConnectionPool(tnt1DSN)
+		require.NoError(t, err)
+		defer tenant1SchemaConnectionPool.Close()
+
+		tenant2SchemaConnectionPool, err := db.OpenDBConnectionPool(tnt2DSN)
+		require.NoError(t, err)
+		defer tenant2SchemaConnectionPool.Close()
+
+		// Checking if the migrations were applied on the Tenant 1
+		ids := getSDPMigrationsApplied(t, ctx, tenant1SchemaConnectionPool)
+		assert.Equal(t, []string{"2023-01-20.0-initial.sql"}, ids)
+		assert.Contains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt1.ID))
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg1", []string{"gorp_migrations"})
+
+		// Checking if the migrations were applied on the Tenant 2
+		ids = getSDPMigrationsApplied(t, ctx, tenant2SchemaConnectionPool)
+		assert.Equal(t, []string{"2023-01-20.0-initial.sql"}, ids)
+		assert.Contains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt1.ID))
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{"gorp_migrations"})
+
+		buf.Reset()
+		rootCmd.SetArgs([]string{"db", "migrate", "down", "1", "--database-url", dbt.DSN, "--log-level", "TRACE", "--all"})
+		err = rootCmd.Execute()
+		require.NoError(t, err)
+
+		// Checking if the migrations were applied on the Tenant 1
+		ids = getSDPMigrationsApplied(t, context.Background(), tenant1SchemaConnectionPool)
+		assert.Equal(t, []string{}, ids)
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg1", []string{"gorp_migrations"})
+
+		// Checking if the migrations were applied on the Tenant 2
+		ids = getSDPMigrationsApplied(t, context.Background(), tenant2SchemaConnectionPool)
+		assert.Equal(t, []string{}, ids)
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{"gorp_migrations"})
+	})
+
+	t.Run("migrate up and down --tenant-id", func(t *testing.T) {
+		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
+
+		// Creating Tenants
+		tnt1, err := m.AddTenant(ctx, "myorg1")
+		require.NoError(t, err)
+
+		tnt2, err := m.AddTenant(ctx, "myorg2")
+		require.NoError(t, err)
+
+		_, err = dbConnectionPool.ExecContext(ctx, "CREATE SCHEMA sdp_myorg1")
+		require.NoError(t, err)
+		_, err = dbConnectionPool.ExecContext(ctx, "CREATE SCHEMA sdp_myorg2")
+		require.NoError(t, err)
+
+		buf.Reset()
+		log.DefaultLogger.SetOutput(buf)
+		rootCmd := SetupCLI("x.y.z", "1234567890abcdef")
+		rootCmd.SetArgs([]string{"db", "migrate", "up", "1", "--database-url", dbt.DSN, "--log-level", "TRACE", "--tenant-id", tnt1.ID})
+		err = rootCmd.Execute()
+		require.NoError(t, err)
+
+		tnt1DSN, err := m.GetDSNForTenant(ctx, tnt1.Name)
+		require.NoError(t, err)
+
+		tnt2DSN, err := m.GetDSNForTenant(ctx, tnt2.Name)
+		require.NoError(t, err)
+
+		tenant1SchemaConnectionPool, err := db.OpenDBConnectionPool(tnt1DSN)
+		require.NoError(t, err)
+		defer tenant1SchemaConnectionPool.Close()
+
+		tenant2SchemaConnectionPool, err := db.OpenDBConnectionPool(tnt2DSN)
+		require.NoError(t, err)
+		defer tenant2SchemaConnectionPool.Close()
+
+		// Checking if the migrations were applied on the Tenant 1 schema
+		ids := getSDPMigrationsApplied(t, ctx, tenant1SchemaConnectionPool)
+		assert.Equal(t, []string{"2023-01-20.0-initial.sql"}, ids)
+		assert.Contains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt1.ID))
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg1", []string{"gorp_migrations"})
+
+		// Checking if the migrations were not applied on the Tenant 2 schema
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{})
+		assert.NotContains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt2.ID))
+
+		buf.Reset()
+		rootCmd.SetArgs([]string{"db", "migrate", "down", "1", "--database-url", dbt.DSN, "--log-level", "TRACE", "--tenant-id", tnt1.ID})
+		err = rootCmd.Execute()
+		require.NoError(t, err)
+
+		// Checking if the migrations were applied on the Tenant 1 schema
+		ids = getSDPMigrationsApplied(t, ctx, tenant1SchemaConnectionPool)
+		assert.Equal(t, []string{}, ids)
+		assert.Contains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt1.ID))
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg1", []string{"gorp_migrations"})
+
+		// Checking if the migrations were not applied on the Tenant 2 schema
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{})
+		assert.NotContains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt2.ID))
+	})
+
+	t.Run("migrate up and down auth migrations --all", func(t *testing.T) {
+		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
+
+		// Creating Tenants
+		tnt1, err := m.AddTenant(ctx, "myorg1")
+		require.NoError(t, err)
+
+		tnt2, err := m.AddTenant(ctx, "myorg2")
+		require.NoError(t, err)
+
+		_, err = dbConnectionPool.ExecContext(ctx, "CREATE SCHEMA sdp_myorg1")
+		require.NoError(t, err)
+		_, err = dbConnectionPool.ExecContext(ctx, "CREATE SCHEMA sdp_myorg2")
+		require.NoError(t, err)
+
+		buf.Reset()
+		log.DefaultLogger.SetOutput(buf)
+		rootCmd := SetupCLI("x.y.z", "1234567890abcdef")
+		rootCmd.SetArgs([]string{"db", "auth", "migrate", "up", "1", "--database-url", dbt.DSN, "--log-level", "TRACE", "--all"})
+		err = rootCmd.Execute()
+		require.NoError(t, err)
+
+		tnt1DSN, err := m.GetDSNForTenant(ctx, tnt1.Name)
+		require.NoError(t, err)
+
+		tnt2DSN, err := m.GetDSNForTenant(ctx, tnt2.Name)
+		require.NoError(t, err)
+
+		tenant1SchemaConnectionPool, err := db.OpenDBConnectionPool(tnt1DSN)
+		require.NoError(t, err)
+		defer tenant1SchemaConnectionPool.Close()
+
+		tenant2SchemaConnectionPool, err := db.OpenDBConnectionPool(tnt2DSN)
+		require.NoError(t, err)
+		defer tenant2SchemaConnectionPool.Close()
+
+		// Checking if the migrations were applied on the Tenant 1
+		ids := getAuthMigrationsApplied(t, ctx, tenant1SchemaConnectionPool)
+		assert.Equal(t, []string{"2023-02-09.0.add-users-table.sql"}, ids)
+		assert.Contains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt1.ID))
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg1", []string{"auth_migrations", "auth_users"})
+
+		// Checking if the migrations were applied on the Tenant 2
+		ids = getAuthMigrationsApplied(t, ctx, tenant2SchemaConnectionPool)
+		assert.Equal(t, []string{"2023-02-09.0.add-users-table.sql"}, ids)
+		assert.Contains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt1.ID))
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{"auth_migrations", "auth_users"})
+
+		buf.Reset()
+		rootCmd.SetArgs([]string{"db", "auth", "migrate", "down", "1", "--database-url", dbt.DSN, "--log-level", "TRACE", "--all"})
+		err = rootCmd.Execute()
+		require.NoError(t, err)
+
+		// Checking if the migrations were applied on the Tenant 1
+		ids = getAuthMigrationsApplied(t, context.Background(), tenant1SchemaConnectionPool)
+		assert.Equal(t, []string{}, ids)
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg1", []string{"auth_migrations"})
+
+		// Checking if the migrations were applied on the Tenant 2
+		ids = getAuthMigrationsApplied(t, context.Background(), tenant2SchemaConnectionPool)
+		assert.Equal(t, []string{}, ids)
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{"auth_migrations"})
+	})
+
+	t.Run("migrate up and down auth migrations --tenant-id", func(t *testing.T) {
+		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
+
+		// Creating Tenants
+		tnt1, err := m.AddTenant(ctx, "myorg1")
+		require.NoError(t, err)
+
+		tnt2, err := m.AddTenant(ctx, "myorg2")
+		require.NoError(t, err)
+
+		_, err = dbConnectionPool.ExecContext(ctx, "CREATE SCHEMA sdp_myorg1")
+		require.NoError(t, err)
+		_, err = dbConnectionPool.ExecContext(ctx, "CREATE SCHEMA sdp_myorg2")
+		require.NoError(t, err)
+
+		buf.Reset()
+		log.DefaultLogger.SetOutput(buf)
+		rootCmd := SetupCLI("x.y.z", "1234567890abcdef")
+		rootCmd.SetArgs([]string{"db", "auth", "migrate", "up", "1", "--database-url", dbt.DSN, "--log-level", "TRACE", "--tenant-id", tnt1.ID})
+		err = rootCmd.Execute()
+		require.NoError(t, err)
+
+		tnt1DSN, err := m.GetDSNForTenant(ctx, tnt1.Name)
+		require.NoError(t, err)
+
+		tnt2DSN, err := m.GetDSNForTenant(ctx, tnt2.Name)
+		require.NoError(t, err)
+
+		tenant1SchemaConnectionPool, err := db.OpenDBConnectionPool(tnt1DSN)
+		require.NoError(t, err)
+		defer tenant1SchemaConnectionPool.Close()
+
+		tenant2SchemaConnectionPool, err := db.OpenDBConnectionPool(tnt2DSN)
+		require.NoError(t, err)
+		defer tenant2SchemaConnectionPool.Close()
+
+		// Checking if the migrations were applied on the Tenant 1 schema
+		ids := getAuthMigrationsApplied(t, ctx, tenant1SchemaConnectionPool)
+		assert.Equal(t, []string{"2023-02-09.0.add-users-table.sql"}, ids)
+		assert.Contains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt1.ID))
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg1", []string{"auth_migrations", "auth_users"})
+
+		// Checking if the migrations were not applied on the Tenant 2 schema
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{})
+		assert.NotContains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt2.ID))
+
+		buf.Reset()
+		rootCmd.SetArgs([]string{"db", "auth", "migrate", "down", "1", "--database-url", dbt.DSN, "--log-level", "TRACE", "--tenant-id", tnt1.ID})
+		err = rootCmd.Execute()
+		require.NoError(t, err)
+
+		// Checking if the migrations were applied on the Tenant 1 schema
+		ids = getAuthMigrationsApplied(t, ctx, tenant1SchemaConnectionPool)
+		assert.Equal(t, []string{}, ids)
+		assert.Contains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt1.ID))
+		assert.Contains(t, buf.String(), "Successfully applied 1 migrations.")
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg1", []string{"auth_migrations"})
+
+		// Checking if the migrations were not applied on the Tenant 2 schema
+		tenant.TenantSchemaHasTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{})
+		assert.NotContains(t, buf.String(), fmt.Sprintf("applying migrations on tenant ID %s", tnt2.ID))
+	})
 }
 
 func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -13,9 +13,9 @@ import (
 type MigrationTableName string
 
 const (
-	StellarMultitenantMigrationsTableName = "migrations"
-	StellarSDPMigrationsTableName         = "gorp_migrations"
-	StellarAuthMigrationsTableName        = "auth_migrations"
+	StellarMultiTenantMigrationsTableName MigrationTableName = "migrations"
+	StellarSDPMigrationsTableName         MigrationTableName = "gorp_migrations"
+	StellarAuthMigrationsTableName        MigrationTableName = "auth_migrations"
 )
 
 func Migrate(dbURL string, dir migrate.MigrationDirection, count int, migrationFiles embed.FS, tableName MigrationTableName) (int, error) {

--- a/db/migrate_test.go
+++ b/db/migrate_test.go
@@ -103,12 +103,12 @@ func TestMigrate_upApplyOne_Tenant_migrations(t *testing.T) {
 
 	ctx := context.Background()
 
-	n, err := Migrate(db.DSN, migrate.Up, 1, tenantmigrations.FS, StellarMultitenantMigrationsTableName)
+	n, err := Migrate(db.DSN, migrate.Up, 1, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 
 	ids := []string{}
-	err = dbConnectionPool.SelectContext(ctx, &ids, fmt.Sprintf("SELECT id FROM %s", StellarMultitenantMigrationsTableName))
+	err = dbConnectionPool.SelectContext(ctx, &ids, fmt.Sprintf("SELECT id FROM %s", StellarMultiTenantMigrationsTableName))
 	require.NoError(t, err)
 	wantIDs := []string{"2023-10-16.0.add-tenants-table.sql"}
 	assert.Equal(t, wantIDs, ids)
@@ -123,16 +123,16 @@ func TestMigrate_downApplyOne_Tenant_migrations(t *testing.T) {
 
 	ctx := context.Background()
 
-	n, err := Migrate(db.DSN, migrate.Up, 2, tenantmigrations.FS, StellarMultitenantMigrationsTableName)
+	n, err := Migrate(db.DSN, migrate.Up, 2, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 
-	n, err = Migrate(db.DSN, migrate.Down, 1, tenantmigrations.FS, StellarMultitenantMigrationsTableName)
+	n, err = Migrate(db.DSN, migrate.Down, 1, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 
 	ids := []string{}
-	err = dbConnectionPool.SelectContext(ctx, &ids, fmt.Sprintf("SELECT id FROM %s", StellarMultitenantMigrationsTableName))
+	err = dbConnectionPool.SelectContext(ctx, &ids, fmt.Sprintf("SELECT id FROM %s", StellarMultiTenantMigrationsTableName))
 	require.NoError(t, err)
 	wantIDs := []string{}
 	assert.Equal(t, wantIDs, ids)
@@ -156,19 +156,19 @@ func TestMigrate_upAndDownAllTheWayTwice_Tenant_migrations(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	n, err := Migrate(db.DSN, migrate.Up, count, tenantmigrations.FS, StellarMultitenantMigrationsTableName)
+	n, err := Migrate(db.DSN, migrate.Up, count, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
 	require.NoError(t, err)
 	require.Equal(t, count, n)
 
-	n, err = Migrate(db.DSN, migrate.Down, count, tenantmigrations.FS, StellarMultitenantMigrationsTableName)
+	n, err = Migrate(db.DSN, migrate.Down, count, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
 	require.NoError(t, err)
 	require.Equal(t, count, n)
 
-	n, err = Migrate(db.DSN, migrate.Up, count, tenantmigrations.FS, StellarMultitenantMigrationsTableName)
+	n, err = Migrate(db.DSN, migrate.Up, count, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
 	require.NoError(t, err)
 	require.Equal(t, count, n)
 
-	n, err = Migrate(db.DSN, migrate.Down, count, tenantmigrations.FS, StellarMultitenantMigrationsTableName)
+	n, err = Migrate(db.DSN, migrate.Down, count, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
 	require.NoError(t, err)
 	require.Equal(t, count, n)
 }

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -61,8 +61,8 @@ services:
       - -c
       - |
         sleep 5
-        ./stellar-disbursement-platform db migrate up
-        ./stellar-disbursement-platform db auth migrate up
+        ./stellar-disbursement-platform db migrate up --all
+        ./stellar-disbursement-platform db auth migrate up --all
         ./stellar-disbursement-platform db setup-for-network
         ./stellar-disbursement-platform serve
     depends_on:

--- a/helmchart/sdp/templates/02.1-deployment-sdp.yaml
+++ b/helmchart/sdp/templates/02.1-deployment-sdp.yaml
@@ -59,8 +59,8 @@ spec:
         - sh
         - -c
         - |
-          ./stellar-disbursement-platform db migrate up &&
-          ./stellar-disbursement-platform db auth migrate up &&
+          ./stellar-disbursement-platform db migrate up --all &&
+          ./stellar-disbursement-platform db auth migrate up --all &&
           ./stellar-disbursement-platform db setup-for-network &&
           ./stellar-disbursement-platform channel-accounts verify --delete-invalid-accounts
           ./stellar-disbursement-platform channel-accounts ensure --num-channel-accounts-ensure {{ .Values.tss.configMap.data.NUM_CHANNEL_ACCOUNTS | default 1 }}

--- a/internal/integrationtests/docker-compose-e2e-tests.yml
+++ b/internal/integrationtests/docker-compose-e2e-tests.yml
@@ -72,8 +72,8 @@ services:
       - -c
       - |
         sleep 5
-        ./stellar-disbursement-platform db migrate up
-        ./stellar-disbursement-platform db auth migrate up
+        ./stellar-disbursement-platform db migrate up --all
+        ./stellar-disbursement-platform db auth migrate up --all
         ./stellar-disbursement-platform db setup-for-network
         ./stellar-disbursement-platform serve
     depends_on:

--- a/internal/integrationtests/docker-compose-e2e-tests.yml
+++ b/internal/integrationtests/docker-compose-e2e-tests.yml
@@ -72,6 +72,7 @@ services:
       - -c
       - |
         sleep 5
+        ./stellar-disbursement-platform db tenant migrate up
         ./stellar-disbursement-platform db migrate up --all
         ./stellar-disbursement-platform db auth migrate up --all
         ./stellar-disbursement-platform db setup-for-network

--- a/stellar-multitenant/pkg/cli/add_tenants_test.go
+++ b/stellar-multitenant/pkg/cli/add_tenants_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lib/pq"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
@@ -19,23 +18,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-func DeleteAllTenantsFixture(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool) {
-	q := "DELETE FROM tenants"
-	_, err := dbConnectionPool.ExecContext(ctx, q)
-	require.NoError(t, err)
-
-	var schemasToDrop []string
-	q = "SELECT schema_name FROM information_schema.schemata WHERE schema_name ILIKE 'sdp_%'"
-	err = dbConnectionPool.SelectContext(ctx, &schemasToDrop, q)
-	require.NoError(t, err)
-
-	for _, schema := range schemasToDrop {
-		q = fmt.Sprintf("DROP SCHEMA %s CASCADE", pq.QuoteIdentifier(schema))
-		_, err = dbConnectionPool.ExecContext(ctx, q)
-		require.NoError(t, err)
-	}
-}
 
 func Test_validateTenantNameArg(t *testing.T) {
 	testCases := []struct {
@@ -105,7 +87,7 @@ func Test_executeAddTenant(t *testing.T) {
 	networkType := "testnet"
 
 	t.Run("adds a new tenant successfully", func(t *testing.T) {
-		DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
+		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
 
 		getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
 
@@ -124,7 +106,7 @@ func Test_executeAddTenant(t *testing.T) {
 	})
 
 	t.Run("duplicated tenant name", func(t *testing.T) {
-		DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
+		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
 
 		getEntries := log.DefaultLogger.StartTest(log.DebugLevel)
 

--- a/stellar-multitenant/pkg/cli/migrate.go
+++ b/stellar-multitenant/pkg/cli/migrate.go
@@ -17,6 +17,11 @@ func MigrateCmd(databaseFlagName string) *cobra.Command {
 	migrateCmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Apply Stellar Multitenant database migrations",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cmd.Parent().PersistentPreRun != nil {
+				cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {
 				log.Fatalf("Error calling help command: %s", err.Error())

--- a/stellar-multitenant/pkg/cli/migrate.go
+++ b/stellar-multitenant/pkg/cli/migrate.go
@@ -78,7 +78,7 @@ func MigrateCmd(databaseFlagName string) *cobra.Command {
 }
 
 func runMigration(databaseURL string, dir migrate.MigrationDirection, count int) error {
-	numMigrationsRun, err := db.Migrate(databaseURL, dir, count, migrations.FS, db.StellarMultitenantMigrationsTableName)
+	numMigrationsRun, err := db.Migrate(databaseURL, dir, count, migrations.FS, db.StellarMultiTenantMigrationsTableName)
 	if err != nil {
 		return fmt.Errorf("running migrations: %w", err)
 	}

--- a/stellar-multitenant/pkg/cli/migrate_test.go
+++ b/stellar-multitenant/pkg/cli/migrate_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func getMigrationsApplied(t *testing.T, ctx context.Context, db *sql.DB) []string {
-	rows, err := db.QueryContext(ctx, fmt.Sprintf("SELECT id FROM %s", dbpkg.StellarMultitenantMigrationsTableName))
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("SELECT id FROM %s", dbpkg.StellarMultiTenantMigrationsTableName))
 	require.NoError(t, err)
 
 	defer rows.Close()
@@ -95,7 +95,7 @@ func Test_MigrateCmd(t *testing.T) {
 			args:   []string{"--multitenant-db-url", "", "migrate", "down", "1"},
 			expect: "Successfully applied 1 migrations.",
 			preRunFunc: func(t *testing.T, db *stellardbtest.DB) {
-				_, err := dbpkg.Migrate(db.DSN, migrate.Up, 1, migrations.FS, dbpkg.StellarMultitenantMigrationsTableName)
+				_, err := dbpkg.Migrate(db.DSN, migrate.Up, 1, migrations.FS, dbpkg.StellarMultiTenantMigrationsTableName)
 				require.NoError(t, err)
 
 				conn := db.Open()
@@ -115,7 +115,7 @@ func Test_MigrateCmd(t *testing.T) {
 			envVars: map[string]string{"MULTITENANT_DB_URL": ""},
 			expect:  "Successfully applied 1 migrations.",
 			preRunFunc: func(t *testing.T, db *stellardbtest.DB) {
-				_, err := dbpkg.Migrate(db.DSN, migrate.Up, 1, migrations.FS, dbpkg.StellarMultitenantMigrationsTableName)
+				_, err := dbpkg.Migrate(db.DSN, migrate.Up, 1, migrations.FS, dbpkg.StellarMultiTenantMigrationsTableName)
 				require.NoError(t, err)
 
 				conn := db.Open()

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -48,6 +48,15 @@ func (m *Manager) GetDSNForTenant(ctx context.Context, tenantName string) (strin
 	return u.String(), nil
 }
 
+func (m *Manager) GetAllTenants(ctx context.Context) ([]Tenant, error) {
+	const q = `SELECT * FROM tenants`
+	var tenants []Tenant
+	if err := m.db.SelectContext(ctx, &tenants, q); err != nil {
+		return nil, fmt.Errorf("getting all tenants: %w", err)
+	}
+	return tenants, nil
+}
+
 func (m *Manager) GetTenantByID(ctx context.Context, id string) (*Tenant, error) {
 	const q = "SELECT * FROM tenants WHERE id = $1"
 	var t Tenant

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -137,3 +137,54 @@ func Test_Manager_UpdateTenantConfig(t *testing.T) {
 		assert.ElementsMatch(t, []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"}, tnt.CORSAllowedOrigins)
 	})
 }
+
+func Test_Manager_GetAllTenants(t *testing.T) {
+	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+
+	m := NewManager(WithDatabase(dbConnectionPool))
+	tnt1, err := m.AddTenant(ctx, "myorg1")
+	require.NoError(t, err)
+	tnt2, err := m.AddTenant(ctx, "myorg2")
+	require.NoError(t, err)
+
+	tenants, err := m.GetAllTenants(ctx)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, tenants, []Tenant{*tnt1, *tnt2})
+}
+
+func Test_Manager_GetTenantByName(t *testing.T) {
+	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+
+	m := NewManager(WithDatabase(dbConnectionPool))
+	_, err = m.AddTenant(ctx, "myorg1")
+	require.NoError(t, err)
+	tnt2, err := m.AddTenant(ctx, "myorg2")
+	require.NoError(t, err)
+
+	t.Run("gets tenant successfully", func(t *testing.T) {
+		tntDB, err := m.GetTenantByName(ctx, "myorg2")
+		require.NoError(t, err)
+		assert.Equal(t, tnt2, tntDB)
+	})
+
+	t.Run("returns error when tenant is not found", func(t *testing.T) {
+		tntDB, err := m.GetTenantByName(ctx, "unknown")
+		assert.ErrorIs(t, err, ErrTenantDoesNotExist)
+		assert.Nil(t, tntDB)
+	})
+}

--- a/v1_compatibility/docker-compose.yml
+++ b/v1_compatibility/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     - -c
     - |
       sleep 5
-      ./stellar-disbursement-platform db migrate up
+      ./stellar-disbursement-platform db migrate up --all
     depends_on:
     - db
     - sdp-v1


### PR DESCRIPTION
### What

This PR modifies the SDP's `db` CLI command and `setup-for-network` CLI command to be tenant-aware. It means being able to run these commands for all or a specific tenant.

### Why

We should be able to apply the migrations to the tenants and also setup it for the given network.

### Known limitations

Fix the e2e test and SDP anchor platform compatibility.

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
