### PR TITLE
[SDP-962] Change SEP-24 Flow to display different verifications based on Disbursement's verification type

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -42,7 +42,7 @@ func NewModels(dbConnectionPool db.DBConnectionPool) (*Models, error) {
 		Payment:                  &PaymentModel{dbConnectionPool: dbConnectionPool},
 		Receiver:                 &ReceiverModel{},
 		DisbursementInstructions: NewDisbursementInstructionModel(dbConnectionPool),
-		ReceiverVerification:     &ReceiverVerificationModel{},
+		ReceiverVerification:     &ReceiverVerificationModel{dbConnectionPool: dbConnectionPool},
 		ReceiverWallet:           &ReceiverWalletModel{dbConnectionPool: dbConnectionPool},
 		DisbursementReceivers:    &DisbursementReceiverModel{dbConnectionPool: dbConnectionPool},
 		Message:                  &MessageModel{dbConnectionPool: dbConnectionPool},

--- a/internal/data/receiver_verification.go
+++ b/internal/data/receiver_verification.go
@@ -94,6 +94,7 @@ func (m *ReceiverVerificationModel) GetAllByReceiverId(ctx context.Context, sqlE
 	return receiverVerifications, nil
 }
 
+// GetLatestByPhoneNumber returns the latest updated receiver verification for some receiver that is associated with a phone number.
 func (m *ReceiverVerificationModel) GetLatestByPhoneNumber(ctx context.Context, phoneNumber string) (*ReceiverVerification, error) {
 	receiverVerifications := []ReceiverVerification{}
 	query := `
@@ -101,8 +102,7 @@ func (m *ReceiverVerificationModel) GetLatestByPhoneNumber(ctx context.Context, 
 			rv.*
 		FROM 
 			receiver_verifications rv
-		JOIN receivers r 
-			ON rv.receiver_id = r.id
+		JOIN receivers r ON rv.receiver_id = r.id
 		WHERE r.phone_number = $1
 		ORDER BY
 			rv.updated_at DESC

--- a/internal/data/receiver_verification.go
+++ b/internal/data/receiver_verification.go
@@ -110,7 +110,7 @@ func (m *ReceiverVerificationModel) GetLatestByPhoneNumber(ctx context.Context, 
 
 	err := m.dbConnectionPool.SelectContext(ctx, &receiverVerifications, query, phoneNumber)
 	if err != nil {
-		return nil, fmt.Errorf("error querying receiver verifications: %w", err)
+		return nil, fmt.Errorf("error querying receiver verifications for phone number %s: %w", phoneNumber, err)
 	}
 
 	if len(receiverVerifications) == 0 {

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -136,12 +136,14 @@ func Test_ReceiverVerificationModel_GetReceiverVerificationByReceiverId(t *testi
 
 	ctx := context.Background()
 
-	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{})
+	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{
+		PhoneNumber: "+13334445555",
+	})
 
 	t.Run("returns error when the receiver has no verifications registered", func(t *testing.T) {
-		receiverVerificationModel := ReceiverVerificationModel{}
-		_, err := receiverVerificationModel.GetLatestByPhoneNumber(ctx, dbConnectionPool, "+13334445555")
-		require.Error(t, err, fmt.Errorf("cannot query any receiver verifications for receiver id %s", receiver.ID))
+		receiverVerificationModel := ReceiverVerificationModel{dbConnectionPool: dbConnectionPool}
+		_, err := receiverVerificationModel.GetLatestByPhoneNumber(ctx, receiver.PhoneNumber)
+		require.Error(t, err, fmt.Errorf("cannot query any receiver verifications for phone number %s", receiver.PhoneNumber))
 	})
 
 	t.Run("returns the latest receiver verification for a list of receiver verifications", func(t *testing.T) {
@@ -164,8 +166,8 @@ func Test_ReceiverVerificationModel_GetReceiverVerificationByReceiverId(t *testi
 			VerificationValue: "5678",
 		})
 
-		receiverVerificationModel := ReceiverVerificationModel{}
-		actualVerification, err := receiverVerificationModel.GetLatestByReceiverId(ctx, dbConnectionPool, receiver.ID)
+		receiverVerificationModel := ReceiverVerificationModel{dbConnectionPool: dbConnectionPool}
+		actualVerification, err := receiverVerificationModel.GetLatestByPhoneNumber(ctx, receiver.PhoneNumber)
 		require.NoError(t, err)
 
 		assert.Equal(t,

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -140,7 +140,7 @@ func Test_ReceiverVerificationModel_GetReceiverVerificationByReceiverId(t *testi
 
 	t.Run("returns error when the receiver has no verifications registered", func(t *testing.T) {
 		receiverVerificationModel := ReceiverVerificationModel{}
-		_, err := receiverVerificationModel.GetLatestByReceiverId(ctx, dbConnectionPool, receiver.ID)
+		_, err := receiverVerificationModel.GetLatestByPhoneNumber(ctx, dbConnectionPool, "+13334445555")
 		require.Error(t, err, fmt.Errorf("cannot query any receiver verifications for receiver id %s", receiver.ID))
 	})
 

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -148,18 +148,20 @@ func Test_ReceiverVerificationModel_GetReceiverVerificationByReceiverId(t *testi
 
 	t.Run("returns the latest receiver verification for a list of receiver verifications", func(t *testing.T) {
 		earlierTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
-		CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
+		verification1 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
 			VerificationField: VerificationFieldDateOfBirth,
 			VerificationValue: "1990-01-01",
-			UpdatedAt:         &earlierTime,
 		})
-		CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
+		verification1.UpdatedAt = earlierTime
+
+		verification2 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
 			VerificationField: VerificationFieldPin,
 			VerificationValue: "1234",
-			UpdatedAt:         &earlierTime,
 		})
+		verification2.UpdatedAt = earlierTime
+
 		verification3 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
 			VerificationField: VerificationFieldNationalID,

--- a/internal/htmltemplate/tmpl/receiver_register.tmpl
+++ b/internal/htmltemplate/tmpl/receiver_register.tmpl
@@ -119,39 +119,31 @@
               />
             </div>
             <div class="Form__item">
-              {{ if .VerificationField eq "DATE_OF_BIRTH" }}
+              {{ if eq .VerificationField "DATE_OF_BIRTH" }}
                 <label for="verification">Date of birth</label>
                 <input
                   type="date"
-                  id="date-of-birth"
-                  name="date-of-birth"
+                  id="verification"
+                  name="date_of_birth"
                   required
                 />
-              {{ else if .VerificationField eq "PIN" }}
+              {{ else if eq .VerificationField "PIN" }}
                 <label for="verification">Pin</label>
                 <input
-                  type="string"
-                  id="pin"
+                  type="text"
+                  id="verification"
                   name="pin"
                   required
                 />
-              {{ else if .VerificationField eq "NATIONAL_ID" }}
+              {{ else if eq .VerificationField "NATIONAL_ID" }}
                 <label for="verification">National ID</label>
                 <input
-                  type="string"
-                  id="national-id"
-                  name="national-id"
+                  type="text"
+                  id="verification"
+                  name="national_id"
                   required
                 />
               {{ end }}
-              <!--<label for="verification">Date of birth</label>
-              <input
-                type="date"
-                id="verification"
-                name="verification"
-                required
-              />
-            </div-->
 
             <div class="g-recaptcha" data-sitekey="{{.ReCAPTCHASiteKey}}"></div>
 

--- a/internal/htmltemplate/tmpl/receiver_register.tmpl
+++ b/internal/htmltemplate/tmpl/receiver_register.tmpl
@@ -87,7 +87,7 @@
         </div>
       </section>
 
-      <!-- Enter passcode and verification type page -->
+      <!-- Enter passcode and verification field page -->
       <section data-section="passcode" style="display: none">
         <div class="WalletRegistration__MainContent">
           <h2>Enter passcode</h2>

--- a/internal/htmltemplate/tmpl/receiver_register.tmpl
+++ b/internal/htmltemplate/tmpl/receiver_register.tmpl
@@ -119,14 +119,39 @@
               />
             </div>
             <div class="Form__item">
-              <label for="verification">Date of birth</label>
+              {{ if .VerificationField eq "DATE_OF_BIRTH" }}
+                <label for="verification">Date of birth</label>
+                <input
+                  type="date"
+                  id="date-of-birth"
+                  name="date-of-birth"
+                  required
+                />
+              {{ else if .VerificationField eq "PIN" }}
+                <label for="verification">Pin</label>
+                <input
+                  type="string"
+                  id="pin"
+                  name="pin"
+                  required
+                />
+              {{ else if .VerificationField eq "NATIONAL_ID" }}
+                <label for="verification">National ID</label>
+                <input
+                  type="string"
+                  id="national-id"
+                  name="national-id"
+                  required
+                />
+              {{ end }}
+              <!--<label for="verification">Date of birth</label>
               <input
                 type="date"
                 id="verification"
                 name="verification"
                 required
               />
-            </div>
+            </div-->
 
             <div class="g-recaptcha" data-sitekey="{{.ReCAPTCHASiteKey}}"></div>
 

--- a/internal/htmltemplate/tmpl/receiver_register.tmpl
+++ b/internal/htmltemplate/tmpl/receiver_register.tmpl
@@ -119,37 +119,12 @@
               />
             </div>
             <div class="Form__item">
-              <!--{{ if eq .VerificationField "DATE_OF_BIRTH" }}
-                <label for="verification">Date of birth</label>
-                <input
-                  type="date"
-                  id="verification"
-                  name="date_of_birth"
-                  required
-                />
-              {{ else if eq .VerificationField "PIN" }}
-                <label for="verification">Pin</label>
-                <input
-                  type="text"
-                  id="verification"
-                  name="pin"
-                  required
-                />
-              {{ else if eq .VerificationField "NATIONAL_ID" }}
-                <label for="verification">National ID</label>
-                <input
-                  type="text"
-                  id="verification"
-                  name="national_id"
-                  required
-                />
-              {{ end }}-->
-                <label for="verification"></label>
-                <input
-                  type="text"
-                  id="verification"
-                  required
-                />
+              <label for="verification"></label>
+              <input
+                type="text"
+                id="verification"
+                required
+              />
 
             <div class="g-recaptcha" data-sitekey="{{.ReCAPTCHASiteKey}}"></div>
 

--- a/internal/htmltemplate/tmpl/receiver_register.tmpl
+++ b/internal/htmltemplate/tmpl/receiver_register.tmpl
@@ -121,7 +121,6 @@
             <div class="Form__item">
               <label for="verification"></label>
               <input
-                type="text"
                 id="verification"
                 required
               />

--- a/internal/htmltemplate/tmpl/receiver_register.tmpl
+++ b/internal/htmltemplate/tmpl/receiver_register.tmpl
@@ -87,7 +87,7 @@
         </div>
       </section>
 
-      <!-- Enter passcode and DOB page -->
+      <!-- Enter passcode and verification type page -->
       <section data-section="passcode" style="display: none">
         <div class="WalletRegistration__MainContent">
           <h2>Enter passcode</h2>
@@ -119,7 +119,7 @@
               />
             </div>
             <div class="Form__item">
-              {{ if eq .VerificationField "DATE_OF_BIRTH" }}
+              <!--{{ if eq .VerificationField "DATE_OF_BIRTH" }}
                 <label for="verification">Date of birth</label>
                 <input
                   type="date"
@@ -143,7 +143,13 @@
                   name="national_id"
                   required
                 />
-              {{ end }}
+              {{ end }}-->
+                <label for="verification"></label>
+                <input
+                  type="text"
+                  id="verification"
+                  required
+                />
 
             <div class="g-recaptcha" data-sitekey="{{.ReCAPTCHASiteKey}}"></div>
 

--- a/internal/serve/httphandler/receiver_registration.go
+++ b/internal/serve/httphandler/receiver_registration.go
@@ -15,7 +15,7 @@ import (
 type ReceiverRegistrationHandler struct {
 	ReceiverWalletModel       *data.ReceiverWalletModel
 	ReceiverVerificationModel *data.ReceiverVerificationModel
-	Models *data.Models
+	Models                    *data.Models
 	ReCAPTCHASiteKey          string
 }
 
@@ -80,7 +80,7 @@ func (h ReceiverRegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 			return
 		}*/
 
-		tmplData.VerificationField = data.VerificationFieldPin
+		//tmplData.VerificationField = data.VerificationFieldPin
 	}
 
 	registerPage, err := htmlTpl.ExecuteHTMLTemplate(htmlTemplateName, tmplData)

--- a/internal/serve/httphandler/receiver_registration.go
+++ b/internal/serve/httphandler/receiver_registration.go
@@ -73,14 +73,6 @@ func (h ReceiverRegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		htmlTemplateName = "receiver_registered_successfully.tmpl"
 		tmplData.Title = "Registration Complete 🎉"
 		tmplData.Message = "Your Stellar wallet has been registered successfully!"
-	} else {
-		/*latestReceiverVerification, err := h.Models.ReceiverVerification.GetLatestByReceiverId(ctx, "abc")
-		if err != nil {
-			httperror.InternalError(ctx, "Cannot find receiver verifications for receiver wallet", err, nil).Render(w)
-			return
-		}*/
-
-		//tmplData.VerificationField = data.VerificationFieldPin
 	}
 
 	registerPage, err := htmlTpl.ExecuteHTMLTemplate(htmlTemplateName, tmplData)

--- a/internal/serve/httphandler/receiver_registration.go
+++ b/internal/serve/httphandler/receiver_registration.go
@@ -13,19 +13,16 @@ import (
 )
 
 type ReceiverRegistrationHandler struct {
-	ReceiverWalletModel       *data.ReceiverWalletModel
-	ReceiverVerificationModel *data.ReceiverVerificationModel
-	Models                    *data.Models
-	ReCAPTCHASiteKey          string
+	ReceiverWalletModel *data.ReceiverWalletModel
+	ReCAPTCHASiteKey    string
 }
 
 type ReceiverRegistrationData struct {
-	StellarAccount    string
-	JWTToken          string
-	Title             string
-	Message           string
-	ReCAPTCHASiteKey  string
-	VerificationField data.VerificationField
+	StellarAccount   string
+	JWTToken         string
+	Title            string
+	Message          string
+	ReCAPTCHASiteKey string
 }
 
 // ServeHTTP will serve the SEP-24 deposit page needed to register users.

--- a/internal/serve/httphandler/receiver_registration.go
+++ b/internal/serve/httphandler/receiver_registration.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/anchorplatform"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 	htmlTpl "github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 )
@@ -16,7 +15,7 @@ import (
 type ReceiverRegistrationHandler struct {
 	ReceiverWalletModel       *data.ReceiverWalletModel
 	ReceiverVerificationModel *data.ReceiverVerificationModel
-	DBConnectionPool          db.DBConnectionPool
+	Models *data.Models
 	ReCAPTCHASiteKey          string
 }
 
@@ -75,13 +74,13 @@ func (h ReceiverRegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		tmplData.Title = "Registration Complete 🎉"
 		tmplData.Message = "Your Stellar wallet has been registered successfully!"
 	} else {
-		latestReceiverVerification, err := h.ReceiverVerificationModel.GetLatestByReceiverId(ctx, h.DBConnectionPool, rw.Receiver.ID)
+		/*latestReceiverVerification, err := h.Models.ReceiverVerification.GetLatestByReceiverId(ctx, "abc")
 		if err != nil {
 			httperror.InternalError(ctx, "Cannot find receiver verifications for receiver wallet", err, nil).Render(w)
 			return
-		}
+		}*/
 
-		tmplData.VerificationField = latestReceiverVerification.VerificationField
+		tmplData.VerificationField = data.VerificationFieldPin
 	}
 
 	registerPage, err := htmlTpl.ExecuteHTMLTemplate(htmlTemplateName, tmplData)

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -35,8 +35,8 @@ type ReceiverSendOTPRequest struct {
 }
 
 type ReceiverSendOTPResponseBody struct {
-	Message          string                 `json:"message"`
-	VerificationType data.VerificationField `json:"verification_type"`
+	Message           string                 `json:"message"`
+	VerificationField data.VerificationField `json:"verification_field"`
 }
 
 func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -156,8 +156,8 @@ func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	response := ReceiverSendOTPResponseBody{
-		Message:          "if your phone number is registered, you'll receive an OTP",
-		VerificationType: receiverVerification.VerificationField,
+		Message:           "if your phone number is registered, you'll receive an OTP",
+		VerificationField: receiverVerification.VerificationField,
 	}
 	httpjson.RenderStatus(w, http.StatusOK, response, httpjson.JSON)
 }

--- a/internal/serve/httphandler/receiver_send_otp_handler_test.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler_test.go
@@ -53,9 +53,14 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 
 	ctx := context.Background()
 
-	receiver1 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: "+380443973607"})
+	phoneNumber := "+380443973607"
+	receiver1 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: phoneNumber})
 	receiver2 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
 	wallet1 := data.CreateWalletFixture(t, ctx, dbConnectionPool, "testWallet", "https://home.page", "home.page", "wallet123://")
+	data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
+		ReceiverID:        receiver1.ID,
+		VerificationField: data.VerificationFieldDateOfBirth,
+	})
 
 	_ = data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver1.ID, wallet1.ID, data.RegisteredReceiversWalletStatus)
 	_ = data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver2.ID, wallet1.ID, data.RegisteredReceiversWalletStatus)
@@ -157,7 +162,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 		assert.JSONEq(t, `{"error": "request invalid", "extras": {"phone_number": "invalid phone number provided"}}`, string(respBody))
 	})
 
-	t.Run("returns 200 - Ok if the token is in the request context and body it's valid", func(t *testing.T) {
+	t.Run("returns 200 - Ok if the token is in the request context and body is valid", func(t *testing.T) {
 		reCAPTCHAValidator.
 			On("IsTokenValid", mock.Anything, "XyZ").
 			Return(true, nil).
@@ -193,7 +198,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Contains(t, resp.Header.Get("Content-Type"), "/json; charset=utf-8")
-		assert.JSONEq(t, string(respBody), `{"message":"if your phone number is registered, you'll receive an OTP"}`)
+		assert.JSONEq(t, string(respBody), `{"message":"if your phone number is registered, you'll receive an OTP", "verification_type":"DATE_OF_BIRTH"}`)
 	})
 
 	t.Run("returns 200 - parses a custom OTP message template successfully", func(t *testing.T) {
@@ -237,7 +242,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Contains(t, resp.Header.Get("Content-Type"), "/json; charset=utf-8")
-		assert.JSONEq(t, string(respBody), `{"message":"if your phone number is registered, you'll receive an OTP"}`)
+		assert.JSONEq(t, string(respBody), `{"message":"if your phone number is registered, you'll receive an OTP", "verification_type":"DATE_OF_BIRTH"}`)
 	})
 
 	t.Run("returns 500 - InternalServerError when something goes wrong when sending the SMS", func(t *testing.T) {
@@ -303,6 +308,47 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 		wantsBody := `
 			{
 				"error": "Cannot validate reCAPTCHA token"
+			}
+		`
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.JSONEq(t, wantsBody, string(respBody))
+	})
+
+	t.Run("returns 500 - InternalServerError if phone number is not associated with receiver verification", func(t *testing.T) {
+		requestSendOTP := ReceiverSendOTPRequest{
+			PhoneNumber:    "+14152223333",
+			ReCAPTCHAToken: "XyZ",
+		}
+		reqBody, err := json.Marshal(requestSendOTP)
+		require.NoError(t, err)
+
+		reCAPTCHAValidator.
+			On("IsTokenValid", mock.Anything, "XyZ").
+			Return(true, nil).
+			Once()
+		req, err := http.NewRequest(http.MethodPost, "/wallet-registration/otp", strings.NewReader(string(reqBody)))
+		require.NoError(t, err)
+
+		validClaims := &anchorplatform.SEP24JWTClaims{
+			ClientDomainClaim: wallet1.SEP10ClientDomain,
+			RegisteredClaims: jwt.RegisteredClaims{
+				ID:        "test-transaction-id",
+				Subject:   "GBLTXF46JTCGMWFJASQLVXMMA36IPYTDCN4EN73HRXCGDCGYBZM3A444",
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+			},
+		}
+		req = req.WithContext(context.WithValue(req.Context(), anchorplatform.SEP24ClaimsContextKey, validClaims))
+
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		resp := rr.Result()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		wantsBody := `
+			{
+				"error": "Cannot find latest receiver verification for receiver"
 			}
 		`
 		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)

--- a/internal/serve/httphandler/receiver_send_otp_handler_test.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler_test.go
@@ -198,7 +198,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Contains(t, resp.Header.Get("Content-Type"), "/json; charset=utf-8")
-		assert.JSONEq(t, string(respBody), `{"message":"if your phone number is registered, you'll receive an OTP", "verification_type":"DATE_OF_BIRTH"}`)
+		assert.JSONEq(t, string(respBody), `{"message":"if your phone number is registered, you'll receive an OTP", "verification_field":"DATE_OF_BIRTH"}`)
 	})
 
 	t.Run("returns 200 - parses a custom OTP message template successfully", func(t *testing.T) {
@@ -242,7 +242,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Contains(t, resp.Header.Get("Content-Type"), "/json; charset=utf-8")
-		assert.JSONEq(t, string(respBody), `{"message":"if your phone number is registered, you'll receive an OTP", "verification_type":"DATE_OF_BIRTH"}`)
+		assert.JSONEq(t, string(respBody), `{"message":"if your phone number is registered, you'll receive an OTP", "verification_field":"DATE_OF_BIRTH"}`)
 	})
 
 	t.Run("returns 500 - InternalServerError when something goes wrong when sending the SMS", func(t *testing.T) {
@@ -319,8 +319,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 			PhoneNumber:    "+14152223333",
 			ReCAPTCHAToken: "XyZ",
 		}
-		reqBody, err := json.Marshal(requestSendOTP)
-		require.NoError(t, err)
+		reqBody, _ = json.Marshal(requestSendOTP)
 
 		reCAPTCHAValidator.
 			On("IsTokenValid", mock.Anything, "XyZ").

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -96,8 +96,8 @@ async function submitPhoneNumber(event) {
     "#g-recaptcha-response"
   );
   const buttonEls = phoneNumberSectionEl.querySelectorAll("[data-button]");
-  const verificationTypeTitle = document.querySelector("label[for='verification']");
-  const verificationTypeInput = document.querySelector("#verification");
+  const verificationFieldTitle = document.querySelector("label[for='verification']");
+  const verificationFieldInput = document.querySelector("#verification");
 
   if (!reCAPTCHATokenEl || !reCAPTCHATokenEl.value) {
     toggleErrorNotification(
@@ -135,20 +135,20 @@ async function submitPhoneNumber(event) {
       return;
     }
 
-    function showNextPage(verificationType) {
-      verificationTypeInput.type = "text";
-      if(verificationType === "DATE_OF_BIRTH") {
-        verificationTypeTitle.textContent = "Date_of_birth";
-        verificationTypeInput.name = "date_of_birth";
-        verificationTypeInput.type = "date";
+    function showNextPage(verificationField) {
+      verificationFieldInput.type = "text";
+      if(verificationField === "DATE_OF_BIRTH") {
+        verificationFieldTitle.textContent = "Date_of_birth";
+        verificationFieldInput.name = "date_of_birth";
+        verificationFieldInput.type = "date";
       }
-      else if(verificationType === "NATIONAL_ID") {
-        verificationTypeTitle.textContent = "National_ID";
-        verificationTypeInput.name = "national_id";
+      else if(verificationField === "NATIONAL_ID") {
+        verificationFieldTitle.textContent = "National_ID";
+        verificationFieldInput.name = "national_id";
       }
-      else if(verificationType === "PIN") {
-        verificationTypeTitle.textContent = "Pin";
-        verificationTypeInput.name = "pin";
+      else if(verificationField === "PIN") {
+        verificationFieldTitle.textContent = "Pin";
+        verificationFieldInput.name = "pin";
       }
 
       phoneNumberSectionEl.style.display = "none";

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -136,10 +136,11 @@ async function submitPhoneNumber(event) {
     }
 
     function showNextPage(verificationType) {
-      verificationTypeInput.type = "date";
+      verificationTypeInput.type = "text";
       if(verificationType === "DATE_OF_BIRTH") {
         verificationTypeTitle.textContent = "Date_of_birth";
         verificationTypeInput.name = "date_of_birth";
+        verificationTypeInput.type = "date";
       }
       else if(verificationType === "NATIONAL_ID") {
         verificationTypeTitle.textContent = "National_ID";
@@ -148,7 +149,6 @@ async function submitPhoneNumber(event) {
       else if(verificationType === "PIN") {
         verificationTypeTitle.textContent = "Pin";
         verificationTypeInput.name = "pin";
-        verificationTypeInput.type = "text";
       }
 
       phoneNumberSectionEl.style.display = "none";

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -51,9 +51,9 @@ async function sendSms(phoneNumber, reCAPTCHAToken, onSuccess, onError) {
           recaptcha_token: reCAPTCHAToken,
         }),
       });
-      await request.json();
+      const resp = await request.json();
 
-      onSuccess();
+      onSuccess(resp.verification_type);
     } catch (error) {
       onError(error);
     }
@@ -96,6 +96,8 @@ async function submitPhoneNumber(event) {
     "#g-recaptcha-response"
   );
   const buttonEls = phoneNumberSectionEl.querySelectorAll("[data-button]");
+  const verificationTypeTitle = document.querySelector("label[for='verification']");
+  const verificationTypeInput = document.querySelector("#verification"); // id verification
 
   if (!reCAPTCHATokenEl || !reCAPTCHATokenEl.value) {
     toggleErrorNotification(
@@ -133,7 +135,23 @@ async function submitPhoneNumber(event) {
       return;
     }
 
-    function showNextPage() {
+    function showNextPage(verificationType) {
+      if(verificationType === "DATE_OF_BIRTH") {
+        verificationTypeTitle.textContent = "Date_of_birth"
+        verificationTypeInput.name = "date_of_birth"
+        verificationTypeInput.type = "date"
+      }
+      else if(verificationType === "NATIONAL_ID") {
+        verificationTypeTitle.textContent = "National_ID"
+        verificationTypeInput.name = "national_id"
+        verificationTypeInput.type = "text"
+      }
+      else if(verificationType === "PIN") {
+        verificationTypeTitle.textContent = "Pin"
+        verificationTypeInput.name = "pin"
+        verificationTypeInput.type = "text"
+      }
+
       phoneNumberSectionEl.style.display = "none";
       reCAPTCHATokenEl.style.display = "none";
       passcodeSectionEl.style.display = "flex";
@@ -169,8 +187,7 @@ async function submitOtp(event) {
   );
   const otpEl = document.getElementById("otp");
   const verificationEl = document.getElementById("verification");
-  const verificationType = verificationEl.className;
-  console.log(verificationType);
+  const verificationType = verificationEl.getAttribute("name");
 
   const buttonEls = passcodeSectionEl.querySelectorAll("[data-button]");
 

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -53,7 +53,7 @@ async function sendSms(phoneNumber, reCAPTCHAToken, onSuccess, onError) {
       });
       const resp = await request.json();
 
-      onSuccess(resp.verification_type);
+      onSuccess(resp.verification_field);
     } catch (error) {
       onError(error);
     }
@@ -97,7 +97,7 @@ async function submitPhoneNumber(event) {
   );
   const buttonEls = phoneNumberSectionEl.querySelectorAll("[data-button]");
   const verificationTypeTitle = document.querySelector("label[for='verification']");
-  const verificationTypeInput = document.querySelector("#verification"); // id verification
+  const verificationTypeInput = document.querySelector("#verification");
 
   if (!reCAPTCHATokenEl || !reCAPTCHATokenEl.value) {
     toggleErrorNotification(
@@ -136,20 +136,19 @@ async function submitPhoneNumber(event) {
     }
 
     function showNextPage(verificationType) {
+      verificationTypeInput.type = "date";
       if(verificationType === "DATE_OF_BIRTH") {
-        verificationTypeTitle.textContent = "Date_of_birth"
-        verificationTypeInput.name = "date_of_birth"
-        verificationTypeInput.type = "date"
+        verificationTypeTitle.textContent = "Date_of_birth";
+        verificationTypeInput.name = "date_of_birth";
       }
       else if(verificationType === "NATIONAL_ID") {
-        verificationTypeTitle.textContent = "National_ID"
-        verificationTypeInput.name = "national_id"
-        verificationTypeInput.type = "text"
+        verificationTypeTitle.textContent = "National_ID";
+        verificationTypeInput.name = "national_id";
       }
       else if(verificationType === "PIN") {
-        verificationTypeTitle.textContent = "Pin"
-        verificationTypeInput.name = "pin"
-        verificationTypeInput.type = "text"
+        verificationTypeTitle.textContent = "Pin";
+        verificationTypeInput.name = "pin";
+        verificationTypeInput.type = "text";
       }
 
       phoneNumberSectionEl.style.display = "none";
@@ -187,7 +186,7 @@ async function submitOtp(event) {
   );
   const otpEl = document.getElementById("otp");
   const verificationEl = document.getElementById("verification");
-  const verificationType = verificationEl.getAttribute("name");
+  const verificationField = verificationEl.getAttribute("name");
 
   const buttonEls = passcodeSectionEl.querySelectorAll("[data-button]");
 
@@ -232,7 +231,7 @@ async function submitOtp(event) {
             phone_number: phoneNumber,
             otp: otp,
             verification: verification,
-            verification_type: verificationType,
+            verification_type: verificationField,
             recaptcha_token: reCAPTCHATokenEl.value,
           }),
         });

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -138,13 +138,13 @@ async function submitPhoneNumber(event) {
     function showNextPage(verificationField) {
       verificationFieldInput.type = "text";
       if(verificationField === "DATE_OF_BIRTH") {
-        verificationFieldTitle.textContent = "Date_of_birth";
+        verificationFieldTitle.textContent = "Date of birth";
         verificationFieldInput.name = "date_of_birth";
         verificationFieldInput.type = "date";
       }
-      else if(verificationField === "NATIONAL_ID") {
-        verificationFieldTitle.textContent = "National_ID";
-        verificationFieldInput.name = "national_id";
+      else if(verificationField === "NATIONAL_ID_NUMBER") {
+        verificationFieldTitle.textContent = "National ID number";
+        verificationFieldInput.name = "national_id_number";
       }
       else if(verificationField === "PIN") {
         verificationFieldTitle.textContent = "Pin";

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -169,6 +169,8 @@ async function submitOtp(event) {
   );
   const otpEl = document.getElementById("otp");
   const verificationEl = document.getElementById("verification");
+  const verificationType = verificationEl.className;
+  console.log(verificationType);
 
   const buttonEls = passcodeSectionEl.querySelectorAll("[data-button]");
 
@@ -213,7 +215,7 @@ async function submitOtp(event) {
             phone_number: phoneNumber,
             otp: otp,
             verification: verification,
-            verification_type: "date_of_birth",
+            verification_type: verificationType,
             recaptcha_token: reCAPTCHATokenEl.value,
           }),
         });

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -380,7 +380,12 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 	mux.Route("/wallet-registration", func(r chi.Router) {
 		sep24QueryTokenAuthenticationMiddleware := anchorplatform.SEP24QueryTokenAuthenticateMiddleware(o.sep24JWTManager, o.NetworkPassphrase)
-		r.With(sep24QueryTokenAuthenticationMiddleware).Get("/start", httphandler.ReceiverRegistrationHandler{ReceiverWalletModel: o.Models.ReceiverWallet, ReCAPTCHASiteKey: o.ReCAPTCHASiteKey}.ServeHTTP) // This loads the SEP-24 PII registration webpage.
+		r.With(sep24QueryTokenAuthenticationMiddleware).Get("/start", httphandler.ReceiverRegistrationHandler{
+			ReceiverWalletModel: o.Models.ReceiverWallet,
+			ReceiverVerificationModel: o.Models.ReceiverVerification,
+			Models: o.Models,
+			ReCAPTCHASiteKey: o.ReCAPTCHASiteKey,
+		}.ServeHTTP) // This loads the SEP-24 PII registration webpage.
 
 		sep24HeaderTokenAuthenticationMiddleware := anchorplatform.SEP24HeaderTokenAuthenticateMiddleware(o.sep24JWTManager, o.NetworkPassphrase)
 		r.With(sep24HeaderTokenAuthenticationMiddleware).Post("/otp", httphandler.ReceiverSendOTPHandler{Models: o.Models, SMSMessengerClient: o.SMSMessengerClient, ReCAPTCHAValidator: reCAPTCHAValidator}.ServeHTTP)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -381,10 +381,10 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	mux.Route("/wallet-registration", func(r chi.Router) {
 		sep24QueryTokenAuthenticationMiddleware := anchorplatform.SEP24QueryTokenAuthenticateMiddleware(o.sep24JWTManager, o.NetworkPassphrase)
 		r.With(sep24QueryTokenAuthenticationMiddleware).Get("/start", httphandler.ReceiverRegistrationHandler{
-			ReceiverWalletModel: o.Models.ReceiverWallet,
+			ReceiverWalletModel:       o.Models.ReceiverWallet,
 			ReceiverVerificationModel: o.Models.ReceiverVerification,
-			Models: o.Models,
-			ReCAPTCHASiteKey: o.ReCAPTCHASiteKey,
+			Models:                    o.Models,
+			ReCAPTCHASiteKey:          o.ReCAPTCHASiteKey,
 		}.ServeHTTP) // This loads the SEP-24 PII registration webpage.
 
 		sep24HeaderTokenAuthenticationMiddleware := anchorplatform.SEP24HeaderTokenAuthenticateMiddleware(o.sep24JWTManager, o.NetworkPassphrase)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -381,10 +381,8 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	mux.Route("/wallet-registration", func(r chi.Router) {
 		sep24QueryTokenAuthenticationMiddleware := anchorplatform.SEP24QueryTokenAuthenticateMiddleware(o.sep24JWTManager, o.NetworkPassphrase)
 		r.With(sep24QueryTokenAuthenticationMiddleware).Get("/start", httphandler.ReceiverRegistrationHandler{
-			ReceiverWalletModel:       o.Models.ReceiverWallet,
-			ReceiverVerificationModel: o.Models.ReceiverVerification,
-			Models:                    o.Models,
-			ReCAPTCHASiteKey:          o.ReCAPTCHASiteKey,
+			ReceiverWalletModel: o.Models.ReceiverWallet,
+			ReCAPTCHASiteKey:    o.ReCAPTCHASiteKey,
 		}.ServeHTTP) // This loads the SEP-24 PII registration webpage.
 
 		sep24HeaderTokenAuthenticationMiddleware := anchorplatform.SEP24HeaderTokenAuthenticateMiddleware(o.sep24JWTManager, o.NetworkPassphrase)

--- a/internal/serve/validators/receiver_registration_validator.go
+++ b/internal/serve/validators/receiver_registration_validator.go
@@ -42,8 +42,19 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 	// validate verification field
 	// date of birth with format 2006-01-02
 	if vt == data.VerificationFieldDateOfBirth {
-		_, err := time.Parse("2006-01-02", verification)
+		dob, err := time.Parse("2006-01-02", verification)
 		rv.CheckError(err, "verification", "invalid date of birth format. Correct format: 1990-01-01")
+
+		// check if date of birth is in the past
+		rv.Check(dob.Before(time.Now()), "verification", "date of birth cannot be in the future")
+	} else if vt == data.VerificationFieldPin {
+		if len(verification) < VERIFICATION_FIELD_PIN_MIN_LENGTH || len(verification) > VERIFICATION_FIELD_PIN_MAX_LENGTH {
+			rv.addError("verification", "invalid pin. Cannot have less than 4 or more than 8 characters in pin")
+		}
+	} else if vt == data.VerificationFieldNationalID {
+		if len(verification) > VERIFICATION_FIELD_MAX_ID_LENGTH {
+			rv.addError("verification", "invalid national id. Cannot have more than 50 characters in national id")
+		}
 	} else {
 		// TODO: validate other VerificationField types.
 		log.Warnf("Verification type %v is not being validated for ValidateReceiver", vt)

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -83,6 +83,36 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 		assert.Equal(t, "invalid date of birth format. Correct format: 1990-01-01", validator.Errors["verification"])
 	})
 
+	t.Run("Invalid pin", func(t *testing.T) {
+		validator := NewReceiverRegistrationValidator()
+
+		receiverInfo := data.ReceiverRegistrationRequest{
+			PhoneNumber:       "+380445555555",
+			OTP:               "123456",
+			VerificationValue: "ABCDE1234",
+			VerificationType:  "PIN",
+		}
+		validator.ValidateReceiver(&receiverInfo)
+
+		assert.Equal(t, 1, len(validator.Errors))
+		assert.Equal(t, "invalid pin. Cannot have less than 4 or more than 8 characters in pin", validator.Errors["verification"])
+	})
+
+	t.Run("Invalid national ID number", func(t *testing.T) {
+		validator := NewReceiverRegistrationValidator()
+
+		receiverInfo := data.ReceiverRegistrationRequest{
+			PhoneNumber:       "+380445555555",
+			OTP:               "123456",
+			VerificationValue: "6UZMB56FWTKV4U0PJ21TBR6VOQVYSGIMZG2HW2S0L7EK5K83W78XXXXX",
+			VerificationType:  "NATIONAL_ID_NUMBER",
+		}
+		validator.ValidateReceiver(&receiverInfo)
+
+		assert.Equal(t, 1, len(validator.Errors))
+		assert.Equal(t, "invalid national id. Cannot have more than 50 characters in national id", validator.Errors["verification"])
+	})
+
 	t.Run("Valid receiver values", func(t *testing.T) {
 		validator := NewReceiverRegistrationValidator()
 
@@ -99,6 +129,22 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 		assert.Equal(t, "123456", receiverInfo.OTP)
 		assert.Equal(t, "1990-01-01", receiverInfo.VerificationValue)
 		assert.Equal(t, data.VerificationField("DATE_OF_BIRTH"), receiverInfo.VerificationType)
+
+		receiverInfo.VerificationValue = "1234"
+		receiverInfo.VerificationType = "pin"
+		validator.ValidateReceiver(&receiverInfo)
+
+		assert.Equal(t, 0, len(validator.Errors))
+		assert.Equal(t, "1234", receiverInfo.VerificationValue)
+		assert.Equal(t, data.VerificationField("PIN"), receiverInfo.VerificationType)
+
+		receiverInfo.VerificationValue = "NATIONALIDNUMBER123"
+		receiverInfo.VerificationType = "national_id_number"
+		validator.ValidateReceiver(&receiverInfo)
+
+		assert.Equal(t, 0, len(validator.Errors))
+		assert.Equal(t, "NATIONALIDNUMBER123", receiverInfo.VerificationValue)
+		assert.Equal(t, data.VerificationField("NATIONAL_ID_NUMBER"), receiverInfo.VerificationType)
 	})
 }
 


### PR DESCRIPTION
### What
Modify the `SEP-24` flow to perform verification for an entered phone number based on the latest verification type.

### Why
The current `SEP-24` flow is hardcoded to only accept date of birth but we will have disbursement files that will include pin and national id, and the front-end will need to change to be able to parse those values.

example of the flow using `PIN`
<img width="1140" alt="Screenshot 2023-12-14 at 11 01 50 AM" src="https://github.com/stellar/stellar-disbursement-platform-backend/assets/20179122/fecab715-a802-4442-ae46-4f6d43780b0c">

<img width="497" alt="Screenshot 2023-12-14 at 11 05 32 AM" src="https://github.com/stellar/stellar-disbursement-platform-backend/assets/20179122/dcc5e9cf-49bb-457c-9f91-98c6f72735aa">

<img width="498" alt="Screenshot 2023-12-14 at 11 06 00 AM" src="https://github.com/stellar/stellar-disbursement-platform-backend/assets/20179122/b44a1cba-f71a-447a-8ecb-228c2a7c5cca">

<img width="498" alt="Screenshot 2023-12-14 at 11 06 11 AM" src="https://github.com/stellar/stellar-disbursement-platform-backend/assets/20179122/58cfb359-d580-4771-bdb6-03c225f0dfc0">

The same tests have been repeated with `DATE_OF_BIRTH` and `NATIONAL_ID`
### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
* [ ] This PR's title starts with the name of the package, area, or subject affected by the change.

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
