### PR TITLE
SDP-980 Remove CORS from tenant configuration

### DIFF
--- a/db/migrate_test.go
+++ b/db/migrate_test.go
@@ -125,11 +125,11 @@ func TestMigrate_downApplyOne_Tenant_migrations(t *testing.T) {
 
 	n, err := Migrate(db.DSN, migrate.Up, 2, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
 	require.NoError(t, err)
-	require.Equal(t, 1, n)
+	require.Equal(t, 2, n)
 
-	n, err = Migrate(db.DSN, migrate.Down, 1, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
+	n, err = Migrate(db.DSN, migrate.Down, 2, tenantmigrations.FS, StellarMultiTenantMigrationsTableName)
 	require.NoError(t, err)
-	require.Equal(t, 1, n)
+	require.Equal(t, 2, n)
 
 	ids := []string{}
 	err = dbConnectionPool.SelectContext(ctx, &ids, fmt.Sprintf("SELECT id FROM %s", StellarMultiTenantMigrationsTableName))

--- a/db/migrations/tenant-migrations/2023-11-14.0.drop-unused-cors-column.sql
+++ b/db/migrations/tenant-migrations/2023-11-14.0.drop-unused-cors-column.sql
@@ -1,0 +1,12 @@
+-- Drop unused cors allowed origins column.
+
+-- +migrate Up
+
+ALTER TABLE public.tenants
+    DROP COLUMN IF EXISTS cors_allowed_origins;
+
+
+-- +migrate Down
+
+ALTER TABLE public.tenants
+    ADD COLUMN cors_allowed_origins text[] NULL;

--- a/stellar-multitenant/pkg/cli/config_tenant.go
+++ b/stellar-multitenant/pkg/cli/config_tenant.go
@@ -14,14 +14,13 @@ import (
 )
 
 type tenantOptions struct {
-	ID                 string
-	EmailSenderType    *tenant.EmailSenderType
-	SMSSenderType      *tenant.SMSSenderType
-	EnableMFA          *bool
-	EnableReCAPTCHA    *bool
-	CORSAllowedOrigins []string
-	BaseURL            *string
-	SDPUIBaseURL       *string
+	ID              string
+	EmailSenderType *tenant.EmailSenderType
+	SMSSenderType   *tenant.SMSSenderType
+	EnableMFA       *bool
+	EnableReCAPTCHA *bool
+	BaseURL         *string
+	SDPUIBaseURL    *string
 }
 
 func ConfigTenantCmd() *cobra.Command {
@@ -64,14 +63,6 @@ func ConfigTenantCmd() *cobra.Command {
 			OptType:        types.String,
 			CustomSetValue: utils.SetConfigOptionOptionalBoolean,
 			ConfigKey:      &to.EnableReCAPTCHA,
-			Required:       false,
-		},
-		{
-			Name:           "cors-allowed-origins",
-			Usage:          `Cors URLs that are allowed to access the endpoints, separated by ","`,
-			OptType:        types.String,
-			CustomSetValue: utils.SetCORSAllowedOrigins,
-			ConfigKey:      &to.CORSAllowedOrigins,
 			Required:       false,
 		},
 		{
@@ -128,14 +119,13 @@ func executeConfigTenant(ctx context.Context, to *tenantOptions, dbURL string) e
 
 	m := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
 	_, err = m.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
-		ID:                 to.ID,
-		EmailSenderType:    to.EmailSenderType,
-		SMSSenderType:      to.SMSSenderType,
-		EnableMFA:          to.EnableMFA,
-		EnableReCAPTCHA:    to.EnableReCAPTCHA,
-		CORSAllowedOrigins: to.CORSAllowedOrigins,
-		BaseURL:            to.BaseURL,
-		SDPUIBaseURL:       to.SDPUIBaseURL,
+		ID:              to.ID,
+		EmailSenderType: to.EmailSenderType,
+		SMSSenderType:   to.SMSSenderType,
+		EnableMFA:       to.EnableMFA,
+		EnableReCAPTCHA: to.EnableReCAPTCHA,
+		BaseURL:         to.BaseURL,
+		SDPUIBaseURL:    to.SDPUIBaseURL,
 	})
 	if err != nil {
 		return fmt.Errorf("updating tenant config: %w", err)

--- a/stellar-multitenant/pkg/cli/utils/custom_set_value.go
+++ b/stellar-multitenant/pkg/cli/utils/custom_set_value.go
@@ -4,12 +4,9 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/viper"
-	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/support/config"
-	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
@@ -42,55 +39,6 @@ func SetConfigOptionSMSSenderType(co *config.ConfigOption) error {
 	}
 
 	*(co.ConfigKey.(**tenant.SMSSenderType)) = &smsSenderType
-	return nil
-}
-
-func SetConfigOptionStellarPublicKey(co *config.ConfigOption) error {
-	publicKey := viper.GetString(co.Name)
-	if publicKey == "" {
-		return nil
-	}
-
-	kp, err := keypair.ParseAddress(publicKey)
-	if err != nil {
-		return fmt.Errorf("error validating public key: %w", err)
-	}
-
-	key, ok := co.ConfigKey.(**string)
-	if !ok {
-		return fmt.Errorf("the expected type for this config key is a string, but got a %T instead", co.ConfigKey)
-	}
-	addr := kp.Address()
-	*key = &addr
-
-	return nil
-}
-
-func SetCORSAllowedOrigins(co *config.ConfigOption) error {
-	corsAllowedOriginsOptions := viper.GetString(co.Name)
-	if corsAllowedOriginsOptions == "" {
-		return nil
-	}
-
-	corsAllowedOrigins := strings.Split(corsAllowedOriginsOptions, ",")
-
-	// validate addresses
-	for _, address := range corsAllowedOrigins {
-		_, err := url.ParseRequestURI(address)
-		if err != nil {
-			return fmt.Errorf("error parsing cors addresses: %w", err)
-		}
-		if address == "*" {
-			log.Warn(`The value "*" for the CORS Allowed Origins is too permissive and not recommended.`)
-		}
-	}
-
-	key, ok := co.ConfigKey.(*[]string)
-	if !ok {
-		return fmt.Errorf("the expected type for this config key is a string slice, but got a %T instead", co.ConfigKey)
-	}
-	*key = corsAllowedOrigins
-
 	return nil
 }
 

--- a/stellar-multitenant/pkg/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/pkg/internal/httphandler/tenants_handler.go
@@ -80,13 +80,12 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	tnt, err = h.Manager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
-		ID:                 tnt.ID,
-		EmailSenderType:    &reqBody.EmailSenderType,
-		SMSSenderType:      &reqBody.SMSSenderType,
-		EnableMFA:          &reqBody.EnableMFA,
-		EnableReCAPTCHA:    &reqBody.EnableReCAPTCHA,
-		CORSAllowedOrigins: reqBody.CORSAllowedOrigins,
-		BaseURL:            &reqBody.BaseURL,
+		ID:              tnt.ID,
+		EmailSenderType: &reqBody.EmailSenderType,
+		SMSSenderType:   &reqBody.SMSSenderType,
+		EnableMFA:       &reqBody.EnableMFA,
+		EnableReCAPTCHA: &reqBody.EnableReCAPTCHA,
+		BaseURL:         &reqBody.BaseURL,
 	})
 	if err != nil {
 		httperror.InternalError(ctx, "Could not update tenant config", err, nil).Render(rw)
@@ -117,15 +116,14 @@ func (t TenantsHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	tenantID := chi.URLParam(r, "id")
 
 	tnt, err := t.Manager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
-		ID:                 tenantID,
-		EmailSenderType:    reqBody.EmailSenderType,
-		SMSSenderType:      reqBody.SMSSenderType,
-		EnableMFA:          reqBody.EnableMFA,
-		EnableReCAPTCHA:    reqBody.EnableReCAPTCHA,
-		CORSAllowedOrigins: reqBody.CORSAllowedOrigins,
-		BaseURL:            reqBody.BaseURL,
-		SDPUIBaseURL:       reqBody.SDPUIBaseURL,
-		Status:             reqBody.Status,
+		ID:              tenantID,
+		EmailSenderType: reqBody.EmailSenderType,
+		SMSSenderType:   reqBody.SMSSenderType,
+		EnableMFA:       reqBody.EnableMFA,
+		EnableReCAPTCHA: reqBody.EnableReCAPTCHA,
+		BaseURL:         reqBody.BaseURL,
+		SDPUIBaseURL:    reqBody.SDPUIBaseURL,
+		Status:          reqBody.Status,
 	})
 	if err != nil {
 		if errors.Is(tenant.ErrEmptyUpdateTenant, err) {

--- a/stellar-multitenant/pkg/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/pkg/internal/httphandler/tenants_handler_test.go
@@ -135,7 +135,6 @@ func Test_TenantHandler_Get(t *testing.T) {
 					"sms_sender_type": "DRY_RUN",
 					"enable_mfa": true,
 					"enable_recaptcha": true,
-					"cors_allowed_origins": null,
 					"base_url": null,
 					"sdp_ui_base_url": null,
 					"status": "TENANT_CREATED",
@@ -149,7 +148,6 @@ func Test_TenantHandler_Get(t *testing.T) {
 					"sms_sender_type": "DRY_RUN",
 					"enable_mfa": true,
 					"enable_recaptcha": true,
-					"cors_allowed_origins": null,
 					"base_url": null,
 					"sdp_ui_base_url": null,
 					"status": "TENANT_CREATED",
@@ -184,7 +182,6 @@ func Test_TenantHandler_Get(t *testing.T) {
 				"sms_sender_type": "DRY_RUN",
 				"enable_mfa": true,
 				"enable_recaptcha": true,
-				"cors_allowed_origins": null,
 				"base_url": null,
 				"sdp_ui_base_url": null,
 				"status": "TENANT_CREATED",
@@ -218,7 +215,6 @@ func Test_TenantHandler_Get(t *testing.T) {
 				"sms_sender_type": "DRY_RUN",
 				"enable_mfa": true,
 				"enable_recaptcha": true,
-				"cors_allowed_origins": null,
 				"base_url": null,
 				"sdp_ui_base_url": null,
 				"status": "TENANT_CREATED",
@@ -297,7 +293,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 					"base_url": "invalid base URL value",
 					"email_sender_type": "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
 					"sms_sender_type": "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
-					"cors_allowed_origins": "provide at least one CORS allowed origins",
 					"sdp_ui_base_url": "invalid SDP UI base URL value"
 				}
 			}
@@ -330,7 +325,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"sms_sender_type": "DRY_RUN",
 				"enable_recaptcha": true,
 				"enable_mfa": false,
-				"cors_allowed_origins": ["*"],
 				"base_url": "https://backend.sdp.org",
 				"sdp_ui_base_url": "https://aid-org.sdp.org"
 			}
@@ -359,7 +353,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"sms_sender_type": "DRY_RUN",
 				"enable_mfa": false,
 				"enable_recaptcha": true,
-				"cors_allowed_origins": ["*"],
 				"base_url": "https://backend.sdp.org",
 				"sdp_ui_base_url": "https://aid-org.sdp.org",
 				"status": "TENANT_PROVISIONED",
@@ -484,28 +477,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 		runBadRequestPatchTest(t, r, url, "status", "invalid status value")
 	})
 
-	t.Run("returns BadRequest when CORSAllowedOrigins is not valid", func(t *testing.T) {
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPatch, url, strings.NewReader(`{"cors_allowed_origins": ["invalid"]}`))
-		require.NoError(t, err)
-		r.ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		defer resp.Body.Close()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-
-		expectedRespBody := `{
-			"error": "invalid request body",
-			"extras": {
-				"cors_allowed_origins":"invalid URL value for cors_allowed_origins[0] = invalid"
-			}
-		}`
-		assert.JSONEq(t, string(expectedRespBody), string(respBody))
-	})
-
 	t.Run("successfully updates EmailSenderType of a tenant", func(t *testing.T) {
 		reqBody := `{"email_sender_type": "AWS_EMAIL"}`
 		expectedRespBody := `
@@ -513,7 +484,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"sms_sender_type": "DRY_RUN",
 			"enable_mfa": true,
 			"enable_recaptcha": true,
-			"cors_allowed_origins": null,
 			"base_url": null,
 			"sdp_ui_base_url": null,
 			"status": "TENANT_CREATED",
@@ -529,7 +499,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"sms_sender_type": "TWILIO_SMS",
 			"enable_mfa": true,
 			"enable_recaptcha": true,
-			"cors_allowed_origins": null,
 			"base_url": null,
 			"sdp_ui_base_url": null,
 			"status": "TENANT_CREATED",
@@ -545,7 +514,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"sms_sender_type": "DRY_RUN",
 			"enable_mfa": false,
 			"enable_recaptcha": true,
-			"cors_allowed_origins": null,
 			"base_url": null,
 			"sdp_ui_base_url": null,
 			"status": "TENANT_CREATED",
@@ -561,23 +529,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"sms_sender_type": "DRY_RUN",
 			"enable_mfa": true,
 			"enable_recaptcha": false,
-			"cors_allowed_origins": null,
-			"base_url": null,
-			"sdp_ui_base_url": null,
-			"status": "TENANT_CREATED",
-		`
-
-		runSuccessfulRequestPatchTest(t, r, ctx, dbConnectionPool, handler, reqBody, expectedRespBody)
-	})
-
-	t.Run("successfully updates CORSAllowedOrigins of a tenant", func(t *testing.T) {
-		reqBody := `{"cors_allowed_origins": ["http://valid.com"]}`
-		expectedRespBody := `
-			"email_sender_type": "DRY_RUN",
-			"sms_sender_type": "DRY_RUN",
-			"enable_mfa": true,
-			"enable_recaptcha": true,
-			"cors_allowed_origins": ["http://valid.com"],
 			"base_url": null,
 			"sdp_ui_base_url": null,
 			"status": "TENANT_CREATED",
@@ -593,7 +544,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"sms_sender_type": "DRY_RUN",
 			"enable_mfa": true,
 			"enable_recaptcha": true,
-			"cors_allowed_origins": null,
 			"base_url": "http://valid.com",
 			"sdp_ui_base_url": null,
 			"status": "TENANT_CREATED",
@@ -609,7 +559,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"sms_sender_type": "DRY_RUN",
 			"enable_mfa": true,
 			"enable_recaptcha": true,
-			"cors_allowed_origins": null,
 			"base_url": null,
 			"sdp_ui_base_url": "http://valid.com",
 			"status": "TENANT_CREATED",
@@ -625,7 +574,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"sms_sender_type": "DRY_RUN",
 			"enable_mfa": true,
 			"enable_recaptcha": true,
-			"cors_allowed_origins": null,
 			"base_url": null,
 			"sdp_ui_base_url": null,
 			"status": "TENANT_ACTIVATED",
@@ -640,7 +588,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"sms_sender_type": "AWS_SMS",
 			"enable_mfa": false,
 			"enable_recaptcha": false,
-			"cors_allowed_origins": ["http://valid.com"],
 			"base_url": "http://valid.com",
 			"sdp_ui_base_url": "http://valid.com",
 			"status": "TENANT_ACTIVATED"
@@ -651,7 +598,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"sms_sender_type": "AWS_SMS",
 			"enable_mfa": false,
 			"enable_recaptcha": false,
-			"cors_allowed_origins": ["http://valid.com"],
 			"base_url": "http://valid.com",
 			"sdp_ui_base_url": "http://valid.com",
 			"status": "TENANT_ACTIVATED",

--- a/stellar-multitenant/pkg/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/pkg/internal/validators/tenant_validator.go
@@ -12,29 +12,27 @@ import (
 var validTenantName *regexp.Regexp = regexp.MustCompile(`^[a-z-]+$`)
 
 type TenantRequest struct {
-	Name               string                 `json:"name"`
-	OwnerEmail         string                 `json:"owner_email"`
-	OwnerFirstName     string                 `json:"owner_first_name"`
-	OwnerLastName      string                 `json:"owner_last_name"`
-	OrganizationName   string                 `json:"organization_name"`
-	EmailSenderType    tenant.EmailSenderType `json:"email_sender_type"`
-	SMSSenderType      tenant.SMSSenderType   `json:"sms_sender_type"`
-	EnableMFA          bool                   `json:"enable_mfa"`
-	EnableReCAPTCHA    bool                   `json:"enable_recaptcha"`
-	CORSAllowedOrigins []string               `json:"cors_allowed_origins"`
-	BaseURL            string                 `json:"base_url"`
-	SDPUIBaseURL       string                 `json:"sdp_ui_base_url"`
+	Name             string                 `json:"name"`
+	OwnerEmail       string                 `json:"owner_email"`
+	OwnerFirstName   string                 `json:"owner_first_name"`
+	OwnerLastName    string                 `json:"owner_last_name"`
+	OrganizationName string                 `json:"organization_name"`
+	EmailSenderType  tenant.EmailSenderType `json:"email_sender_type"`
+	SMSSenderType    tenant.SMSSenderType   `json:"sms_sender_type"`
+	EnableMFA        bool                   `json:"enable_mfa"`
+	EnableReCAPTCHA  bool                   `json:"enable_recaptcha"`
+	BaseURL          string                 `json:"base_url"`
+	SDPUIBaseURL     string                 `json:"sdp_ui_base_url"`
 }
 
 type UpdateTenantRequest struct {
-	EmailSenderType    *tenant.EmailSenderType `json:"email_sender_type"`
-	SMSSenderType      *tenant.SMSSenderType   `json:"sms_sender_type"`
-	EnableMFA          *bool                   `json:"enable_mfa"`
-	EnableReCAPTCHA    *bool                   `json:"enable_recaptcha"`
-	CORSAllowedOrigins []string                `json:"cors_allowed_origins"`
-	BaseURL            *string                 `json:"base_url"`
-	SDPUIBaseURL       *string                 `json:"sdp_ui_base_url"`
-	Status             *tenant.TenantStatus    `json:"status"`
+	EmailSenderType *tenant.EmailSenderType `json:"email_sender_type"`
+	SMSSenderType   *tenant.SMSSenderType   `json:"sms_sender_type"`
+	EnableMFA       *bool                   `json:"enable_mfa"`
+	EnableReCAPTCHA *bool                   `json:"enable_recaptcha"`
+	BaseURL         *string                 `json:"base_url"`
+	SDPUIBaseURL    *string                 `json:"sdp_ui_base_url"`
+	Status          *tenant.TenantStatus    `json:"status"`
 }
 
 type TenantValidator struct {
@@ -72,13 +70,6 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 		tv.Check(false, "sdp_ui_base_url", "invalid SDP UI base URL value")
 	}
 
-	tv.Check(len(reqBody.CORSAllowedOrigins) != 0, "cors_allowed_origins", "provide at least one CORS allowed origins")
-	for i, cors := range reqBody.CORSAllowedOrigins {
-		if _, err = url.ParseRequestURI(cors); err != nil {
-			tv.Check(false, "cors_allowed_origins", fmt.Sprintf("invalid URL value for cors_allowed_origins[%d] = %s", i, cors))
-		}
-	}
-
 	if tv.HasErrors() {
 		return nil
 	}
@@ -103,14 +94,6 @@ func (tv *TenantValidator) ValidateUpdateTenantRequest(reqBody *UpdateTenantRequ
 		SMSSenderType, smsErr := tenant.ParseSMSSenderType(string(*reqBody.SMSSenderType))
 		tv.CheckError(smsErr, "sms_sender_type", fmt.Sprintf("invalid sms sender type. Expected one of these values: %s", []tenant.SMSSenderType{tenant.TwilioSMSSenderType, tenant.AWSSMSSenderType, tenant.DryRunSMSSenderType}))
 		reqBody.SMSSenderType = &SMSSenderType
-	}
-
-	if reqBody.CORSAllowedOrigins != nil && len(reqBody.CORSAllowedOrigins) != 0 {
-		for i, cors := range reqBody.CORSAllowedOrigins {
-			if _, err = url.ParseRequestURI(cors); err != nil {
-				tv.Check(false, "cors_allowed_origins", fmt.Sprintf("invalid URL value for cors_allowed_origins[%d] = %s", i, cors))
-			}
-		}
 	}
 
 	if reqBody.BaseURL != nil {

--- a/stellar-multitenant/pkg/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/pkg/internal/validators/tenant_validator_test.go
@@ -22,16 +22,15 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"name":                 "invalid tenant name. It should only contains lower case letters and dash (-)",
-			"owner_email":          "invalid email",
-			"owner_first_name":     "owner_first_name is required",
-			"owner_last_name":      "owner_last_name is required",
-			"organization_name":    "organization_name is required",
-			"base_url":             "invalid base URL value",
-			"email_sender_type":    "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
-			"sms_sender_type":      "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
-			"cors_allowed_origins": "provide at least one CORS allowed origins",
-			"sdp_ui_base_url":      "invalid SDP UI base URL value",
+			"name":              "invalid tenant name. It should only contains lower case letters and dash (-)",
+			"owner_email":       "invalid email",
+			"owner_first_name":  "owner_first_name is required",
+			"owner_last_name":   "owner_last_name is required",
+			"organization_name": "organization_name is required",
+			"base_url":          "invalid base URL value",
+			"email_sender_type": "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
+			"sms_sender_type":   "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
+			"sdp_ui_base_url":   "invalid SDP UI base URL value",
 		}, tv.Errors)
 
 		reqBody.Name = "aid-org"
@@ -39,33 +38,31 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"owner_email":          "invalid email",
-			"owner_first_name":     "owner_first_name is required",
-			"owner_last_name":      "owner_last_name is required",
-			"organization_name":    "organization_name is required",
-			"base_url":             "invalid base URL value",
-			"email_sender_type":    "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
-			"sms_sender_type":      "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
-			"cors_allowed_origins": "provide at least one CORS allowed origins",
-			"sdp_ui_base_url":      "invalid SDP UI base URL value",
+			"owner_email":       "invalid email",
+			"owner_first_name":  "owner_first_name is required",
+			"owner_last_name":   "owner_last_name is required",
+			"organization_name": "organization_name is required",
+			"base_url":          "invalid base URL value",
+			"email_sender_type": "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
+			"sms_sender_type":   "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
+			"sdp_ui_base_url":   "invalid SDP UI base URL value",
 		}, tv.Errors)
 	})
 
 	t.Run("returns error when name is invalid", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:               "aid org",
-			OwnerEmail:         "owner@email.org",
-			OwnerFirstName:     "Owner",
-			OwnerLastName:      "Owner",
-			OrganizationName:   "Aid Org",
-			EmailSenderType:    tenant.AWSEmailSenderType,
-			SMSSenderType:      tenant.TwilioSMSSenderType,
-			EnableMFA:          true,
-			EnableReCAPTCHA:    true,
-			CORSAllowedOrigins: []string{"*"},
-			SDPUIBaseURL:       "http://localhost:3000",
-			BaseURL:            "http://localhost:8000",
+			Name:             "aid org",
+			OwnerEmail:       "owner@email.org",
+			OwnerFirstName:   "Owner",
+			OwnerLastName:    "Owner",
+			OrganizationName: "Aid Org",
+			EmailSenderType:  tenant.AWSEmailSenderType,
+			SMSSenderType:    tenant.TwilioSMSSenderType,
+			EnableMFA:        true,
+			EnableReCAPTCHA:  true,
+			SDPUIBaseURL:     "http://localhost:3000",
+			BaseURL:          "http://localhost:8000",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -78,18 +75,17 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("returns error when owner info is invalid", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:               "aid-org",
-			OwnerEmail:         "invalid",
-			OwnerFirstName:     "",
-			OwnerLastName:      "",
-			OrganizationName:   "",
-			EmailSenderType:    tenant.AWSEmailSenderType,
-			SMSSenderType:      tenant.TwilioSMSSenderType,
-			EnableMFA:          true,
-			EnableReCAPTCHA:    true,
-			CORSAllowedOrigins: []string{"*"},
-			BaseURL:            "http://localhost:8000",
-			SDPUIBaseURL:       "http://localhost:3000",
+			Name:             "aid-org",
+			OwnerEmail:       "invalid",
+			OwnerFirstName:   "",
+			OwnerLastName:    "",
+			OrganizationName: "",
+			EmailSenderType:  tenant.AWSEmailSenderType,
+			SMSSenderType:    tenant.TwilioSMSSenderType,
+			EnableMFA:        true,
+			EnableReCAPTCHA:  true,
+			BaseURL:          "http://localhost:8000",
+			SDPUIBaseURL:     "http://localhost:3000",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -114,18 +110,17 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("validates the email sender type successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:               "aid-org",
-			OwnerEmail:         "owner@email.org",
-			OwnerFirstName:     "Owner",
-			OwnerLastName:      "Owner",
-			OrganizationName:   "Aid Org",
-			EmailSenderType:    "invalid",
-			SMSSenderType:      tenant.TwilioSMSSenderType,
-			EnableMFA:          true,
-			EnableReCAPTCHA:    true,
-			CORSAllowedOrigins: []string{"*"},
-			SDPUIBaseURL:       "http://localhost:3000",
-			BaseURL:            "http://localhost:8000",
+			Name:             "aid-org",
+			OwnerEmail:       "owner@email.org",
+			OwnerFirstName:   "Owner",
+			OwnerLastName:    "Owner",
+			OrganizationName: "Aid Org",
+			EmailSenderType:  "invalid",
+			SMSSenderType:    tenant.TwilioSMSSenderType,
+			EnableMFA:        true,
+			EnableReCAPTCHA:  true,
+			SDPUIBaseURL:     "http://localhost:3000",
+			BaseURL:          "http://localhost:8000",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -141,18 +136,17 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("validates the sms sender type successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:               "aid-org",
-			OwnerEmail:         "owner@email.org",
-			OwnerFirstName:     "Owner",
-			OwnerLastName:      "Owner",
-			OrganizationName:   "Aid Org",
-			EmailSenderType:    tenant.AWSEmailSenderType,
-			SMSSenderType:      "invalid",
-			EnableMFA:          true,
-			EnableReCAPTCHA:    true,
-			CORSAllowedOrigins: []string{"*"},
-			SDPUIBaseURL:       "http://localhost:3000",
-			BaseURL:            "http://localhost:8000",
+			Name:             "aid-org",
+			OwnerEmail:       "owner@email.org",
+			OwnerFirstName:   "Owner",
+			OwnerLastName:    "Owner",
+			OrganizationName: "Aid Org",
+			EmailSenderType:  tenant.AWSEmailSenderType,
+			SMSSenderType:    "invalid",
+			EnableMFA:        true,
+			EnableReCAPTCHA:  true,
+			SDPUIBaseURL:     "http://localhost:3000",
+			BaseURL:          "http://localhost:8000",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -168,26 +162,24 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("validates the URLs successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:               "aid-org",
-			OwnerEmail:         "owner@email.org",
-			OwnerFirstName:     "Owner",
-			OwnerLastName:      "Owner",
-			OrganizationName:   "Aid Org",
-			EmailSenderType:    tenant.AWSEmailSenderType,
-			SMSSenderType:      tenant.TwilioSMSSenderType,
-			EnableMFA:          true,
-			EnableReCAPTCHA:    true,
-			CORSAllowedOrigins: []string{"http://valid.com", "%invalid%"},
-			SDPUIBaseURL:       "%invalid%",
-			BaseURL:            "%invalid%",
+			Name:             "aid-org",
+			OwnerEmail:       "owner@email.org",
+			OwnerFirstName:   "Owner",
+			OwnerLastName:    "Owner",
+			OrganizationName: "Aid Org",
+			EmailSenderType:  tenant.AWSEmailSenderType,
+			SMSSenderType:    tenant.TwilioSMSSenderType,
+			EnableMFA:        true,
+			EnableReCAPTCHA:  true,
+			SDPUIBaseURL:     "%invalid%",
+			BaseURL:          "%invalid%",
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"base_url":             "invalid base URL value",
-			"sdp_ui_base_url":      "invalid SDP UI base URL value",
-			"cors_allowed_origins": "invalid URL value for cors_allowed_origins[1] = %invalid%",
+			"base_url":        "invalid base URL value",
+			"sdp_ui_base_url": "invalid SDP UI base URL value",
 		}, tv.Errors)
 	})
 }
@@ -209,16 +201,14 @@ func TestTenantValidator_ValidateUpdateTenantRequest(t *testing.T) {
 		tv := NewTenantValidator()
 		invalidValue := "invalid"
 		reqBody := &UpdateTenantRequest{
-			CORSAllowedOrigins: []string{invalidValue},
-			BaseURL:            &invalidValue,
-			SDPUIBaseURL:       &invalidValue,
+			BaseURL:      &invalidValue,
+			SDPUIBaseURL: &invalidValue,
 		}
 		tv.ValidateUpdateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"base_url":             "invalid base URL value",
-			"cors_allowed_origins": "invalid URL value for cors_allowed_origins[0] = invalid",
-			"sdp_ui_base_url":      "invalid SDP UI base URL value",
+			"base_url":        "invalid base URL value",
+			"sdp_ui_base_url": "invalid SDP UI base URL value",
 		}, tv.Errors)
 	})
 
@@ -227,13 +217,12 @@ func TestTenantValidator_ValidateUpdateTenantRequest(t *testing.T) {
 		enable := false
 		url := "http://valid.com"
 		reqBody := &UpdateTenantRequest{
-			EmailSenderType:    &tenant.AWSEmailSenderType,
-			SMSSenderType:      &tenant.AWSSMSSenderType,
-			EnableMFA:          &enable,
-			EnableReCAPTCHA:    &enable,
-			CORSAllowedOrigins: []string{url},
-			BaseURL:            &url,
-			SDPUIBaseURL:       &url,
+			EmailSenderType: &tenant.AWSEmailSenderType,
+			SMSSenderType:   &tenant.AWSSMSSenderType,
+			EnableMFA:       &enable,
+			EnableReCAPTCHA: &enable,
+			BaseURL:         &url,
+			SDPUIBaseURL:    &url,
 		}
 		tv.ValidateUpdateTenantRequest(reqBody)
 		assert.False(t, tv.HasErrors())

--- a/stellar-multitenant/pkg/tenant/fixtures.go
+++ b/stellar-multitenant/pkg/tenant/fixtures.go
@@ -40,7 +40,7 @@ func ResetTenantConfigFixture(t *testing.T, ctx context.Context, dbConnectionPoo
 		SET
 			email_sender_type = DEFAULT, sms_sender_type = DEFAULT,
 			enable_mfa = DEFAULT, enable_recaptcha = DEFAULT,
-			cors_allowed_origins = NULL, base_url = NULL, sdp_ui_base_url = NULL
+			base_url = NULL, sdp_ui_base_url = NULL
 		WHERE
 			id = $1
 		RETURNING *

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -180,11 +180,6 @@ func (m *Manager) UpdateTenantConfig(ctx context.Context, tu *TenantUpdate) (*Te
 		args = append(args, *tu.SDPUIBaseURL)
 	}
 
-	if tu.CORSAllowedOrigins != nil && len(tu.CORSAllowedOrigins) > 0 {
-		fields = append(fields, "cors_allowed_origins = ?")
-		args = append(args, pq.Array(tu.CORSAllowedOrigins))
-	}
-
 	if tu.Status != nil {
 		fields = append(fields, "status = ?")
 		args = append(args, *tu.Status)

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -90,15 +90,13 @@ func Test_Manager_UpdateTenantConfig(t *testing.T) {
 		assert.True(t, tntDB.EnableReCAPTCHA)
 		assert.Nil(t, tntDB.BaseURL)
 		assert.Nil(t, tntDB.SDPUIBaseURL)
-		assert.Empty(t, tntDB.CORSAllowedOrigins)
 
 		// Partial Update
 		tnt, err := m.UpdateTenantConfig(ctx, &TenantUpdate{
-			ID:                 tntDB.ID,
-			EmailSenderType:    &AWSEmailSenderType,
-			EnableMFA:          &[]bool{false}[0],
-			CORSAllowedOrigins: []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"},
-			SDPUIBaseURL:       &[]string{"https://myorg.frontend.io"}[0],
+			ID:              tntDB.ID,
+			EmailSenderType: &AWSEmailSenderType,
+			EnableMFA:       &[]bool{false}[0],
+			SDPUIBaseURL:    &[]string{"https://myorg.frontend.io"}[0],
 		})
 		require.NoError(t, err)
 
@@ -108,7 +106,6 @@ func Test_Manager_UpdateTenantConfig(t *testing.T) {
 		assert.True(t, tnt.EnableReCAPTCHA)
 		assert.Nil(t, tnt.BaseURL)
 		assert.Equal(t, "https://myorg.frontend.io", *tnt.SDPUIBaseURL)
-		assert.ElementsMatch(t, []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"}, tnt.CORSAllowedOrigins)
 
 		tnt, err = m.UpdateTenantConfig(ctx, &TenantUpdate{
 			ID:              tntDB.ID,
@@ -124,7 +121,6 @@ func Test_Manager_UpdateTenantConfig(t *testing.T) {
 		assert.False(t, tnt.EnableReCAPTCHA)
 		assert.Equal(t, "https://myorg.backend.io", *tnt.BaseURL)
 		assert.Equal(t, "https://myorg.frontend.io", *tnt.SDPUIBaseURL)
-		assert.ElementsMatch(t, []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"}, tnt.CORSAllowedOrigins)
 	})
 }
 

--- a/stellar-multitenant/pkg/tenant/tenant.go
+++ b/stellar-multitenant/pkg/tenant/tenant.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/lib/pq"
 	"golang.org/x/exp/slices"
 )
 
@@ -43,30 +42,28 @@ func ParseSMSSenderType(smsSenderTypeStr string) (SMSSenderType, error) {
 }
 
 type Tenant struct {
-	ID                 string          `json:"id" db:"id"`
-	Name               string          `json:"name" db:"name"`
-	EmailSenderType    EmailSenderType `json:"email_sender_type" db:"email_sender_type"`
-	SMSSenderType      SMSSenderType   `json:"sms_sender_type" db:"sms_sender_type"`
-	EnableMFA          bool            `json:"enable_mfa" db:"enable_mfa"`
-	EnableReCAPTCHA    bool            `json:"enable_recaptcha" db:"enable_recaptcha"`
-	CORSAllowedOrigins pq.StringArray  `json:"cors_allowed_origins" db:"cors_allowed_origins"`
-	BaseURL            *string         `json:"base_url" db:"base_url"`
-	SDPUIBaseURL       *string         `json:"sdp_ui_base_url" db:"sdp_ui_base_url"`
-	Status             TenantStatus    `json:"status" db:"status"`
-	CreatedAt          time.Time       `json:"created_at" db:"created_at"`
-	UpdatedAt          time.Time       `json:"updated_at" db:"updated_at"`
+	ID              string          `json:"id" db:"id"`
+	Name            string          `json:"name" db:"name"`
+	EmailSenderType EmailSenderType `json:"email_sender_type" db:"email_sender_type"`
+	SMSSenderType   SMSSenderType   `json:"sms_sender_type" db:"sms_sender_type"`
+	EnableMFA       bool            `json:"enable_mfa" db:"enable_mfa"`
+	EnableReCAPTCHA bool            `json:"enable_recaptcha" db:"enable_recaptcha"`
+	BaseURL         *string         `json:"base_url" db:"base_url"`
+	SDPUIBaseURL    *string         `json:"sdp_ui_base_url" db:"sdp_ui_base_url"`
+	Status          TenantStatus    `json:"status" db:"status"`
+	CreatedAt       time.Time       `json:"created_at" db:"created_at"`
+	UpdatedAt       time.Time       `json:"updated_at" db:"updated_at"`
 }
 
 type TenantUpdate struct {
-	ID                 string           `db:"id"`
-	EmailSenderType    *EmailSenderType `db:"email_sender_type"`
-	SMSSenderType      *SMSSenderType   `db:"sms_sender_type"`
-	EnableMFA          *bool            `db:"enable_mfa"`
-	EnableReCAPTCHA    *bool            `db:"enable_recaptcha"`
-	CORSAllowedOrigins []string         `db:"cors_allowed_origins"`
-	BaseURL            *string          `db:"base_url"`
-	SDPUIBaseURL       *string          `db:"sdp_ui_base_url"`
-	Status             *TenantStatus    `db:"status"`
+	ID              string           `db:"id"`
+	EmailSenderType *EmailSenderType `db:"email_sender_type"`
+	SMSSenderType   *SMSSenderType   `db:"sms_sender_type"`
+	EnableMFA       *bool            `db:"enable_mfa"`
+	EnableReCAPTCHA *bool            `db:"enable_recaptcha"`
+	BaseURL         *string          `db:"base_url"`
+	SDPUIBaseURL    *string          `db:"sdp_ui_base_url"`
+	Status          *TenantStatus    `db:"status"`
 }
 
 type TenantStatus string
@@ -112,12 +109,6 @@ func (tu *TenantUpdate) Validate() error {
 		return fmt.Errorf("invalid SDP UI base URL")
 	}
 
-	for _, u := range tu.CORSAllowedOrigins {
-		if !isValidURL(u) {
-			return fmt.Errorf("invalid CORS allowed origin url: %q", u)
-		}
-	}
-
 	if tu.Status != nil && !tu.Status.IsValid() {
 		return fmt.Errorf("invalid tenant status: %q", *tu.Status)
 	}
@@ -130,7 +121,6 @@ func (tu *TenantUpdate) areAllFieldsEmpty() bool {
 		tu.SMSSenderType == nil &&
 		tu.EnableMFA == nil &&
 		tu.EnableReCAPTCHA == nil &&
-		tu.CORSAllowedOrigins == nil &&
 		tu.BaseURL == nil &&
 		tu.SDPUIBaseURL == nil &&
 		tu.Status == nil)

--- a/stellar-multitenant/pkg/tenant/tenant_test.go
+++ b/stellar-multitenant/pkg/tenant/tenant_test.go
@@ -40,11 +40,6 @@ func Test_TenantUpdate_Validate(t *testing.T) {
 		assert.EqualError(t, err, "invalid SDP UI base URL")
 
 		tu.SDPUIBaseURL = nil
-		tu.CORSAllowedOrigins = []string{"inv@lid$"}
-		err = tu.Validate()
-		assert.EqualError(t, err, `invalid CORS allowed origin url: "inv@lid$"`)
-
-		tu.CORSAllowedOrigins = nil
 		tenantStatus := TenantStatus("invalid")
 		tu.Status = &tenantStatus
 		err = tu.Validate()
@@ -53,15 +48,14 @@ func Test_TenantUpdate_Validate(t *testing.T) {
 
 	t.Run("valid values", func(t *testing.T) {
 		tu := TenantUpdate{
-			ID:                 "abc",
-			EmailSenderType:    &AWSEmailSenderType,
-			SMSSenderType:      &TwilioSMSSenderType,
-			EnableMFA:          &[]bool{true}[0],
-			EnableReCAPTCHA:    &[]bool{true}[0],
-			CORSAllowedOrigins: []string{"https://myorg.sdp.io", "https://myorg-dev.sdp.io"},
-			BaseURL:            &[]string{"https://myorg.backend.io"}[0],
-			SDPUIBaseURL:       &[]string{"https://myorg.frontend.io"}[0],
-			Status:             &[]TenantStatus{ProvisionedTenantStatus}[0],
+			ID:              "abc",
+			EmailSenderType: &AWSEmailSenderType,
+			SMSSenderType:   &TwilioSMSSenderType,
+			EnableMFA:       &[]bool{true}[0],
+			EnableReCAPTCHA: &[]bool{true}[0],
+			BaseURL:         &[]string{"https://myorg.backend.io"}[0],
+			SDPUIBaseURL:    &[]string{"https://myorg.frontend.io"}[0],
+			Status:          &[]TenantStatus{ProvisionedTenantStatus}[0],
 		}
 		err := tu.Validate()
 		assert.NoError(t, err)


### PR DESCRIPTION
Matching kube PR https://github.com/stellar/kube/pull/1859

### TL;DR 
Experimented with multiple solutions to enable CORS in multi-tenancy. We don't need to have a CORS configuration per tenant as we originally thought, we can use a generic wildcard config thanks to this library https://github.com/rs/cors. 

### Explanation
We originally thought that we will need to define one cors configuration per tenant as CORS headers either allow wildcard `*` or a strict domain e.g. `https://redcorp.mtn-sdp-backend-dev.stellar.org` , `https://bluecorp.mtn-sdp-backend-dev.stellar.org` 

The initial implementation I tested relied on that concept 
```go
func CorsMiddleware(corsAllowedOrigins []string) func(http.Handler) http.Handler {
	return func(next http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

			allowedOrigins := corsAllowedOrigins

			// Extract tenant from context if possible
			ctx := r.Context()
			t, err := tenant.GetTenantFromContext(ctx)
			if err != nil {
				if !errors.Is(err, tenant.ErrTenantNotFoundInContext) {
					log.Ctx(ctx).Errorf("Error getting tenant from context: %s", err)
				}
			} else {
				allowedOrigins = append(allowedOrigins, t.CORSAllowedOrigins...)
			}

			// Dynamically set the CORS allowed origins based on the tenant
			cors := cors.New(cors.Options{
				AllowedOrigins: allowedOrigins,
				AllowedHeaders: []string{"*"},
				AllowedMethods: []string{"GET", "PUT", "POST", "PATCH", "DELETE", "HEAD", "OPTIONS"},
			})

			cors.Handler(next).ServeHTTP(w, r)
		})
	}
}
```

This works fine for most cases but requires the CORS middleware to be tenant-aware. Which means that middleware needs to be injected differently & conditionally depending on a tenant's existence. 

**CORS library**
https://github.com/rs/cors
When experimenting with other solutions before committing to the one described above, I found out that the CORS library we use allows for wildcard domains. Even though the header doesn't accept a wildcard, the library does a treatment based on the configuration and the origin header and sets the proper strict cors header. 
From the documentation : 
```
// AllowedOrigins is a list of origins a cross-domain request can be executed from.
// If the special "*" value is present in the list, all origins will be allowed.
// An origin may contain a wildcard (*) to replace 0 or more characters
// (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penalty.
// Only one wildcard can be used per origin.
```
This solves our problems. 
