### PR TITLE
Hotfix/improve error logs for debugging

### DIFF
--- a/internal/data/wallets.go
+++ b/internal/data/wallets.go
@@ -110,7 +110,7 @@ func (wm *WalletModel) FindWallets(ctx context.Context, enabledFilter *bool) ([]
 	var args []interface{}
 
 	if enabledFilter != nil {
-		whereClause = "WHERE w.enabled = $1"
+		whereClause = "WHERE w.enabled = $1 "
 		args = append(args, *enabledFilter)
 	}
 

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -62,10 +62,11 @@ func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	truncatedPhoneNumber := utils.TruncateString(receiverSendOTPRequest.PhoneNumber, 3)
 	if phoneValidateErr := utils.ValidatePhoneNumber(receiverSendOTPRequest.PhoneNumber); phoneValidateErr != nil {
 		extras := map[string]interface{}{"phone_number": "phone_number is required"}
 		if !errors.Is(phoneValidateErr, utils.ErrEmptyPhoneNumber) {
-			phoneValidateErr = fmt.Errorf("validating phone number %s: %w", utils.TruncateString(receiverSendOTPRequest.PhoneNumber, len(receiverSendOTPRequest.PhoneNumber)/4), phoneValidateErr)
+			phoneValidateErr = fmt.Errorf("validating phone number %s: %w", truncatedPhoneNumber, phoneValidateErr)
 			log.Ctx(ctx).Error(phoneValidateErr)
 			extras["phone_number"] = "invalid phone number provided"
 		}
@@ -110,7 +111,7 @@ func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	if numberOfUpdatedRows < 1 {
-		log.Ctx(ctx).Warnf("updated no rows in receiver send OTP handler for phone number: %s", utils.TruncateString(receiverSendOTPRequest.PhoneNumber, len(receiverSendOTPRequest.PhoneNumber)/4))
+		log.Ctx(ctx).Warnf("updated no rows in ReceiverSendOTPHandler, please verify if the provided phone number (%s) and client_domain (%s) are both valid", truncatedPhoneNumber, sep24Claims.ClientDomainClaim)
 	} else {
 		sendOTPData := ReceiverSendOTPData{
 			OTP:              newOTP,
@@ -140,7 +141,7 @@ func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			Message:       builder.String(),
 		}
 
-		log.Ctx(ctx).Infof("sending OTP message to phone number: %s", utils.TruncateString(receiverSendOTPRequest.PhoneNumber, 3))
+		log.Ctx(ctx).Infof("sending OTP message to phone number: %s", truncatedPhoneNumber)
 		err = h.SMSMessengerClient.SendMessage(smsMessage)
 		if err != nil {
 			httperror.InternalError(ctx, "Cannot send OTP message", err, nil).Render(w)

--- a/internal/transactionsubmission/utils/errors.go
+++ b/internal/transactionsubmission/utils/errors.go
@@ -67,7 +67,7 @@ func NewHorizonErrorWrapper(err error) *HorizonErrorWrapper {
 
 	resultCodes, resCodeErr := hError.ResultCodes()
 	if resCodeErr != nil {
-		log.Errorf("parsing result_codes: %v", resCodeErr)
+		log.Warnf("parsing result_codes: %v", resCodeErr)
 	}
 
 	return &HorizonErrorWrapper{


### PR DESCRIPTION
### What

Add the client_domain when logging the message where the user with the {phone_number, client_domain} pair could not be found.

Also, updated a log from error to warn.

### Why

Better debuggability.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
