### PR TITLE
chore: use pull_request_target event to allow forks to run jobs.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# we set `sdp-backend` as code owners
+# require approval from 1 member of `sdp-backend` team
+@stellar/sdp-backend

--- a/.github/workflows/anchor_platform_integration_check.yml
+++ b/.github/workflows/anchor_platform_integration_check.yml
@@ -8,8 +8,12 @@ on:
       - "release/**"
       - "releases/**"
       - "hotfix/**"
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
   workflow_call: # allows this workflow to be called from another workflow
+
+permissions:
+  contents: read
 
 jobs:
   anchor-integration:

--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -8,8 +8,12 @@ on:
       - "release/**"
       - "releases/**"
       - "hotfix/**"
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
   workflow_call: # allows this workflow to be called from another workflow
+
+permissions:
+  contents: read
 
 env:
   USER_EMAIL: "sdp_user@stellar.org"


### PR DESCRIPTION
### What
Use `pull_request_target` event for workflows that use github environment secrets. 
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

* The github secrets we have on this repository are all testnet stellar accounts. So this should be fine in terms of security. 
* Our `main` and `develop` branches are also protected
* Added explicit `permissions` to restrict `GITHUB_TOKEN` for these workflows because for `pull_request_target event`, the `GITHUB_TOKEN` is granted read/write repository permission. 
* Added CODEOWNERS file to restrict who can approve PRs. 


### Why
Allow PRs coming from forks to run the e2e tests. 