### PR TITLE
SDP-977 Generate a Multi-tenant SEP1 TOML

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -138,6 +138,13 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 			Required:       true,
 		},
 		{
+			Name:      "instance-name",
+			Usage:     `Name of the SDP instance. Example: "SDP Testnet".`,
+			OptType:   types.String,
+			ConfigKey: &serveOpts.InstanceName,
+			Required:  true,
+		},
+		{
 			Name:           "ec256-public-key",
 			Usage:          "The EC256 Public Key used to validate the token signature. This EC key needs to be at least as strong as prime256v1 (P-256).",
 			OptType:        types.String,

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -95,6 +95,7 @@ func Test_serve(t *testing.T) {
 		GitCommit:                       "1234567890abcdef",
 		Port:                            8000,
 		Version:                         "x.y.z",
+		InstanceName:                    "SDP Testnet",
 		MonitorService:                  &mMonitorService,
 		DatabaseDSN:                     randomDatabaseDSN,
 		EC256PublicKey:                  "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER88h7AiQyVDysRTxKvBB6CaiO/kS\ncvGyimApUE/12gFhNTRf37SE19CSCllKxstnVFOpLLWB7Qu5OJ0Wvcz3hg==\n-----END PUBLIC KEY-----",
@@ -207,6 +208,7 @@ func Test_serve(t *testing.T) {
 	t.Setenv("RECAPTCHA_SITE_KEY", serveOpts.ReCAPTCHASiteKey)
 	t.Setenv("RECAPTCHA_SITE_SECRET_KEY", serveOpts.ReCAPTCHASiteSecretKey)
 	t.Setenv("CORS_ALLOWED_ORIGINS", "*")
+	t.Setenv("INSTANCE_NAME", serveOpts.InstanceName)
 
 	// test & assert
 	rootCmd.SetArgs([]string{"--environment", "test", "serve", "--metrics-type", "PROMETHEUS"})

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -44,6 +44,9 @@ services:
       ENABLE_MFA: "false"
       ENABLE_RECAPTCHA: "false"
 
+      # multi-tenant
+      INSTANCE_NAME: "SDP Testnet on Docker"
+
       # secrets:
       AWS_ACCESS_KEY_ID: MY_AWS_ACCESS_KEY_ID
       AWS_REGION: MY_AWS_REGION

--- a/internal/serve/httphandler/stellar_toml_handler.go
+++ b/internal/serve/httphandler/stellar_toml_handler.go
@@ -5,6 +5,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+
 	"github.com/stellar/go/network"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
@@ -16,6 +20,7 @@ type StellarTomlHandler struct {
 	NetworkPassphrase        string
 	Models                   *data.Models
 	Sep10SigningPublicKey    string
+	InstanceName             string
 }
 
 const (
@@ -46,11 +51,11 @@ func (s *StellarTomlHandler) buildGeneralInformation() string {
 	`, accounts, s.Sep10SigningPublicKey, s.NetworkPassphrase, s.horizonURL(), webAuthEndpoint, transferServerSep0024)
 }
 
-func (s *StellarTomlHandler) buildOrganizationDocumentation(organization data.Organization) string {
+func (s *StellarTomlHandler) buildOrganizationDocumentation(instanceName string) string {
 	return fmt.Sprintf(`
 		[DOCUMENTATION]
 		ORG_NAME=%q
-	`, organization.Name)
+	`, instanceName)
 }
 
 // buildCurrencyInformation will create the currency information for all assets register in the application.
@@ -84,20 +89,35 @@ func (s *StellarTomlHandler) buildCurrencyInformation(assets []data.Asset) strin
 
 // ServeHTTP will serve the stellar.toml file needed to register users through SEP-24.
 func (s StellarTomlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	assets, err := s.Models.Assets.GetAll(r.Context())
 	ctx := r.Context()
+	var stellarToml string
+	_, err := tenant.GetTenantFromContext(ctx)
 	if err != nil {
-		httperror.InternalError(ctx, "Cannot retrieve assets", err, nil).Render(w)
-		return
+		// return a general stellar.toml file for this instance because no tenant is present.
+		networkType, innerErr := utils.GetNetworkTypeFromNetworkPassphrase(s.NetworkPassphrase)
+		if innerErr != nil {
+			httperror.InternalError(ctx, "Couldn't generate stellar.toml file for this instance", innerErr, nil).Render(w)
+			return
+		}
+		instanceAssets := services.DefaultAssetsNetworkMap[networkType]
+		stellarToml = s.buildGeneralInformation() + s.buildOrganizationDocumentation(s.InstanceName) + s.buildCurrencyInformation(instanceAssets)
+	} else {
+		// return a stellar.toml file for this tenant.
+		organization, innerErr := s.Models.Organizations.Get(r.Context())
+		if innerErr != nil {
+			httperror.InternalError(ctx, "Cannot retrieve organization", err, nil).Render(w)
+			return
+		}
+
+		assets, innerErr := s.Models.Assets.GetAll(ctx)
+		if innerErr != nil {
+			httperror.InternalError(ctx, "Cannot retrieve assets", innerErr, nil).Render(w)
+			return
+		}
+
+		stellarToml = s.buildGeneralInformation() + s.buildOrganizationDocumentation(organization.Name) + s.buildCurrencyInformation(assets)
 	}
 
-	organization, err := s.Models.Organizations.Get(r.Context())
-	if err != nil {
-		httperror.InternalError(ctx, "Cannot retrieve organization", err, nil).Render(w)
-		return
-	}
-
-	stellarToml := s.buildGeneralInformation() + s.buildOrganizationDocumentation(*organization) + s.buildCurrencyInformation(assets)
 	stellarToml = strings.TrimSpace(stellarToml)
 	stellarToml = strings.ReplaceAll(stellarToml, "\t", "")
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -52,6 +52,7 @@ type ServeOptions struct {
 	GitCommit                       string
 	Port                            int
 	Version                         string
+	InstanceName                    string
 	MonitorService                  monitor.MonitorServiceInterface
 	DatabaseDSN                     string
 	dbConnectionPool                db.DBConnectionPool
@@ -387,6 +388,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		NetworkPassphrase:        o.NetworkPassphrase,
 		Models:                   o.Models,
 		Sep10SigningPublicKey:    o.Sep10SigningPublicKey,
+		InstanceName:             o.InstanceName,
 	}.ServeHTTP)
 
 	mux.Route("/wallet-registration", func(r chi.Router) {

--- a/stellar-auth/pkg/auth/jwt_manager.go
+++ b/stellar-auth/pkg/auth/jwt_manager.go
@@ -75,9 +75,9 @@ func (m *defaultJWTManager) GenerateToken(ctx context.Context, user *User, expir
 	}
 
 	// TODO: Always throw this error after migrations are merged [SDP-953]
-	currentTenant, ok := tenant.GetTenantFromContext(ctx)
-	if !ok {
-		log.Ctx(ctx).Error("tenant not found in context")
+	currentTenant, err := tenant.GetTenantFromContext(ctx)
+	if err != nil {
+		log.Ctx(ctx).Error(err)
 	} else {
 		c.TenantID = currentTenant.ID
 	}

--- a/stellar-multitenant/pkg/router/multitenant_data_source_router.go
+++ b/stellar-multitenant/pkg/router/multitenant_data_source_router.go
@@ -10,10 +10,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
-var (
-	ErrTenantNotFoundInContext = errors.New("tenant not found in context")
-	ErrNoDataSourcesAvailable  = errors.New("no data sources are available")
-)
+var ErrNoDataSourcesAvailable = errors.New("no data sources are available")
 
 type MultiTenantDataSourceRouter struct {
 	dataSources   sync.Map
@@ -28,9 +25,9 @@ func NewMultiTenantDataSourceRouter(tenantManager tenant.ManagerInterface) *Mult
 }
 
 func (m *MultiTenantDataSourceRouter) GetDataSource(ctx context.Context) (db.DBConnectionPool, error) {
-	currentTenant, ok := tenant.GetTenantFromContext(ctx)
-	if !ok {
-		return nil, ErrTenantNotFoundInContext
+	currentTenant, err := tenant.GetTenantFromContext(ctx)
+	if err != nil {
+		return nil, tenant.ErrTenantNotFoundInContext
 	}
 
 	return m.GetDataSourceForTenant(ctx, *currentTenant)

--- a/stellar-multitenant/pkg/router/multitenant_data_source_router_test.go
+++ b/stellar-multitenant/pkg/router/multitenant_data_source_router_test.go
@@ -27,7 +27,7 @@ func TestMultiTenantDataSourceRouter_GetDataSource(t *testing.T) {
 	t.Run("error tenant not found in context", func(t *testing.T) {
 		dbcp, err := router.GetDataSource(ctx)
 		require.Nil(t, dbcp)
-		require.EqualError(t, err, ErrTenantNotFoundInContext.Error())
+		require.EqualError(t, err, tenant.ErrTenantNotFoundInContext.Error())
 	})
 
 	t.Run("successfully getting data source", func(t *testing.T) {

--- a/stellar-multitenant/pkg/tenant/fixtures.go
+++ b/stellar-multitenant/pkg/tenant/fixtures.go
@@ -118,9 +118,15 @@ func CreateTenantFixture(t *testing.T, ctx context.Context, sqlExec db.SQLExecut
 	}
 
 	err := sqlExec.GetContext(ctx, tnt, query, tnt.Name)
-	require.NoError(t, err)
+	require.Nil(t, err)
 
 	return tnt
+}
+
+func LoadDefaultTenantInContext(t *testing.T, dbConnectionPool db.DBConnectionPool) context.Context {
+	ctx := context.Background()
+	tnt := CreateTenantFixture(t, ctx, dbConnectionPool, "default-tenant")
+	return SaveTenantInContext(ctx, tnt)
 }
 
 func CheckSchemaExistsFixture(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, schemaName string) bool {

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	ErrTenantDoesNotExist   = errors.New("tenant does not exist")
-	ErrDuplicatedTenantName = errors.New("duplicated tenant name")
-	ErrEmptyTenantName      = errors.New("tenant name cannot be empty")
-	ErrEmptyUpdateTenant    = errors.New("provide at least one field to be updated")
+	ErrTenantDoesNotExist      = errors.New("tenant does not exist")
+	ErrDuplicatedTenantName    = errors.New("duplicated tenant name")
+	ErrEmptyTenantName         = errors.New("tenant name cannot be empty")
+	ErrEmptyUpdateTenant       = errors.New("provide at least one field to be updated")
+	ErrTenantNotFoundInContext = errors.New("tenant not found in context")
 )
 
 type tenantContextKey struct{}
@@ -205,9 +206,12 @@ func (m *Manager) UpdateTenantConfig(ctx context.Context, tu *TenantUpdate) (*Te
 }
 
 // GetTenantFromContext retrieves the tenant information from the context.
-func GetTenantFromContext(ctx context.Context) (*Tenant, bool) {
+func GetTenantFromContext(ctx context.Context) (*Tenant, error) {
 	currentTenant, ok := ctx.Value(tenantContextKey{}).(*Tenant)
-	return currentTenant, ok
+	if !ok {
+		return nil, ErrTenantNotFoundInContext
+	}
+	return currentTenant, nil
 }
 
 // SaveTenantInContext stores the tenant information in the context.


### PR DESCRIPTION
## Why
- Currently we can't start up Anchor platform because it attempts fetching a TOML file without specifying a tenant. 
- We need a way to identify the instance's TOML file. 
- Fix anchor tests

## What 
TOML file currently gets generated based on one organization’s name, assets and distribution accounts. 

We need to change the  SDP TOML file to be dynamically generated depending on knowledge of the tenant. We will have a distinction between a tenant’s TOML file and the host’s TOML file. 

### instance (host) TOML file

- Has the aggregated list of assets supported by all tenants
- Anchor needs this on startup. 

### tenant’s TOML file

- Has the information of a particular tenant. 
- Used during wallet registration process.
