### PR TITLE
SDP-969 - Remove Distribution account and SEP10 account from tenant config

### DIFF
--- a/db/migrations/tenant-migrations/2023-10-16.0.add-tenants-table.sql
+++ b/db/migrations/tenant-migrations/2023-10-16.0.add-tenants-table.sql
@@ -23,8 +23,6 @@ CREATE TABLE public.tenants
     name text NOT NULL,
     email_sender_type email_sender_type DEFAULT 'DRY_RUN'::email_sender_type,
     sms_sender_type sms_sender_type DEFAULT 'DRY_RUN'::sms_sender_type,
-    sep10_signing_public_key text NULL,
-    distribution_public_key text NULL,
     enable_mfa boolean DEFAULT true,
     enable_recaptcha boolean DEFAULT true,
     cors_allowed_origins text[] NULL,

--- a/stellar-multitenant/pkg/cli/config_tenant.go
+++ b/stellar-multitenant/pkg/cli/config_tenant.go
@@ -14,16 +14,14 @@ import (
 )
 
 type tenantOptions struct {
-	ID                    string
-	EmailSenderType       *tenant.EmailSenderType
-	SMSSenderType         *tenant.SMSSenderType
-	SEP10SigningPublicKey *string
-	DistributionPublicKey *string
-	EnableMFA             *bool
-	EnableReCAPTCHA       *bool
-	CORSAllowedOrigins    []string
-	BaseURL               *string
-	SDPUIBaseURL          *string
+	ID                 string
+	EmailSenderType    *tenant.EmailSenderType
+	SMSSenderType      *tenant.SMSSenderType
+	EnableMFA          *bool
+	EnableReCAPTCHA    *bool
+	CORSAllowedOrigins []string
+	BaseURL            *string
+	SDPUIBaseURL       *string
 }
 
 func ConfigTenantCmd() *cobra.Command {
@@ -50,22 +48,6 @@ func ConfigTenantCmd() *cobra.Command {
 			OptType:        types.String,
 			CustomSetValue: utils.SetConfigOptionSMSSenderType,
 			ConfigKey:      &to.SMSSenderType,
-			Required:       false,
-		},
-		{
-			Name:           "sep10-signing-public-key",
-			Usage:          "The public key of the Stellar account that signs the SEP-10 transactions. It's also used to sign URLs.",
-			OptType:        types.String,
-			CustomSetValue: utils.SetConfigOptionStellarPublicKey,
-			ConfigKey:      &to.SEP10SigningPublicKey,
-			Required:       false,
-		},
-		{
-			Name:           "distribution-public-key",
-			Usage:          "The public key of the Stellar distribution account that sends the Stellar payments.",
-			OptType:        types.String,
-			CustomSetValue: utils.SetConfigOptionStellarPublicKey,
-			ConfigKey:      &to.DistributionPublicKey,
 			Required:       false,
 		},
 		{
@@ -146,16 +128,14 @@ func executeConfigTenant(ctx context.Context, to *tenantOptions, dbURL string) e
 
 	m := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
 	_, err = m.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
-		ID:                    to.ID,
-		EmailSenderType:       to.EmailSenderType,
-		SMSSenderType:         to.SMSSenderType,
-		SEP10SigningPublicKey: to.SEP10SigningPublicKey,
-		DistributionPublicKey: to.DistributionPublicKey,
-		EnableMFA:             to.EnableMFA,
-		EnableReCAPTCHA:       to.EnableReCAPTCHA,
-		CORSAllowedOrigins:    to.CORSAllowedOrigins,
-		BaseURL:               to.BaseURL,
-		SDPUIBaseURL:          to.SDPUIBaseURL,
+		ID:                 to.ID,
+		EmailSenderType:    to.EmailSenderType,
+		SMSSenderType:      to.SMSSenderType,
+		EnableMFA:          to.EnableMFA,
+		EnableReCAPTCHA:    to.EnableReCAPTCHA,
+		CORSAllowedOrigins: to.CORSAllowedOrigins,
+		BaseURL:            to.BaseURL,
+		SDPUIBaseURL:       to.SDPUIBaseURL,
 	})
 	if err != nil {
 		return fmt.Errorf("updating tenant config: %w", err)

--- a/stellar-multitenant/pkg/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/pkg/internal/httphandler/tenants_handler.go
@@ -80,15 +80,13 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	tnt, err = h.Manager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
-		ID:                    tnt.ID,
-		EmailSenderType:       &reqBody.EmailSenderType,
-		SMSSenderType:         &reqBody.SMSSenderType,
-		SEP10SigningPublicKey: &reqBody.SEP10SigningPublicKey,
-		DistributionPublicKey: &reqBody.DistributionPublicKey,
-		EnableMFA:             &reqBody.EnableMFA,
-		EnableReCAPTCHA:       &reqBody.EnableReCAPTCHA,
-		CORSAllowedOrigins:    reqBody.CORSAllowedOrigins,
-		BaseURL:               &reqBody.BaseURL,
+		ID:                 tnt.ID,
+		EmailSenderType:    &reqBody.EmailSenderType,
+		SMSSenderType:      &reqBody.SMSSenderType,
+		EnableMFA:          &reqBody.EnableMFA,
+		EnableReCAPTCHA:    &reqBody.EnableReCAPTCHA,
+		CORSAllowedOrigins: reqBody.CORSAllowedOrigins,
+		BaseURL:            &reqBody.BaseURL,
 	})
 	if err != nil {
 		httperror.InternalError(ctx, "Could not update tenant config", err, nil).Render(rw)
@@ -119,17 +117,15 @@ func (t TenantsHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	tenantID := chi.URLParam(r, "id")
 
 	tnt, err := t.Manager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
-		ID:                    tenantID,
-		EmailSenderType:       reqBody.EmailSenderType,
-		SMSSenderType:         reqBody.SMSSenderType,
-		SEP10SigningPublicKey: reqBody.SEP10SigningPublicKey,
-		DistributionPublicKey: reqBody.DistributionPublicKey,
-		EnableMFA:             reqBody.EnableMFA,
-		EnableReCAPTCHA:       reqBody.EnableReCAPTCHA,
-		CORSAllowedOrigins:    reqBody.CORSAllowedOrigins,
-		BaseURL:               reqBody.BaseURL,
-		SDPUIBaseURL:          reqBody.SDPUIBaseURL,
-		Status:                reqBody.Status,
+		ID:                 tenantID,
+		EmailSenderType:    reqBody.EmailSenderType,
+		SMSSenderType:      reqBody.SMSSenderType,
+		EnableMFA:          reqBody.EnableMFA,
+		EnableReCAPTCHA:    reqBody.EnableReCAPTCHA,
+		CORSAllowedOrigins: reqBody.CORSAllowedOrigins,
+		BaseURL:            reqBody.BaseURL,
+		SDPUIBaseURL:       reqBody.SDPUIBaseURL,
+		Status:             reqBody.Status,
 	})
 	if err != nil {
 		if errors.Is(tenant.ErrEmptyUpdateTenant, err) {

--- a/stellar-multitenant/pkg/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/pkg/internal/validators/tenant_validator.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/stellar/go/strkey"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -13,33 +12,29 @@ import (
 var validTenantName *regexp.Regexp = regexp.MustCompile(`^[a-z-]+$`)
 
 type TenantRequest struct {
-	Name                  string                 `json:"name"`
-	OwnerEmail            string                 `json:"owner_email"`
-	OwnerFirstName        string                 `json:"owner_first_name"`
-	OwnerLastName         string                 `json:"owner_last_name"`
-	OrganizationName      string                 `json:"organization_name"`
-	EmailSenderType       tenant.EmailSenderType `json:"email_sender_type"`
-	SMSSenderType         tenant.SMSSenderType   `json:"sms_sender_type"`
-	SEP10SigningPublicKey string                 `json:"sep10_signing_public_key"`
-	DistributionPublicKey string                 `json:"distribution_public_key"`
-	EnableMFA             bool                   `json:"enable_mfa"`
-	EnableReCAPTCHA       bool                   `json:"enable_recaptcha"`
-	CORSAllowedOrigins    []string               `json:"cors_allowed_origins"`
-	BaseURL               string                 `json:"base_url"`
-	SDPUIBaseURL          string                 `json:"sdp_ui_base_url"`
+	Name               string                 `json:"name"`
+	OwnerEmail         string                 `json:"owner_email"`
+	OwnerFirstName     string                 `json:"owner_first_name"`
+	OwnerLastName      string                 `json:"owner_last_name"`
+	OrganizationName   string                 `json:"organization_name"`
+	EmailSenderType    tenant.EmailSenderType `json:"email_sender_type"`
+	SMSSenderType      tenant.SMSSenderType   `json:"sms_sender_type"`
+	EnableMFA          bool                   `json:"enable_mfa"`
+	EnableReCAPTCHA    bool                   `json:"enable_recaptcha"`
+	CORSAllowedOrigins []string               `json:"cors_allowed_origins"`
+	BaseURL            string                 `json:"base_url"`
+	SDPUIBaseURL       string                 `json:"sdp_ui_base_url"`
 }
 
 type UpdateTenantRequest struct {
-	EmailSenderType       *tenant.EmailSenderType `json:"email_sender_type"`
-	SMSSenderType         *tenant.SMSSenderType   `json:"sms_sender_type"`
-	SEP10SigningPublicKey *string                 `json:"sep10_signing_public_key"`
-	DistributionPublicKey *string                 `json:"distribution_public_key"`
-	EnableMFA             *bool                   `json:"enable_mfa"`
-	EnableReCAPTCHA       *bool                   `json:"enable_recaptcha"`
-	CORSAllowedOrigins    []string                `json:"cors_allowed_origins"`
-	BaseURL               *string                 `json:"base_url"`
-	SDPUIBaseURL          *string                 `json:"sdp_ui_base_url"`
-	Status                *tenant.TenantStatus    `json:"status"`
+	EmailSenderType    *tenant.EmailSenderType `json:"email_sender_type"`
+	SMSSenderType      *tenant.SMSSenderType   `json:"sms_sender_type"`
+	EnableMFA          *bool                   `json:"enable_mfa"`
+	EnableReCAPTCHA    *bool                   `json:"enable_recaptcha"`
+	CORSAllowedOrigins []string                `json:"cors_allowed_origins"`
+	BaseURL            *string                 `json:"base_url"`
+	SDPUIBaseURL       *string                 `json:"sdp_ui_base_url"`
+	Status             *tenant.TenantStatus    `json:"status"`
 }
 
 type TenantValidator struct {
@@ -68,9 +63,6 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 
 	reqBody.SMSSenderType, err = tenant.ParseSMSSenderType(string(reqBody.SMSSenderType))
 	tv.CheckError(err, "sms_sender_type", fmt.Sprintf("invalid sms sender type. Expected one of these values: %s", []tenant.SMSSenderType{tenant.TwilioSMSSenderType, tenant.AWSSMSSenderType, tenant.DryRunSMSSenderType}))
-
-	tv.Check(strkey.IsValidEd25519PublicKey(reqBody.SEP10SigningPublicKey), "sep10_signing_public_key", "invalid public key")
-	tv.Check(strkey.IsValidEd25519PublicKey(reqBody.DistributionPublicKey), "distribution_public_key", "invalid public key")
 
 	if _, err = url.ParseRequestURI(reqBody.BaseURL); err != nil {
 		tv.Check(false, "base_url", "invalid base URL value")
@@ -111,14 +103,6 @@ func (tv *TenantValidator) ValidateUpdateTenantRequest(reqBody *UpdateTenantRequ
 		SMSSenderType, smsErr := tenant.ParseSMSSenderType(string(*reqBody.SMSSenderType))
 		tv.CheckError(smsErr, "sms_sender_type", fmt.Sprintf("invalid sms sender type. Expected one of these values: %s", []tenant.SMSSenderType{tenant.TwilioSMSSenderType, tenant.AWSSMSSenderType, tenant.DryRunSMSSenderType}))
 		reqBody.SMSSenderType = &SMSSenderType
-	}
-
-	if reqBody.SEP10SigningPublicKey != nil {
-		tv.Check(strkey.IsValidEd25519PublicKey(*reqBody.SEP10SigningPublicKey), "sep10_signing_public_key", "invalid public key")
-	}
-
-	if reqBody.DistributionPublicKey != nil {
-		tv.Check(strkey.IsValidEd25519PublicKey(*reqBody.DistributionPublicKey), "distribution_public_key", "invalid public key")
 	}
 
 	if reqBody.CORSAllowedOrigins != nil && len(reqBody.CORSAllowedOrigins) != 0 {

--- a/stellar-multitenant/pkg/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/pkg/internal/validators/tenant_validator_test.go
@@ -3,7 +3,6 @@ package validators
 import (
 	"testing"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,18 +22,16 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"name":                     "invalid tenant name. It should only contains lower case letters and dash (-)",
-			"owner_email":              "invalid email",
-			"owner_first_name":         "owner_first_name is required",
-			"owner_last_name":          "owner_last_name is required",
-			"organization_name":        "organization_name is required",
-			"base_url":                 "invalid base URL value",
-			"email_sender_type":        "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
-			"sms_sender_type":          "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
-			"cors_allowed_origins":     "provide at least one CORS allowed origins",
-			"sdp_ui_base_url":          "invalid SDP UI base URL value",
-			"sep10_signing_public_key": "invalid public key",
-			"distribution_public_key":  "invalid public key",
+			"name":                 "invalid tenant name. It should only contains lower case letters and dash (-)",
+			"owner_email":          "invalid email",
+			"owner_first_name":     "owner_first_name is required",
+			"owner_last_name":      "owner_last_name is required",
+			"organization_name":    "organization_name is required",
+			"base_url":             "invalid base URL value",
+			"email_sender_type":    "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
+			"sms_sender_type":      "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
+			"cors_allowed_origins": "provide at least one CORS allowed origins",
+			"sdp_ui_base_url":      "invalid SDP UI base URL value",
 		}, tv.Errors)
 
 		reqBody.Name = "aid-org"
@@ -42,37 +39,33 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"owner_email":              "invalid email",
-			"owner_first_name":         "owner_first_name is required",
-			"owner_last_name":          "owner_last_name is required",
-			"organization_name":        "organization_name is required",
-			"base_url":                 "invalid base URL value",
-			"email_sender_type":        "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
-			"sms_sender_type":          "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
-			"cors_allowed_origins":     "provide at least one CORS allowed origins",
-			"sdp_ui_base_url":          "invalid SDP UI base URL value",
-			"sep10_signing_public_key": "invalid public key",
-			"distribution_public_key":  "invalid public key",
+			"owner_email":          "invalid email",
+			"owner_first_name":     "owner_first_name is required",
+			"owner_last_name":      "owner_last_name is required",
+			"organization_name":    "organization_name is required",
+			"base_url":             "invalid base URL value",
+			"email_sender_type":    "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
+			"sms_sender_type":      "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
+			"cors_allowed_origins": "provide at least one CORS allowed origins",
+			"sdp_ui_base_url":      "invalid SDP UI base URL value",
 		}, tv.Errors)
 	})
 
 	t.Run("returns error when name is invalid", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:                  "aid org",
-			OwnerEmail:            "owner@email.org",
-			OwnerFirstName:        "Owner",
-			OwnerLastName:         "Owner",
-			OrganizationName:      "Aid Org",
-			EmailSenderType:       tenant.AWSEmailSenderType,
-			SMSSenderType:         tenant.TwilioSMSSenderType,
-			SEP10SigningPublicKey: keypair.MustRandom().Address(),
-			DistributionPublicKey: keypair.MustRandom().Address(),
-			EnableMFA:             true,
-			EnableReCAPTCHA:       true,
-			CORSAllowedOrigins:    []string{"*"},
-			SDPUIBaseURL:          "http://localhost:3000",
-			BaseURL:               "http://localhost:8000",
+			Name:               "aid org",
+			OwnerEmail:         "owner@email.org",
+			OwnerFirstName:     "Owner",
+			OwnerLastName:      "Owner",
+			OrganizationName:   "Aid Org",
+			EmailSenderType:    tenant.AWSEmailSenderType,
+			SMSSenderType:      tenant.TwilioSMSSenderType,
+			EnableMFA:          true,
+			EnableReCAPTCHA:    true,
+			CORSAllowedOrigins: []string{"*"},
+			SDPUIBaseURL:       "http://localhost:3000",
+			BaseURL:            "http://localhost:8000",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -85,20 +78,18 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("returns error when owner info is invalid", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:                  "aid-org",
-			OwnerEmail:            "invalid",
-			OwnerFirstName:        "",
-			OwnerLastName:         "",
-			OrganizationName:      "",
-			EmailSenderType:       tenant.AWSEmailSenderType,
-			SMSSenderType:         tenant.TwilioSMSSenderType,
-			SEP10SigningPublicKey: keypair.MustRandom().Address(),
-			DistributionPublicKey: keypair.MustRandom().Address(),
-			EnableMFA:             true,
-			EnableReCAPTCHA:       true,
-			CORSAllowedOrigins:    []string{"*"},
-			BaseURL:               "http://localhost:8000",
-			SDPUIBaseURL:          "http://localhost:3000",
+			Name:               "aid-org",
+			OwnerEmail:         "invalid",
+			OwnerFirstName:     "",
+			OwnerLastName:      "",
+			OrganizationName:   "",
+			EmailSenderType:    tenant.AWSEmailSenderType,
+			SMSSenderType:      tenant.TwilioSMSSenderType,
+			EnableMFA:          true,
+			EnableReCAPTCHA:    true,
+			CORSAllowedOrigins: []string{"*"},
+			BaseURL:            "http://localhost:8000",
+			SDPUIBaseURL:       "http://localhost:3000",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -123,20 +114,18 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("validates the email sender type successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:                  "aid-org",
-			OwnerEmail:            "owner@email.org",
-			OwnerFirstName:        "Owner",
-			OwnerLastName:         "Owner",
-			OrganizationName:      "Aid Org",
-			EmailSenderType:       "invalid",
-			SMSSenderType:         tenant.TwilioSMSSenderType,
-			SEP10SigningPublicKey: keypair.MustRandom().Address(),
-			DistributionPublicKey: keypair.MustRandom().Address(),
-			EnableMFA:             true,
-			EnableReCAPTCHA:       true,
-			CORSAllowedOrigins:    []string{"*"},
-			SDPUIBaseURL:          "http://localhost:3000",
-			BaseURL:               "http://localhost:8000",
+			Name:               "aid-org",
+			OwnerEmail:         "owner@email.org",
+			OwnerFirstName:     "Owner",
+			OwnerLastName:      "Owner",
+			OrganizationName:   "Aid Org",
+			EmailSenderType:    "invalid",
+			SMSSenderType:      tenant.TwilioSMSSenderType,
+			EnableMFA:          true,
+			EnableReCAPTCHA:    true,
+			CORSAllowedOrigins: []string{"*"},
+			SDPUIBaseURL:       "http://localhost:3000",
+			BaseURL:            "http://localhost:8000",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -152,20 +141,18 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("validates the sms sender type successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:                  "aid-org",
-			OwnerEmail:            "owner@email.org",
-			OwnerFirstName:        "Owner",
-			OwnerLastName:         "Owner",
-			OrganizationName:      "Aid Org",
-			EmailSenderType:       tenant.AWSEmailSenderType,
-			SMSSenderType:         "invalid",
-			SEP10SigningPublicKey: keypair.MustRandom().Address(),
-			DistributionPublicKey: keypair.MustRandom().Address(),
-			EnableMFA:             true,
-			EnableReCAPTCHA:       true,
-			CORSAllowedOrigins:    []string{"*"},
-			SDPUIBaseURL:          "http://localhost:3000",
-			BaseURL:               "http://localhost:8000",
+			Name:               "aid-org",
+			OwnerEmail:         "owner@email.org",
+			OwnerFirstName:     "Owner",
+			OwnerLastName:      "Owner",
+			OrganizationName:   "Aid Org",
+			EmailSenderType:    tenant.AWSEmailSenderType,
+			SMSSenderType:      "invalid",
+			EnableMFA:          true,
+			EnableReCAPTCHA:    true,
+			CORSAllowedOrigins: []string{"*"},
+			SDPUIBaseURL:       "http://localhost:3000",
+			BaseURL:            "http://localhost:8000",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -178,50 +165,21 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		assert.False(t, tv.HasErrors())
 	})
 
-	t.Run("validates the public keys successfully", func(t *testing.T) {
-		tv := NewTenantValidator()
-		reqBody := &TenantRequest{
-			Name:                  "aid-org",
-			OwnerEmail:            "owner@email.org",
-			OwnerFirstName:        "Owner",
-			OwnerLastName:         "Owner",
-			OrganizationName:      "Aid Org",
-			EmailSenderType:       tenant.AWSEmailSenderType,
-			SMSSenderType:         tenant.TwilioSMSSenderType,
-			SEP10SigningPublicKey: "invalid",
-			DistributionPublicKey: "invalid",
-			EnableMFA:             true,
-			EnableReCAPTCHA:       true,
-			CORSAllowedOrigins:    []string{"*"},
-			SDPUIBaseURL:          "http://localhost:3000",
-			BaseURL:               "http://localhost:8000",
-		}
-
-		tv.ValidateCreateTenantRequest(reqBody)
-		assert.True(t, tv.HasErrors())
-		assert.Equal(t, map[string]interface{}{
-			"sep10_signing_public_key": "invalid public key",
-			"distribution_public_key":  "invalid public key",
-		}, tv.Errors)
-	})
-
 	t.Run("validates the URLs successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:                  "aid-org",
-			OwnerEmail:            "owner@email.org",
-			OwnerFirstName:        "Owner",
-			OwnerLastName:         "Owner",
-			OrganizationName:      "Aid Org",
-			EmailSenderType:       tenant.AWSEmailSenderType,
-			SMSSenderType:         tenant.TwilioSMSSenderType,
-			SEP10SigningPublicKey: keypair.MustRandom().Address(),
-			DistributionPublicKey: keypair.MustRandom().Address(),
-			EnableMFA:             true,
-			EnableReCAPTCHA:       true,
-			CORSAllowedOrigins:    []string{"http://valid.com", "%invalid%"},
-			SDPUIBaseURL:          "%invalid%",
-			BaseURL:               "%invalid%",
+			Name:               "aid-org",
+			OwnerEmail:         "owner@email.org",
+			OwnerFirstName:     "Owner",
+			OwnerLastName:      "Owner",
+			OrganizationName:   "Aid Org",
+			EmailSenderType:    tenant.AWSEmailSenderType,
+			SMSSenderType:      tenant.TwilioSMSSenderType,
+			EnableMFA:          true,
+			EnableReCAPTCHA:    true,
+			CORSAllowedOrigins: []string{"http://valid.com", "%invalid%"},
+			SDPUIBaseURL:       "%invalid%",
+			BaseURL:            "%invalid%",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -251,38 +209,31 @@ func TestTenantValidator_ValidateUpdateTenantRequest(t *testing.T) {
 		tv := NewTenantValidator()
 		invalidValue := "invalid"
 		reqBody := &UpdateTenantRequest{
-			SEP10SigningPublicKey: &invalidValue,
-			DistributionPublicKey: &invalidValue,
-			CORSAllowedOrigins:    []string{invalidValue},
-			BaseURL:               &invalidValue,
-			SDPUIBaseURL:          &invalidValue,
+			CORSAllowedOrigins: []string{invalidValue},
+			BaseURL:            &invalidValue,
+			SDPUIBaseURL:       &invalidValue,
 		}
 		tv.ValidateUpdateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"base_url":                 "invalid base URL value",
-			"cors_allowed_origins":     "invalid URL value for cors_allowed_origins[0] = invalid",
-			"distribution_public_key":  "invalid public key",
-			"sdp_ui_base_url":          "invalid SDP UI base URL value",
-			"sep10_signing_public_key": "invalid public key",
+			"base_url":             "invalid base URL value",
+			"cors_allowed_origins": "invalid URL value for cors_allowed_origins[0] = invalid",
+			"sdp_ui_base_url":      "invalid SDP UI base URL value",
 		}, tv.Errors)
 	})
 
 	t.Run("validates request body successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
-		key := keypair.MustRandom().Address()
 		enable := false
 		url := "http://valid.com"
 		reqBody := &UpdateTenantRequest{
-			EmailSenderType:       &tenant.AWSEmailSenderType,
-			SMSSenderType:         &tenant.AWSSMSSenderType,
-			SEP10SigningPublicKey: &key,
-			DistributionPublicKey: &key,
-			EnableMFA:             &enable,
-			EnableReCAPTCHA:       &enable,
-			CORSAllowedOrigins:    []string{url},
-			BaseURL:               &url,
-			SDPUIBaseURL:          &url,
+			EmailSenderType:    &tenant.AWSEmailSenderType,
+			SMSSenderType:      &tenant.AWSSMSSenderType,
+			EnableMFA:          &enable,
+			EnableReCAPTCHA:    &enable,
+			CORSAllowedOrigins: []string{url},
+			BaseURL:            &url,
+			SDPUIBaseURL:       &url,
 		}
 		tv.ValidateUpdateTenantRequest(reqBody)
 		assert.False(t, tv.HasErrors())

--- a/stellar-multitenant/pkg/tenant/fixtures.go
+++ b/stellar-multitenant/pkg/tenant/fixtures.go
@@ -38,8 +38,8 @@ func ResetTenantConfigFixture(t *testing.T, ctx context.Context, dbConnectionPoo
 	const q = `
 		UPDATE tenants
 		SET
-			email_sender_type = DEFAULT, sms_sender_type = DEFAULT, sep10_signing_public_key = NULL,
-			distribution_public_key = NULL, enable_mfa = DEFAULT, enable_recaptcha = DEFAULT,
+			email_sender_type = DEFAULT, sms_sender_type = DEFAULT,
+			enable_mfa = DEFAULT, enable_recaptcha = DEFAULT,
 			cors_allowed_origins = NULL, base_url = NULL, sdp_ui_base_url = NULL
 		WHERE
 			id = $1

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -159,16 +159,6 @@ func (m *Manager) UpdateTenantConfig(ctx context.Context, tu *TenantUpdate) (*Te
 		args = append(args, *tu.SMSSenderType)
 	}
 
-	if tu.SEP10SigningPublicKey != nil {
-		fields = append(fields, "sep10_signing_public_key = ?")
-		args = append(args, *tu.SEP10SigningPublicKey)
-	}
-
-	if tu.DistributionPublicKey != nil {
-		fields = append(fields, "distribution_public_key = ?")
-		args = append(args, *tu.DistributionPublicKey)
-	}
-
 	if tu.EnableMFA != nil {
 		fields = append(fields, "enable_mfa = ?")
 		args = append(args, *tu.EnableMFA)

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stretchr/testify/assert"
@@ -87,8 +86,6 @@ func Test_Manager_UpdateTenantConfig(t *testing.T) {
 		tntDB = ResetTenantConfigFixture(t, ctx, dbConnectionPool, tntDB.ID)
 		assert.Equal(t, tntDB.EmailSenderType, DryRunEmailSenderType)
 		assert.Equal(t, tntDB.SMSSenderType, DryRunSMSSenderType)
-		assert.Nil(t, tntDB.SEP10SigningPublicKey)
-		assert.Nil(t, tntDB.DistributionPublicKey)
 		assert.True(t, tntDB.EnableMFA)
 		assert.True(t, tntDB.EnableReCAPTCHA)
 		assert.Nil(t, tntDB.BaseURL)
@@ -96,21 +93,17 @@ func Test_Manager_UpdateTenantConfig(t *testing.T) {
 		assert.Empty(t, tntDB.CORSAllowedOrigins)
 
 		// Partial Update
-		addr := keypair.MustRandom().Address()
 		tnt, err := m.UpdateTenantConfig(ctx, &TenantUpdate{
-			ID:                    tntDB.ID,
-			EmailSenderType:       &AWSEmailSenderType,
-			SEP10SigningPublicKey: &addr,
-			EnableMFA:             &[]bool{false}[0],
-			CORSAllowedOrigins:    []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"},
-			SDPUIBaseURL:          &[]string{"https://myorg.frontend.io"}[0],
+			ID:                 tntDB.ID,
+			EmailSenderType:    &AWSEmailSenderType,
+			EnableMFA:          &[]bool{false}[0],
+			CORSAllowedOrigins: []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"},
+			SDPUIBaseURL:       &[]string{"https://myorg.frontend.io"}[0],
 		})
 		require.NoError(t, err)
 
 		assert.Equal(t, tnt.EmailSenderType, AWSEmailSenderType)
 		assert.Equal(t, tnt.SMSSenderType, DryRunSMSSenderType)
-		assert.Equal(t, addr, *tnt.SEP10SigningPublicKey)
-		assert.Nil(t, tnt.DistributionPublicKey)
 		assert.False(t, tnt.EnableMFA)
 		assert.True(t, tnt.EnableReCAPTCHA)
 		assert.Nil(t, tnt.BaseURL)
@@ -118,18 +111,15 @@ func Test_Manager_UpdateTenantConfig(t *testing.T) {
 		assert.ElementsMatch(t, []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"}, tnt.CORSAllowedOrigins)
 
 		tnt, err = m.UpdateTenantConfig(ctx, &TenantUpdate{
-			ID:                    tntDB.ID,
-			SMSSenderType:         &TwilioSMSSenderType,
-			DistributionPublicKey: &addr,
-			EnableReCAPTCHA:       &[]bool{false}[0],
-			BaseURL:               &[]string{"https://myorg.backend.io"}[0],
+			ID:              tntDB.ID,
+			SMSSenderType:   &TwilioSMSSenderType,
+			EnableReCAPTCHA: &[]bool{false}[0],
+			BaseURL:         &[]string{"https://myorg.backend.io"}[0],
 		})
 		require.NoError(t, err)
 
 		assert.Equal(t, tnt.EmailSenderType, AWSEmailSenderType)
 		assert.Equal(t, tnt.SMSSenderType, TwilioSMSSenderType)
-		assert.Equal(t, addr, *tnt.SEP10SigningPublicKey)
-		assert.Equal(t, addr, *tnt.DistributionPublicKey)
 		assert.False(t, tnt.EnableMFA)
 		assert.False(t, tnt.EnableReCAPTCHA)
 		assert.Equal(t, "https://myorg.backend.io", *tnt.BaseURL)

--- a/stellar-multitenant/pkg/tenant/tenant.go
+++ b/stellar-multitenant/pkg/tenant/tenant.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/lib/pq"
-	"github.com/stellar/go/strkey"
 	"golang.org/x/exp/slices"
 )
 
@@ -44,34 +43,30 @@ func ParseSMSSenderType(smsSenderTypeStr string) (SMSSenderType, error) {
 }
 
 type Tenant struct {
-	ID                    string          `json:"id" db:"id"`
-	Name                  string          `json:"name" db:"name"`
-	EmailSenderType       EmailSenderType `json:"email_sender_type" db:"email_sender_type"`
-	SMSSenderType         SMSSenderType   `json:"sms_sender_type" db:"sms_sender_type"`
-	SEP10SigningPublicKey *string         `json:"sep10_signing_public_key" db:"sep10_signing_public_key"`
-	DistributionPublicKey *string         `json:"distribution_public_key" db:"distribution_public_key"`
-	EnableMFA             bool            `json:"enable_mfa" db:"enable_mfa"`
-	EnableReCAPTCHA       bool            `json:"enable_recaptcha" db:"enable_recaptcha"`
-	CORSAllowedOrigins    pq.StringArray  `json:"cors_allowed_origins" db:"cors_allowed_origins"`
-	BaseURL               *string         `json:"base_url" db:"base_url"`
-	SDPUIBaseURL          *string         `json:"sdp_ui_base_url" db:"sdp_ui_base_url"`
-	Status                TenantStatus    `json:"status" db:"status"`
-	CreatedAt             time.Time       `json:"created_at" db:"created_at"`
-	UpdatedAt             time.Time       `json:"updated_at" db:"updated_at"`
+	ID                 string          `json:"id" db:"id"`
+	Name               string          `json:"name" db:"name"`
+	EmailSenderType    EmailSenderType `json:"email_sender_type" db:"email_sender_type"`
+	SMSSenderType      SMSSenderType   `json:"sms_sender_type" db:"sms_sender_type"`
+	EnableMFA          bool            `json:"enable_mfa" db:"enable_mfa"`
+	EnableReCAPTCHA    bool            `json:"enable_recaptcha" db:"enable_recaptcha"`
+	CORSAllowedOrigins pq.StringArray  `json:"cors_allowed_origins" db:"cors_allowed_origins"`
+	BaseURL            *string         `json:"base_url" db:"base_url"`
+	SDPUIBaseURL       *string         `json:"sdp_ui_base_url" db:"sdp_ui_base_url"`
+	Status             TenantStatus    `json:"status" db:"status"`
+	CreatedAt          time.Time       `json:"created_at" db:"created_at"`
+	UpdatedAt          time.Time       `json:"updated_at" db:"updated_at"`
 }
 
 type TenantUpdate struct {
-	ID                    string           `db:"id"`
-	EmailSenderType       *EmailSenderType `db:"email_sender_type"`
-	SMSSenderType         *SMSSenderType   `db:"sms_sender_type"`
-	SEP10SigningPublicKey *string          `db:"sep10_signing_public_key"`
-	DistributionPublicKey *string          `db:"distribution_public_key"`
-	EnableMFA             *bool            `db:"enable_mfa"`
-	EnableReCAPTCHA       *bool            `db:"enable_recaptcha"`
-	CORSAllowedOrigins    []string         `db:"cors_allowed_origins"`
-	BaseURL               *string          `db:"base_url"`
-	SDPUIBaseURL          *string          `db:"sdp_ui_base_url"`
-	Status                *TenantStatus    `db:"status"`
+	ID                 string           `db:"id"`
+	EmailSenderType    *EmailSenderType `db:"email_sender_type"`
+	SMSSenderType      *SMSSenderType   `db:"sms_sender_type"`
+	EnableMFA          *bool            `db:"enable_mfa"`
+	EnableReCAPTCHA    *bool            `db:"enable_recaptcha"`
+	CORSAllowedOrigins []string         `db:"cors_allowed_origins"`
+	BaseURL            *string          `db:"base_url"`
+	SDPUIBaseURL       *string          `db:"sdp_ui_base_url"`
+	Status             *TenantStatus    `db:"status"`
 }
 
 type TenantStatus string
@@ -109,14 +104,6 @@ func (tu *TenantUpdate) Validate() error {
 		}
 	}
 
-	if tu.SEP10SigningPublicKey != nil && !strkey.IsValidEd25519PublicKey(*tu.SEP10SigningPublicKey) {
-		return fmt.Errorf("invalid SEP-10 signing public key")
-	}
-
-	if tu.DistributionPublicKey != nil && !strkey.IsValidEd25519PublicKey(*tu.DistributionPublicKey) {
-		return fmt.Errorf("invalid distribution public key")
-	}
-
 	if tu.BaseURL != nil && !isValidURL(*tu.BaseURL) {
 		return fmt.Errorf("invalid base URL")
 	}
@@ -141,8 +128,6 @@ func (tu *TenantUpdate) Validate() error {
 func (tu *TenantUpdate) areAllFieldsEmpty() bool {
 	return (tu.EmailSenderType == nil &&
 		tu.SMSSenderType == nil &&
-		tu.SEP10SigningPublicKey == nil &&
-		tu.DistributionPublicKey == nil &&
 		tu.EnableMFA == nil &&
 		tu.EnableReCAPTCHA == nil &&
 		tu.CORSAllowedOrigins == nil &&

--- a/stellar-multitenant/pkg/tenant/tenant_test.go
+++ b/stellar-multitenant/pkg/tenant/tenant_test.go
@@ -3,7 +3,6 @@ package tenant
 import (
 	"testing"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,22 +28,12 @@ func Test_TenantUpdate_Validate(t *testing.T) {
 		assert.EqualError(t, err, `invalid SMS sender type: invalid sms sender type "invalid"`)
 
 		tu.SMSSenderType = nil
-		addr := "invalid"
-		tu.SEP10SigningPublicKey = &addr
-		err = tu.Validate()
-		assert.EqualError(t, err, "invalid SEP-10 signing public key")
-
-		tu.SEP10SigningPublicKey = nil
-		tu.DistributionPublicKey = &addr
-		err = tu.Validate()
-		assert.EqualError(t, err, "invalid distribution public key")
-
-		tu.DistributionPublicKey = nil
 		u := "inv@lid$"
 		tu.BaseURL = &u
 		err = tu.Validate()
 		assert.EqualError(t, err, "invalid base URL")
 
+		tu.SMSSenderType = nil
 		tu.BaseURL = nil
 		tu.SDPUIBaseURL = &u
 		err = tu.Validate()
@@ -64,17 +53,15 @@ func Test_TenantUpdate_Validate(t *testing.T) {
 
 	t.Run("valid values", func(t *testing.T) {
 		tu := TenantUpdate{
-			ID:                    "abc",
-			EmailSenderType:       &AWSEmailSenderType,
-			SMSSenderType:         &TwilioSMSSenderType,
-			SEP10SigningPublicKey: &[]string{keypair.MustRandom().Address()}[0],
-			DistributionPublicKey: &[]string{keypair.MustRandom().Address()}[0],
-			EnableMFA:             &[]bool{true}[0],
-			EnableReCAPTCHA:       &[]bool{true}[0],
-			CORSAllowedOrigins:    []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"},
-			BaseURL:               &[]string{"https://myorg.backend.io"}[0],
-			SDPUIBaseURL:          &[]string{"https://myorg.frontend.io"}[0],
-			Status:                &[]TenantStatus{ProvisionedTenantStatus}[0],
+			ID:                 "abc",
+			EmailSenderType:    &AWSEmailSenderType,
+			SMSSenderType:      &TwilioSMSSenderType,
+			EnableMFA:          &[]bool{true}[0],
+			EnableReCAPTCHA:    &[]bool{true}[0],
+			CORSAllowedOrigins: []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"},
+			BaseURL:            &[]string{"https://myorg.backend.io"}[0],
+			SDPUIBaseURL:       &[]string{"https://myorg.frontend.io"}[0],
+			Status:             &[]TenantStatus{ProvisionedTenantStatus}[0],
 		}
 		err := tu.Validate()
 		assert.NoError(t, err)


### PR DESCRIPTION
### What

- Remove **Distribution account** from tenant configuration
- Remove **SEP 10 account** from tenant configuration

### Why

- **SEP 10 account**: We will only need one SEP10 account for the whole SDP instance (all tenants). SEP10 is used for authentication between the wallet and the SDP (host). Anchor wouldn't work with one SEP10 account per organization.
- **Distribution account**: Distribution account will be set at the organization level. Regardless of how we will decide to provision and configure the distribution account, it won't be a configuration at the tenant level. We don't want to the admins (hosts) to know anything about the orgs distribution account. 


### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [ ] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
