### PR TITLE
chore - expose admin port for the service

### DIFF
--- a/helmchart/sdp/templates/03.1-service-sdp.yaml
+++ b/helmchart/sdp/templates/03.1-service-sdp.yaml
@@ -12,6 +12,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ include "sdp.adminPort" . }}
+      targetPort: admin
+      protocol: TCP
+      name: admin
     
   selector:
     {{- include "sdp.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
### What

We need to expose the admin port 8003 in order to be able to access the admin from outside of the container. 

This doesn't create an Ingress to the admin API.
