### PR TITLE
SDP-927 - [SEP24] add configuration for multi-tenant registration flow

### DIFF
--- a/.github/workflows/anchor_platform_integration_check.yml
+++ b/.github/workflows/anchor_platform_integration_check.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Anchor Validation Tests (@stellar/anchor-tests)
         run: |
           npm install -g @stellar/anchor-tests
-          stellar-anchor-tests --home-domain http://localhost:8080 --seps 1 10
+          stellar-anchor-tests --home-domain http://localhost:8000 --seps 1 10
 
       - name: Docker logs
         if: always()

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -92,7 +92,7 @@ services:
 
   anchor-platform:
     container_name: anchor-platform
-    image: stellar/anchor-platform:2.4.0
+    image: stellar/anchor-platform:2.5.2
     command: --sep-server --platform-server --platform linux/amd64
     ports:
       - "8080:8080" # sep-server
@@ -115,7 +115,9 @@ services:
       METRICS_ENABLED: "false"  # Metrics would be available at port 8082
       METRICS_EXTRAS_ENABLED: "false"
       SEP10_ENABLED: "true"
-      SEP10_HOME_DOMAIN: localhost:8080
+      SEP10_HOME_DOMAINS: "localhost:8000" # Comma separated list of home domains
+      SEP10_HOME_DOMAIN: ""
+      SEP10_WEB_AUTH_DOMAIN: "localhost:8080"
       # SEP10_CLIENT_ATTRIBUTION_REQUIRED: true  # RECOMMENDED
       # SEP10_CLIENT_ATTRIBUTION_ALLOW_LIST: "demo-wallet-server.stellar.org,https://example.com"  # RECOMMENDED
       SEP24_ENABLED: "true"
@@ -177,6 +179,7 @@ services:
     image: docker.io/bitnami/kafka:3.6
     ports:
       - "9094:9094"
+      - "9092:9092"
     volumes:
       - "kafka-data:/bitnami"
     environment:


### PR DESCRIPTION
### What 
This configuration was used to test wallet registration multi-tenancy. 
* `SEP10_HOME_DOMAINS: "redcorp.stellar.local:8000,bluecorp.stellar.local:8000"` defines the two tenants in the allowable home domains. 
* `SEP10_HOME_DOMAIN: ""` is needed as a workaround to bypass anchor's default values. 
* `SEP10_WEB_AUTH_DOMAIN: "localhost:8080"` defines the proper web auth domain. 

Tested that using the multi-tenant SDP as a home domain instead of the anchor works properly. The multi-tenant home domain is properly passed in the JWT token could be used to identify the tenant and register the wallet appropriately. 
<img width="1548" alt="image" src="https://github.com/stellar/stellar-disbursement-platform-backend/assets/4129193/a6b39702-30cf-4d80-afc1-6c5f009ed037">

### Notes
* The example tenants used in `SEP10_HOME_DOMAINS` are actually coming from the `dev/main.sh` startup script that creates two tenants `redcorp` and `bluecorp`. 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
