### PR TITLE
[SDP-1032] Add logs for any changes in user profile or the organization profile

### DIFF
--- a/internal/data/organizations.go
+++ b/internal/data/organizations.go
@@ -49,16 +49,16 @@ type Organization struct {
 }
 
 type OrganizationUpdate struct {
-	Name                          string
-	Logo                          []byte
-	TimezoneUTCOffset             string
-	IsApprovalRequired            *bool
-	SMSResendInterval             *int64
-	PaymentCancellationPeriodDays *int64
+	Name                          string `json:",omitempty"`
+	Logo                          []byte `json:",omitempty"`
+	TimezoneUTCOffset             string `json:",omitempty"`
+	IsApprovalRequired            *bool  `json:",omitempty"`
+	SMSResendInterval             *int64 `json:",omitempty"`
+	PaymentCancellationPeriodDays *int64 `json:",omitempty"`
 
 	// Using pointers to accept empty strings
-	SMSRegistrationMessageTemplate *string
-	OTPMessageTemplate             *string
+	SMSRegistrationMessageTemplate *string `json:",omitempty"`
+	OTPMessageTemplate             *string `json:",omitempty"`
 }
 
 type LogoType string

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -171,17 +171,19 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 		httperror.InternalError(ctx, "Cannot convert organization update to map", err, nil).Render(rw)
 		return
 	}
-	var nonEmptyKeys []string
+	var nonEmptyChanges []string
 	for k, v := range requestDict {
-		if utils.IsEmpty(v) || v == "" || v == nil {
-			continue
-		} else {
-			nonEmptyKeys = append(nonEmptyKeys, k)
+		if !utils.IsEmpty(v) {
+			value := v
+			if k == "Logo" {
+				value = "..."
+			}
+			nonEmptyChanges = append(nonEmptyChanges, fmt.Sprintf("%s='%v'", k, value))
 		}
 	}
-	sort.Strings(nonEmptyKeys)
+	sort.Strings(nonEmptyChanges)
 
-	log.Ctx(ctx).Warnf("[PatchOrganizationProfile] - userID %s will update the organization fields %v", user.ID, nonEmptyKeys)
+	log.Ctx(ctx).Warnf("[PatchOrganizationProfile] - userID %s will update the organization fields [%s]", user.ID, strings.Join(nonEmptyChanges, ", "))
 	err = h.Models.Organizations.Update(ctx, &organizationUpdate)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot update organization", err, nil).Render(rw)

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -302,7 +302,7 @@ func (h ProfileHandler) PatchUserPassword(rw http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	log.Ctx(ctx).Warnf("[UpdateUserPassword] - Will update password for user account ID %s", user.ID)
+	log.Ctx(ctx).Warnf("[PatchUserPassword] - Will update password for user account ID %s", user.ID)
 	err = h.AuthManager.UpdatePassword(ctx, token, reqBody.CurrentPassword, reqBody.NewPassword)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot update user password", err, nil).Render(rw)

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -888,6 +888,7 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 		mockAuthManagerFn func(authManagerMock *auth.AuthManagerMock)
 		wantStatusCode    int
 		wantRespBody      string
+		wantLogEntries    []string
 	}{
 		{
 			name:           "returns Unauthorized when no token is found",
@@ -1007,6 +1008,10 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			},
 			wantStatusCode: http.StatusOK,
 			wantRespBody:   `{"message": "user profile updated successfully"}`,
+			wantLogEntries: []string{
+				"[PatchUserProfile] - Will update email for userID user-id to ema...com",
+				"[PatchUserProfile] - Will update password for userID user-id",
+			},
 		},
 	}
 
@@ -1061,9 +1066,10 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			assert.JSONEq(t, tc.wantRespBody, string(respBody))
 
 			// Validate logs
