### PR TITLE
Chore: Update CI `check` to run the exhaustive validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: go install github.com/nishanths/exhaustive/cmd/exhaustive@latest
 
       - name: Run exhaustive
-        run: exhaustive ./...
+        run: exhaustive -default-signifies-exhaustive ./...
 
   check-helm-readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Run ./gomod.sh
         run: ./gomod.sh
 
+      - name: Install github.com/nishanths/exhaustive
+        run: go install github.com/nishanths/exhaustive/cmd/exhaustive@latest
+
+      - name: Run exhaustive
+        run: exhaustive ./...
+
   check-helm-readme:
     runs-on: ubuntu-latest
     steps:

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -730,14 +730,12 @@ func CreateMockImage(t *testing.T, width, height int, size ImageSize) image.Imag
 
 	var c color.Color
 	for x := 0; x < width; x++ {
-		if size == ImageSizeMedium {
-			c = mediumImageColor()
-		}
-
 		for y := 0; y < height; y++ {
 			switch size {
 			case ImageSizeSmall:
 				c = smallImageColor()
+			case ImageSizeMedium:
+				c = mediumImageColor()
 			case ImageSizeLarge:
 				c = largeImageColor()
 			}

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -730,12 +730,16 @@ func CreateMockImage(t *testing.T, width, height int, size ImageSize) image.Imag
 
 	var c color.Color
 	for x := 0; x < width; x++ {
+		if size == ImageSizeMedium {
+			c = mediumImageColor()
+		}
+
 		for y := 0; y < height; y++ {
 			switch size {
 			case ImageSizeSmall:
 				c = smallImageColor()
 			case ImageSizeMedium:
-				c = mediumImageColor()
+				// NO-OP
 			case ImageSizeLarge:
 				c = largeImageColor()
 			}

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -234,7 +234,7 @@ func Test_PaymentHandler_GetPayments_Errors(t *testing.T) {
 				"status": "invalid_status",
 			},
 			expectedStatusCode: http.StatusBadRequest,
-			expectedResponse:   `{"error":"request invalid", "extras":{"status":"invalid parameter. valid values are: draft, ready, pending, paused, success, failed"}}`,
+			expectedResponse:   `{"error":"request invalid", "extras":{"status":"invalid parameter. valid values are: DRAFT, READY, PENDING, PAUSED, SUCCESS, FAILED, CANCELLED"}}`,
 		},
 		{
 			name: "returns error when created_at_after is invalid",

--- a/internal/serve/httphandler/user_handler.go
+++ b/internal/serve/httphandler/user_handler.go
@@ -339,19 +339,19 @@ func (h UserHandler) GetAllUsers(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// Order users
+	sortingFn := sort.Sort
+	if queryParams.SortOrder == data.SortOrderDESC {
+		sortingFn = func(data sort.Interface) {
+			sort.Sort(sort.Reverse(data))
+		}
+	}
 	switch queryParams.SortBy {
 	case data.SortFieldEmail:
-		if queryParams.SortOrder == data.SortOrderDESC {
-			sort.Sort(sort.Reverse(UserSorterByEmail(users)))
-		} else {
-			sort.Sort(UserSorterByEmail(users))
-		}
+		sortingFn(UserSorterByEmail(users))
 	case data.SortFieldIsActive:
-		if queryParams.SortOrder == data.SortOrderDESC {
-			sort.Sort(sort.Reverse(UserSorterByIsActive(users)))
-		} else {
-			sort.Sort(UserSorterByIsActive(users))
-		}
+		sortingFn(UserSorterByIsActive(users))
+	default:
+		log.Ctx(ctx).Warnf("unexpected sort field in GetAllUsers: %s", queryParams.SortBy)
 	}
 
 	httpjson.RenderStatus(rw, http.StatusOK, users, httpjson.JSON)

--- a/internal/serve/validators/payment_query_validator.go
+++ b/internal/serve/validators/payment_query_validator.go
@@ -57,10 +57,10 @@ func (qv *PaymentQueryValidator) ValidateAndGetPaymentFilters(filters map[data.F
 func (qv *PaymentQueryValidator) validateAndGetPaymentStatus(status string) data.PaymentStatus {
 	s := data.PaymentStatus(strings.ToUpper(status))
 	switch s {
-	case data.DraftPaymentStatus, data.ReadyPaymentStatus, data.PendingPaymentStatus, data.PausedPaymentStatus, data.SuccessPaymentStatus, data.FailedPaymentStatus:
+	case data.DraftPaymentStatus, data.ReadyPaymentStatus, data.PendingPaymentStatus, data.PausedPaymentStatus, data.SuccessPaymentStatus, data.FailedPaymentStatus, data.CanceledPaymentStatus:
 		return s
 	default:
-		qv.Check(false, string(data.FilterKeyStatus), "invalid parameter. valid values are: draft, ready, pending, paused, success, failed")
+		qv.Check(false, string(data.FilterKeyStatus), "invalid parameter. valid values are: DRAFT, READY, PENDING, PAUSED, SUCCESS, FAILED, CANCELLED")
 		return ""
 	}
 }

--- a/internal/serve/validators/payment_query_validator_test.go
+++ b/internal/serve/validators/payment_query_validator_test.go
@@ -35,7 +35,7 @@ func Test_PaymentQueryValidator_ValidateDisbursementFilters(t *testing.T) {
 		validator.ValidateAndGetPaymentFilters(filters)
 
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid parameter. valid values are: draft, ready, pending, paused, success, failed", validator.Errors["status"])
+		assert.Equal(t, "invalid parameter. valid values are: DRAFT, READY, PENDING, PAUSED, SUCCESS, FAILED, CANCELLED", validator.Errors["status"])
 	})
 
 	t.Run("Invalid date", func(t *testing.T) {
@@ -84,6 +84,6 @@ func Test_PaymentQueryValidator_ValidateAndGetPaymentStatus(t *testing.T) {
 		actual := validator.validateAndGetPaymentStatus(invalidStatus)
 		assert.Empty(t, actual)
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid parameter. valid values are: draft, ready, pending, paused, success, failed", validator.Errors["status"])
+		assert.Equal(t, "invalid parameter. valid values are: DRAFT, READY, PENDING, PAUSED, SUCCESS, FAILED, CANCELLED", validator.Errors["status"])
 	})
 }

--- a/internal/transactionsubmission/manager_test.go
+++ b/internal/transactionsubmission/manager_test.go
@@ -498,6 +498,9 @@ func Test_Manager_ProcessTransactions(t *testing.T) {
 			case signalTypeOSSigquit:
 				err = syscall.Kill(syscall.Getpid(), syscall.SIGQUIT)
 				require.NoError(t, err)
+
+			default:
+				// NO-OP
 			}
 
 			cancel()


### PR DESCRIPTION
### What

Add `exhaustive` check to the CI, and fix the missing enum cases surfaced by this check.

### Why

Go doesn't;t enforce enums to be exhaustive, so adding such a check guarantees that we're covering all the enum use cases properly.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
