### PR TITLE
[SDP-1031] Coinspect SDP-012 Enhance User Awareness for SMS One-Time Password (OTP) Usage

### DIFF
--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
-// OTPMessageDisclaimer contains disclaimer text that needs to be added as part of the OTP message to remind the 
+// OTPMessageDisclaimer contains disclaimer text that needs to be added as part of the OTP message to remind the
 // receiver how sensitive the data is.
 const OTPMessageDisclaimer = " If you did not request this code, please ignore. Do not share your code with anyone."
 

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -18,6 +18,10 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
+// we need to send this disclaimer as part of the message that includes the OTP to remind the user how sensitive
+// this data is
+const OTPMessageDisclaimer = " If you did not request this code, please ignore. Do not share your code with anyone."
+
 type ReceiverSendOTPHandler struct {
 	Models             *data.Models
 	SMSMessengerClient message.MessengerClient
@@ -125,7 +129,7 @@ func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			OrganizationName: organization.Name,
 		}
 
-		otpMessageTemplate := organization.OTPMessageTemplate
+		otpMessageTemplate := organization.OTPMessageTemplate + OTPMessageDisclaimer
 		if !strings.Contains(organization.OTPMessageTemplate, "{{.OTP}}") {
 			// Adding the OTP code to the template
 			otpMessageTemplate = fmt.Sprintf(`{{.OTP}} %s`, strings.TrimSpace(otpMessageTemplate))

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -18,8 +18,8 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
-// we need to send this disclaimer as part of the message that includes the OTP to remind the user how sensitive
-// this data is
+// OTPMessageDisclaimer contains disclaimer text that needs to be added as part of the OTP message to remind the 
+// receiver how sensitive the data is.
 const OTPMessageDisclaimer = " If you did not request this code, please ignore. Do not share your code with anyone."
 
 type ReceiverSendOTPHandler struct {


### PR DESCRIPTION
### What
Add a disclaimer to the SMS message warning users about the risk of sharing their wallet registration OTP with a third party.

### Why
This should address the open issue [SDP-012](https://docs.google.com/spreadsheets/d/1SiDnx3sRHNa4PBPZwrPKwwlUKPhUl-1vTWNHR7rFA4Q/edit#gid=0) in Coinspect's most recent report.

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
