### PR TITLE
SDP-972 make setup-wallets-for-network tests more flexible

### DIFF
--- a/cmd/db_test.go
+++ b/cmd/db_test.go
@@ -210,20 +210,30 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 	wallets, err = models.Wallets.GetAll(ctx)
 	require.NoError(t, err)
 
-	assert.Len(t, wallets, 2)
-	// assert.Equal(t, "Beans App", wallets[0].Name)
-	// assert.Equal(t, "https://www.beansapp.com/disbursements", wallets[0].Homepage)
-	// assert.Equal(t, "api.beansapp.com", wallets[0].SEP10ClientDomain)
-	// assert.Equal(t, "https://www.beansapp.com/disbursements/registration?redirect=true", wallets[0].DeepLinkSchema)
-	assert.Equal(t, "Vibrant Assist", wallets[0].Name)
-	assert.Equal(t, "https://vibrantapp.com/vibrant-assist", wallets[0].Homepage)
-	assert.Equal(t, "api.vibrantapp.com", wallets[0].SEP10ClientDomain)
-	assert.Equal(t, "https://vibrantapp.com/sdp", wallets[0].DeepLinkSchema)
+	// Test only on Vibrant Assist and Vibrant Assist RC. This will help adding wallets without breaking tests.
+	var vibrantAssist, vibrantAssistRC data.Wallet
 
-	assert.Equal(t, "Vibrant Assist RC", wallets[1].Name)
-	assert.Equal(t, "vibrantapp.com/vibrant-assist", wallets[1].Homepage)
-	assert.Equal(t, "vibrantapp.com", wallets[1].SEP10ClientDomain)
-	assert.Equal(t, "https://vibrantapp.com/sdp-rc", wallets[1].DeepLinkSchema)
+	for _, w := range wallets {
+		if w.Name == "Vibrant Assist" {
+			vibrantAssist = w
+		} else if w.Name == "Vibrant Assist RC" {
+			vibrantAssistRC = w
+		}
+	}
+
+	require.NotNil(t, vibrantAssist, "Vibrant Assist wallet not found")
+	require.NotNil(t, vibrantAssistRC, "Vibrant Assist RC wallet not found")
+
+	// Test the two wallets
+	assert.Equal(t, "Vibrant Assist", vibrantAssist.Name)
+	assert.Equal(t, "https://vibrantapp.com/vibrant-assist", vibrantAssist.Homepage)
+	assert.Equal(t, "api.vibrantapp.com", vibrantAssist.SEP10ClientDomain)
+	assert.Equal(t, "https://vibrantapp.com/sdp", vibrantAssist.DeepLinkSchema)
+
+	assert.Equal(t, "Vibrant Assist RC", vibrantAssistRC.Name)
+	assert.Equal(t, "vibrantapp.com/vibrant-assist", vibrantAssistRC.Homepage)
+	assert.Equal(t, "vibrantapp.com", vibrantAssistRC.SEP10ClientDomain)
+	assert.Equal(t, "https://vibrantapp.com/sdp-rc", vibrantAssistRC.DeepLinkSchema)
 
 	expectedLogs := []string{
 		"updating/inserting assets for the 'pubnet' network",

--- a/internal/services/setup_wallets_for_network_service_test.go
+++ b/internal/services/setup_wallets_for_network_service_test.go
@@ -46,10 +46,22 @@ func Test_SetupWalletsForProperNetwork(t *testing.T) {
 		wallets, err := models.Wallets.GetAll(ctx)
 		require.NoError(t, err)
 
-		assert.Len(t, wallets, 2)
-		// assert.Equal(t, "Beans App", wallets[0].Name)
-		assert.Equal(t, "Vibrant Assist", wallets[0].Name)
-		assert.Equal(t, "Vibrant Assist RC", wallets[1].Name)
+		// Test only on Vibrant Assist and Vibrant Assist RC. This will help adding wallets without breaking tests.
+		var vibrantAssist, vibrantAssistRC data.Wallet
+
+		for _, w := range wallets {
+			if w.Name == "Vibrant Assist" {
+				vibrantAssist = w
+			} else if w.Name == "Vibrant Assist RC" {
+				vibrantAssistRC = w
+			}
+		}
+
+		require.NotNil(t, vibrantAssist, "Vibrant Assist wallet not found")
+		require.NotNil(t, vibrantAssistRC, "Vibrant Assist RC wallet not found")
+
+		assert.Equal(t, "Vibrant Assist", vibrantAssist.Name)
+		assert.Equal(t, "Vibrant Assist RC", vibrantAssistRC.Name)
 
 		expectedLogs := []string{
 			"updating/inserting wallets for the 'pubnet' network",


### PR DESCRIPTION
### What
Make setup-wallets-for-network tests more flexible. 

### Why
This would make adding new wallets simpler. 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
