### PR TITLE
[SDP-1049] Validate the Distribution account balance before starting a Disbursement

### DIFF
--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -636,16 +636,6 @@ func newPaymentQuery(baseQuery string, queryParams *QueryParams, paginated bool,
 			qb.AddCondition("p.status = ?", queryParams.Filters[FilterKeyStatus])
 		}
 	}
-	if queryParams.Filters[FilterKeyNotDisbursementID] != nil {
-		if statusSlice, ok := queryParams.Filters[FilterKeyNotDisbursementID].([]string); ok {
-			if len(statusSlice) > 0 {
-				qb.AddCondition("disbursement.id != ANY(?)", pq.Array(statusSlice))
-			}
-		} else {
-			qb.AddCondition("disbursement.id != ?", queryParams.Filters[FilterKeyStatus])
-		}
-	}
-
 	if queryParams.Filters[FilterKeyReceiverID] != nil {
 		qb.AddCondition("p.receiver_id = ?", queryParams.Filters[FilterKeyReceiverID])
 	}

--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -636,6 +636,15 @@ func newPaymentQuery(baseQuery string, queryParams *QueryParams, paginated bool,
 			qb.AddCondition("p.status = ?", queryParams.Filters[FilterKeyStatus])
 		}
 	}
+	if queryParams.Filters[FilterKeyNotDisbursementID] != nil {
+		if statusSlice, ok := queryParams.Filters[FilterKeyNotDisbursementID].([]string); ok {
+			if len(statusSlice) > 0 {
+				qb.AddCondition("disbursement.id != ANY(?)", pq.Array(statusSlice))
+			}
+		} else {
+			qb.AddCondition("disbursement.id != ?", queryParams.Filters[FilterKeyStatus])
+		}
+	}
 
 	if queryParams.Filters[FilterKeyReceiverID] != nil {
 		qb.AddCondition("p.receiver_id = ?", queryParams.Filters[FilterKeyReceiverID])

--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -628,8 +628,15 @@ func (p *PaymentModel) GetByIDs(ctx context.Context, sqlExec db.SQLExecuter, pay
 func newPaymentQuery(baseQuery string, queryParams *QueryParams, paginated bool, sqlExec db.SQLExecuter) (string, []interface{}) {
 	qb := NewQueryBuilder(baseQuery)
 	if queryParams.Filters[FilterKeyStatus] != nil {
-		qb.AddCondition("p.status = ?", queryParams.Filters[FilterKeyStatus])
+		if statusSlice, ok := queryParams.Filters[FilterKeyStatus].([]PaymentStatus); ok {
+			if len(statusSlice) > 0 {
+				qb.AddCondition("p.status = ANY(?)", pq.Array(statusSlice))
+			}
+		} else {
+			qb.AddCondition("p.status = ?", queryParams.Filters[FilterKeyStatus])
+		}
 	}
+
 	if queryParams.Filters[FilterKeyReceiverID] != nil {
 		qb.AddCondition("p.receiver_id = ?", queryParams.Filters[FilterKeyReceiverID])
 	}

--- a/internal/data/payments_state_machine.go
+++ b/internal/data/payments_state_machine.go
@@ -54,6 +54,12 @@ func PaymentStatuses() []PaymentStatus {
 	return []PaymentStatus{DraftPaymentStatus, ReadyPaymentStatus, PendingPaymentStatus, PausedPaymentStatus, SuccessPaymentStatus, FailedPaymentStatus, CanceledPaymentStatus}
 }
 
+// PaymentInProgressStatuses returns a list of payment statuses that are in progress and could block potential new payments
+// from being initiated if the distribution balance is low.
+func PaymentInProgressStatuses() []PaymentStatus {
+	return []PaymentStatus{ReadyPaymentStatus, PendingPaymentStatus, PausedPaymentStatus}
+}
+
 // SourceStatuses returns a list of states that the payment status can transition from given the target state
 func (status PaymentStatus) SourceStatuses() []PaymentStatus {
 	stateMachine := PaymentStateMachineWithInitialState(DraftPaymentStatus)

--- a/internal/data/payments_test.go
+++ b/internal/data/payments_test.go
@@ -343,7 +343,7 @@ func Test_PaymentModelGetAll(t *testing.T) {
 		assert.Equal(t, []Payment{*expectedPayment1, *expectedPayment2}, actualPayments)
 	})
 
-	t.Run("returns payments successfully with filter", func(t *testing.T) {
+	t.Run("returns payments successfully with one status filter", func(t *testing.T) {
 		filters := map[FilterKey]interface{}{
 			FilterKeyStatus: PendingPaymentStatus,
 		}
@@ -351,6 +351,19 @@ func Test_PaymentModelGetAll(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(actualPayments))
 		assert.Equal(t, []Payment{*expectedPayment2}, actualPayments)
+	})
+
+	t.Run("returns payments successfully with list of status filters", func(t *testing.T) {
+		filters := map[FilterKey]interface{}{
+			FilterKeyStatus: []PaymentStatus{
+				DraftPaymentStatus,
+				PendingPaymentStatus,
+			},
+		}
+		actualPayments, err := paymentModel.GetAll(ctx, &QueryParams{Filters: filters}, dbConnectionPool)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(actualPayments))
+		assert.Equal(t, []Payment{*expectedPayment1, *expectedPayment2}, actualPayments)
 	})
 
 	t.Run("should not return duplicated entries when receiver are in more than one disbursements with different wallets", func(t *testing.T) {

--- a/internal/data/query_params.go
+++ b/internal/data/query_params.go
@@ -29,8 +29,9 @@ const (
 type FilterKey string
 
 const (
-	FilterKeyStatus          FilterKey = "status"
-	FilterKeyReceiverID      FilterKey = "receiver_id"
-	FilterKeyCreatedAtAfter  FilterKey = "created_at_after"
-	FilterKeyCreatedAtBefore FilterKey = "created_at_before"
+	FilterKeyStatus            FilterKey = "status"
+	FilterKeyReceiverID        FilterKey = "receiver_id"
+	FilterKeyNotDisbursementID FilterKey = "not_disbursement_id"
+	FilterKeyCreatedAtAfter    FilterKey = "created_at_after"
+	FilterKeyCreatedAtBefore   FilterKey = "created_at_before"
 )

--- a/internal/data/query_params.go
+++ b/internal/data/query_params.go
@@ -29,9 +29,8 @@ const (
 type FilterKey string
 
 const (
-	FilterKeyStatus            FilterKey = "status"
-	FilterKeyReceiverID        FilterKey = "receiver_id"
-	FilterKeyNotDisbursementID FilterKey = "not_disbursement_id"
-	FilterKeyCreatedAtAfter    FilterKey = "created_at_after"
-	FilterKeyCreatedAtBefore   FilterKey = "created_at_before"
+	FilterKeyStatus          FilterKey = "status"
+	FilterKeyReceiverID      FilterKey = "receiver_id"
+	FilterKeyCreatedAtAfter  FilterKey = "created_at_after"
+	FilterKeyCreatedAtBefore FilterKey = "created_at_before"
 )

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -385,7 +385,7 @@ func (d DisbursementHandler) PatchDisbursementStatus(w http.ResponseWriter, r *h
 		case errors.Is(err, services.ErrDisbursementWalletDisabled):
 			httperror.BadRequest(services.ErrDisbursementWalletDisabled.Error(), err, nil).Render(w)
 		case errors.Is(err, services.ErrDisbursementWalletInsufficientBalance):
-			httperror.Conflict(services.ErrDisbursementNotFound.Error(), err, nil).Render(w)
+			httperror.Conflict(services.ErrDisbursementWalletInsufficientBalance.Error(), err, nil).Render(w)
 		default:
 			msg := fmt.Sprintf("Cannot update disbursement ID %s with status: %s", disbursementID, toStatus)
 			httperror.InternalError(ctx, msg, err, nil).Render(w)

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/gocarina/gocsv"
+	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
 
@@ -26,10 +27,12 @@ import (
 )
 
 type DisbursementHandler struct {
-	Models           *data.Models
-	MonitorService   monitor.MonitorServiceInterface
-	DBConnectionPool db.DBConnectionPool
-	AuthManager      auth.AuthManager
+	Models             *data.Models
+	MonitorService     monitor.MonitorServiceInterface
+	DBConnectionPool   db.DBConnectionPool
+	AuthManager        auth.AuthManager
+	HorizonClient      horizonclient.ClientInterface
+	DistributionPubKey string
 }
 
 type PostDisbursementRequest struct {
@@ -169,7 +172,7 @@ func (d DisbursementHandler) GetDisbursements(w http.ResponseWriter, r *http.Req
 	}
 
 	ctx := r.Context()
-	disbursementManagementService := services.NewDisbursementManagementService(d.Models, d.DBConnectionPool, d.AuthManager)
+	disbursementManagementService := services.NewDisbursementManagementService(d.Models, d.DBConnectionPool, d.AuthManager, d.HorizonClient)
 	resultWithTotal, err := disbursementManagementService.GetDisbursementsWithCount(ctx, queryParams)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot retrieve disbursements", err, nil).Render(w)
@@ -278,7 +281,7 @@ func (d DisbursementHandler) GetDisbursement(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	disbursementManagementService := services.NewDisbursementManagementService(d.Models, d.DBConnectionPool, d.AuthManager)
+	disbursementManagementService := services.NewDisbursementManagementService(d.Models, d.DBConnectionPool, d.AuthManager, d.HorizonClient)
 	response, err := disbursementManagementService.AppendUserMetadata(ctx, []*data.Disbursement{disbursement})
 	if err != nil {
 		httperror.NotFound("disbursement user metadata not found", err, nil).Render(w)
@@ -304,7 +307,7 @@ func (d DisbursementHandler) GetDisbursementReceivers(w http.ResponseWriter, r *
 		return
 	}
 
-	disbursementManagementService := services.NewDisbursementManagementService(d.Models, d.DBConnectionPool, d.AuthManager)
+	disbursementManagementService := services.NewDisbursementManagementService(d.Models, d.DBConnectionPool, d.AuthManager, d.HorizonClient)
 	resultWithTotal, err := disbursementManagementService.GetDisbursementReceiversWithCount(ctx, disbursementID, queryParams)
 	if err != nil {
 		if errors.Is(err, services.ErrDisbursementNotFound) {
@@ -351,14 +354,14 @@ func (d DisbursementHandler) PatchDisbursementStatus(w http.ResponseWriter, r *h
 		return
 	}
 
-	disbursementManagementService := services.NewDisbursementManagementService(d.Models, d.DBConnectionPool, d.AuthManager)
+	disbursementManagementService := services.NewDisbursementManagementService(d.Models, d.DBConnectionPool, d.AuthManager, d.HorizonClient)
 	response := UpdateDisbursementStatusResponseBody{}
 
 	ctx := r.Context()
 	disbursementID := chi.URLParam(r, "id")
 	switch toStatus {
 	case data.StartedDisbursementStatus:
-		err = disbursementManagementService.StartDisbursement(ctx, disbursementID)
+		err = disbursementManagementService.StartDisbursement(ctx, disbursementID, d.DistributionPubKey)
 		response.Message = "Disbursement started"
 	case data.PausedDisbursementStatus:
 		err = disbursementManagementService.PauseDisbursement(ctx, disbursementID)

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -384,6 +384,8 @@ func (d DisbursementHandler) PatchDisbursementStatus(w http.ResponseWriter, r *h
 			httperror.Forbidden("Disbursement can't be started by its creator. Approval by another user is required.", err, nil).Render(w)
 		case errors.Is(err, services.ErrDisbursementWalletDisabled):
 			httperror.BadRequest(services.ErrDisbursementWalletDisabled.Error(), err, nil).Render(w)
+		case errors.Is(err, services.ErrDisbursementWalletInsufficientBalance):
+			httperror.Conflict(services.ErrDisbursementNotFound.Error(), err, nil).Render(w)
 		default:
 			msg := fmt.Sprintf("Cannot update disbursement ID %s with status: %s", disbursementID, toStatus)
 			httperror.InternalError(ctx, msg, err, nil).Render(w)

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -1259,20 +1259,6 @@ func Test_DisbursementHandler_PatchDisbursementStatus(t *testing.T) {
 	distributionPubKey := "ABC"
 	asset := data.GetAssetFixture(t, ctx, dbConnectionPool, data.FixtureAssetUSDC)
 
-	hMock.On(
-		"AccountDetail", horizonclient.AccountRequest{AccountID: distributionPubKey},
-	).Return(horizon.Account{
-		Balances: []horizon.Balance{
-			{
-				Balance: "10000",
-				Asset: base.Asset{
-					Code:   asset.Code,
-					Issuer: asset.Issuer,
-				},
-			},
-		},
-	}, nil)
-
 	handler := &DisbursementHandler{
 		Models:             models,
 		DBConnectionPool:   models.DBConnectionPool,
@@ -1371,6 +1357,20 @@ func Test_DisbursementHandler_PatchDisbursementStatus(t *testing.T) {
 	})
 
 	t.Run("disbursement can be started by approver who is not a creator", func(t *testing.T) {
+		hMock.On(
+			"AccountDetail", horizonclient.AccountRequest{AccountID: distributionPubKey},
+		).Return(horizon.Account{
+			Balances: []horizon.Balance{
+				{
+					Balance: "10000",
+					Asset: base.Asset{
+						Code:   asset.Code,
+						Issuer: asset.Issuer,
+					},
+				},
+			},
+		}, nil).Once()
+
 		data.EnableDisbursementApproval(t, ctx, handler.Models.Organizations)
 		defer data.DisableDisbursementApproval(t, ctx, handler.Models.Organizations)
 
@@ -1414,6 +1414,20 @@ func Test_DisbursementHandler_PatchDisbursementStatus(t *testing.T) {
 	})
 
 	t.Run("disbursement started - then paused", func(t *testing.T) {
+		hMock.On(
+			"AccountDetail", horizonclient.AccountRequest{AccountID: distributionPubKey},
+		).Return(horizon.Account{
+			Balances: []horizon.Balance{
+				{
+					Balance: "10000",
+					Asset: base.Asset{
+						Code:   asset.Code,
+						Issuer: asset.Issuer,
+					},
+				},
+			},
+		}, nil).Once()
+
 		authManagerMock.
 			On("GetUser", mock.Anything, token).
 			Return(user, nil).
@@ -1513,6 +1527,7 @@ func Test_DisbursementHandler_PatchDisbursementStatus(t *testing.T) {
 	})
 
 	authManagerMock.AssertExpectations(t)
+	hMock.AssertExpectations(t)
 }
 
 func Test_DisbursementHandler_GetDisbursementInstructions(t *testing.T) {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -251,11 +251,12 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 		r.Route("/disbursements", func(r chi.Router) {
 			handler := httphandler.DisbursementHandler{
-				Models:           o.Models,
-				MonitorService:   o.MonitorService,
-				DBConnectionPool: o.dbConnectionPool,
-				AuthManager:      authManager,
-				HorizonClient:    o.horizonClient,
+				Models:             o.Models,
+				MonitorService:     o.MonitorService,
+				DBConnectionPool:   o.dbConnectionPool,
+				AuthManager:        authManager,
+				HorizonClient:      o.horizonClient,
+				DistributionPubKey: o.DistributionPublicKey,
 			}
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Post("/", handler.PostDisbursement)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -255,6 +255,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				MonitorService:   o.MonitorService,
 				DBConnectionPool: o.dbConnectionPool,
 				AuthManager:      authManager,
+				HorizonClient:    o.horizonClient,
 			}
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Post("/", handler.PostDisbursement)

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -39,10 +39,11 @@ type DisbursementWithUserMetadata struct {
 }
 
 var (
-	ErrDisbursementNotFound        = errors.New("disbursement not found")
-	ErrDisbursementNotReadyToStart = errors.New("disbursement is not ready to be started")
-	ErrDisbursementNotReadyToPause = errors.New("disbursement is not ready to be paused")
-	ErrDisbursementWalletDisabled  = errors.New("disbursement wallet is disabled")
+	ErrDisbursementNotFound                  = errors.New("disbursement not found")
+	ErrDisbursementNotReadyToStart           = errors.New("disbursement is not ready to be started")
+	ErrDisbursementNotReadyToPause           = errors.New("disbursement is not ready to be paused")
+	ErrDisbursementWalletDisabled            = errors.New("disbursement wallet is disabled")
+	ErrDisbursementWalletInsufficientBalance = errors.New("disbursement wallet has insufficient balance to fulfill disbursement and current pending payments")
 
 	ErrDisbursementStatusCantBeChanged = errors.New("disbursement status can't be changed to the requested status")
 	ErrDisbursementStartedByCreator    = errors.New("disbursement can't be started by its creator")
@@ -282,7 +283,7 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 				disbursementID,
 				totalPendingAmount,
 			)
-			return fmt.Errorf("cannot start disbursement with id %s: insufficient balance on distribution account", disbursementID)
+			return ErrDisbursementWalletInsufficientBalance
 		}
 
 		// 5. Update all correct payment status to `ready`

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -251,10 +251,9 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 		incompletePayments, err := s.models.Payment.GetAll(ctx, &data.QueryParams{
 			Filters: map[data.FilterKey]interface{}{
 				data.FilterKeyStatus: []data.PaymentStatus{
-					data.DraftPaymentStatus,
 					data.ReadyPaymentStatus,
+					data.PendingPaymentStatus,
 					data.PausedPaymentStatus,
-					data.FailedPaymentStatus,
 				},
 			},
 		}, dbTx)

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -507,10 +507,14 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		log.DefaultLogger.SetOutput(buf)
 
 		err = service.StartDisbursement(ctx, disbursement.ID, distributionPubKey)
-		require.EqualError(t, err, fmt.Sprintf(
-			"running atomic function in RunInTransactionWithResult: cannot start disbursement with id %s: insufficient balance on distribution account",
-			disbursement.ID,
-		))
+		require.EqualError(
+			t,
+			err,
+			fmt.Sprintf(
+				"running atomic function in RunInTransactionWithResult: %s",
+				ErrDisbursementWalletInsufficientBalance.Error(),
+			),
+		)
 
 		// PendingTotal includes payments associated with 'readyDisbursement' that were moved from the draft to ready status
 		assert.Contains(

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -485,6 +485,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			disbursement.ID,
 		))
 
+		// PendingTotal includes payments associated with 'readyDisbursement' that were moved from the draft to ready status
 		assert.Contains(
 			t,
 			buf.String(),

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -421,16 +421,16 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		require.NoError(t, err)
 
 		// check disbursement status
-		disbursement, err := models.Disbursements.Get(context.Background(), models.DBConnectionPool, readyDisbursement.ID)
-		require.NoError(t, err)
+		disbursement, getDisbursementErr := models.Disbursements.Get(context.Background(), models.DBConnectionPool, readyDisbursement.ID)
+		require.NoError(t, getDisbursementErr)
 		require.Equal(t, data.StartedDisbursementStatus, disbursement.Status)
 
 		// check disbursement history
 		require.Equal(t, disbursement.StatusHistory[1].UserID, user.ID)
 
 		// check receivers wallets status
-		receiverWallets, err := models.ReceiverWallet.GetByReceiverIDsAndWalletID(ctx, models.DBConnectionPool, receiverIds, wallet.ID)
-		require.NoError(t, err)
+		receiverWallets, getReceiversErr := models.ReceiverWallet.GetByReceiverIDsAndWalletID(ctx, models.DBConnectionPool, receiverIds, wallet.ID)
+		require.NoError(t, getReceiversErr)
 		require.Equal(t, 4, len(receiverWallets))
 		rwExpectedStatuses := map[string]data.ReceiversWalletStatus{
 			rwDraft1.ID:     data.ReadyReceiversWalletStatus,
@@ -444,8 +444,8 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 
 		// check payments status
 		for _, p := range payments {
-			payment, err := models.Payment.Get(ctx, p.ID, dbConnectionPool)
-			require.NoError(t, err)
+			payment, getPaymentErr := models.Payment.Get(ctx, p.ID, dbConnectionPool)
+			require.NoError(t, getPaymentErr)
 			require.Equal(t, data.ReadyPaymentStatus, payment.Status)
 		}
 	})


### PR DESCRIPTION
### What
Add a extra validation step before transitioning disbursement to the `READY` status to check whether distribution account holds enough of target asset balance to fulfill any pending payments along with the payments on the target disbursement.

Pending payments from other disbursements are any in the status
- `PAUSED`
- `READY`
- `PENDING`

and exclude those in any terminal statuses `SUCCESS`, `CANCELED` and `FAILED` as we as `PAUSED` as those payments can remain in that state indefinitely.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
