### PR TITLE
chore: add CODEOWNERS and change secrets to vars.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# we set `sdp-backend` as code owners
+# require approval from 1 member of `sdp-backend` team
+@stellar/sdp-backend

--- a/.github/workflows/anchor_platform_integration_check.yml
+++ b/.github/workflows/anchor_platform_integration_check.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: "Anchor Integration Tests"
     env:
-      DISTRIBUTION_PUBLIC_KEY: ${{ secrets.DISTRIBUTION_PUBLIC_KEY }}
-      DISTRIBUTION_SEED: ${{ secrets.DISTRIBUTION_SEED }}
-      SEP10_SIGNING_PUBLIC_KEY: ${{ secrets.SEP10_SIGNING_PUBLIC_KEY }}
-      SEP10_SIGNING_PRIVATE_KEY: ${{ secrets.SEP10_SIGNING_PRIVATE_KEY }}
+      DISTRIBUTION_PUBLIC_KEY: ${{ vars.DISTRIBUTION_PUBLIC_KEY }}
+      DISTRIBUTION_SEED: ${{ vars.DISTRIBUTION_SEED }}
+      SEP10_SIGNING_PUBLIC_KEY: ${{ vars.SEP10_SIGNING_PUBLIC_KEY }}
+      SEP10_SIGNING_PRIVATE_KEY: ${{ vars.SEP10_SIGNING_PRIVATE_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: "Receiver Registration - E2E Integration Tests"
     env:
-      DISTRIBUTION_PUBLIC_KEY: ${{ secrets.DISTRIBUTION_PUBLIC_KEY }}
-      DISTRIBUTION_SEED: ${{ secrets.DISTRIBUTION_SEED }}
-      SEP10_SIGNING_PUBLIC_KEY: ${{ secrets.SEP10_SIGNING_PUBLIC_KEY }}
-      SEP10_SIGNING_PRIVATE_KEY: ${{ secrets.SEP10_SIGNING_PRIVATE_KEY }}
+      DISTRIBUTION_PUBLIC_KEY: ${{ vars.DISTRIBUTION_PUBLIC_KEY }}
+      DISTRIBUTION_SEED: ${{ vars.DISTRIBUTION_SEED }}
+      SEP10_SIGNING_PUBLIC_KEY: ${{ vars.SEP10_SIGNING_PUBLIC_KEY }}
+      SEP10_SIGNING_PRIVATE_KEY: ${{ vars.SEP10_SIGNING_PRIVATE_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### What

* Add CODEOWNERS to protect main and develop branches
* Change `secrets` to `vars` to facilitate running github actions for PRs coming from forked repositories. 
