### PR TITLE
[SDP-1022] Hotfix: update Vibrant Assist's `client_domain`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > Place unreleased changes here.
 
+## [1.0.1](https://github.com/stellar/stellar-disbursement-platform-backend/compare/1.0.0...1.0.1)
+
+### Changed
+
+- Update log message for better debugging. [#125](https://github.com/stellar/stellar-disbursement-platform-backend/pull/125)
+
+### Fixed
+
+- Fix client_domain from the Viobrant Assist wallet. [#126](https://github.com/stellar/stellar-disbursement-platform-backend/pull/126)
+
 ## [1.0.0](https://github.com/stellar/stellar-disbursement-platform-backend/compare/1.0.0-rc2...1.0.0)
 
 ### Added

--- a/cmd/db_test.go
+++ b/cmd/db_test.go
@@ -217,7 +217,7 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 	// assert.Equal(t, "https://www.beansapp.com/disbursements/registration?redirect=true", wallets[0].DeepLinkSchema)
 	assert.Equal(t, "Vibrant Assist", wallets[0].Name)
 	assert.Equal(t, "https://vibrantapp.com/vibrant-assist", wallets[0].Homepage)
-	assert.Equal(t, "api.vibrantapp.com", wallets[0].SEP10ClientDomain)
+	assert.Equal(t, "vibrantapp.com", wallets[0].SEP10ClientDomain)
 	assert.Equal(t, "https://vibrantapp.com/sdp", wallets[0].DeepLinkSchema)
 
 	assert.Equal(t, "Vibrant Assist RC", wallets[1].Name)
@@ -235,7 +235,7 @@ func Test_DatabaseCommand_db_setup_for_network(t *testing.T) {
 		"Name: Vibrant Assist",
 		"Homepage: https://vibrantapp.com/vibrant-assist",
 		"Deep Link Schema: https://vibrantapp.com/sdp",
-		"SEP-10 Client Domain: api.vibrantapp.com",
+		"SEP-10 Client Domain: vibrantapp.com",
 	}
 
 	logs := buf.String()

--- a/helmchart/sdp/Chart.yaml
+++ b/helmchart/sdp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stellar-disbursement-platform
 description: A Helm chart for the Stellar Disbursement Platform Backend (A.K.A. `sdp`)
 version: 0.9.3
-appVersion: "1.0.0"
+appVersion: "1.0.1"
 type: application
 maintainers:
   - name: Stellar Development Foundation

--- a/internal/services/setup_wallets_for_network_service_test.go
+++ b/internal/services/setup_wallets_for_network_service_test.go
@@ -60,7 +60,7 @@ func Test_SetupWalletsForProperNetwork(t *testing.T) {
 			"Name: Vibrant Assist",
 			"Homepage: https://vibrantapp.com/vibrant-assist",
 			"Deep Link Schema: https://vibrantapp.com/sdp",
-			"SEP-10 Client Domain: api.vibrantapp.com",
+			"SEP-10 Client Domain: vibrantapp.com",
 		}
 
 		logs := buf.String()
@@ -89,7 +89,7 @@ func Test_SetupWalletsForProperNetwork(t *testing.T) {
 					Name:              "Vibrant Assist",
 					Homepage:          "https://vibrantapp.com/vibrant-assist",
 					DeepLinkSchema:    "https://aidpubnet.netlify.app",
-					SEP10ClientDomain: "api.vibrantapp.com",
+					SEP10ClientDomain: "vibrantapp.com",
 				},
 				{
 					Name:              "BOSS Money",
@@ -118,7 +118,7 @@ func Test_SetupWalletsForProperNetwork(t *testing.T) {
 
 		assert.Equal(t, "Vibrant Assist", wallets[1].Name)
 		assert.Equal(t, "https://vibrantapp.com/vibrant-assist", wallets[1].Homepage)
-		assert.Equal(t, "api.vibrantapp.com", wallets[1].SEP10ClientDomain)
+		assert.Equal(t, "vibrantapp.com", wallets[1].SEP10ClientDomain)
 		assert.Equal(t, "https://aidpubnet.netlify.app", wallets[1].DeepLinkSchema)
 
 		expectedLogs := []string{
@@ -130,7 +130,7 @@ func Test_SetupWalletsForProperNetwork(t *testing.T) {
 			"Name: Vibrant Assist",
 			"Homepage: https://vibrantapp.com/vibrant-assist",
 			"Deep Link Schema: https://aidpubnet.netlify.app",
-			"SEP-10 Client Domain: api.vibrantapp.com",
+			"SEP-10 Client Domain: vibrantapp.com",
 		}
 
 		logs := buf.String()
@@ -152,7 +152,7 @@ func Test_SetupWalletsForProperNetwork(t *testing.T) {
 					Name:              "Vibrant Assist",
 					Homepage:          "https://vibrantapp.com/vibrant-assist",
 					DeepLinkSchema:    "https://aidpubnet.netlify.app",
-					SEP10ClientDomain: "api.vibrantapp.com",
+					SEP10ClientDomain: "vibrantapp.com",
 					Assets: []data.Asset{
 						{
 							Code:   "USDC",
@@ -241,7 +241,7 @@ func Test_SetupWalletsForProperNetwork(t *testing.T) {
 			"Name: Vibrant Assist",
 			"Homepage: https://vibrantapp.com/vibrant-assist",
 			"Deep Link Schema: https://aidpubnet.netlify.app",
-			"SEP-10 Client Domain: api.vibrantapp.com",
+			"SEP-10 Client Domain: vibrantapp.com",
 			"Assets:",
 			"* USDC - GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
 		}

--- a/internal/services/wallets/wallets_pubnet.go
+++ b/internal/services/wallets/wallets_pubnet.go
@@ -7,7 +7,7 @@ var PubnetWallets = []data.Wallet{
 		Name:              "Vibrant Assist",
 		Homepage:          "https://vibrantapp.com/vibrant-assist",
 		DeepLinkSchema:    "https://vibrantapp.com/sdp",
-		SEP10ClientDomain: "api.vibrantapp.com",
+		SEP10ClientDomain: "vibrantapp.com",
 		Assets: []data.Asset{
 			{
 				Code:   "USDC",

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 
 // Version is the official version of this application. Whenever it's changed
 // here, it also needs to be updated at the `helmchart/Chart.yaml#appVersion“.
-const Version = "1.0.0"
+const Version = "1.0.1"
 
 // GitCommit is populated at build time by
 // go build -ldflags "-X main.GitCommit=$GIT_COMMIT"


### PR DESCRIPTION
### What

Update client_domain on Vibrant Assist from api.vibrantapp.com to vibrantapp.com.

### Why

It was incorrect.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
