### PR TITLE
[SDP-1025]: New endpoint to cancel individual payment in ready status

### DIFF
--- a/internal/data/payments_state_machine.go
+++ b/internal/data/payments_state_machine.go
@@ -66,6 +66,16 @@ func (status PaymentStatus) SourceStatuses() []PaymentStatus {
 	return fromStates
 }
 
+// ToPaymentStatus converts a string to a PaymentStatus
+func ToPaymentStatus(s string) (PaymentStatus, error) {
+	err := PaymentStatus(s).Validate()
+	if err != nil {
+		return "", err
+	}
+
+	return PaymentStatus(strings.ToUpper(s)), nil
+}
+
 func (status PaymentStatus) State() State {
 	return State(status)
 }

--- a/internal/data/payments_state_machine_test.go
+++ b/internal/data/payments_state_machine_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,4 +59,156 @@ func Test_PaymentStatus_SourceStatuses(t *testing.T) {
 func Test_PaymentStatus_PaymentStatuses(t *testing.T) {
 	expectedStatuses := []PaymentStatus{DraftPaymentStatus, ReadyPaymentStatus, PendingPaymentStatus, PausedPaymentStatus, SuccessPaymentStatus, FailedPaymentStatus, CanceledPaymentStatus}
 	require.Equal(t, expectedStatuses, PaymentStatuses())
+}
+
+func Test_PaymentStatus_ToPaymentStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		actual string
+		want   PaymentStatus
+		err    error
+	}{
+		{
+			name:   "valid entry",
+			actual: "CANCELED",
+			want:   CanceledPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "valid lower case",
+			actual: "canceled",
+			want:   CanceledPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "valid weird case",
+			actual: "CancEled",
+			want:   CanceledPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "invalid entry",
+			actual: "NOT_VALID",
+			want:   CanceledPaymentStatus,
+			err:    fmt.Errorf("invalid payment status: NOT_VALID"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToPaymentStatus(tt.actual)
+
+			if tt.err != nil {
+				require.EqualError(t, err, tt.err.Error())
+				return
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_PaymentStatus_TransitionTo(t *testing.T) {
+	tests := []struct {
+		name   string
+		actual PaymentStatus
+		target PaymentStatus
+		err    error
+	}{
+		{
+			name:   "disbursement started transition - success",
+			actual: DraftPaymentStatus,
+			target: ReadyPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "disbursement started transition - success",
+			actual: DraftPaymentStatus,
+			target: ReadyPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "payment gets submitted if user is ready",
+			actual: ReadyPaymentStatus,
+			target: PendingPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "user pauses payment transition",
+			actual: ReadyPaymentStatus,
+			target: PausedPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "user cancels payment transition",
+			actual: ReadyPaymentStatus,
+			target: CanceledPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "user resumes payment transition",
+			actual: PausedPaymentStatus,
+			target: ReadyPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "payment fails transition",
+			actual: PendingPaymentStatus,
+			target: FailedPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "payment is retried transition",
+			actual: FailedPaymentStatus,
+			target: PendingPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "payment succeeds transition",
+			actual: PendingPaymentStatus,
+			target: SuccessPaymentStatus,
+			err:    nil,
+		},
+		{
+			name:   "invalid cancellation 1",
+			actual: DraftPaymentStatus,
+			target: CanceledPaymentStatus,
+			err:    fmt.Errorf("cannot transition from DRAFT to CANCELED"),
+		},
+		{
+			name:   "invalid cancellation 2",
+			actual: PendingPaymentStatus,
+			target: CanceledPaymentStatus,
+			err:    fmt.Errorf("cannot transition from PENDING to CANCELED"),
+		},
+		{
+			name:   "invalid cancellation 3",
+			actual: PausedPaymentStatus,
+			target: CanceledPaymentStatus,
+			err:    fmt.Errorf("cannot transition from PAUSED to CANCELED"),
+		},
+		{
+			name:   "invalid cancellation 4",
+			actual: FailedPaymentStatus,
+			target: CanceledPaymentStatus,
+			err:    fmt.Errorf("cannot transition from FAILED to CANCELED"),
+		},
+		{
+			name:   "invalid cancellation 5",
+			actual: SuccessPaymentStatus,
+			target: CanceledPaymentStatus,
+			err:    fmt.Errorf("cannot transition from SUCCESS to CANCELED"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.actual.TransitionTo(tt.target)
+			if tt.err != nil {
+				require.EqualError(t, err, tt.err.Error())
+				return
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -179,7 +179,7 @@ func (p PaymentsHandler) PatchPaymentStatus(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	paymentManagementService := services.NewPaymentManagementService(p.Models, p.DBConnectionPool, p.AuthManager)
+	paymentManagementService := services.NewPaymentManagementService(p.Models, p.DBConnectionPool)
 	response := UpdatePaymentStatusResponseBody{}
 
 	ctx := r.Context()

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -18,6 +19,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpresponse"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 	"github.com/stretchr/testify/assert"
@@ -1009,4 +1011,150 @@ func Test_PaymentsHandler_getPaymentsWithCount(t *testing.T) {
 		assert.Equal(t, response.Total, 2)
 		assert.Equal(t, response.Result, []data.Payment{*payment2, *payment})
 	})
+}
+
+func Test_PaymentsHandler_PatchPaymentStatus(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+
+	authManagerMock := &auth.AuthManagerMock{}
+
+	handler := &PaymentsHandler{
+		Models:           models,
+		DBConnectionPool: models.DBConnectionPool,
+		AuthManager:      authManagerMock,
+	}
+
+	ctx := context.Background()
+
+	r := chi.NewRouter()
+	r.Patch("/payments/{id}/status", handler.PatchPaymentStatus)
+
+	// create fixtures
+	wallet := data.CreateDefaultWalletFixture(t, ctx, dbConnectionPool)
+	asset := data.GetAssetFixture(t, ctx, dbConnectionPool, data.FixtureAssetUSDC)
+	country := data.GetCountryFixture(t, ctx, dbConnectionPool, data.FixtureCountryUSA)
+
+	// create disbursements
+	startedDisbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
+		Name:    "ready disbursement",
+		Status:  data.StartedDisbursementStatus,
+		Asset:   asset,
+		Wallet:  wallet,
+		Country: country,
+	})
+
+	// create disbursement receivers
+	receiver1 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+	receiver2 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+
+	rw1 := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver1.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+	rw2 := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver2.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+
+	readyPayment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+		ReceiverWallet: rw1,
+		Disbursement:   startedDisbursement,
+		Asset:          *asset,
+		Amount:         "100",
+		Status:         data.ReadyPaymentStatus,
+	})
+	draftPayment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+		ReceiverWallet: rw2,
+		Disbursement:   startedDisbursement,
+		Asset:          *asset,
+		Amount:         "200",
+		Status:         data.DraftPaymentStatus,
+	})
+
+	reqBody := bytes.NewBuffer(nil)
+	t.Run("invalid body", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, fmt.Sprintf("/payments/%s/status", readyPayment.ID), reqBody)
+		require.NoError(t, err)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "invalid request body")
+	})
+
+	t.Run("invalid status", func(t *testing.T) {
+		err := json.NewEncoder(reqBody).Encode(PatchPaymentStatusRequest{Status: "INVALID"})
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, fmt.Sprintf("/payments/%s/status", readyPayment.ID), reqBody)
+		require.NoError(t, err)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "invalid status")
+	})
+
+	t.Run("payment not found", func(t *testing.T) {
+		err := json.NewEncoder(reqBody).Encode(PatchPaymentStatusRequest{Status: "CANCELED"})
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, fmt.Sprintf("/payments/%s/status", "invalid-id"), reqBody)
+		require.NoError(t, err)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusNotFound, rr.Code)
+		require.Contains(t, rr.Body.String(), "payment not found")
+	})
+
+	t.Run("payment can't be canceled", func(t *testing.T) {
+		err := json.NewEncoder(reqBody).Encode(PatchDisbursementStatusRequest{Status: "CANCELED"})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("/payments/%s/status", draftPayment.ID), reqBody)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), services.ErrPaymentNotReadyToCancel.Error())
+	})
+
+	t.Run("payment status can't be changed", func(t *testing.T) {
+		err := json.NewEncoder(reqBody).Encode(PatchDisbursementStatusRequest{Status: "READY"})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("/payments/%s/status", readyPayment.ID), reqBody)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), services.ErrPaymentStatusCantBeChanged.Error())
+	})
+
+	t.Run("payment canceled successfully", func(t *testing.T) {
+		err := json.NewEncoder(reqBody).Encode(PatchDisbursementStatusRequest{Status: "Canceled"})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("/payments/%s/status", readyPayment.ID), reqBody)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Contains(t, rr.Body.String(), "Payment canceled")
+
+		payment, err := handler.Models.Payment.Get(context.Background(), readyPayment.ID, models.DBConnectionPool)
+		require.NoError(t, err)
+		require.Equal(t, data.CanceledPaymentStatus, payment.Status)
+	})
+
+	authManagerMock.AssertExpectations(t)
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -253,6 +253,8 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.Get("/", paymentsHandler.GetPayments)
 			r.Get("/{id}", paymentsHandler.GetPayment)
 			r.Patch("/retry", paymentsHandler.RetryPayments)
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+				Patch("/{id}/status", paymentsHandler.PatchPaymentStatus)
 		})
 
 		r.Route("/receivers", func(r chi.Router) {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -284,11 +284,12 @@ func Test_handleHTTP_authenticatedEndpoints(t *testing.T) {
 		{http.MethodGet, "/disbursements"},
 		{http.MethodGet, "/disbursements/1234"},
 		{http.MethodGet, "/disbursements/1234/receivers"},
-		{http.MethodGet, "/disbursements/1234/status"},
+		{http.MethodPatch, "/disbursements/1234/status"},
 		// Payments
 		{http.MethodGet, "/payments"},
 		{http.MethodGet, "/payments/1234"},
 		{http.MethodPatch, "/payments/retry"},
+		{http.MethodPatch, "/payments/1234/status"},
 		// Receivers
 		{http.MethodGet, "/receivers"},
 		{http.MethodGet, "/receivers/1234"},

--- a/internal/services/payment_management_service.go
+++ b/internal/services/payment_management_service.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
 
 // PaymentManagementService is a service for managing disbursements.
 type PaymentManagementService struct {
 	models           *data.Models
 	dbConnectionPool db.DBConnectionPool
-	authManager      auth.AuthManager
 }
 
 var (
@@ -24,11 +22,10 @@ var (
 )
 
 // NewPaymentManagementService is a factory function for creating a new PaymentManagementService.
-func NewPaymentManagementService(models *data.Models, dbConnectionPool db.DBConnectionPool, authManager auth.AuthManager) *PaymentManagementService {
+func NewPaymentManagementService(models *data.Models, dbConnectionPool db.DBConnectionPool) *PaymentManagementService {
 	return &PaymentManagementService{
 		models:           models,
 		dbConnectionPool: dbConnectionPool,
-		authManager:      authManager,
 	}
 }
 

--- a/internal/services/payment_management_service.go
+++ b/internal/services/payment_management_service.go
@@ -36,9 +36,8 @@ func (s *PaymentManagementService) CancelPayment(ctx context.Context, paymentID 
 		if err != nil {
 			if errors.Is(err, data.ErrRecordNotFound) {
 				return ErrPaymentNotFound
-			} else {
-				return fmt.Errorf("error getting payment with id %s: %w", paymentID, err)
 			}
+			return fmt.Errorf("error getting payment with id %s: %w", paymentID, err)
 		}
 
 		// 1. Verify Transition is Possible

--- a/internal/services/payment_management_service.go
+++ b/internal/services/payment_management_service.go
@@ -1,0 +1,65 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+)
+
+// PaymentManagementService is a service for managing disbursements.
+type PaymentManagementService struct {
+	models           *data.Models
+	dbConnectionPool db.DBConnectionPool
+	authManager      auth.AuthManager
+}
+
+var (
+	ErrPaymentNotFound            = errors.New("payment not found")
+	ErrPaymentNotReadyToCancel    = errors.New("payment is not ready to be canceled")
+	ErrPaymentStatusCantBeChanged = errors.New("payment status can't be changed to the requested status")
+)
+
+// NewPaymentManagementService is a factory function for creating a new PaymentManagementService.
+func NewPaymentManagementService(models *data.Models, dbConnectionPool db.DBConnectionPool, authManager auth.AuthManager) *PaymentManagementService {
+	return &PaymentManagementService{
+		models:           models,
+		dbConnectionPool: dbConnectionPool,
+		authManager:      authManager,
+	}
+}
+
+// CancelPayment update payment to status 'canceled'
+func (s *PaymentManagementService) CancelPayment(ctx context.Context, paymentID string) error {
+	return db.RunInTransaction(ctx, s.dbConnectionPool, nil, func(dbTx db.DBTransaction) error {
+		payment, err := s.models.Payment.Get(ctx, paymentID, dbTx)
+		if err != nil {
+			if errors.Is(err, data.ErrRecordNotFound) {
+				return ErrPaymentNotFound
+			} else {
+				return fmt.Errorf("error getting disbursement with id %s: %w", paymentID, err)
+			}
+		}
+
+		// 1. Verify Transition is Possible
+		err = payment.Status.TransitionTo(data.PaymentStatus(data.CanceledPaymentStatus))
+		if err != nil {
+			return ErrPaymentNotReadyToCancel
+		}
+
+		// 2. Update payment status to `canceled`
+		numRowsAffected, err := s.models.Payment.UpdateStatuses(ctx, dbTx, []*data.Payment{payment}, data.CanceledPaymentStatus)
+		if err != nil {
+			return fmt.Errorf("error updating payment status with id %s to 'canceled': %w", paymentID, err)
+		}
+
+		if numRowsAffected == 0 {
+			return ErrPaymentStatusCantBeChanged
+		}
+
+		return nil
+	})
+}

--- a/internal/services/payment_management_service.go
+++ b/internal/services/payment_management_service.go
@@ -40,7 +40,7 @@ func (s *PaymentManagementService) CancelPayment(ctx context.Context, paymentID 
 			if errors.Is(err, data.ErrRecordNotFound) {
 				return ErrPaymentNotFound
 			} else {
-				return fmt.Errorf("error getting disbursement with id %s: %w", paymentID, err)
+				return fmt.Errorf("error getting payment with id %s: %w", paymentID, err)
 			}
 		}
 

--- a/internal/services/payment_management_service_test.go
+++ b/internal/services/payment_management_service_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,16 +25,7 @@ func Test_PaymentManagementService_CancelPayment(t *testing.T) {
 	token := "token"
 	ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
 
-	user := &auth.User{
-		ID:    "user-id",
-		Email: "email@email.com",
-	}
-	authManagerMock := &auth.AuthManagerMock{}
-	authManagerMock.
-		On("GetUser", ctx, token).
-		Return(user, nil)
-
-	service := NewPaymentManagementService(models, models.DBConnectionPool, authManagerMock)
+	service := NewPaymentManagementService(models, models.DBConnectionPool)
 
 	// create fixtures
 	wallet := data.CreateDefaultWalletFixture(t, ctx, dbConnectionPool)

--- a/internal/services/payment_management_service_test.go
+++ b/internal/services/payment_management_service_test.go
@@ -1,0 +1,120 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_PaymentManagementService_CancelPayment(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	models, outerErr := data.NewModels(dbConnectionPool)
+	require.NoError(t, outerErr)
+
+	token := "token"
+	ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+
+	user := &auth.User{
+		ID:    "user-id",
+		Email: "email@email.com",
+	}
+	authManagerMock := &auth.AuthManagerMock{}
+	authManagerMock.
+		On("GetUser", ctx, token).
+		Return(user, nil)
+
+	service := NewPaymentManagementService(models, models.DBConnectionPool, authManagerMock)
+
+	// create fixtures
+	wallet := data.CreateDefaultWalletFixture(t, ctx, dbConnectionPool)
+	asset := data.GetAssetFixture(t, ctx, dbConnectionPool, data.FixtureAssetUSDC)
+	country := data.GetCountryFixture(t, ctx, dbConnectionPool, data.FixtureCountryUSA)
+
+	// create disbursements
+	startedDisbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
+		Name:    "ready disbursement",
+		Status:  data.StartedDisbursementStatus,
+		Asset:   asset,
+		Wallet:  wallet,
+		Country: country,
+	})
+
+	// create disbursement receivers
+	receiver1 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+	receiver2 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+	receiver3 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+	receiver4 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+
+	rw1 := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver1.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+	rw2 := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver2.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+	rw3 := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver3.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+	rwReady := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver4.ID, wallet.ID, data.ReadyReceiversWalletStatus)
+
+	readyPayment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+		ReceiverWallet: rw1,
+		Disbursement:   startedDisbursement,
+		Asset:          *asset,
+		Amount:         "100",
+		Status:         data.ReadyPaymentStatus,
+	})
+	draftPayment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+		ReceiverWallet: rw2,
+		Disbursement:   startedDisbursement,
+		Asset:          *asset,
+		Amount:         "200",
+		Status:         data.DraftPaymentStatus,
+	})
+	pausedPayment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+		ReceiverWallet: rw3,
+		Disbursement:   startedDisbursement,
+		Asset:          *asset,
+		Amount:         "300",
+		Status:         data.PausedPaymentStatus,
+	})
+	pendingPayment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+		ReceiverWallet: rwReady,
+		Disbursement:   startedDisbursement,
+		Asset:          *asset,
+		Amount:         "400",
+		Status:         data.PendingPaymentStatus,
+	})
+
+	t.Run("payment doesn't exist", func(t *testing.T) {
+		id := "5e1f1c7f5b6c9c0001c1b1b1"
+
+		err := service.CancelPayment(ctx, id)
+		require.ErrorIs(t, err, ErrPaymentNotFound)
+	})
+
+	t.Run("payment not ready to cancel", func(t *testing.T) {
+		err := service.CancelPayment(ctx, draftPayment.ID)
+		require.ErrorIs(t, err, ErrPaymentNotReadyToCancel)
+
+		err = service.CancelPayment(ctx, pausedPayment.ID)
+		require.ErrorIs(t, err, ErrPaymentNotReadyToCancel)
+
+		err = service.CancelPayment(ctx, pendingPayment.ID)
+		require.ErrorIs(t, err, ErrPaymentNotReadyToCancel)
+	})
+
+	t.Run("payment canceled", func(t *testing.T) {
+		err := service.CancelPayment(ctx, readyPayment.ID)
+		require.NoError(t, err)
+
+		payment, err := models.Payment.Get(ctx, readyPayment.ID, models.DBConnectionPool)
+		require.NoError(t, err)
+		require.Equal(t, data.CanceledPaymentStatus, payment.Status)
+	})
+}


### PR DESCRIPTION
### What

Implement a new endpoint PATCH /payments/{id}/status that allows the user to change the status of an individual payment

### Why

 UNHCR asked for the ability to cancel individual payments. 

### Known limitations

Make sure to return an error if the transition is not possible. We only allow payments in ready status to be cancelled. There is a state machine that can be used to check if the transition is possible.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