-			if tc.wantStatusCode == http.StatusOK {
-				assert.Contains(t, buf.String(), "[PatchUserProfile] - Will update email for userID user-id to ema...com")
-				assert.Contains(t, buf.String(), "[PatchUserProfile] - Will update password for userID user-id")
+			if len(tc.wantLogEntries) > 0 {
+				for _, entry := range tc.wantLogEntries {
+					assert.Contains(t, buf.String(), entry)
+				}
 			}
 		})
 	}
@@ -1078,6 +1084,7 @@ func Test_ProfileHandler_PatchUserPassword(t *testing.T) {
 		mockAuthManagerFn func(authManagerMock *auth.AuthManagerMock)
 		wantStatusCode    int
 		wantRespBody      string
+		wantLogEntries    []string
 	}{
 		{
 			name:           "returns Unauthorized error when no token is found",
@@ -1185,6 +1192,9 @@ func Test_ProfileHandler_PatchUserPassword(t *testing.T) {
 			},
 			wantStatusCode: http.StatusOK,
 			wantRespBody:   `{"message": "user password updated successfully"}`,
+			wantLogEntries: []string{
+				"[PatchUserPassword] - Will update password for user account ID user-id",
+			},
 		},
 	}
 
@@ -1239,8 +1249,10 @@ func Test_ProfileHandler_PatchUserPassword(t *testing.T) {
 			assert.JSONEq(t, tc.wantRespBody, string(respBody))
 
 			// Validate logs
-			if tc.wantStatusCode == http.StatusOK {
-				require.Contains(t, buf.String(), "[PatchUserPassword] - Will update password for user account ID user-id")
+			if len(tc.wantLogEntries) > 0 {
+				for _, entry := range tc.wantLogEntries {
+					assert.Contains(t, buf.String(), entry)
+				}
 			}
 		})
 	}

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -286,7 +286,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Nil(t, org.Logo)
 
 		// validate logs
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name='My Org Name']")
 	})
 
 	t.Run("🎉 successfully updates the organization's timezone UTC offset", func(t *testing.T) {
@@ -336,7 +336,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Nil(t, org.Logo)
 
 		// validate logs
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [TimezoneUTCOffset]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [TimezoneUTCOffset='-03:00']")
 	})
 
 	t.Run("🎉 successfully updates the organization's IsApprovalRequired", func(t *testing.T) {
@@ -382,7 +382,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.True(t, org.IsApprovalRequired)
 
 		// validate logs
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [IsApprovalRequired]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [IsApprovalRequired='true']")
 	})
 
 	t.Run("🎉 successfully updates the organization's logo", func(t *testing.T) {
@@ -472,7 +472,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Equal(t, "MyCustomAid", org.Name)
 
 		// validate logs
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Logo]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Logo='...']")
 	})
 
 	t.Run("🎉 successfully updates organization name, timezone UTC offset and logo", func(t *testing.T) {
@@ -531,7 +531,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Equal(t, imgBuf.Bytes(), org.Logo)
 
 		// validate logs
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Logo Name TimezoneUTCOffset]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Logo='...', Name='My Org Name', TimezoneUTCOffset='-03:00']")
 	})
 
 	t.Run("🎉 successfully updates organization's SMS Registration Message Template", func(t *testing.T) {
@@ -614,8 +614,9 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Equal(t, defaultMessage, org.SMSRegistrationMessageTemplate)
 
 		// validate logs
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [SMSRegistrationMessageTemplate]")
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [SMSRegistrationMessageTemplate='My custom receiver wallet registration invite. MyOrg 👋']")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name='MyOrg']")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [SMSRegistrationMessageTemplate='']")
 	})
 
 	t.Run("🎉 successfully updates organization's OTP Message Template", func(t *testing.T) {
@@ -699,8 +700,9 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Equal(t, defaultMessage, org.OTPMessageTemplate)
 
 		// validate logs
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [OTPMessageTemplate]")
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [OTPMessageTemplate='']")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [OTPMessageTemplate='Here's your OTP Code to complete your registration. MyOrg 👋']")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name='MyOrg']")
 	})
 
 	t.Run("🎉 successfully updates organization's SMS Resend Interval", func(t *testing.T) {
@@ -784,8 +786,9 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Nil(t, org.SMSResendInterval)
 
 		// validate logs
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [SMSResendInterval]")
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
+		require.Contains(t, buf.String(), `[PatchOrganizationProfile] - userID user-id will update the organization fields [SMSResendInterval='2']`)
+		require.Contains(t, buf.String(), `[PatchOrganizationProfile] - userID user-id will update the organization fields [Name='MyOrg']`)
+		require.Contains(t, buf.String(), `[PatchOrganizationProfile] - userID user-id will update the organization fields [SMSResendInterval='0']`)
 	})
 
 	t.Run("🎉 successfully updates organization's Payment Cancellation Period", func(t *testing.T) {
@@ -870,8 +873,9 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Nil(t, org.PaymentCancellationPeriodDays)
 
 		// validate logs
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [PaymentCancellationPeriodDays]")
-		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [PaymentCancellationPeriodDays='2']")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name='MyOrg']")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [PaymentCancellationPeriodDays='0']")
 	})
 }
 

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -666,10 +666,8 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			assert.JSONEq(t, tc.wantRespBody, string(respBody))
 
 			// Validate logs
