### PR TITLE
[SDP-984] cmd/httphandler: Use tenant's configuration for `EnableMFA` and `EnableReCaptcha`

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -277,22 +277,6 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 			Required:       true,
 		},
 		{
-			Name:        "enable-mfa",
-			Usage:       "Enable MFA using email.",
-			OptType:     types.Bool,
-			ConfigKey:   &serveOpts.EnableMFA,
-			FlagDefault: true,
-			Required:    false,
-		},
-		{
-			Name:        "enable-recaptcha",
-			Usage:       "Enable ReCAPTCHA for login and forgot password.",
-			OptType:     types.Bool,
-			ConfigKey:   &serveOpts.EnableReCAPTCHA,
-			FlagDefault: true,
-			Required:    false,
-		},
-		{
 			Name:        "horizon-url",
 			Usage:       "Stellar Horizon URL.",
 			OptType:     types.String,

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -117,8 +117,6 @@ func Test_serve(t *testing.T) {
 		DistributionSeed:                "SBHQEYSACD5DOK5I656NKLAMOHC6VT64ATOWWM2VJ3URGDGMVGNPG4ON",
 		ReCAPTCHASiteKey:                "reCAPTCHASiteKey",
 		ReCAPTCHASiteSecretKey:          "reCAPTCHASiteSecretKey",
-		EnableMFA:                       true,
-		EnableReCAPTCHA:                 true,
 		EnableScheduler:                 true,
 		EnableMultiTenantDB:             false,
 	}

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -41,8 +41,6 @@ services:
       DISTRIBUTION_SEED: ${DISTRIBUTION_SEED}
       RECAPTCHA_SITE_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
       CORS_ALLOWED_ORIGINS: "*"
-      ENABLE_MFA: "false"
-      ENABLE_RECAPTCHA: "false"
       BROKERS: "kafka:9092"
       CONSUMER_GROUP_ID: "group-id"
 

--- a/helmchart/sdp/values.yaml
+++ b/helmchart/sdp/values.yaml
@@ -145,8 +145,6 @@ sdp:
       SMS_SENDER_TYPE: DRY_RUN
       RECAPTCHA_SITE_KEY: #required
       CORS_ALLOWED_ORIGINS: "*"
-      ENABLE_RECAPTCHA: "false"
-      ENABLE_MFA: "false"
       SDP_UI_BASE_URL: #required
 
   ## @extra sdp.kubeSecrets Kubernetes secrets are used to manage sensitive information, such as API keys and private keys. It's crucial that these details are kept private.

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
@@ -29,7 +30,6 @@ type ForgotPasswordHandler struct {
 	UIBaseURL          string
 	Models             *data.Models
 	ReCAPTCHAValidator validators.ReCAPTCHAValidator
-	ReCAPTCHAEnabled   bool
 }
 
 type ForgotPasswordRequest struct {
@@ -53,7 +53,14 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	ctx := r.Context()
 
-	if h.ReCAPTCHAEnabled {
+	tnt, err := tenant.GetTenantFromContext(ctx)
+	if err != nil {
+		log.Ctx(ctx).Errorf("error getting tenant from context: %s", err)
+		httperror.Unauthorized("", err, nil).Render(w)
+		return
+	}
+
+	if tnt.EnableReCAPTCHA {
 		// validating reCAPTCHA Token
 		isValid, recaptchaErr := h.ReCAPTCHAValidator.IsTokenValid(ctx, forgotPasswordRequest.ReCAPTCHAToken)
 		if recaptchaErr != nil {

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -379,18 +379,29 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 	t.Run("Should return http status 401 when error getting tenant from context", func(t *testing.T) {
 		ctxWithoutTenant := context.Background()
 		requestBody := `
-        { 
-            "email": "valid@email.com" ,
-            "recaptcha_token": "validToken"
-        }`
+			{ 
+				"email": "valid@email.com",
+				"recaptcha_token": "validToken"
+			}
+		`
 
 		rr := httptest.NewRecorder()
 		req, err := http.NewRequestWithContext(ctxWithoutTenant, http.MethodPost, url, strings.NewReader(requestBody))
 		require.NoError(t, err)
 
 		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
+
+		wantsBody := `
+			{
+				"error": "Not authorized."
+			}
+		`
 		resp := rr.Result()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.JSONEq(t, wantsBody, string(respBody))
 	})
 
 	authenticatorMock.AssertExpectations(t)

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -399,7 +399,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		resp := rr.Result()
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		
+
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
 	})

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
@@ -49,8 +51,12 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		Models:             models,
 		UIBaseURL:          uiBaseURL,
 		ReCAPTCHAValidator: reCAPTCHAValidatorMock,
-		ReCAPTCHAEnabled:   true,
 	}
+
+	tnt := tenant.Tenant{
+		EnableReCAPTCHA: true,
+	}
+	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
 
 	t.Run("Should return http status 200 on a valid request", func(t *testing.T) {
 		requestBody := `
@@ -60,7 +66,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		}`
 
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
 		require.NoError(t, err)
 
 		authenticatorMock.
@@ -106,7 +112,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		}`
 
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
 		require.NoError(t, err)
 
 		authenticatorMock.
@@ -124,7 +130,6 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 			Models:             models,
 			UIBaseURL:          "%invalid%",
 			ReCAPTCHAValidator: reCAPTCHAValidatorMock,
-			ReCAPTCHAEnabled:   true,
 		}.ServeHTTP).ServeHTTP(rr, req)
 
 		resp := rr.Result()
@@ -139,7 +144,8 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		}`
 
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
+
 		require.NoError(t, err)
 
 		authenticatorMock.
@@ -166,7 +172,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		}`
 
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
 		require.NoError(t, err)
 
 		authenticatorMock.
@@ -192,7 +198,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		}`
 
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
 		require.NoError(t, err)
 
 		reCAPTCHAValidatorMock.
@@ -226,7 +232,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		}`
 
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
 		require.NoError(t, err)
 
 		authenticatorMock.
@@ -281,7 +287,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		}`
 
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
 		require.NoError(t, err)
 
 		authenticatorMock.
@@ -316,7 +322,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		}`
 
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
 		require.NoError(t, err)
 
 		reCAPTCHAValidatorMock.
@@ -347,7 +353,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		}`
 
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
 		require.NoError(t, err)
 
 		reCAPTCHAValidatorMock.
@@ -368,6 +374,23 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
+	})
+
+	t.Run("Should return http status 401 when error getting tenant from context", func(t *testing.T) {
+		ctxWithoutTenant := context.Background()
+		requestBody := `
+        { 
+            "email": "valid@email.com" ,
+            "recaptcha_token": "validToken"
+        }`
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(ctxWithoutTenant, http.MethodPost, url, strings.NewReader(requestBody))
+		require.NoError(t, err)
+
+		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
+		resp := rr.Result()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	})
 
 	authenticatorMock.AssertExpectations(t)

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -255,7 +255,17 @@ func Test_LoginHandler(t *testing.T) {
 
 		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
 		resp := rr.Result()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		wantsBody := `
