### PR TITLE
SDP-977 - Multi-tenant Docker Compose

### DIFF
--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -9,6 +9,9 @@ on:
       - "releases/**"
       - "hotfix/**"
   pull_request:
+    branches-ignore:
+      - sdp-multitenant # TODO: SDP-968 - re-enable end to end tests for multi-tenant SDP
+
   workflow_call: # allows this workflow to be called from another workflow
 
 env:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -433,7 +433,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 				}
 				go scheduler.StartScheduler(crashTrackerClient.Clone(), schedulerJobRegistrars...)
 			} else {
-				log.Ctx(ctx).Info("Scheduler Service is disabled.")
+				log.Ctx(ctx).Warn("Scheduler Service is disabled.")
 			}
 
 			// Starting Metrics Server (background job)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -118,6 +118,8 @@ func Test_serve(t *testing.T) {
 		ReCAPTCHASiteSecretKey:          "reCAPTCHASiteSecretKey",
 		EnableMFA:                       true,
 		EnableReCAPTCHA:                 true,
+		EnableScheduler:                 true,
+		EnableMultiTenantDB:             false,
 	}
 	var err error
 	serveOpts.AnchorPlatformAPIService, err = anchorplatform.NewAnchorPlatformAPIService(httpclient.DefaultClient(), serveOpts.AnchorPlatformBasePlatformURL, serveOpts.AnchorPlatformOutgoingJWTSecret)
