### PR TITLE
cmd: verify if the URL List config value is required

### DIFF
--- a/cmd/utils/custom_set_value.go
+++ b/cmd/utils/custom_set_value.go
@@ -207,9 +207,19 @@ func SetConfigOptionURLString(co *config.ConfigOption) error {
 
 func SetConfigOptionURLList(co *config.ConfigOption) error {
 	urlsStr := viper.GetString(co.Name)
+	urlsStr = strings.TrimSpace(urlsStr)
+
+	key, ok := co.ConfigKey.(*[]string)
+	if !ok {
+		return fmt.Errorf("the expected type for this config key is a string slice, but got a %T instead", co.ConfigKey)
+	}
 
 	if urlsStr == "" {
-		return fmt.Errorf("url list cannot be empty")
+		if co.Required {
+			return fmt.Errorf("url list cannot be empty")
+		}
+		*key = make([]string, 0)
+		return nil
 	}
 
 	urls := strings.Split(urlsStr, ",")
@@ -220,10 +230,6 @@ func SetConfigOptionURLList(co *config.ConfigOption) error {
 		}
 	}
 
-	key, ok := co.ConfigKey.(*[]string)
-	if !ok {
-		return fmt.Errorf("the expected type for this config key is a string slice, but got a %T instead", co.ConfigKey)
-	}
 	*key = urls
 
 	return nil

--- a/cmd/utils/custom_set_value_test.go
+++ b/cmd/utils/custom_set_value_test.go
@@ -597,11 +597,6 @@ func Test_SetConfigOptionURLList(t *testing.T) {
 
 	testCases := []customSetterTestCase[[]string]{
 		{
-			name:            "returns an error if the list is empty",
-			args:            []string{"--brokers", ""},
-			wantErrContains: "cannot be empty",
-		},
-		{
 			name:       "🎉 handles string list successfully (from CLI args)",
 			args:       []string{"--brokers", "kafka:9092,localhost:9093,kafka://broker:9092"},
 			wantResult: []string{"kafka:9092", "localhost:9093", "kafka://broker:9092"},
@@ -611,6 +606,16 @@ func Test_SetConfigOptionURLList(t *testing.T) {
 			envValue:   "kafka:9092,localhost:9093",
 			wantResult: []string{"kafka:9092", "localhost:9093"},
 		},
+		{
+			name:       "🎉 handles when event broker type is empty but it's not required",
+			args:       []string{"--brokers", ""},
+			wantResult: []string{},
+		},
+		{
+			name:       "🎉 handles when event broker type are spaces but it's not required",
+			args:       []string{"--brokers", "    "},
+			wantResult: []string{},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -619,6 +624,17 @@ func Test_SetConfigOptionURLList(t *testing.T) {
 			customSetterTester[[]string](t, tc, co)
 		})
 	}
+
+	tc := customSetterTestCase[[]string]{
+		name:            "returns an error if the list is empty and it's required",
+		args:            []string{"--brokers", "   "}, // Workaround to test empty values
+		wantErrContains: "cannot be empty",
+	}
+	t.Run(tc.name, func(t *testing.T) {
+		opts.brokers = []string{}
+		co.Required = true
+		customSetterTester[[]string](t, tc, co)
+	})
 }
 
 func Test_SetConfigOptionStringList(t *testing.T) {


### PR DESCRIPTION
### What

This PR fixes the `SetConfigOptionURLList` adding a check if the config value is empty.

### Why

It was returning errors even if it wasn't a required value.

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
