### PR TITLE
[SDP-1001] Move all TSS-related tables to the tss schema

### DIFF
--- a/cmd/channel_accounts.go
+++ b/cmd/channel_accounts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/go/txnbuild"
 
 	cmdUtils "github.com/stellar/stellar-disbursement-platform-backend/cmd/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	di "github.com/stellar/stellar-disbursement-platform-backend/internal/dependencyinjection"
 	txSubSvc "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/services"
@@ -62,7 +63,11 @@ func (c *ChannelAccountsCommand) Command() *cobra.Command {
 			}
 
 			// Inject server dependencies
-			svcOpts.DatabaseDSN = globalOptions.DatabaseURL
+			tssDatabaseDSN, err := router.GetDNSForTSS(globalOptions.DatabaseURL)
+			if err != nil {
+				log.Ctx(ctx).Fatalf("Error getting TSS database DSN: %v", err)
+			}
+			svcOpts.DatabaseDSN = tssDatabaseDSN
 			svcOpts.NetworkPassphrase = globalOptions.NetworkPassphrase
 			c.Service, err = txSubSvc.NewChannelAccountService(ctx, *svcOpts)
 			if err != nil {

--- a/cmd/db/db.go
+++ b/cmd/db/db.go
@@ -14,6 +14,7 @@ import (
 	adminmigrations "github.com/stellar/stellar-disbursement-platform-backend/db/migrations/admin-migrations"
 	authmigrations "github.com/stellar/stellar-disbursement-platform-backend/db/migrations/auth-migrations"
 	sdpmigrations "github.com/stellar/stellar-disbursement-platform-backend/db/migrations/sdp-migrations"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	sdpUtils "github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
@@ -222,7 +223,7 @@ func (c *DatabaseCommand) tssMigrationsCmd(ctx context.Context, globalOptions *u
 			return fmt.Errorf("creating the 'tss' database schema if needed: %w", err)
 		}
 
-		dbURL, err := tssMigrationsManager.getTSSDatabaseDSN()
+		dbURL, err := router.GetDNSForTSS(tssMigrationsManager.RootDatabaseDSN)
 		if err != nil {
 			return fmt.Errorf("getting the TSS database DSN: %w", err)
 		}

--- a/cmd/db/tss_migrations.go
+++ b/cmd/db/tss_migrations.go
@@ -3,12 +3,13 @@ package db
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/stellar/go/support/log"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	tssmigrations "github.com/stellar/stellar-disbursement-platform-backend/db/migrations/tss-migrations"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
 )
 
 type TSSDatabaseMigrationManager struct {
@@ -17,7 +18,7 @@ type TSSDatabaseMigrationManager struct {
 }
 
 func (m *TSSDatabaseMigrationManager) SchemaName() string {
-	return "tss"
+	return router.TSSSchemaName
 }
 
 func NewTSSDatabaseMigrationManager(rootDatabaseDSN string) (*TSSDatabaseMigrationManager, error) {
@@ -40,19 +41,6 @@ func (m *TSSDatabaseMigrationManager) createTSSSchemaIfNeeded(ctx context.Contex
 	}
 
 	return nil
-}
-
-func (m *TSSDatabaseMigrationManager) getTSSDatabaseDSN() (string, error) {
-	dbURL, err := url.Parse(m.RootDatabaseDSN)
-	if err != nil {
-		return "", fmt.Errorf("parsing database DSN: %w", err)
-	}
-
-	q := dbURL.Query()
-	q.Set("search_path", m.SchemaName())
-	dbURL.RawQuery = q.Encode()
-
-	return dbURL.String(), nil
 }
 
 func (m *TSSDatabaseMigrationManager) deleteTSSSchemaIfNeeded(ctx context.Context) error {

--- a/cmd/db/tss_migrations_test.go
+++ b/cmd/db/tss_migrations_test.go
@@ -111,22 +111,6 @@ func Test_TSSDatabaseMigrationManager_deleteTSSSchemaIfNeeded(t *testing.T) {
 	assert.False(t, exists)
 }
 
-func Test_TSSDatabaseMigrationManager_getTSSDatabaseDSN(t *testing.T) {
-	dbt := dbtest.Open(t)
-	defer dbt.Close()
-	manager, err := NewTSSDatabaseMigrationManager(dbt.DSN)
-	require.NoError(t, err)
-	defer manager.RootDBConnectionPool.Close()
-
-	// Checks that the search_path is not set.
-	require.NotContains(t, manager.RootDatabaseDSN, "search_path=tss")
-
-	// Sets the search_path to tss.
-	updatedDSN, err := manager.getTSSDatabaseDSN()
-	require.NoError(t, err)
-	require.Contains(t, updatedDSN, "search_path=tss")
-}
-
 func Test_runTSSMigrations(t *testing.T) {
 	dbt := dbtest.OpenWithoutMigrations(t)
 	defer dbt.Close()

--- a/cmd/db_test.go
+++ b/cmd/db_test.go
@@ -145,7 +145,7 @@ func Test_DatabaseCommand_db_sdp_migrate(t *testing.T) {
 		}
 	})
 
-	t.Run("migrate up and down --all", func(t *testing.T) {
+	t.Run("db sdp migrate up and down --all", func(t *testing.T) {
 		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
 
 		// Creating Tenants
@@ -213,7 +213,7 @@ func Test_DatabaseCommand_db_sdp_migrate(t *testing.T) {
 		tenant.TenantSchemaMatchTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{"sdp_migrations"})
 	})
 
-	t.Run("migrate up and down --tenant-id", func(t *testing.T) {
+	t.Run("db sdp migrate up and down --tenant-id", func(t *testing.T) {
 		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
 
 		// Creating Tenants
@@ -277,7 +277,7 @@ func Test_DatabaseCommand_db_sdp_migrate(t *testing.T) {
 		assert.NotContains(t, buf.String(), fmt.Sprintf("Applying migrations on tenant ID %s", tnt2.ID))
 	})
 
-	t.Run("migrate up and down auth migrations --all", func(t *testing.T) {
+	t.Run("db sdp migrate up and down auth migrations --all", func(t *testing.T) {
 		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
 
 		// Creating Tenants
@@ -345,7 +345,7 @@ func Test_DatabaseCommand_db_sdp_migrate(t *testing.T) {
 		tenant.TenantSchemaMatchTablesFixture(t, ctx, dbConnectionPool, "sdp_myorg2", []string{"auth_migrations"})
 	})
 
-	t.Run("migrate up and down auth migrations --tenant-id", func(t *testing.T) {
+	t.Run("db sdp migrate up and down auth migrations --tenant-id", func(t *testing.T) {
 		tenant.DeleteAllTenantsFixture(t, ctx, dbConnectionPool)
 
 		// Creating Tenants

--- a/cmd/db_test.go
+++ b/cmd/db_test.go
@@ -104,7 +104,7 @@ func Test_DatabaseCommand_db_help(t *testing.T) {
 }
 
 func Test_DatabaseCommand_db_sdp_migrate(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)

--- a/cmd/transaction_submitter.go
+++ b/cmd/transaction_submitter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stellar/go/txnbuild"
 
 	cmdUtils "github.com/stellar/stellar-disbursement-platform-backend/cmd/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	di "github.com/stellar/stellar-disbursement-platform-backend/internal/dependencyinjection"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
@@ -170,8 +171,12 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 			metricsServeOpts.MonitorService = &tssMonitorSvc
 
 			// Inject server dependencies
+			tssDatabaseDSN, err := router.GetDNSForTSS(globalOptions.DatabaseURL)
+			if err != nil {
+				log.Ctx(ctx).Fatalf("Error getting TSS database DSN: %v", err)
+			}
+			submitterOpts.DatabaseDSN = tssDatabaseDSN
 			submitterOpts.MonitorService = tssMonitorSvc
-			submitterOpts.DatabaseDSN = globalOptions.DatabaseURL
 			submitterOpts.NetworkPassphrase = globalOptions.NetworkPassphrase
 			submitterOpts.PrivateKeyEncrypter = tssUtils.DefaultPrivateKeyEncrypter{}
 

--- a/db/dbtest/dbtest.go
+++ b/db/dbtest/dbtest.go
@@ -50,7 +50,7 @@ func Open(t *testing.T) *dbtest.DB {
 	return db
 }
 
-func OpenWithTenantMigrationsOnly(t *testing.T) *dbtest.DB {
+func OpenWithAdminMigrationsOnly(t *testing.T) *dbtest.DB {
 	db := OpenWithoutMigrations(t)
 
 	conn := db.Open()

--- a/db/dbtest/dbtest_test.go
+++ b/db/dbtest/dbtest_test.go
@@ -29,4 +29,9 @@ func TestOpen(t *testing.T) {
 	err = session.Get(&count, `SELECT COUNT(*) FROM auth_migrations`)
 	require.NoError(t, err)
 	assert.Greater(t, count, 0)
+
+	// Per-tenant Auth Migrations
+	err = session.Get(&count, `SELECT COUNT(*) FROM tss_migrations`)
+	require.NoError(t, err)
+	assert.Greater(t, count, 0)
 }

--- a/db/migrations/sdp-migrations/2023-07-05.0-tss-transactions-table-constraints.sql
+++ b/db/migrations/sdp-migrations/2023-07-05.0-tss-transactions-table-constraints.sql
@@ -29,6 +29,4 @@ ALTER TABLE submitter_transactions
     DROP COLUMN xdr_received,
     ALTER COLUMN external_id DROP NOT NULL,
     ALTER COLUMN status DROP DEFAULT,
-    ALTER COLUMN amount TYPE numeric(10,2),
-    DROP CONSTRAINT unique_stellar_transaction_hash,
-    DROP CONSTRAINT check_retry_count;
+    ALTER COLUMN amount TYPE NUMERIC(10,2);

--- a/db/migrations/sdp-migrations/2024-01-03.1-drop-channel-accounts-table.sql
+++ b/db/migrations/sdp-migrations/2024-01-03.1-drop-channel-accounts-table.sql
@@ -1,0 +1,20 @@
+-- +migrate Up
+
+DROP TRIGGER refresh_channel_accounts_updated_at ON channel_accounts;
+
+DROP TABLE channel_accounts;
+
+
+-- +migrate Down
+
+CREATE TABLE channel_accounts (
+    public_key VARCHAR(64) PRIMARY KEY,
+    private_key VARCHAR(256),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    locked_at TIMESTAMPTZ,
+    locked_until_ledger_number INTEGER
+);
+
+-- TRIGGER: updated_at
+CREATE TRIGGER refresh_channel_accounts_updated_at BEFORE UPDATE ON channel_accounts FOR EACH ROW EXECUTE PROCEDURE update_at_refresh();

--- a/db/router/router.go
+++ b/db/router/router.go
@@ -1,0 +1,42 @@
+package router
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const (
+	TSSSchemaName       string = "tss"
+	SDPSchemaNamePrefix string = "sdp_"
+)
+
+// GetDSNForTSS returns the database DSN for the TSS schema. It is basically the same as the root database DSN, but
+// with the `search_path` query parameter (AKA schema) set to `tss`.
+func GetDNSForTSS(dataSourceName string) (string, error) {
+	u, err := url.Parse(dataSourceName)
+	if err != nil {
+		return "", fmt.Errorf("parsing database DSN: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("search_path", TSSSchemaName)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+// GetDSNForTenant returns the database DSN for the tenant schema. It is basically the same as the root database DSN,
+// but with the `search_path` query parameter (AKA schema) set to `sdp_<tenant_name>`.
+func GetDSNForTenant(dataSourceName, tenantName string) (string, error) {
+	u, err := url.Parse(dataSourceName)
+	if err != nil {
+		return "", fmt.Errorf("parsing database DSN: %w", err)
+	}
+
+	q := u.Query()
+	schemaName := fmt.Sprintf("%s%s", SDPSchemaNamePrefix, tenantName)
+	q.Set("search_path", schemaName)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}

--- a/db/router/router_test.go
+++ b/db/router/router_test.go
@@ -1,0 +1,36 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetTSSDatabaseDSN(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	// Checks that the search_path is not set.
+	require.NotContains(t, dbt.DSN, "search_path="+TSSSchemaName)
+
+	// Sets the search_path to tss.
+	updatedDSN, err := GetDNSForTSS(dbt.DSN)
+	require.NoError(t, err)
+	t.Log(updatedDSN)
+	require.Contains(t, updatedDSN, "search_path="+TSSSchemaName)
+}
+
+func Test_GetDSNForTenant(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	// Checks that the search_path is not set.
+	require.NotContains(t, dbt.DSN, "search_path="+SDPSchemaNamePrefix+"test")
+
+	// Sets the search_path to tss.
+	updatedDSN, err := GetDSNForTenant(dbt.DSN, "test")
+	require.NoError(t, err)
+	t.Log(updatedDSN)
+	require.Contains(t, updatedDSN, "search_path="+SDPSchemaNamePrefix+"test")
+}

--- a/internal/transactionsubmission/engine/signature_service_test.go
+++ b/internal/transactionsubmission/engine/signature_service_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Test_NewDefaultSignatureService(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func Test_NewDefaultSignatureService(t *testing.T) {
 }
 
 func Test_DefaultSignatureService_DistributionAccount(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func Test_DefaultSignatureService_NetworkPassphrase(t *testing.T) {
 }
 
 func Test_DefaultSignatureService_getKPsForAccounts(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -239,7 +239,7 @@ func Test_DefaultSignatureService_getKPsForAccounts(t *testing.T) {
 }
 
 func Test_DefaultSignatureService_SignStellarTransaction(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -330,7 +330,7 @@ func Test_DefaultSignatureService_SignStellarTransaction(t *testing.T) {
 }
 
 func Test_DefaultSignatureService_SignFeeBumpStellarTransaction(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -432,7 +432,7 @@ func Test_DefaultSignatureService_SignFeeBumpStellarTransaction(t *testing.T) {
 }
 
 func Test_DefaultSignatureService_BatchInsert(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -529,7 +529,7 @@ func Test_DefaultSignatureService_BatchInsert(t *testing.T) {
 }
 
 func Test_DefaultSignatureService_Delete(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)

--- a/internal/transactionsubmission/horizon.go
+++ b/internal/transactionsubmission/horizon.go
@@ -80,7 +80,7 @@ func CreateChannelAccountsOnChain(ctx context.Context, horizonClient horizonclie
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate keypair: %w", err)
 		}
-		log.Ctx(ctx).Infof("creating sponsored stellar account with address: %s", channelAccountKP.Address())
+		log.Ctx(ctx).Infof("Creating sponsored Stellar account with address: %s", channelAccountKP.Address())
 
 		sponsoredCreateAccountOps = append(
 			sponsoredCreateAccountOps,

--- a/internal/transactionsubmission/horizon_test.go
+++ b/internal/transactionsubmission/horizon_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_CreateChannelAccountsOnChain(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -191,7 +191,7 @@ func Test_CreateChannelAccountsOnChain(t *testing.T) {
 }
 
 func Test_DeleteChannelAccountOnChain(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)

--- a/internal/transactionsubmission/manager_test.go
+++ b/internal/transactionsubmission/manager_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func Test_SubmitterOptions_validate(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 
 	testCases := []struct {
@@ -194,7 +194,7 @@ func Test_SubmitterOptions_validate(t *testing.T) {
 }
 
 func Test_NewManager(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -371,7 +371,7 @@ func Test_NewManager(t *testing.T) {
 }
 
 func Test_Manager_ProcessTransactions(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)

--- a/internal/transactionsubmission/services/channel_accounts_service_test.go
+++ b/internal/transactionsubmission/services/channel_accounts_service_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func Test_ChannelAccounts_CreateAccount_Success(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -84,7 +84,7 @@ func Test_ChannelAccounts_CreateAccount_Success(t *testing.T) {
 }
 
 func Test_ChannelAccounts_CreateAccount_CannotFindRootAccount_Failure(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func Test_ChannelAccounts_CreateAccount_CannotFindRootAccount_Failure(t *testing
 }
 
 func Test_ChannelAccounts_CreateAccount_Insert_Failure(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func Test_ChannelAccounts_CreateAccount_Insert_Failure(t *testing.T) {
 }
 
 func Test_ChannelAccounts_VerifyAccounts_Success(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -222,7 +222,7 @@ func Test_ChannelAccounts_VerifyAccounts_Success(t *testing.T) {
 }
 
 func Test_ChannelAccounts_VerifyAccounts_LoadChannelAccountsError_Failure(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func Test_ChannelAccounts_VerifyAccounts_LoadChannelAccountsError_Failure(t *tes
 }
 
 func Test_ChannelAccounts_VerifyAccounts_NotFound(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -318,7 +318,7 @@ func Test_ChannelAccounts_VerifyAccounts_NotFound(t *testing.T) {
 }
 
 func Test_ChannelAccounts_DeleteAccount_Success(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -378,7 +378,7 @@ func Test_ChannelAccounts_DeleteAccount_Success(t *testing.T) {
 }
 
 func Test_ChannelAccounts_DeleteAccount_All_Success(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -447,7 +447,7 @@ func Test_ChannelAccounts_DeleteAccount_All_Success(t *testing.T) {
 }
 
 func Test_ChannelAccounts_DeleteAccount_FindByPublicKey_Failure(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -487,7 +487,7 @@ func Test_ChannelAccounts_DeleteAccount_FindByPublicKey_Failure(t *testing.T) {
 }
 
 func Test_ChannelAccounts_DeleteAccount_DeleteFromDatabaseError(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -550,7 +550,7 @@ func Test_ChannelAccounts_DeleteAccount_DeleteFromDatabaseError(t *testing.T) {
 }
 
 func Test_ChannelAccounts_DeleteAccount_SubmitTransaction_Failure(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -614,7 +614,7 @@ func Test_ChannelAccounts_DeleteAccount_SubmitTransaction_Failure(t *testing.T) 
 }
 
 func Test_ChannelAccounts_EnsureChannelAccounts_Exact_Success(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -649,7 +649,7 @@ func Test_ChannelAccounts_EnsureChannelAccounts_Exact_Success(t *testing.T) {
 }
 
 func Test_ChannelAccounts_EnsureChannelAccounts_Add_Success(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -706,7 +706,7 @@ func Test_ChannelAccounts_EnsureChannelAccounts_Add_Success(t *testing.T) {
 }
 
 func Test_ChannelAccounts_EnsureChannelAccounts_Delete_Success(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)

--- a/internal/transactionsubmission/store/channel_account_test.go
+++ b/internal/transactionsubmission/store/channel_account_test.go
@@ -48,7 +48,7 @@ func Test_ChannelAccount_IsLocked(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_BatchInsert_GetAll(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -184,7 +184,7 @@ func Test_ChannelAccountModel_BatchInsert_GetAll(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_Insert_Get(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -316,7 +316,7 @@ func Test_ChannelAccountModel_Insert_Get(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_Insert_Count(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -352,7 +352,7 @@ func Test_ChannelAccountModel_Insert_Count(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_Insert_Delete(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -438,7 +438,7 @@ func Test_ChannelAccountModel_queryFilterForLockedState(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_Lock(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -504,7 +504,7 @@ func Test_ChannelAccountModel_Lock(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_Unlock(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -557,7 +557,7 @@ func Test_ChannelAccountModel_Unlock(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_Lock_Unlock(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -602,7 +602,7 @@ func Test_ChannelAccountModel_Lock_Unlock(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_DeleteIfLockedUntil(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -663,7 +663,7 @@ func Test_ChannelAccountModel_DeleteIfLockedUntil(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_GetAndLockAll(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -702,7 +702,7 @@ func Test_ChannelAccountModel_GetAndLockAll(t *testing.T) {
 }
 
 func Test_ChannelAccountModel_GetAndLock(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)

--- a/internal/transactionsubmission/store/channel_transaction_bundle_test.go
+++ b/internal/transactionsubmission/store/channel_transaction_bundle_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_NewChannelTransactionBundleModel(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func Test_NewChannelTransactionBundleModel(t *testing.T) {
 }
 
 func Test_ChannelTransactionBundleModel_LoadAndLockTuples(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)

--- a/internal/transactionsubmission/store/fixtures_test.go
+++ b/internal/transactionsubmission/store/fixtures_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_Fixtures_CreateTransactionFixture(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
@@ -62,7 +62,7 @@ func Test_Fixtures_CreateTransactionFixture(t *testing.T) {
 }
 
 func Test_Fixtures_CreateAndDeleteAllTransactionFixtures(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
@@ -106,7 +106,7 @@ func Test_Fixtures_CreateAndDeleteAllTransactionFixtures(t *testing.T) {
 }
 
 func Test_Fixtures_CreateChannelAccountsOnChainFixtures(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)

--- a/internal/transactionsubmission/store/transactions_test.go
+++ b/internal/transactionsubmission/store/transactions_test.go
@@ -48,7 +48,7 @@ func Test_Transaction_IsLocked(t *testing.T) {
 }
 
 func Test_TransactionModel_Insert(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func Test_TransactionModel_Insert(t *testing.T) {
 }
 
 func Test_TransactionModel_BulkInsert(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -167,7 +167,7 @@ func Test_TransactionModel_BulkInsert(t *testing.T) {
 }
 
 func Test_TransactionModel_UpdateStatusToSuccess(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -259,7 +259,7 @@ func Test_TransactionModel_UpdateStatusToSuccess(t *testing.T) {
 }
 
 func Test_TransactionModel_UpdateStatusToError(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -354,7 +354,7 @@ func Test_TransactionModel_UpdateStatusToError(t *testing.T) {
 }
 
 func Test_TransactionModel_UpdateStellarTransactionHashAndXDRSent(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -471,7 +471,7 @@ func Test_TransactionModel_UpdateStellarTransactionHashAndXDRSent(t *testing.T) 
 }
 
 func Test_TransactionModel_UpdateStellarTransactionXDRReceived(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -546,7 +546,7 @@ func Test_TransactionModel_UpdateStellarTransactionXDRReceived(t *testing.T) {
 }
 
 func Test_Transaction_validate(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -650,7 +650,7 @@ func Test_Transaction_validate(t *testing.T) {
 }
 
 func Test_TransactionModel_GetTransactionBatchForUpdate(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -761,7 +761,7 @@ func Test_TransactionModel_GetTransactionBatchForUpdate(t *testing.T) {
 }
 
 func Test_TransactionModel_UpdateSyncedTransactions(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -893,7 +893,7 @@ func Test_TransactionModel_queryFilterForLockedState(t *testing.T) {
 }
 
 func Test_TransactionModel_Lock(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -985,7 +985,7 @@ func Test_TransactionModel_Lock(t *testing.T) {
 }
 
 func Test_TransactionModel_Unlock(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -1060,7 +1060,7 @@ func Test_TransactionModel_Unlock(t *testing.T) {
 }
 
 func Test_TransactionModel_PrepareTransactionForReprocessing(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/txnbuild"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
@@ -27,9 +31,6 @@ import (
 	storeMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/store/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/utils"
 	sdpUtlis "github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 // getTransactionWorkerInstance is used to create a valid instance of the class TransactionWorker, which is needed in

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -98,7 +98,7 @@ func createTxJobFixture(t *testing.T, ctx context.Context, dbConnectionPool db.D
 }
 
 func Test_NewTransactionWorker(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -258,7 +258,7 @@ func Test_NewTransactionWorker(t *testing.T) {
 }
 
 func Test_TransactionWorker_handleSuccessfulTransaction(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -459,7 +459,7 @@ func Test_TransactionWorker_handleSuccessfulTransaction(t *testing.T) {
 }
 
 func Test_TransactionWorker_reconcileSubmittedTransaction(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -576,7 +576,7 @@ func Test_TransactionWorker_reconcileSubmittedTransaction(t *testing.T) {
 }
 
 func Test_TransactionWorker_validateJob(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -697,7 +697,7 @@ func Test_TransactionWorker_validateJob(t *testing.T) {
 }
 
 func Test_TransactionWorker_buildAndSignTransaction(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -853,7 +853,7 @@ func Test_TransactionWorker_buildAndSignTransaction(t *testing.T) {
 }
 
 func Test_TransactionWorker_submit(t *testing.T) {
-	dbt := dbtest.Open(t)
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
 	defer dbt.Close()
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)

--- a/stellar-multitenant/pkg/cli/add_tenants_test.go
+++ b/stellar-multitenant/pkg/cli/add_tenants_test.go
@@ -242,7 +242,6 @@ Flags:
 			"auth_user_mfa_codes",
 			"auth_user_password_reset",
 			"auth_users",
-			"channel_accounts",
 			"countries",
 			"disbursements",
 			"sdp_migrations",
@@ -252,7 +251,6 @@ Flags:
 			"receiver_verifications",
 			"receiver_wallets",
 			"receivers",
-			"submitter_transactions",
 			"wallets",
 			"wallets_assets",
 		}
@@ -311,7 +309,6 @@ Flags:
 			"auth_user_mfa_codes",
 			"auth_user_password_reset",
 			"auth_users",
-			"channel_accounts",
 			"countries",
 			"disbursements",
 			"sdp_migrations",
@@ -321,7 +318,6 @@ Flags:
 			"receiver_verifications",
 			"receiver_wallets",
 			"receivers",
-			"submitter_transactions",
 			"wallets",
 			"wallets_assets",
 		}

--- a/stellar-multitenant/pkg/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/pkg/internal/httphandler/tenants_handler_test.go
@@ -76,7 +76,7 @@ func runSuccessfulRequestPatchTest(t *testing.T, r *chi.Mux, ctx context.Context
 }
 
 func Test_TenantHandler_Get(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
@@ -247,7 +247,7 @@ func Test_TenantHandler_Get(t *testing.T) {
 }
 
 func Test_TenantHandler_Post(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
@@ -403,7 +403,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 }
 
 func Test_TenantHandler_Patch(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)

--- a/stellar-multitenant/pkg/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/pkg/internal/httphandler/tenants_handler_test.go
@@ -370,7 +370,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 			"auth_user_mfa_codes",
 			"auth_user_password_reset",
 			"auth_users",
-			"channel_accounts",
 			"countries",
 			"disbursements",
 			"sdp_migrations",
@@ -380,7 +379,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 			"receiver_verifications",
 			"receiver_wallets",
 			"receivers",
-			"submitter_transactions",
 			"wallets",
 			"wallets_assets",
 		}

--- a/stellar-multitenant/pkg/internal/provisioning/manager_test.go
+++ b/stellar-multitenant/pkg/internal/provisioning/manager_test.go
@@ -78,7 +78,6 @@ func Test_Manager_ProvisionNewTenant(t *testing.T) {
 			"auth_user_mfa_codes",
 			"auth_user_password_reset",
 			"auth_users",
-			"channel_accounts",
 			"countries",
 			"disbursements",
 			"sdp_migrations",
@@ -88,7 +87,6 @@ func Test_Manager_ProvisionNewTenant(t *testing.T) {
 			"receiver_verifications",
 			"receiver_wallets",
 			"receivers",
-			"submitter_transactions",
 			"wallets",
 			"wallets_assets",
 		}
@@ -135,7 +133,6 @@ func Test_Manager_ProvisionNewTenant(t *testing.T) {
 			"auth_user_mfa_codes",
 			"auth_user_password_reset",
 			"auth_users",
-			"channel_accounts",
 			"countries",
 			"disbursements",
 			"sdp_migrations",
@@ -145,7 +142,6 @@ func Test_Manager_ProvisionNewTenant(t *testing.T) {
 			"receiver_verifications",
 			"receiver_wallets",
 			"receivers",
-			"submitter_transactions",
 			"wallets",
 			"wallets_assets",
 		}
@@ -221,7 +217,6 @@ func Test_Manager_RunMigrationsForTenant(t *testing.T) {
 		"auth_user_mfa_codes",
 		"auth_user_password_reset",
 		"auth_users",
-		"channel_accounts",
 		"countries",
 		"disbursements",
 		"sdp_migrations",
@@ -231,7 +226,6 @@ func Test_Manager_RunMigrationsForTenant(t *testing.T) {
 		"receiver_verifications",
 		"receiver_wallets",
 		"receivers",
-		"submitter_transactions",
 		"wallets",
 		"wallets_assets",
 	}

--- a/stellar-multitenant/pkg/internal/provisioning/manager_test.go
+++ b/stellar-multitenant/pkg/internal/provisioning/manager_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Test_Manager_ProvisionNewTenant(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
@@ -160,7 +160,7 @@ func Test_Manager_ProvisionNewTenant(t *testing.T) {
 }
 
 func Test_Manager_RunMigrationsForTenant(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)

--- a/stellar-multitenant/pkg/router/multitenant_data_source_router_test.go
+++ b/stellar-multitenant/pkg/router/multitenant_data_source_router_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMultiTenantDataSourceRouter_GetDataSource(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
@@ -47,7 +47,7 @@ func TestMultiTenantDataSourceRouter_GetDataSource(t *testing.T) {
 }
 
 func TestMultiTenantDataSourceRouter_GetAllDataSources(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
@@ -93,7 +93,7 @@ func TestMultiTenantDataSourceRouter_GetAllDataSources(t *testing.T) {
 }
 
 func TestMultiTenantDataSourceRouter_AnyDataSource(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -5,11 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/lib/pq"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
 )
 
 var (
@@ -41,15 +42,8 @@ func (m *Manager) GetDSNForTenant(ctx context.Context, tenantName string) (strin
 	if err != nil {
 		return "", fmt.Errorf("getting database DSN: %w", err)
 	}
-	u, err := url.Parse(dataSourceName)
-	if err != nil {
-		return "", fmt.Errorf("parsing database DSN: %w", err)
-	}
-	q := u.Query()
-	schemaName := fmt.Sprintf("sdp_%s", tenantName)
-	q.Set("search_path", schemaName)
-	u.RawQuery = q.Encode()
-	return u.String(), nil
+
+	return router.GetDSNForTenant(dataSourceName, tenantName)
 }
 
 var selectQuery string = `

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -125,7 +125,7 @@ func Test_Manager_UpdateTenantConfig(t *testing.T) {
 }
 
 func Test_Manager_GetAllTenants(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
@@ -147,7 +147,7 @@ func Test_Manager_GetAllTenants(t *testing.T) {
 }
 
 func Test_Manager_GetTenantByID(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
@@ -176,7 +176,7 @@ func Test_Manager_GetTenantByID(t *testing.T) {
 }
 
 func Test_Manager_GetTenantByName(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
@@ -205,7 +205,7 @@ func Test_Manager_GetTenantByName(t *testing.T) {
 }
 
 func Test_Manager_GetTenantByIDOrName(t *testing.T) {
-	dbt := dbtest.OpenWithTenantMigrationsOnly(t)
+	dbt := dbtest.OpenWithAdminMigrationsOnly(t)
 	defer dbt.Close()
 
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)


### PR DESCRIPTION
### What

Move all TSS-related tables to the tss schema.

### Why

Close https://stellarorg.atlassian.net/browse/SDP-1001.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