@@ -209,6 +211,8 @@ func Test_serve(t *testing.T) {
 	t.Setenv("RECAPTCHA_SITE_SECRET_KEY", serveOpts.ReCAPTCHASiteSecretKey)
 	t.Setenv("CORS_ALLOWED_ORIGINS", "*")
 	t.Setenv("INSTANCE_NAME", serveOpts.InstanceName)
+	t.Setenv("ENABLE_SCHEDULER", "true")
+	t.Setenv("ENABLE_MULTITENANT_DB", "false")
 
 	// test & assert
 	rootCmd.SetArgs([]string{"--environment", "test", "serve", "--metrics-type", "PROMETHEUS"})

--- a/dev/docker-compose-frontend.yml
+++ b/dev/docker-compose-frontend.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   sdp-frontend:
     container_name: sdp-frontend
-    image: stellar/stellar-disbursement-platform-frontend:edge
+    image: stellar/stellar-disbursement-platform-frontend:multitenant-alpha
     ports:
       - "3000:80"
     volumes:

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -1,11 +1,11 @@
 version: '3.8'
 services:
   db:
-    container_name: sdp_v2_database
+    container_name: sdp_v2_database-mtn
     image: postgres:14-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_DB: sdp
+      POSTGRES_DB: sdp_mtn
       PGDATA: /data/postgres
     ports:
       - "5432:5432"
@@ -24,7 +24,7 @@ services:
       - "8003:8003"
     environment:
       BASE_URL: http://localhost:8000
-      DATABASE_URL: postgres://postgres@db:5432/sdp?sslmode=disable
+      DATABASE_URL: postgres://postgres@db:5432/sdp_mtn?sslmode=disable
       ENVIRONMENT: localhost
       LOG_LEVEL: TRACE
       PORT: "8000"
@@ -40,12 +40,13 @@ services:
       DISTRIBUTION_PUBLIC_KEY: ${DISTRIBUTION_PUBLIC_KEY}
       DISTRIBUTION_SEED: ${DISTRIBUTION_SEED}
       RECAPTCHA_SITE_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
-      CORS_ALLOWED_ORIGINS: http://localhost:3000
+      CORS_ALLOWED_ORIGINS: "*"
       ENABLE_MFA: "false"
       ENABLE_RECAPTCHA: "false"
 
       # multi-tenant
       INSTANCE_NAME: "SDP Testnet on Docker"
+      ENABLE_SCHEDULER: "false"
 
       # secrets:
       AWS_ACCESS_KEY_ID: MY_AWS_ACCESS_KEY_ID
@@ -69,7 +70,7 @@ services:
         ./stellar-disbursement-platform db tenant migrate up
         ./stellar-disbursement-platform db migrate up --all
         ./stellar-disbursement-platform db auth migrate up --all
-        ./stellar-disbursement-platform db setup-for-network
+        ./stellar-disbursement-platform db setup-for-network --all
         ./stellar-disbursement-platform serve
     depends_on:
       - db

--- a/dev/docker-compose-tss.yml
+++ b/dev/docker-compose-tss.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "9000:9000"
     environment:
-      DATABASE_URL: postgres://postgres@db:5432/sdp?sslmode=disable
+      DATABASE_URL: postgres://postgres@db:5432/sdp_mtn?sslmode=disable
       NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
       HORIZON_URL: "https://horizon-testnet.stellar.org"
       NUM_CHANNEL_ACCOUNTS: "3"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -20,10 +20,10 @@ services:
     extends:
       file: docker-compose-sdp-anchor.yml
       service: anchor-platform
-  sdp-tss:
-    extends:
-      file: docker-compose-tss.yml
-      service: sdp-tss
+#  sdp-tss:
+#    extends:
+#      file: docker-compose-tss.yml
+#      service: sdp-tss
   sdp-frontend:
     extends:
       file: docker-compose-frontend.yml

--- a/dev/main.sh
+++ b/dev/main.sh
@@ -2,6 +2,13 @@
 # This script is used to locally start the integration between SDP and AnchorPlatform for the SEP-24 deposit flow, needed for registering users.
 set -eu
 
+# Check if curl is installed
+if ! command -v curl &> /dev/null
+then
+    echo "Error: curl is not installed. Please install curl to continue."
+    exit 1
+fi
+
 export DIVIDER="----------------------------------------"
 
 # prepare

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/router"
+
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/stellar/go/clients/horizonclient"
@@ -31,7 +33,6 @@ import (
 	txnsubmitterutils "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/router"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
@@ -106,11 +107,12 @@ func (opts *ServeOptions) SetupDependencies() error {
 	if err != nil {
 		return fmt.Errorf("error connecting to the database: %w", err)
 	}
-	opts.tenantManager = tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
-	opts.tenantRouter = router.NewMultiTenantDataSourceRouter(opts.tenantManager)
 
 	// Setup Multi-Tenant Database when enabled
 	if opts.EnableMultiTenantDB {
+		opts.tenantManager = tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
+		opts.tenantRouter = router.NewMultiTenantDataSourceRouter(opts.tenantManager)
+
 		mtnDbConnectionPool, innerErr := db.NewConnectionPoolWithRouter(opts.tenantRouter)
 		if innerErr != nil {
 			return fmt.Errorf("error connecting to the multi-tenant database: %w", innerErr)

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -224,6 +224,7 @@ func getServeOptionsForTests(t *testing.T, databaseDSN string) ServeOptions {
 		Version:                         "x.y.z",
 		NetworkPassphrase:               network.TestNetworkPassphrase,
 		DistributionSeed:                keypair.MustRandom().Seed(),
+		EnableMultiTenantDB:             false,
 	}
 	err = serveOptions.SetupDependencies()
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes 
- Add new environment variable `ENABLE_SCHEDULER`  (default: false): This flag enables the scheduler. Scheduler will remain disabled until work on Kafka is completed. 
- Add new environment variable `ENABLE_MULTITENANT_DB` (default: true): When this flag is enabled, we use the Multi-tenant connection pool with router for the API. When it's disabled, we use the single tenant connection pool. 
- Set `CORS_ALLOWED_ORIGINS: "*"` in docker-compose. This is needed until we fix SDP-980
- Use `multitenant-alpha` frontend-image for docker-compose. 
- Disable TSS for docker-compose. This will remain disabled until work on Kafka is completed. 
- `main.sh` add scripts for creating example tenants during local development. 
- Disable `e2e tests` when PR target is `sdp-multitenant`. This will remain disabled until Kafka work is completed. 