### PR TITLE
[SDP-996] Make `POST /assets` idempotent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,9 +14,9 @@
 
 #### PR Structure
 
-* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
+* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
+* [ ] This PR title and description are clear enough for anyone to review it.
 * [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).
-* [ ] This PR's title starts with the name of the package, area, or subject affected by the change.
 
 #### Thoroughness
 

--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -123,7 +123,7 @@ func (a *AssetModel) GetAll(ctx context.Context) ([]Asset, error) {
 	return assets, nil
 }
 
-// Insert is idempotent and returns a new asset if it doesn't exist or the existing one if it does, clrearing the
+// Insert is idempotent and returns a new asset if it doesn't exist or the existing one if it does, clearing the
 // deleted_at field if it was marked as deleted.
 func (a *AssetModel) Insert(ctx context.Context, sqlExec db.SQLExecuter, code string, issuer string) (*Asset, error) {
 	const query = `
@@ -140,7 +140,7 @@ func (a *AssetModel) Insert(ctx context.Context, sqlExec db.SQLExecuter, code st
 			RETURNING *
 		)
 		SELECT * FROM upsert_asset
-		UNION ALL  -- // The UNION statement is applied to prevent the updated_at field from beong autoupdated when the asset already exists.
+		UNION ALL  -- // The UNION statement is applied to prevent the updated_at field from being autoupdated when the asset already exists.
 		SELECT * FROM assets WHERE code = $1 AND issuer = $2 AND NOT EXISTS (SELECT 1 FROM upsert_asset);
 	`
 

--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -132,11 +132,8 @@ func (a *AssetModel) Insert(ctx context.Context, sqlExec db.SQLExecuter, code st
 				(code, issuer)
 			VALUES
 				($1, $2)
-			ON CONFLICT (code, issuer) DO
-			UPDATE SET
-				deleted_at = NULL
-			WHERE
-				assets.deleted_at IS NOT NULL
+			ON CONFLICT (code, issuer) DO UPDATE
+				SET deleted_at = NULL WHERE assets.deleted_at IS NOT NULL
 			RETURNING *
 		)
 		SELECT * FROM upsert_asset

--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -123,7 +123,8 @@ func (a *AssetModel) GetAll(ctx context.Context) ([]Asset, error) {
 	return assets, nil
 }
 
-func (a *AssetModel) Insert(ctx context.Context, sqlExec db.SQLExecuter, code string, issuer string) (*Asset, error) {
+// Ensure creates an asset if it doesn't exist, otherwise it returns the existing asset, clearing the deleted_at field.
+func (a *AssetModel) Ensure(ctx context.Context, sqlExec db.SQLExecuter, code string, issuer string) (*Asset, error) {
 	const query = `
 		INSERT INTO assets
 			(code, issuer)

--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -132,8 +132,6 @@ func (a *AssetModel) Insert(ctx context.Context, sqlExec db.SQLExecuter, code st
 		ON CONFLICT (code, issuer) DO
 		UPDATE SET
 			deleted_at = NULL
-		WHERE
-			assets.deleted_at IS NOT NULL
 		RETURNING *
 	`
 

--- a/internal/data/assets_test.go
+++ b/internal/data/assets_test.go
@@ -149,7 +149,7 @@ func Test_AssetModel_Ensure(t *testing.T) {
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
 
-		asset, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
+		asset, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, asset)
 
@@ -163,11 +163,11 @@ func Test_AssetModel_Ensure(t *testing.T) {
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
 
-		usdt, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
+		usdt, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, usdt)
 
-		usdc, err := assetModel.Ensure(ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+		usdc, err := assetModel.Insert(ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
 		require.NoError(t, err)
 		assert.NotNil(t, usdt)
 
@@ -181,7 +181,7 @@ func Test_AssetModel_Ensure(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, usdcDB.DeletedAt)
 
-		reCreatedUSDT, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
+		reCreatedUSDT, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, reCreatedUSDT)
 
@@ -208,11 +208,11 @@ func Test_AssetModel_Ensure(t *testing.T) {
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
 
-		asset, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
+		asset, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, asset)
 
-		idempotentAsset, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
+		idempotentAsset, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, idempotentAsset)
 		assert.Equal(t, asset.Code, idempotentAsset.Code)
@@ -224,7 +224,7 @@ func Test_AssetModel_Ensure(t *testing.T) {
 	t.Run("creates the stellar native asset successfully", func(t *testing.T) {
 		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
 
-		asset, err := assetModel.Ensure(ctx, dbConnectionPool, "XLM", "")
+		asset, err := assetModel.Insert(ctx, dbConnectionPool, "XLM", "")
 		require.NoError(t, err)
 		assert.NotNil(t, asset)
 
@@ -235,7 +235,7 @@ func Test_AssetModel_Ensure(t *testing.T) {
 	t.Run("does not create an asset with empty issuer (unless it's XLM)", func(t *testing.T) {
 		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
 
-		asset, err := assetModel.Ensure(ctx, dbConnectionPool, "USDC", "")
+		asset, err := assetModel.Insert(ctx, dbConnectionPool, "USDC", "")
 		assert.EqualError(t, err, `error inserting asset: pq: new row for relation "assets" violates check constraint "asset_issuer_length_check"`)
 		assert.Nil(t, asset)
 	})
@@ -243,11 +243,11 @@ func Test_AssetModel_Ensure(t *testing.T) {
 	t.Run("does not create an asset with a invalid issuer", func(t *testing.T) {
 		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
 
-		asset, err := assetModel.Ensure(ctx, dbConnectionPool, "USDC", "INVALID")
+		asset, err := assetModel.Insert(ctx, dbConnectionPool, "USDC", "INVALID")
 		assert.EqualError(t, err, `error inserting asset: pq: new row for relation "assets" violates check constraint "asset_issuer_length_check"`)
 		assert.Nil(t, asset)
 
-		asset, err = assetModel.Ensure(ctx, dbConnectionPool, "XLM", "INVALID")
+		asset, err = assetModel.Insert(ctx, dbConnectionPool, "XLM", "INVALID")
 		assert.EqualError(t, err, `error inserting asset: pq: new row for relation "assets" violates check constraint "asset_issuer_length_check"`)
 		assert.Nil(t, asset)
 	})

--- a/internal/data/assets_test.go
+++ b/internal/data/assets_test.go
@@ -132,7 +132,7 @@ func Test_AssetModelGetByWalletID(t *testing.T) {
 	})
 }
 
-func Test_AssetModelInsert(t *testing.T) {
+func Test_AssetModel_Ensure(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 
@@ -149,7 +149,7 @@ func Test_AssetModelInsert(t *testing.T) {
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
 
-		asset, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
+		asset, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, asset)
 
@@ -163,11 +163,11 @@ func Test_AssetModelInsert(t *testing.T) {
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
 
-		usdt, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
+		usdt, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, usdt)
 
-		usdc, err := assetModel.Insert(ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+		usdc, err := assetModel.Ensure(ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
 		require.NoError(t, err)
 		assert.NotNil(t, usdt)
 
@@ -181,7 +181,7 @@ func Test_AssetModelInsert(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, usdcDB.DeletedAt)
 
-		reCreatedUSDT, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
+		reCreatedUSDT, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, reCreatedUSDT)
 
@@ -208,11 +208,11 @@ func Test_AssetModelInsert(t *testing.T) {
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
 
-		asset, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
+		asset, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, asset)
 
-		idempotentAsset, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
+		idempotentAsset, err := assetModel.Ensure(ctx, dbConnectionPool, code, issuer)
 		require.NoError(t, err)
 		assert.NotNil(t, idempotentAsset)
 		assert.Equal(t, asset.Code, idempotentAsset.Code)
@@ -224,7 +224,7 @@ func Test_AssetModelInsert(t *testing.T) {
 	t.Run("creates the stellar native asset successfully", func(t *testing.T) {
 		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
 
-		asset, err := assetModel.Insert(ctx, dbConnectionPool, "XLM", "")
+		asset, err := assetModel.Ensure(ctx, dbConnectionPool, "XLM", "")
 		require.NoError(t, err)
 		assert.NotNil(t, asset)
 
@@ -232,10 +232,10 @@ func Test_AssetModelInsert(t *testing.T) {
 		assert.Empty(t, asset.Issuer)
 	})
 
-	t.Run("does not create an asset with empty issuer", func(t *testing.T) {
+	t.Run("does not create an asset with empty issuer (unless it's XLM)", func(t *testing.T) {
 		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
 
-		asset, err := assetModel.Insert(ctx, dbConnectionPool, "USDC", "")
+		asset, err := assetModel.Ensure(ctx, dbConnectionPool, "USDC", "")
 		assert.EqualError(t, err, `error inserting asset: pq: new row for relation "assets" violates check constraint "asset_issuer_length_check"`)
 		assert.Nil(t, asset)
 	})
@@ -243,11 +243,11 @@ func Test_AssetModelInsert(t *testing.T) {
 	t.Run("does not create an asset with a invalid issuer", func(t *testing.T) {
 		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
 
-		asset, err := assetModel.Insert(ctx, dbConnectionPool, "USDC", "INVALID")
+		asset, err := assetModel.Ensure(ctx, dbConnectionPool, "USDC", "INVALID")
 		assert.EqualError(t, err, `error inserting asset: pq: new row for relation "assets" violates check constraint "asset_issuer_length_check"`)
 		assert.Nil(t, asset)
 
-		asset, err = assetModel.Insert(ctx, dbConnectionPool, "XLM", "INVALID")
+		asset, err = assetModel.Ensure(ctx, dbConnectionPool, "XLM", "INVALID")
 		assert.EqualError(t, err, `error inserting asset: pq: new row for relation "assets" violates check constraint "asset_issuer_length_check"`)
 		assert.Nil(t, asset)
 	})

--- a/internal/data/assets_test.go
+++ b/internal/data/assets_test.go
@@ -203,7 +203,7 @@ func Test_AssetModelInsert(t *testing.T) {
 		assert.NotNil(t, usdcDB.DeletedAt)
 	})
 
-	t.Run("does not insert the same asset again", func(t *testing.T) {
+	t.Run("asset insertion is idempotent", func(t *testing.T) {
 		DeleteAllAssetFixtures(t, ctx, dbConnectionPool.SqlxDB())
 		code := "USDT"
 		issuer := "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG"
@@ -212,9 +212,13 @@ func Test_AssetModelInsert(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, asset)
 
-		duplicatedAsset, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
-		assert.EqualError(t, err, "error inserting asset: sql: no rows in result set")
-		assert.Nil(t, duplicatedAsset)
+		idempotentAsset, err := assetModel.Insert(ctx, dbConnectionPool, code, issuer)
+		require.NoError(t, err)
+		assert.NotNil(t, idempotentAsset)
+		assert.Equal(t, asset.Code, idempotentAsset.Code)
+		assert.Equal(t, asset.Issuer, idempotentAsset.Issuer)
+		assert.Equal(t, asset.DeletedAt, idempotentAsset.DeletedAt)
+		assert.Empty(t, asset.DeletedAt)
 	})
 
 	t.Run("creates the stellar native asset successfully", func(t *testing.T) {

--- a/internal/serve/httphandler/assets_handler.go
+++ b/internal/serve/httphandler/assets_handler.go
@@ -88,7 +88,7 @@ func (c AssetsHandler) CreateAsset(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	asset, err := db.RunInTransactionWithResult(ctx, c.Models.DBConnectionPool, nil, func(dbTx db.DBTransaction) (*data.Asset, error) {
-		insertedAsset, insertErr := c.Models.Assets.Insert(
+		insertedAsset, insertErr := c.Models.Assets.Ensure(
 			ctx,
 			dbTx,
 			assetRequest.Code,

--- a/internal/serve/httphandler/assets_handler.go
+++ b/internal/serve/httphandler/assets_handler.go
@@ -88,7 +88,7 @@ func (c AssetsHandler) CreateAsset(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	asset, err := db.RunInTransactionWithResult(ctx, c.Models.DBConnectionPool, nil, func(dbTx db.DBTransaction) (*data.Asset, error) {
-		insertedAsset, insertErr := c.Models.Assets.Ensure(
+		insertedAsset, insertErr := c.Models.Assets.Insert(
 			ctx,
 			dbTx,
 			assetRequest.Code,

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -310,7 +310,7 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
-	t.Run("failed creating asset, duplicated asset", func(t *testing.T) {
+	t.Run("asset creation is idempotent", func(t *testing.T) {
 		data.DeleteAllAssetFixtures(t, ctx, dbConnectionPool)
 
 		tx, err := txnbuild.NewTransaction(
@@ -344,7 +344,7 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 		signatureService.
 			On("SignStellarTransaction", mock.Anything, tx, distributionKP.Address()).
 			Return(signedTx, nil).
-			Once()
+			Twice()
 
 		horizonClientMock.
 			On("AccountDetail", horizonclient.AccountRequest{
@@ -355,43 +355,34 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 				Sequence:  123,
 				Balances:  []horizon.Balance{},
 			}, nil).
-			Once().
+			Twice().
 			On("SubmitTransactionWithOptions", signedTx, horizonclient.SubmitTxOpts{SkipMemoRequiredCheck: true}).
 			Return(horizon.Transaction{}, nil).
-			Once()
+			Twice()
 
 		// Creating the asset
 		requestBody, err := json.Marshal(AssetRequest{Code: code, Issuer: issuer})
 		require.NoError(t, err)
-
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/assets", bytes.NewReader(requestBody))
 		require.NoError(t, err)
-
 		rr := httptest.NewRecorder()
 		http.HandlerFunc(handler.CreateAsset).ServeHTTP(rr, req)
 
 		resp := rr.Result()
-
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 		// Duplicating the asset
 		requestBody, err = json.Marshal(AssetRequest{Code: code, Issuer: issuer})
 		require.NoError(t, err)
-
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost, "/assets", bytes.NewReader(requestBody))
 		require.NoError(t, err)
-
 		rr = httptest.NewRecorder()
 		http.HandlerFunc(handler.CreateAsset).ServeHTTP(rr, req)
 
 		resp = rr.Result()
 		defer resp.Body.Close()
-
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		assert.Equal(t, http.StatusConflict, resp.StatusCode)
-		assert.JSONEq(t, `{"error": "asset already exists"}`, string(respBody))
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	})
 
 	t.Run("failed creating asset, error adding asset trustline", func(t *testing.T) {

--- a/internal/services/send_receiver_wallets_invite_service.go
+++ b/internal/services/send_receiver_wallets_invite_service.go
@@ -179,7 +179,13 @@ func (s SendReceiverWalletInviteService) SendInvite(ctx context.Context) error {
 	})
 }
 
+// shouldSendInvitationSMS returns true if we should send the invitation SMS to the receiver. It will be used to either
+// send the invitation for the first time, or to resend it automatically according with the organization's SMS Resend
+// Interval and the maximum number of SMS resend attempts.
+
 func (s SendReceiverWalletInviteService) shouldSendInvitationSMS(ctx context.Context, organization *data.Organization, rwa *data.ReceiverWalletAsset) bool {
+	truncatedPhoneNumber := utils.TruncateString(rwa.ReceiverWallet.Receiver.PhoneNumber, 3)
+
 	// We've never sent a Invitation SMS
 	if rwa.ReceiverWallet.InvitationSentAt == nil {
 		return true
@@ -188,8 +194,8 @@ func (s SendReceiverWalletInviteService) shouldSendInvitationSMS(ctx context.Con
 	// If organization's SMS Resend Interval is nil and we've sent the invitation message to the receiver, we won't resend it.
 	if organization.SMSResendInterval == nil && rwa.ReceiverWallet.InvitationSentAt != nil {
 		log.Ctx(ctx).Debugf(
-			"the invitation message was not resent to the receiver %s because the organization's SMS Resend Interval is nil",
-			rwa.ReceiverWallet.Receiver.ID)
+			"the invitation message was not automatically resent to the receiver %s with phone number %s because the organization's SMS Resend Interval is nil",
+			rwa.ReceiverWallet.Receiver.ID, truncatedPhoneNumber)
 		return false
 	}
 
@@ -198,7 +204,8 @@ func (s SendReceiverWalletInviteService) shouldSendInvitationSMS(ctx context.Con
 		// Check if the receiver wallet reached the maximum number of SMS resend attempts.
 		if rwa.ReceiverWallet.ReceiverWalletStats.TotalInvitationSMSResentAttempts >= s.maxInvitationSMSResendAttempts {
 			log.Ctx(ctx).Debugf(
-				"the invitation message was not resent to the receiver because the maximum number of SMS resend attempts has been reached: Receiver ID %s - Wallet ID %s - Total Invitation SMS resent %d - Maximum attempts %d",
+				"the invitation message was not resent to the receiver because the maximum number of SMS resend attempts has been reached: Phone Number: %s - Receiver ID %s - Wallet ID %s - Total Invitation SMS resent %d - Maximum attempts %d",
+				truncatedPhoneNumber,
 				rwa.ReceiverWallet.Receiver.ID,
 				rwa.WalletID,
 				rwa.ReceiverWallet.ReceiverWalletStats.TotalInvitationSMSResentAttempts,
@@ -212,7 +219,8 @@ func (s SendReceiverWalletInviteService) shouldSendInvitationSMS(ctx context.Con
 			AddDate(0, 0, -int(*organization.SMSResendInterval*(rwa.ReceiverWallet.ReceiverWalletStats.TotalInvitationSMSResentAttempts+1)))
 		if !rwa.ReceiverWallet.InvitationSentAt.Before(resendPeriod) {
 			log.Ctx(ctx).Debugf(
-				"the invitation message was not resent to the receiver because the receiver is not in the resend period: Receiver ID %s - Wallet ID %s - Last Invitation Sent At %s - SMS Resend Interval %d day(s)",
+				"the invitation message was not automatically resent to the receiver because the receiver is not in the resend period: Phone Number: %s - Receiver ID %s - Wallet ID %s - Last Invitation Sent At %s - SMS Resend Interval %d day(s)",
+				truncatedPhoneNumber,
 				rwa.ReceiverWallet.Receiver.ID,
 				rwa.WalletID,
 				rwa.ReceiverWallet.InvitationSentAt.Format(time.RFC1123),

--- a/internal/services/send_receiver_wallets_invite_service_test.go
+++ b/internal/services/send_receiver_wallets_invite_service_test.go
@@ -760,7 +760,8 @@ func Test_SendReceiverWalletInviteService_shouldSendInvitationSMS(t *testing.T) 
 			ReceiverWallet: data.ReceiverWallet{
 				InvitationSentAt: &invitationSentAt,
 				Receiver: data.Receiver{
-					ID: "receiver-ID",
+					ID:          "receiver-ID",
+					PhoneNumber: "+123456789",
 				},
 				ReceiverWalletStats: data.ReceiverWalletStats{
 					TotalInvitationSMSResentAttempts: maxInvitationSMSResendAttempts,
@@ -778,7 +779,7 @@ func Test_SendReceiverWalletInviteService_shouldSendInvitationSMS(t *testing.T) 
 		require.Len(t, entries, 1)
 		assert.Equal(
 			t,
-			"the invitation message was not resent to the receiver because the maximum number of SMS resend attempts has been reached: Receiver ID receiver-ID - Wallet ID wallet-ID - Total Invitation SMS resent 3 - Maximum attempts 3",
+			"the invitation message was not resent to the receiver because the maximum number of SMS resend attempts has been reached: Phone Number: +12...789 - Receiver ID receiver-ID - Wallet ID wallet-ID - Total Invitation SMS resent 3 - Maximum attempts 3",
 			entries[0].Message,
 		)
 	})
@@ -791,7 +792,8 @@ func Test_SendReceiverWalletInviteService_shouldSendInvitationSMS(t *testing.T) 
 			ReceiverWallet: data.ReceiverWallet{
 				InvitationSentAt: &invitationSentAt,
 				Receiver: data.Receiver{
-					ID: "receiver-ID",
+					ID:          "receiver-ID",
+					PhoneNumber: "+123456789",
 				},
 				ReceiverWalletStats: data.ReceiverWalletStats{
 					TotalInvitationSMSResentAttempts: 1,
@@ -810,7 +812,7 @@ func Test_SendReceiverWalletInviteService_shouldSendInvitationSMS(t *testing.T) 
 		assert.Equal(
 			t,
 			fmt.Sprintf(
-				"the invitation message was not resent to the receiver because the receiver is not in the resend period: Receiver ID receiver-ID - Wallet ID wallet-ID - Last Invitation Sent At %s - SMS Resend Interval 2 day(s)",
+				"the invitation message was not automatically resent to the receiver because the receiver is not in the resend period: Phone Number: +12...789 - Receiver ID receiver-ID - Wallet ID wallet-ID - Last Invitation Sent At %s - SMS Resend Interval 2 day(s)",
 				invitationSentAt.Format(time.RFC1123),
 			),
 			entries[0].Message,


### PR DESCRIPTION
### What

Make `POST /assets` idempotent.

### Why

The previous implementation was causing a hassle with a partner that had seeded their database before using the frontend application.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