-			if len(tc.wantLogEntries) > 0 {
-				for _, entry := range tc.wantLogEntries {
-					assert.Contains(t, buf.String(), entry)
-				}
+			for _, logEntry := range tc.wantLogEntries {
+				assert.Contains(t, buf.String(), logEntry)
 			}
 		})
 	}
@@ -849,10 +847,8 @@ func Test_ProfileHandler_PatchUserPassword(t *testing.T) {
 			assert.JSONEq(t, tc.wantRespBody, string(respBody))
 
 			// Validate logs
-			if len(tc.wantLogEntries) > 0 {
-				for _, entry := range tc.wantLogEntries {
-					assert.Contains(t, buf.String(), entry)
-				}
+			for _, logEntry := range tc.wantLogEntries {
+				assert.Contains(t, buf.String(), logEntry)
 			}
 		})
 	}

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -527,29 +527,6 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			}`,
 		},
 		{
-			name:    "returns BadRequest when the request has an invalid password",
-			token:   "token",
-			reqBody: `{"password": "invalid"}`,
-			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
-				authManagerMock.
-					On("GetUser", mock.Anything, "token").
-					Return(user, nil).
-					Once()
-			},
-			wantStatusCode: http.StatusBadRequest,
-			wantRespBody: `{
-				"error": "The request was invalid in some way.",
-				"extras": {
-					"password": {
-						"digit": "password must contain at least one numberical digit",
-						"length":"password length must be between 12 and 36 characters",
-						"special character":"password must contain at least one special character",
-						"uppercase":"password must contain at least one uppercase letter"
-					}
-				}
-			}`,
-		},
-		{
 			name:    "returns BadRequest if none of the fields are provided",
 			token:   "token",
 			reqBody: `{}`,
@@ -563,7 +540,7 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			wantRespBody: `{
 				"error": "The request was invalid in some way.",
 				"extras": {
-					"details":"provide at least first_name, last_name, email or password."
+					"details":"provide at least first_name, last_name or email."
 				}
 			}`,
 		},
@@ -573,15 +550,14 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			reqBody: `{
 				"first_name": "First",
 				"last_name": "Last",
-				"email": "email@email.com",
-				"password": "!1Az?2By.3Cx"
+				"email": "email@email.com"
 			}`,
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
 					On("GetUser", mock.Anything, "token").
 					Return(user, nil).
 					Once().
-					On("UpdateUser", mock.Anything, "token", "First", "Last", "email@email.com", "!1Az?2By.3Cx").
+					On("UpdateUser", mock.Anything, "token", "First", "Last", "email@email.com", "").
 					Return(errors.New("unexpected error")).
 					Once()
 			},
@@ -594,15 +570,14 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			reqBody: `{
 				"first_name": "First",
 				"last_name": "Last",
-				"email": "email@email.com",
-				"password": "!1Az?2By.3Cx"
+				"email": "email@email.com"
 			}`,
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
 					On("GetUser", mock.Anything, "token").
 					Return(user, nil).
 					Once().
-					On("UpdateUser", mock.Anything, "token", "First", "Last", "email@email.com", "!1Az?2By.3Cx").
+					On("UpdateUser", mock.Anything, "token", "First", "Last", "email@email.com", "").
 					Return(nil).
 					Once()
 			},
@@ -610,7 +585,6 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			wantRespBody:   `{"message": "user profile updated successfully"}`,
 			wantLogEntries: []string{
 				"[PatchUserProfile] - Will update email for userID user-id to ema...com",
-				"[PatchUserProfile] - Will update password for userID user-id",
 			},
 		},
 	}

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -241,7 +241,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Equal(t, "error parsing multipart form: http: request body too large", entries[0].Message)
 	})
 
-	t.Run("updates the organization's name successfully", func(t *testing.T) {
+	t.Run("🎉 successfully updates the organization's name", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)
@@ -289,7 +289,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
 	})
 
-	t.Run("updates the organization's timezone UTC offset successfully", func(t *testing.T) {
+	t.Run("🎉 successfully updates the organization's timezone UTC offset", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)
@@ -339,7 +339,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [TimezoneUTCOffset]")
 	})
 
-	t.Run("updates the organization's IsApprovalRequired successfully", func(t *testing.T) {
+	t.Run("🎉 successfully updates the organization's IsApprovalRequired", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)
@@ -385,7 +385,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [IsApprovalRequired]")
 	})
 
-	t.Run("updates the organization's logo successfully", func(t *testing.T) {
+	t.Run("🎉 successfully updates the organization's logo", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)
@@ -475,7 +475,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Logo]")
 	})
 
-	t.Run("updates organization name, timezone UTC offset and logo successfully", func(t *testing.T) {
+	t.Run("🎉 successfully updates organization name, timezone UTC offset and logo", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)
@@ -534,7 +534,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Logo Name TimezoneUTCOffset]")
 	})
 
-	t.Run("updates organization's SMS Registration Message Template", func(t *testing.T) {
+	t.Run("🎉 successfully updates organization's SMS Registration Message Template", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)
@@ -618,7 +618,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
 	})
 
-	t.Run("updates organization's OTP Message Template", func(t *testing.T) {
+	t.Run("🎉 successfully updates organization's OTP Message Template", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)
@@ -703,7 +703,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
 	})
 
-	t.Run("updates organization's SMS Resend Interval", func(t *testing.T) {
+	t.Run("🎉 successfully updates organization's SMS Resend Interval", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)
@@ -788,7 +788,7 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
 	})
 
-	t.Run("updates organization's Payment Cancellation Period", func(t *testing.T) {
+	t.Run("🎉 successfully updates organization's Payment Cancellation Period", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -242,6 +242,10 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 	})
 
 	t.Run("updates the organization's name successfully", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		resetOrganizationInfo(t, ctx, dbConnectionPool)
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
@@ -280,9 +284,16 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "My Org Name", org.Name)
 		assert.Nil(t, org.Logo)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
 	})
 
 	t.Run("updates the organization's timezone UTC offset successfully", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		resetOrganizationInfo(t, ctx, dbConnectionPool)
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
@@ -323,9 +334,16 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Equal(t, "-03:00", org.TimezoneUTCOffset)
 		assert.Equal(t, "MyCustomAid", org.Name)
 		assert.Nil(t, org.Logo)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [TimezoneUTCOffset]")
 	})
 
 	t.Run("updates the organization's IsApprovalRequired successfully", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		resetOrganizationInfo(t, ctx, dbConnectionPool)
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
@@ -362,9 +380,16 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
 		require.True(t, org.IsApprovalRequired)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [IsApprovalRequired]")
 	})
 
 	t.Run("updates the organization's logo successfully", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		resetOrganizationInfo(t, ctx, dbConnectionPool)
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
@@ -445,9 +470,16 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, imgBuf.Bytes(), org.Logo)
 		assert.Equal(t, "MyCustomAid", org.Name)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Logo]")
 	})
 
 	t.Run("updates organization name, timezone UTC offset and logo successfully", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		resetOrganizationInfo(t, ctx, dbConnectionPool)
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
@@ -497,9 +529,16 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		assert.Equal(t, "My Org Name", org.Name)
 		assert.Equal(t, "-03:00", org.TimezoneUTCOffset)
 		assert.Equal(t, imgBuf.Bytes(), org.Logo)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Logo Name TimezoneUTCOffset]")
 	})
 
 	t.Run("updates organization's SMS Registration Message Template", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		resetOrganizationInfo(t, ctx, dbConnectionPool)
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
@@ -573,9 +612,17 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, defaultMessage, org.SMSRegistrationMessageTemplate)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [SMSRegistrationMessageTemplate]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
 	})
 
 	t.Run("updates organization's OTP Message Template", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		resetOrganizationInfo(t, ctx, dbConnectionPool)
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
@@ -650,9 +697,17 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, defaultMessage, org.OTPMessageTemplate)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [OTPMessageTemplate]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
 	})
 
 	t.Run("updates organization's SMS Resend Interval", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		resetOrganizationInfo(t, ctx, dbConnectionPool)
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
@@ -727,9 +782,17 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
 		assert.Nil(t, org.SMSResendInterval)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [SMSResendInterval]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
 	})
 
 	t.Run("updates organization's Payment Cancellation Period", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		resetOrganizationInfo(t, ctx, dbConnectionPool)
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
@@ -805,6 +868,10 @@ func Test_ProfileHandler_PatchOrganizationProfile(t *testing.T) {
 		org, err = models.Organizations.Get(ctx)
 		require.NoError(t, err)
 		assert.Nil(t, org.PaymentCancellationPeriodDays)
+
+		// validate logs
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [PaymentCancellationPeriodDays]")
+		require.Contains(t, buf.String(), "[PatchOrganizationProfile] - userID user-id will update the organization fields [Name]")
 	})
 }
 
@@ -946,6 +1013,10 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 	})
 
 	t.Run("updates the user profile successfully", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
 		token := "token"
 		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
 
@@ -979,6 +1050,11 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.JSONEq(t, `{"message": "user profile updated successfully"}`, string(respBody))
+
+		// validate logs
+		t.Log(buf.String())
+		require.Contains(t, buf.String(), "[PatchUserProfile] - Will update email for userID user-id to ema...com")
+		require.Contains(t, buf.String(), "[PatchUserProfile] - Will update password for userID user-id")
 	})
 }
 


### PR DESCRIPTION
### What

Start logging important changes on user or organization profiles, for traceability. Here are the functions that are now being logged:

- Changes made through `PatchOrganizationProfile`
  - Log message: `log.Ctx(ctx).Warnf("[PatchOrganizationProfile] - userID %s will update the organization fields %v", user.ID, nonEmptyKeys)`
- Changes made through `PatchUserProfile`
  - Log message: `log.Ctx(ctx).Warnf("[PatchUserProfile] - Will update email for userID %s to %s", user.ID, utils.TruncateString(reqBody.Email, 3))`
- Changes made through `PatchUserPassword`
  - Log message: `log.Ctx(ctx).Warnf("[UpdateUserPassword] - Will update password for user account ID %s", user.ID)`

Also, refactored some tests.

### Why

So we can better track changes made in user profiles or Organization profiles, for accountability.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
