### PR TITLE
[SDP-1014] Preload reCAPTCHA script in attempt to mitigate component loading issues upon login

### DIFF
--- a/internal/htmltemplate/tmpl/receiver_register.tmpl
+++ b/internal/htmltemplate/tmpl/receiver_register.tmpl
@@ -18,6 +18,9 @@
 
     <!-- Phone number input styles -->
     <link rel="stylesheet" href="/static/css/intl-tel-input-v18.2.1.css" />
+
+    <!-- Scripts -->
+    <link rel="preload" href="https://www.google.com/recaptcha/api.js" as="script" />
   </head>
   <body>
     <div class="WalletRegistration">
@@ -215,8 +218,8 @@
       <span data-jwt-token style="display: none">{{.JWTToken}}</span>
     </div>
 
-    <!-- Scripts -->
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    <!-- Scripts 
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script> -->
     <!-- Phone number input script -->
     <script src="/static/js/intl-tel-input-v18.2.1.min.js" async defer></script>
     <script src="/static/js/receiver_registration.js" defer></script>

--- a/internal/htmltemplate/tmpl/receiver_register.tmpl
+++ b/internal/htmltemplate/tmpl/receiver_register.tmpl
@@ -20,6 +20,7 @@
     <link rel="stylesheet" href="/static/css/intl-tel-input-v18.2.1.css" />
 
     <!-- Scripts -->
+    <link rel="preconnect" href="https://www.google.com">
     <link rel="preload" href="https://www.google.com/recaptcha/api.js" as="script" />
   </head>
   <body>

--- a/internal/htmltemplate/tmpl/receiver_register.tmpl
+++ b/internal/htmltemplate/tmpl/receiver_register.tmpl
@@ -217,9 +217,6 @@
       <!-- 👋 Injecting info for the JS here: -->
       <span data-jwt-token style="display: none">{{.JWTToken}}</span>
     </div>
-
-    <!-- Scripts 
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script> -->
     <!-- Phone number input script -->
     <script src="/static/js/intl-tel-input-v18.2.1.min.js" async defer></script>
     <script src="/static/js/receiver_registration.js" defer></script>

--- a/internal/serve/httphandler/receiver_registration_test.go
+++ b/internal/serve/httphandler/receiver_registration_test.go
@@ -89,7 +89,7 @@ func Test_ReceiverRegistrationHandler_ServeHTTP(t *testing.T) {
 		assert.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
 		assert.Contains(t, string(respBody), "<title>Wallet Registration</title>")
 		assert.Contains(t, string(respBody), `<div class="g-recaptcha" data-sitekey="reCAPTCHASiteKey">`)
-		assert.Contains(t, string(respBody), `<script src="https://www.google.com/recaptcha/api.js" async defer></script>`)
+		assert.Contains(t, string(respBody), `<link rel="preload" href="https://www.google.com/recaptcha/api.js" as="script" />`)
 	})
 
 	ctx := context.Background()
@@ -158,6 +158,6 @@ func Test_ReceiverRegistrationHandler_ServeHTTP(t *testing.T) {
 		assert.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
 		assert.Contains(t, string(respBody), "<title>Wallet Registration</title>")
 		assert.Contains(t, string(respBody), `<div class="g-recaptcha" data-sitekey="reCAPTCHASiteKey">`)
-		assert.Contains(t, string(respBody), `<script src="https://www.google.com/recaptcha/api.js" async defer></script>`)
+		assert.Contains(t, string(respBody), `<link rel="preload" href="https://www.google.com/recaptcha/api.js" as="script" />`)
 	})
 }


### PR DESCRIPTION
### What
Modify the receiver registration template to preload the google recaptcha script in the header instead of doing so in the body.

### Why
@torisamples brought up this [issue](https://stellarfoundation.slack.com/archives/C04C9MLM9UZ/p1702420198999679) of the recaptcha taking too long to load or not loading at all at times. Preloading the script may help with the slowness.

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