+			{
+				"error": "Not authorized."
+			}
+		`
+
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.JSONEq(t, wantsBody, string(respBody))
 	})
 	t.Run("returns error when unable to validate recaptcha", func(t *testing.T) {
 		reCAPTCHAValidator.

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 
@@ -67,15 +69,19 @@ func Test_LoginHandler(t *testing.T) {
 	handler := &LoginHandler{
 		AuthManager:        authManager,
 		ReCAPTCHAValidator: reCAPTCHAValidator,
-		ReCAPTCHAEnabled:   true,
 	}
+
+	tnt := tenant.Tenant{
+		EnableReCAPTCHA: true,
+	}
+	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
 
 	const url = "/login"
 
 	t.Run("returns error when body is invalid", func(t *testing.T) {
 		r.Post(url, handler.ServeHTTP)
 
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{}`))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(`{}`))
 		require.NoError(t, err)
 
 		w := httptest.NewRecorder()
@@ -99,7 +105,7 @@ func Test_LoginHandler(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
 
-		req, err = http.NewRequest(http.MethodPost, url, strings.NewReader(`{"email": "testuser"}`))
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(`{"email": "testuser"}`))
 		require.NoError(t, err)
 
 		w = httptest.NewRecorder()
@@ -125,7 +131,7 @@ func Test_LoginHandler(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 
-		req, err = http.NewRequest(http.MethodPost, url, strings.NewReader(`"invalid"`))
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(`"invalid"`))
 		require.NoError(t, err)
 
 		w = httptest.NewRecorder()
