### PR TITLE
[Fix] make password length generation + encryption be consistent with validation reqs

### DIFF
--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -105,12 +105,12 @@ func (a *defaultAuthenticator) CreateUser(ctx context.Context, user *User, passw
 	// In case no password is passed we generate a random OTP (One Time Password)
 	if password == "" {
 		// Random length pasword
-		randomNumber, err := rand.Int(rand.Reader, big.NewInt(maxPasswordLength-minPasswordLength+1))
+		randomNumber, err := rand.Int(rand.Reader, big.NewInt(MaxPasswordLength-MinPasswordLength+1))
 		if err != nil {
 			return nil, fmt.Errorf("error generating random number in create user: %w", err)
 		}
 
-		passwordLength := int(randomNumber.Int64() + minPasswordLength)
+		passwordLength := int(randomNumber.Int64() + MinPasswordLength)
 		password, err = utils.StringWithCharset(passwordLength, utils.PasswordCharset)
 		if err != nil {
 			return nil, fmt.Errorf("error generating random password string in create user: %w", err)

--- a/stellar-auth/pkg/auth/authenticator_test.go
+++ b/stellar-auth/pkg/auth/authenticator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -201,7 +202,7 @@ func Test_DefaultAuthenticator_CreateUser(t *testing.T) {
 		u, err := authenticator.CreateUser(ctx, user, password)
 
 		assert.Nil(t, u)
-		assert.EqualError(t, err, "error encrypting password: password should have at least 8 characters")
+		assert.EqualError(t, err, fmt.Sprintf("error encrypting password: password should have at least %d characters", minPasswordLength))
 
 		passwordEncrypterMock.
 			On("Encrypt", ctx, password).
@@ -696,7 +697,7 @@ func Test_DefaultAuthenticator_UpdateUser(t *testing.T) {
 			Once()
 
 		err := authenticator.UpdateUser(ctx, "user-id", "", "", "", "short")
-		assert.EqualError(t, err, "password should have at least 8 characters")
+		assert.EqualError(t, err, fmt.Sprintf("password should have at least %d characters", minPasswordLength))
 	})
 
 	t.Run("returns error when PasswordEncrypter fails", func(t *testing.T) {

--- a/stellar-auth/pkg/auth/authenticator_test.go
+++ b/stellar-auth/pkg/auth/authenticator_test.go
@@ -202,7 +202,7 @@ func Test_DefaultAuthenticator_CreateUser(t *testing.T) {
 		u, err := authenticator.CreateUser(ctx, user, password)
 
 		assert.Nil(t, u)
-		assert.EqualError(t, err, fmt.Sprintf("error encrypting password: password should have at least %d characters", minPasswordLength))
+		assert.EqualError(t, err, fmt.Sprintf("error encrypting password: password should have at least %d characters", MinPasswordLength))
 
 		passwordEncrypterMock.
 			On("Encrypt", ctx, password).
@@ -697,7 +697,7 @@ func Test_DefaultAuthenticator_UpdateUser(t *testing.T) {
 			Once()
 
 		err := authenticator.UpdateUser(ctx, "user-id", "", "", "", "short")
-		assert.EqualError(t, err, fmt.Sprintf("password should have at least %d characters", minPasswordLength))
+		assert.EqualError(t, err, fmt.Sprintf("password should have at least %d characters", MinPasswordLength))
 	})
 
 	t.Run("returns error when PasswordEncrypter fails", func(t *testing.T) {

--- a/stellar-auth/pkg/auth/password_encrypter.go
+++ b/stellar-auth/pkg/auth/password_encrypter.go
@@ -13,7 +13,8 @@ const (
 	maxPasswordLength = 36
 )
 
-var ErrPasswordTooShort = errors.New("password should have at least 8 characters")
+var ErrPasswordTooShort = fmt.Errorf("password should have at least %d characters", minPasswordLength)
+var ErrPasswordTooLong = fmt.Errorf("password should have at most %d characters", maxPasswordLength)
 
 // PasswordEncrypter is a interface that defines the methods to encrypt passwords and compare a password with its stored hash.
 // This interface is used by `DefaultAuthenticator` as the type of `passwordEncrypter` attribute.
@@ -30,9 +31,12 @@ type PasswordEncrypter interface {
 type DefaultPasswordEncrypter struct{}
 
 func (e *DefaultPasswordEncrypter) Encrypt(ctx context.Context, password string) (string, error) {
-	// Assumes that a password can't have less than 8 characters.
 	if len(password) < minPasswordLength {
 		return "", ErrPasswordTooShort
+	}
+
+	if len(password) > maxPasswordLength {
+		return "", ErrPasswordTooLong
 	}
 
 	encryptedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)

--- a/stellar-auth/pkg/auth/password_encrypter.go
+++ b/stellar-auth/pkg/auth/password_encrypter.go
@@ -13,8 +13,10 @@ const (
 	maxPasswordLength = 36
 )
 
-var ErrPasswordTooShort = fmt.Errorf("password should have at least %d characters", minPasswordLength)
-var ErrPasswordTooLong = fmt.Errorf("password should have at most %d characters", maxPasswordLength)
+var (
+	ErrPasswordTooShort = fmt.Errorf("password should have at least %d characters", minPasswordLength)
+	ErrPasswordTooLong  = fmt.Errorf("password should have at most %d characters", maxPasswordLength)
+)
 
 // PasswordEncrypter is a interface that defines the methods to encrypt passwords and compare a password with its stored hash.
 // This interface is used by `DefaultAuthenticator` as the type of `passwordEncrypter` attribute.

--- a/stellar-auth/pkg/auth/password_encrypter.go
+++ b/stellar-auth/pkg/auth/password_encrypter.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	minPasswordLength = 8
-	maxPasswordLength = 16
+	minPasswordLength = 12
+	maxPasswordLength = 36
 )
 
 var ErrPasswordTooShort = errors.New("password should have at least 8 characters")

--- a/stellar-auth/pkg/auth/password_encrypter.go
+++ b/stellar-auth/pkg/auth/password_encrypter.go
@@ -9,13 +9,13 @@ import (
 )
 
 const (
-	minPasswordLength = 12
-	maxPasswordLength = 36
+	MinPasswordLength = 12
+	MaxPasswordLength = 36
 )
 
 var (
-	ErrPasswordTooShort = fmt.Errorf("password should have at least %d characters", minPasswordLength)
-	ErrPasswordTooLong  = fmt.Errorf("password should have at most %d characters", maxPasswordLength)
+	ErrPasswordTooShort = fmt.Errorf("password should have at least %d characters", MinPasswordLength)
+	ErrPasswordTooLong  = fmt.Errorf("password should have at most %d characters", MaxPasswordLength)
 )
 
 // PasswordEncrypter is a interface that defines the methods to encrypt passwords and compare a password with its stored hash.
@@ -33,11 +33,11 @@ type PasswordEncrypter interface {
 type DefaultPasswordEncrypter struct{}
 
 func (e *DefaultPasswordEncrypter) Encrypt(ctx context.Context, password string) (string, error) {
-	if len(password) < minPasswordLength {
+	if len(password) < MinPasswordLength {
 		return "", ErrPasswordTooShort
 	}
 
-	if len(password) > maxPasswordLength {
+	if len(password) > MaxPasswordLength {
 		return "", ErrPasswordTooLong
 	}
 

--- a/stellar-auth/pkg/auth/password_encrypter_test.go
+++ b/stellar-auth/pkg/auth/password_encrypter_test.go
@@ -29,6 +29,15 @@ func Test_DefaultPasswordEncrypter_Encrypt(t *testing.T) {
 		assert.Empty(t, encryptedPassword)
 	})
 
+	t.Run("returns err when password is too long", func(t *testing.T) {
+		password := "G635a3LBOtS!vh6hyuvZFlgG@wLuE6IRd3k#rk"
+
+		encryptedPassword, err := passwordEncrypter.Encrypt(ctx, password)
+
+		assert.EqualError(t, err, ErrPasswordTooLong.Error())
+		assert.Empty(t, encryptedPassword)
+	})
+
 	t.Run("encrypts the password correctly", func(t *testing.T) {
 		password := "mysecret1234"
 
@@ -68,7 +77,7 @@ func Test_DefaultPasswordEncrypter_ComparePassword(t *testing.T) {
 	})
 
 	t.Run("returns true when the password is correct", func(t *testing.T) {
-		password := "mysecret1234"
+		password := "mysecret1234BxYqMmd7Nhwvw"
 
 		encryptedPassword, err := passwordEncrypter.Encrypt(ctx, password)
 		require.NoError(t, err)

--- a/stellar-auth/pkg/auth/password_encrypter_test.go
+++ b/stellar-auth/pkg/auth/password_encrypter_test.go
@@ -30,7 +30,7 @@ func Test_DefaultPasswordEncrypter_Encrypt(t *testing.T) {
 	})
 
 	t.Run("encrypts the password correctly", func(t *testing.T) {
-		password := "mysecret"
+		password := "mysecret1234"
 
 		encryptedPassword, err := passwordEncrypter.Encrypt(ctx, password)
 		require.NoError(t, err)
@@ -56,7 +56,7 @@ func Test_DefaultPasswordEncrypter_ComparePassword(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("returns false when the password is wrong", func(t *testing.T) {
-		password := "mysecret"
+		password := "mysecret1234"
 
 		encryptedPassword, err := passwordEncrypter.Encrypt(ctx, password)
 		require.NoError(t, err)
@@ -68,7 +68,7 @@ func Test_DefaultPasswordEncrypter_ComparePassword(t *testing.T) {
 	})
 
 	t.Run("returns true when the password is correct", func(t *testing.T) {
-		password := "mysecret"
+		password := "mysecret1234"
 
 		encryptedPassword, err := passwordEncrypter.Encrypt(ctx, password)
 		require.NoError(t, err)

--- a/stellar-auth/pkg/cli/add_user.go
+++ b/stellar-auth/pkg/cli/add_user.go
@@ -40,7 +40,7 @@ func AddUserCmd(databaseURLFlagName string, passwordPrompt PasswordPromptInterfa
 		},
 		{
 			Name:        "password",
-			Usage:       "Sets the user password, it should be at least 12 characters long, if omitted, the command will generate a random one.",
+			Usage:       fmt.Sprintf("Sets the user password, it should be at least %d characters long, if omitted, the command will generate a random one.", auth.MinPasswordLength),
 			OptType:     types.Bool,
 			ConfigKey:   &passwordFlag,
 			FlagDefault: false,
@@ -64,7 +64,7 @@ func AddUserCmd(databaseURLFlagName string, passwordPrompt PasswordPromptInterfa
 	addUser := &cobra.Command{
 		Use:   "add-user <email> <first name> <last name> [--owner] [--roles] [--password]",
 		Short: "Add user to the system",
-		Long:  "Add a user to the system. Email should be unique and password must be at least 12 characters long.",
+		Long:  fmt.Sprintf("Add a user to the system. Email should be unique and password must be at least %d characters long.", auth.MinPasswordLength),
 		Args:  cobra.ExactArgs(3),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()

--- a/stellar-auth/pkg/cli/add_user.go
+++ b/stellar-auth/pkg/cli/add_user.go
@@ -40,7 +40,7 @@ func AddUserCmd(databaseURLFlagName string, passwordPrompt PasswordPromptInterfa
 		},
 		{
 			Name:        "password",
-			Usage:       "Sets the user password, it should be at least 8 characters long, if omitted, the command will generate a random one.",
+			Usage:       "Sets the user password, it should be at least 12 characters long, if omitted, the command will generate a random one.",
 			OptType:     types.Bool,
 			ConfigKey:   &passwordFlag,
 			FlagDefault: false,
@@ -64,7 +64,7 @@ func AddUserCmd(databaseURLFlagName string, passwordPrompt PasswordPromptInterfa
 	addUser := &cobra.Command{
 		Use:   "add-user <email> <first name> <last name> [--owner] [--roles] [--password]",
 		Short: "Add user to the system",
-		Long:  "Add a user to the system. Email should be unique and password must be at least 8 characters long.",
+		Long:  "Add a user to the system. Email should be unique and password must be at least 12 characters long.",
 		Args:  cobra.ExactArgs(3),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()

--- a/stellar-auth/pkg/cli/add_user_test.go
+++ b/stellar-auth/pkg/cli/add_user_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-
 	"strings"
 	"testing"
 

--- a/stellar-auth/pkg/cli/add_user_test.go
+++ b/stellar-auth/pkg/cli/add_user_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -122,7 +123,7 @@ func Test_authAddUserCommand(t *testing.T) {
 		err := testCmd.Execute()
 		require.NoError(t, err)
 
-		expectedUsage := `Add a user to the system. Email should be unique and password must be at least 12 characters long.
+		expectedUsage := fmt.Sprintf(`Add a user to the system. Email should be unique and password must be at least %d characters long.
 
 Usage:
   test add-user <email> <first name> <last name> [--owner] [--roles] [--password] [flags]
@@ -130,8 +131,8 @@ Usage:
 Flags:
   -h, --help       help for add-user
       --owner      Set the user as Owner (superuser). Defaults to "false". (OWNER)
-      --password   Sets the user password, it should be at least 12 characters long, if omitted, the command will generate a random one. (PASSWORD)
-`
+      --password   Sets the user password, it should be at least %d characters long, if omitted, the command will generate a random one. (PASSWORD)
+`, auth.MinPasswordLength, auth.MinPasswordLength)
 		assert.Equal(t, expectedUsage, buf.String())
 
 		addUserCmd = AddUserCmd("database-url", &mockPrompt, []string{"role1", "role2", "role3", "role4"})
@@ -145,7 +146,7 @@ Flags:
 		err = testCmd.Execute()
 		require.NoError(t, err)
 
-		expectedUsage = `Add a user to the system. Email should be unique and password must be at least 12 characters long.
+		expectedUsage = fmt.Sprintf(`Add a user to the system. Email should be unique and password must be at least %d characters long.
 
 Usage:
   test add-user <email> <first name> <last name> [--owner] [--roles] [--password] [flags]
@@ -153,9 +154,9 @@ Usage:
 Flags:
   -h, --help           help for add-user
       --owner          Set the user as Owner (superuser). Defaults to "false". (OWNER)
-      --password       Sets the user password, it should be at least 12 characters long, if omitted, the command will generate a random one. (PASSWORD)
+      --password       Sets the user password, it should be at least %d characters long, if omitted, the command will generate a random one. (PASSWORD)
       --roles string   Set the user roles. It should be comma separated. Example: role1, role2. Available roles: [role1, role2, role3, role4]. (ROLES)
-`
+`, auth.MinPasswordLength, auth.MinPasswordLength)
 		assert.Equal(t, expectedUsage, buf.String())
 	})
 
@@ -206,7 +207,7 @@ func Test_execAddUserFunc(t *testing.T) {
 
 		// Invalid password
 		err = execAddUser(ctx, dbt.DSN, email, firstName, lastName, "pass", false, []string{})
-		assert.EqualError(t, err, "error creating user: error creating user: error encrypting password: password should have at least 12 characters")
+		assert.EqualError(t, err, fmt.Sprintf("error creating user: error creating user: error encrypting password: password should have at least %d characters", auth.MinPasswordLength))
 
 		// Invalid first name
 		err = execAddUser(ctx, dbt.DSN, email, "", lastName, "pass", false, []string{})

--- a/stellar-auth/pkg/cli/add_user_test.go
+++ b/stellar-auth/pkg/cli/add_user_test.go
@@ -195,7 +195,7 @@ func Test_execAddUserFunc(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("User must be valid", func(t *testing.T) {
-		email, password, firstName, lastName := "test@email.com", "mypassword", "First", "Last"
+		email, password, firstName, lastName := "test@email.com", "mypassword12", "First", "Last"
 
 		// Invalid invalid
 		err := execAddUser(ctx, dbt.DSN, "", firstName, lastName, password, false, []string{})
@@ -222,7 +222,7 @@ func Test_execAddUserFunc(t *testing.T) {
 	})
 
 	t.Run("Inserted user must have his password encrypted", func(t *testing.T) {
-		email, password, firstName, lastName := "test2@email.com", "mypassword", "First", "Last"
+		email, password, firstName, lastName := "test2@email.com", "mypassword12", "First", "Last"
 
 		err := execAddUser(ctx, dbt.DSN, email, firstName, lastName, password, false, []string{})
 		require.NoError(t, err)
@@ -240,7 +240,7 @@ func Test_execAddUserFunc(t *testing.T) {
 	})
 
 	t.Run("Email should be unique", func(t *testing.T) {
-		email, password, firstName, lastName := "unique@email.com", "mypassword", "First", "Last"
+		email, password, firstName, lastName := "unique@email.com", "mypassword12", "First", "Last"
 
 		err := execAddUser(ctx, dbt.DSN, email, firstName, lastName, password, false, []string{})
 		require.NoError(t, err)
@@ -250,7 +250,7 @@ func Test_execAddUserFunc(t *testing.T) {
 	})
 
 	t.Run("set the user roles", func(t *testing.T) {
-		email, password, firstName, lastName := "testroles@email.com", "mypassword", "First", "Last"
+		email, password, firstName, lastName := "testroles@email.com", "mypassword12", "First", "Last"
 
 		err := execAddUser(ctx, dbt.DSN, email, firstName, lastName, password, false, []string{"role1", "role2"})
 		require.NoError(t, err)

--- a/stellar-auth/pkg/cli/add_user_test.go
+++ b/stellar-auth/pkg/cli/add_user_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+
 	"strings"
 	"testing"
 
@@ -122,7 +123,7 @@ func Test_authAddUserCommand(t *testing.T) {
 		err := testCmd.Execute()
 		require.NoError(t, err)
 
-		expectedUsage := `Add a user to the system. Email should be unique and password must be at least 8 characters long.
+		expectedUsage := `Add a user to the system. Email should be unique and password must be at least 12 characters long.
 
 Usage:
   test add-user <email> <first name> <last name> [--owner] [--roles] [--password] [flags]
@@ -130,7 +131,7 @@ Usage:
 Flags:
   -h, --help       help for add-user
       --owner      Set the user as Owner (superuser). Defaults to "false". (OWNER)
-      --password   Sets the user password, it should be at least 8 characters long, if omitted, the command will generate a random one. (PASSWORD)
+      --password   Sets the user password, it should be at least 12 characters long, if omitted, the command will generate a random one. (PASSWORD)
 `
 		assert.Equal(t, expectedUsage, buf.String())
 
@@ -145,7 +146,7 @@ Flags:
 		err = testCmd.Execute()
 		require.NoError(t, err)
 
-		expectedUsage = `Add a user to the system. Email should be unique and password must be at least 8 characters long.
+		expectedUsage = `Add a user to the system. Email should be unique and password must be at least 12 characters long.
 
 Usage:
   test add-user <email> <first name> <last name> [--owner] [--roles] [--password] [flags]
@@ -153,7 +154,7 @@ Usage:
 Flags:
   -h, --help           help for add-user
       --owner          Set the user as Owner (superuser). Defaults to "false". (OWNER)
-      --password       Sets the user password, it should be at least 8 characters long, if omitted, the command will generate a random one. (PASSWORD)
+      --password       Sets the user password, it should be at least 12 characters long, if omitted, the command will generate a random one. (PASSWORD)
       --roles string   Set the user roles. It should be comma separated. Example: role1, role2. Available roles: [role1, role2, role3, role4]. (ROLES)
 `
 		assert.Equal(t, expectedUsage, buf.String())
@@ -206,7 +207,7 @@ func Test_execAddUserFunc(t *testing.T) {
 
 		// Invalid password
 		err = execAddUser(ctx, dbt.DSN, email, firstName, lastName, "pass", false, []string{})
-		assert.EqualError(t, err, "error creating user: error creating user: error encrypting password: password should have at least 8 characters")
+		assert.EqualError(t, err, "error creating user: error creating user: error encrypting password: password should have at least 12 characters")
 
 		// Invalid first name
 		err = execAddUser(ctx, dbt.DSN, email, "", lastName, "pass", false, []string{})


### PR DESCRIPTION
### What
Follow up to #143. Mainly just adjusting any reference to the min password length from 8 to 12.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