@@ -167,7 +173,7 @@ func Test_LoginHandler(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(reqBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
 
 		w := httptest.NewRecorder()
@@ -210,7 +216,7 @@ func Test_LoginHandler(t *testing.T) {
 			}
 		`
 
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(reqBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
 
 		w := httptest.NewRecorder()
@@ -234,6 +240,23 @@ func Test_LoginHandler(t *testing.T) {
 		assert.JSONEq(t, wantsBody, string(respBody))
 	})
 
+	t.Run("retturns error when tenant is not found in context", func(t *testing.T) {
+		ctxWithoutTenant := context.Background()
+		reqBody := `
+			{
+				"email": "testuser",
+				"password": "pass1234",
+				"recaptcha_token": "XyZ"
+			}
+		`
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(ctxWithoutTenant, http.MethodPost, url, strings.NewReader(reqBody))
+		require.NoError(t, err)
+
+		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
+		resp := rr.Result()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
 	t.Run("returns error when unable to validate recaptcha", func(t *testing.T) {
 		reCAPTCHAValidator.
 			On("IsTokenValid", mock.Anything, "XyZ").
@@ -250,7 +273,7 @@ func Test_LoginHandler(t *testing.T) {
 			}
 		`
 
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(reqBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
 
 		w := httptest.NewRecorder()
@@ -287,7 +310,7 @@ func Test_LoginHandler(t *testing.T) {
 			}
 		`
 
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(reqBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
 
 		w := httptest.NewRecorder()
@@ -361,7 +384,7 @@ func Test_LoginHandler(t *testing.T) {
 			}
 		`
 
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(reqBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(reqBody))
 		require.NoError(t, err)
 
 		w := httptest.NewRecorder()
@@ -409,11 +432,9 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 	)
 	messengerClientMock := &message.MessengerClientMock{}
 	loginHandler := &LoginHandler{
-		AuthManager:      authManager,
-		ReCAPTCHAEnabled: false,
-		MFAEnabled:       true,
-		Models:           models,
-		MessengerClient:  messengerClientMock,
+		AuthManager:     authManager,
+		Models:          models,
+		MessengerClient: messengerClientMock,
 	}
 
 	user := &auth.User{
@@ -438,6 +459,12 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 	deviceID := "safari-xyz"
 
+	tnt := tenant.Tenant{
+		EnableReCAPTCHA: false,
+		EnableMFA:       true,
+	}
+	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
+
 	t.Run("error getting user from token", func(t *testing.T) {
 		authenticatorMock.
 			On("GetUser", mock.Anything, "userID").
@@ -446,6 +473,7 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 		body := LoginRequest{Email: "testuser@mail.com", Password: "pass1234"}
 		req := httptest.NewRequest(http.MethodPost, "/login", requestToJSON(t, &body))
+		req = req.WithContext(ctx)
 		rw := httptest.NewRecorder()
 
 		loginHandler.ServeHTTP(rw, req)
@@ -462,6 +490,7 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 		body := LoginRequest{Email: "testuser@mail.com", Password: "pass1234"}
 		req := httptest.NewRequest(http.MethodPost, "/login", requestToJSON(t, &body))
+		req = req.WithContext(ctx)
 		rw := httptest.NewRecorder()
 
 		loginHandler.ServeHTTP(rw, req)
@@ -482,6 +511,7 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 		body := LoginRequest{Email: "testuser@mail.com", Password: "pass1234"}
 		req := httptest.NewRequest(http.MethodPost, "/login", requestToJSON(t, &body))
+		req = req.WithContext(ctx)
 		req.Header.Set(DeviceIDHeader, deviceID)
 		rw := httptest.NewRecorder()
 
@@ -503,6 +533,7 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 		body := LoginRequest{Email: "testuser@mail.com", Password: "pass1234"}
 		req := httptest.NewRequest(http.MethodPost, "/login", requestToJSON(t, &body))
+		req = req.WithContext(ctx)
 		req.Header.Set(DeviceIDHeader, deviceID)
 		rw := httptest.NewRecorder()
 
@@ -528,6 +559,7 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 		body := LoginRequest{Email: "testuser@mail.com", Password: "pass1234"}
 		req := httptest.NewRequest(http.MethodPost, "/login", requestToJSON(t, &body))
+		req = req.WithContext(ctx)
 		req.Header.Set(DeviceIDHeader, deviceID)
 		rw := httptest.NewRecorder()
 
@@ -553,6 +585,7 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 		body := LoginRequest{Email: "testuser@mail.com", Password: "pass1234"}
 		req := httptest.NewRequest(http.MethodPost, "/login", requestToJSON(t, &body))
+		req = req.WithContext(ctx)
 		req.Header.Set(DeviceIDHeader, deviceID)
 		rw := httptest.NewRecorder()
 
@@ -582,6 +615,7 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 		body := LoginRequest{Email: "testuser@mail.com", Password: "pass1234"}
 		req := httptest.NewRequest(http.MethodPost, "/login", requestToJSON(t, &body))
+		req = req.WithContext(ctx)
 		req.Header.Set(DeviceIDHeader, deviceID)
 		rw := httptest.NewRecorder()
 
@@ -623,6 +657,7 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 		body := LoginRequest{Email: "testuser@mail.com", Password: "pass1234"}
 		req := httptest.NewRequest(http.MethodPost, "/login", requestToJSON(t, &body))
+		req = req.WithContext(ctx)
 		req.Header.Set(DeviceIDHeader, deviceID)
 		rw := httptest.NewRecorder()
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -85,8 +85,6 @@ type ServeOptions struct {
 	DistributionSeed                string
 	ReCAPTCHASiteKey                string
 	ReCAPTCHASiteSecretKey          string
-	EnableMFA                       bool
-	EnableReCAPTCHA                 bool
 	EnableScheduler                 bool
 	EnableMultiTenantDB             bool
 	tenantManager                   tenant.ManagerInterface
@@ -371,8 +369,6 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			ReCAPTCHAValidator: reCAPTCHAValidator,
 			MessengerClient:    o.EmailMessengerClient,
 			Models:             o.Models,
-			ReCAPTCHAEnabled:   o.EnableReCAPTCHA,
-			MFAEnabled:         o.EnableMFA,
 		}.ServeHTTP)
 		r.Post("/mfa", httphandler.MFAHandler{
 			AuthManager:        authManager,
@@ -385,7 +381,6 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			UIBaseURL:          o.UIBaseURL,
 			Models:             o.Models,
 			ReCAPTCHAValidator: reCAPTCHAValidator,
-			ReCAPTCHAEnabled:   o.EnableReCAPTCHA,
 		}.ServeHTTP)
 		r.Post("/reset-password", httphandler.ResetPasswordHandler{AuthManager: authManager}.ServeHTTP)
 	})


### PR DESCRIPTION
### What

SDP is currently using the instance’s environment variables ENABLE_MFA and ENABLE_RECAPTCHA to control security for auth functionality.  We want to instead use Tenant.EnableMFA and Tenant.EnableReCaptcha.

### Why

To have these controls be tenant-specific. 

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
