### PR TITLE
[SDP-877] Refactor SubmissionService interface and aggregate all Stellar Tx submission stuff in a single object called `SubmitterEngine`

### DIFF
--- a/cmd/channel_accounts.go
+++ b/cmd/channel_accounts.go
@@ -331,6 +331,12 @@ func (c *ChannelAccountsCommand) chAccServicePersistentPreRun(
 		return fmt.Errorf("retrieving horizon client through the dependency injector in %s: %w", cmd.Name(), err)
 	}
 
+	// Prepare Ledger Number Tracker
+	ledgerNumberTracker, err := di.NewLedgerNumberTracker(ctx, horizonClient)
+	if err != nil {
+		return fmt.Errorf("retrieving ledger number tracker through the dependency injector in %s: %w", cmd.Name(), err)
+	}
+
 	// Prepare the signature service
 	sigServiceOptions.NetworkPassphrase = globalOptions.NetworkPassphrase
 	sigServiceOptions.DBConnectionPool = c.TSSDBConnectionPool
@@ -343,6 +349,7 @@ func (c *ChannelAccountsCommand) chAccServicePersistentPreRun(
 	chAccService.SigningService = sigService
 	chAccService.TSSDBConnectionPool = c.TSSDBConnectionPool
 	chAccService.HorizonClient = horizonClient
+	chAccService.LedgerNumberTracker = ledgerNumberTracker
 
 	return nil
 }

--- a/cmd/channel_accounts.go
+++ b/cmd/channel_accounts.go
@@ -38,7 +38,7 @@ func (s *ChAccCmdService) CreateChannelAccounts(ctx context.Context, chAccServic
 }
 
 func (s *ChAccCmdService) EnsureChannelAccountsCount(ctx context.Context, chAccService txSubSvc.ChannelAccountsService, count int) error {
-	return chAccService.CreateChannelAccounts(ctx, count)
+	return chAccService.EnsureChannelAccountsCount(ctx, count)
 }
 
 func (s *ChAccCmdService) DeleteChannelAccount(ctx context.Context, chAccService txSubSvc.ChannelAccountsService, opts txSubSvc.DeleteChannelAccountsOptions) error {

--- a/cmd/channel_accounts.go
+++ b/cmd/channel_accounts.go
@@ -109,7 +109,7 @@ func (c *ChannelAccountsCommand) Command(cmdService ChAccCmdServiceInterface) *c
 func (c *ChannelAccountsCommand) CreateCommand(cmdService ChAccCmdServiceInterface) *cobra.Command {
 	chAccService := txSubSvc.ChannelAccountsService{}
 	txSubmitterOpts := di.TxSubmitterEngineOptions{}
-	configOpts := chAccServiceConfigOptions(&txSubmitterOpts)
+	configOpts := cmdUtils.TransactionSubmitterEngineConfigOptions(&txSubmitterOpts)
 
 	createCmd := &cobra.Command{
 		Use:   "create [count]",
@@ -144,7 +144,7 @@ func (c *ChannelAccountsCommand) CreateCommand(cmdService ChAccCmdServiceInterfa
 func (c *ChannelAccountsCommand) VerifyCommand(cmdService ChAccCmdServiceInterface) *cobra.Command {
 	chAccService := txSubSvc.ChannelAccountsService{}
 	txSubmitterOpts := di.TxSubmitterEngineOptions{}
-	configOpts := chAccServiceConfigOptions(&txSubmitterOpts)
+	configOpts := cmdUtils.TransactionSubmitterEngineConfigOptions(&txSubmitterOpts)
 
 	var deleteInvalidAccounts bool
 	configOpts = append(configOpts, &config.ConfigOption{
@@ -182,7 +182,7 @@ func (c *ChannelAccountsCommand) VerifyCommand(cmdService ChAccCmdServiceInterfa
 func (c *ChannelAccountsCommand) EnsureCommand(cmdService ChAccCmdServiceInterface) *cobra.Command {
 	chAccService := txSubSvc.ChannelAccountsService{}
 	txSubmitterOpts := di.TxSubmitterEngineOptions{}
-	configOpts := chAccServiceConfigOptions(&txSubmitterOpts)
+	configOpts := cmdUtils.TransactionSubmitterEngineConfigOptions(&txSubmitterOpts)
 
 	ensureCmd := &cobra.Command{
 		Use: "ensure",
@@ -219,7 +219,7 @@ func (c *ChannelAccountsCommand) EnsureCommand(cmdService ChAccCmdServiceInterfa
 func (c *ChannelAccountsCommand) DeleteCommand(cmdService ChAccCmdServiceInterface) *cobra.Command {
 	chAccService := txSubSvc.ChannelAccountsService{}
 	txSubmitterOpts := di.TxSubmitterEngineOptions{}
-	configOpts := chAccServiceConfigOptions(&txSubmitterOpts)
+	configOpts := cmdUtils.TransactionSubmitterEngineConfigOptions(&txSubmitterOpts)
 
 	deleteChAccOpts := txSubSvc.DeleteChannelAccountsOptions{}
 	configOpts = append(configOpts, []*config.ConfigOption{
@@ -282,17 +282,6 @@ func (c *ChannelAccountsCommand) ViewCommand(cmdService ChAccCmdServiceInterface
 	}
 
 	return listCmd
-}
-
-// chAccServiceConfigOptions returns the config options for the channel accounts service to be used when the signature
-// service is needed.
-func chAccServiceConfigOptions(txSubmitterOpts *di.TxSubmitterEngineOptions) config.ConfigOptions {
-	return append(
-		cmdUtils.BaseSignatureServiceConfigOptions(&txSubmitterOpts.SignatureServiceOptions),
-		cmdUtils.DistributionSeed(&txSubmitterOpts.SignatureServiceOptions.DistributionPrivateKey),
-		cmdUtils.MaxBaseFee(&txSubmitterOpts.MaxBaseFee),
-		cmdUtils.HorizonURLConfigOption(&txSubmitterOpts.HorizonURL),
-	)
 }
 
 // chAccServicePersistentPreRun runs the persistent pre run for the channel accounts service to be used when the

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -388,13 +388,9 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 
 	// signature service config options:
 	txSubmitterOpts := di.TxSubmitterEngineOptions{}
-	configOpts = append(configOpts,
-		append(
-			cmdUtils.BaseSignatureServiceConfigOptions(&txSubmitterOpts.SignatureServiceOptions),
-			cmdUtils.DistributionSeed(&txSubmitterOpts.SignatureServiceOptions.DistributionPrivateKey),
-			cmdUtils.MaxBaseFee(&txSubmitterOpts.MaxBaseFee),
-			cmdUtils.HorizonURLConfigOption(&txSubmitterOpts.HorizonURL),
-		)...,
+	configOpts = append(
+		configOpts,
+		cmdUtils.TransactionSubmitterEngineConfigOptions(&txSubmitterOpts)...,
 	)
 
 	cmd := &cobra.Command{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -162,6 +162,7 @@ func (s *ServerService) SetupConsumers(ctx context.Context, eventBrokerOptions c
 }
 
 func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorService monitor.MonitorServiceInterface) *cobra.Command {
+	var horizonURL string
 	serveOpts := serve.ServeOptions{}
 	schedulerOptions := scheduler.SchedulerOptions{}
 
@@ -284,7 +285,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 			CustomSetValue: cmdUtils.SetConfigOptionURLString,
 			Required:       true,
 		},
-		cmdUtils.HorizonURLConfigOption(&serveOpts.HorizonURL),
+		cmdUtils.HorizonURLConfigOption(&horizonURL),
 		{
 			Name:        "enable-scheduler",
 			Usage:       "Enable Scheduler for SDP Backend Jobs",
@@ -470,6 +471,13 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 				log.Ctx(ctx).Fatalf("error creating Anchor Platform API Service: %v", err)
 			}
 			serveOpts.AnchorPlatformAPIService = apAPIService
+
+			// Grab horizon client instance
+			horizonClient, err := di.NewHorizonClient(ctx, horizonURL)
+			if err != nil {
+				log.Ctx(ctx).Fatalf("error retrieving horizon client through the dependency injector in %s: %v", cmd.Name(), err)
+			}
+			serveOpts.HorizonClient = horizonClient
 
 			// Setup the TSSDBConnectionPool
 			tssDBConnectionPool, err := di.NewTSSDBConnectionPool(ctx, di.TSSDBConnectionPoolOptions{DatabaseURL: globalOptions.DatabaseURL})

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -103,6 +103,8 @@ func Test_serve(t *testing.T) {
 
 	// mock metric service
 	mMonitorService := monitor.MockMonitorService{}
+	mHorizonClient := &horizonclient.MockClient{}
+	di.SetInstance("horizon_client_instance", mHorizonClient)
 
 	serveOpts := serve.ServeOptions{
 		Environment:                     "test",
@@ -120,7 +122,7 @@ func Test_serve(t *testing.T) {
 		UIBaseURL:                       "http://localhost:3000",
 		ResetTokenExpirationHours:       24,
 		NetworkPassphrase:               network.TestNetworkPassphrase,
-		HorizonURL:                      horizonclient.DefaultTestNetClient.HorizonURL,
+		HorizonClient:                   mHorizonClient,
 		Sep10SigningPublicKey:           "GAX46JJZ3NPUM2EUBTTGFM6ITDF7IGAFNBSVWDONPYZJREHFPP2I5U7S",
 		Sep10SigningPrivateKey:          "SBUSPEKAZKLZSWHRSJ2HWDZUK6I3IVDUWA7JJZSGBLZ2WZIUJI7FPNB5",
 		AnchorPlatformBaseSepURL:        "localhost:8080",

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -101,16 +101,16 @@ func Test_serve(t *testing.T) {
 	distributionSeed := "SBHQEYSACD5DOK5I656NKLAMOHC6VT64ATOWWM2VJ3URGDGMVGNPG4ON"
 
 	// Populate dependency injection:
-	di.SetInstance("tss_db_connection_pool_instance", dbConnectionPool)
+	di.SetInstance(di.TSSDBConnectionPoolInstanceName, dbConnectionPool)
 
 	mHorizonClient := &horizonclient.MockClient{}
-	di.SetInstance("horizon_client_instance", mHorizonClient)
+	di.SetInstance(di.HorizonClientInstanceName, mHorizonClient)
 
 	mLedgerNumberTracker := engineMocks.NewMockLedgerNumberTracker(t)
-	di.SetInstance("ledger_number_tracker_instance", mLedgerNumberTracker)
+	di.SetInstance(di.LedgerNumberTrackerInstanceName, mLedgerNumberTracker)
 
 	mSignatureService := engineMocks.NewMockSignatureService(t)
-	di.SetInstance("signature_service_instance", mSignatureService)
+	di.SetInstance(di.SignatureServiceInstanceName, mSignatureService)
 
 	submitterEngine := engine.SubmitterEngine{
 		HorizonClient:       mHorizonClient,
@@ -118,7 +118,7 @@ func Test_serve(t *testing.T) {
 		LedgerNumberTracker: mLedgerNumberTracker,
 		MaxBaseFee:          100 * txnbuild.MinBaseFee,
 	}
-	di.SetInstance("tx_submitter_engine_instance", submitterEngine)
+	di.SetInstance(di.TxSubmitterEngineInstanceName, submitterEngine)
 
 	ctx := context.Background()
 

--- a/cmd/transaction_submitter.go
+++ b/cmd/transaction_submitter.go
@@ -112,13 +112,9 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 
 	// txSubmitterOpts
 	txSubmitterOpts := di.TxSubmitterEngineOptions{}
-	configOpts = append(configOpts,
-		append(
-			cmdUtils.BaseSignatureServiceConfigOptions(&txSubmitterOpts.SignatureServiceOptions),
-			cmdUtils.DistributionSeed(&txSubmitterOpts.SignatureServiceOptions.DistributionPrivateKey),
-			cmdUtils.MaxBaseFee(&txSubmitterOpts.MaxBaseFee),
-			cmdUtils.HorizonURLConfigOption(&txSubmitterOpts.HorizonURL),
-		)...,
+	configOpts = append(
+		configOpts,
+		cmdUtils.TransactionSubmitterEngineConfigOptions(&txSubmitterOpts)...,
 	)
 
 	// event broker options:

--- a/cmd/transaction_submitter.go
+++ b/cmd/transaction_submitter.go
@@ -172,8 +172,8 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 			}
 
 			// Inject server dependencies
-			tssOpts.DBConnectionPool = tssDBConnectionPool
 			tssOpts.SubmitterEngine = submitterEngine
+			tssOpts.DBConnectionPool = tssDBConnectionPool
 			tssOpts.MonitorService = tssMonitorSvc
 
 			// Inject crash tracker options dependencies

--- a/cmd/transaction_submitter.go
+++ b/cmd/transaction_submitter.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve"
 	txSub "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 	tssMonitor "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/monitor"
 )
 
@@ -65,16 +64,14 @@ func (s *TxSubmitterService) StartMetricsServe(ctx context.Context, opts serve.M
 }
 
 func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterface) *cobra.Command {
-	var horizonURL string
-	submitterOpts := txSub.SubmitterOptions{}
+	tssOpts := txSub.SubmitterOptions{}
 
 	configOpts := config.ConfigOptions{
-		cmdUtils.HorizonURLConfigOption(&horizonURL),
 		{
 			Name:        "num-channel-accounts",
 			Usage:       "Number of channel accounts to utilize for transaction submission",
 			OptType:     types.Int,
-			ConfigKey:   &submitterOpts.NumChannelAccounts,
+			ConfigKey:   &tssOpts.NumChannelAccounts,
 			FlagDefault: 2,
 			Required:    false,
 		},
@@ -82,11 +79,10 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 			Name:        "queue-polling-interval",
 			Usage:       "Polling interval (seconds) to query the database for pending transactions to process",
 			OptType:     types.Int,
-			ConfigKey:   &submitterOpts.QueuePollingInterval,
+			ConfigKey:   &tssOpts.QueuePollingInterval,
 			FlagDefault: 6,
 			Required:    true,
 		},
-		cmdUtils.MaxBaseFee(&submitterOpts.MaxBaseFee),
 	}
 
 	// metrics server options
@@ -114,12 +110,14 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 	crashTrackerOptions := crashtracker.CrashTrackerOptions{}
 	configOpts = append(configOpts, cmdUtils.CrashTrackerTypeConfigOption(&crashTrackerOptions.CrashTrackerType))
 
-	// signature service config options:
-	sigServiceOptions := engine.SignatureServiceOptions{}
+	// txSubmitterOpts
+	txSubmitterOpts := di.TxSubmitterEngineOptions{}
 	configOpts = append(configOpts,
 		append(
-			cmdUtils.BaseSignatureServiceConfigOptions(&sigServiceOptions),
-			cmdUtils.DistributionSeed(&sigServiceOptions.DistributionPrivateKey),
+			cmdUtils.BaseSignatureServiceConfigOptions(&txSubmitterOpts.SignatureServiceOptions),
+			cmdUtils.DistributionSeed(&txSubmitterOpts.SignatureServiceOptions.DistributionPrivateKey),
+			cmdUtils.MaxBaseFee(&txSubmitterOpts.MaxBaseFee),
+			cmdUtils.HorizonURLConfigOption(&txSubmitterOpts.HorizonURL),
 		)...,
 	)
 
@@ -165,25 +163,18 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 				log.Ctx(ctx).Fatalf("error getting TSS DB connection pool: %v", err)
 			}
 
-			// Grab horizon client instance
-			horizonClient, err := di.NewHorizonClient(ctx, horizonURL)
+			// Setup the Submitter Engine
+			txSubmitterOpts.SignatureServiceOptions.DBConnectionPool = tssDBConnectionPool
+			txSubmitterOpts.SignatureServiceOptions.NetworkPassphrase = globalOptions.NetworkPassphrase
+			submitterEngine, err := di.NewTxSubmitterEngine(ctx, txSubmitterOpts)
 			if err != nil {
-				log.Ctx(ctx).Fatalf("error retrieving horizon client through the dependency injector in %s: %v", cmd.Name(), err)
-			}
-
-			// Setup the signature service
-			sigServiceOptions.DBConnectionPool = tssDBConnectionPool
-			sigServiceOptions.NetworkPassphrase = globalOptions.NetworkPassphrase
-			signatureService, err := di.NewSignatureService(ctx, sigServiceOptions)
-			if err != nil {
-				log.Ctx(ctx).Fatalf("error creating signature service: %v", err)
+				log.Ctx(ctx).Fatalf("error creating submitter engine: %v", err)
 			}
 
 			// Inject server dependencies
-			submitterOpts.DBConnectionPool = tssDBConnectionPool
-			submitterOpts.SignatureService = signatureService
-			submitterOpts.MonitorService = tssMonitorSvc
-			submitterOpts.HorizonClient = horizonClient
+			tssOpts.DBConnectionPool = tssDBConnectionPool
+			tssOpts.SubmitterEngine = submitterEngine
+			tssOpts.MonitorService = tssMonitorSvc
 
 			// Inject crash tracker options dependencies
 			globalOptions.PopulateCrashTrackerOptions(&crashTrackerOptions)
@@ -192,7 +183,7 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 			if err != nil {
 				log.Ctx(ctx).Fatalf("error creating crash tracker client: %s", err.Error())
 			}
-			submitterOpts.CrashTrackerClient = crashTrackerClient
+			tssOpts.CrashTrackerClient = crashTrackerClient
 		},
 		Run: func(cmd *cobra.Command, _ []string) {
 			ctx := cmd.Context()
@@ -203,16 +194,16 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 					log.Ctx(ctx).Fatalf("error creating Kafka Producer: %v", err)
 				}
 				defer kafkaProducer.Close()
-				submitterOpts.EventProducer = kafkaProducer
+				tssOpts.EventProducer = kafkaProducer
 			} else {
 				log.Ctx(ctx).Warn("Event Broker Type is NONE.")
 			}
 
 			// Starting Metrics Server (background job)
-			go submitterService.StartMetricsServe(ctx, metricsServeOpts, &serve.HTTPServer{}, submitterOpts.CrashTrackerClient)
+			go submitterService.StartMetricsServe(ctx, metricsServeOpts, &serve.HTTPServer{}, tssOpts.CrashTrackerClient)
 
 			// Start transaction submission service
-			submitterService.StartSubmitter(ctx, submitterOpts)
+			submitterService.StartSubmitter(ctx, tssOpts)
 		},
 	}
 	err := configOpts.Init(cmd)

--- a/internal/dependencyinjection/anchor_platform_service.go
+++ b/internal/dependencyinjection/anchor_platform_service.go
@@ -18,8 +18,10 @@ func NewAnchorPlatformAPIService(anchorPlatformBasePlatformURL, anchorPlatformOu
 		return nil, fmt.Errorf("anchor platform outgoing JWT secret cannot be empty")
 	}
 
+	instanceName := anchorPlatformAPIServiceInstanceName
+
 	// If there is already an instance of the service, we return the same instance
-	if instance, ok := dependenciesStoreMap[anchorPlatformAPIServiceInstanceName]; ok {
+	if instance, ok := GetInstance(instanceName); ok {
 		if anchorPlatformAPIService, ok := instance.(anchorplatform.AnchorPlatformAPIServiceInterface); ok {
 			return anchorPlatformAPIService, nil
 		}

--- a/internal/dependencyinjection/anchor_platform_service_test.go
+++ b/internal/dependencyinjection/anchor_platform_service_test.go
@@ -61,8 +61,10 @@ func Test_NewAnchorPlatformAPIService_existingInstanceIsReturned(t *testing.T) {
 
 	defer ClearInstancesTestHelper(t)
 
+	instanceName := anchorPlatformAPIServiceInstanceName
+
 	// STEP 1: assert that the instance is nil
-	_, ok := dependenciesStoreMap[anchorPlatformAPIServiceInstanceName]
+	_, ok := GetInstance(instanceName)
 	require.False(t, ok)
 
 	// STEP 2: create a new instance
@@ -71,7 +73,7 @@ func Test_NewAnchorPlatformAPIService_existingInstanceIsReturned(t *testing.T) {
 	require.NotNil(t, apService1)
 
 	// STEP 3: assert that the instance is not nil
-	storedAPService, ok := dependenciesStoreMap[anchorPlatformAPIServiceInstanceName]
+	storedAPService, ok := GetInstance(instanceName)
 	require.True(t, ok)
 	require.NotNil(t, storedAPService)
 	require.True(t, apService1 == storedAPService)

--- a/internal/dependencyinjection/crash_tracker.go
+++ b/internal/dependencyinjection/crash_tracker.go
@@ -22,7 +22,7 @@ func NewCrashTracker(ctx context.Context, opts crashtracker.CrashTrackerOptions)
 	instanceName := buildCrashTrackerInstanceName(opts.CrashTrackerType)
 
 	// Already initialized
-	if instance, ok := dependenciesStoreMap[instanceName]; ok {
+	if instance, ok := GetInstance(instanceName); ok {
 		if crashTrackerInstance, ok := instance.(crashtracker.CrashTrackerClient); ok {
 			return crashTrackerInstance, nil
 		}

--- a/internal/dependencyinjection/db_connection_pool.go
+++ b/internal/dependencyinjection/db_connection_pool.go
@@ -19,7 +19,7 @@ type DBConnectionPoolOptions struct {
 func NewDBConnectionPool(ctx context.Context, opts DBConnectionPoolOptions) (db.DBConnectionPool, error) {
 	// If there is already an instance of the service, we return the same instance
 	instanceName := dbConnectionPoolInstanceName
-	if instance, ok := dependenciesStoreMap[instanceName]; ok {
+	if instance, ok := GetInstance(instanceName); ok {
 		if dbConnectionPoolInstance, ok := instance.(db.DBConnectionPool); ok {
 			return dbConnectionPoolInstance, nil
 		}

--- a/internal/dependencyinjection/email_client.go
+++ b/internal/dependencyinjection/email_client.go
@@ -34,7 +34,7 @@ func NewEmailClient(opts EmailClientOptions) (message.MessengerClient, error) {
 
 	// If there is already an instance of the service, we return the same instance
 	instanceName := buildEmailClientInstanceName(opts.MessengerOptions.MessengerType)
-	if instance, ok := dependenciesStoreMap[instanceName]; ok {
+	if instance, ok := GetInstance(instanceName); ok {
 		if emailClientInstance, ok := instance.(message.MessengerClient); ok {
 			return emailClientInstance, nil
 		}

--- a/internal/dependencyinjection/fixtures.go
+++ b/internal/dependencyinjection/fixtures.go
@@ -4,5 +4,10 @@ import "testing"
 
 func ClearInstancesTestHelper(t *testing.T) {
 	t.Helper()
-	dependenciesStoreMap = make(map[string]interface{})
+
+	// Range over the map and delete each entry.
+	dependenciesStore.Range(func(key, value interface{}) bool {
+		dependenciesStore.Delete(key)
+		return true // Continue iteration
+	})
 }

--- a/internal/dependencyinjection/horizon_client.go
+++ b/internal/dependencyinjection/horizon_client.go
@@ -1,0 +1,37 @@
+package dependencyinjection
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
+)
+
+const horizonClientInstanceName = "horizon_client_instance"
+
+// NewHorizonClient creates a new horizon client instance, or retrives an instance that was already
+// created before.
+func NewHorizonClient(ctx context.Context, horizonURL string) (horizonclient.ClientInterface, error) {
+	instanceName := horizonClientInstanceName
+
+	// Already initialized
+	if instance, ok := GetInstance(instanceName); ok {
+		if castedInstance, ok2 := instance.(horizonclient.ClientInterface); ok2 {
+			return castedInstance, nil
+		}
+		return nil, fmt.Errorf("trying to cast an existing horizon client instance")
+	}
+
+	// Setup a new instance
+	log.Ctx(ctx).Infof("⚙️ Setting up Horizon Client")
+	newInstance := &horizonclient.Client{
+		HorizonURL: horizonURL,
+		HTTP:       httpclient.DefaultClient(),
+	}
+
+	SetInstance(instanceName, newInstance)
+
+	return newInstance, nil
+}

--- a/internal/dependencyinjection/horizon_client.go
+++ b/internal/dependencyinjection/horizon_client.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
 )
 
-const horizonClientInstanceName = "horizon_client_instance"
+const HorizonClientInstanceName = "horizon_client_instance"
 
 // NewHorizonClient creates a new horizon client instance, or retrives an instance that was already
 // created before.
 func NewHorizonClient(ctx context.Context, horizonURL string) (horizonclient.ClientInterface, error) {
-	instanceName := horizonClientInstanceName
+	instanceName := HorizonClientInstanceName
 
 	// Already initialized
 	if instance, ok := GetInstance(instanceName); ok {

--- a/internal/dependencyinjection/horizon_client_test.go
+++ b/internal/dependencyinjection/horizon_client_test.go
@@ -30,7 +30,7 @@ func Test_dependencyinjection_NewHorizonClient(t *testing.T) {
 	t.Run("should return an error if there's an invalid instance pre-stored", func(t *testing.T) {
 		ClearInstancesTestHelper(t)
 
-		SetInstance(horizonClientInstanceName, false)
+		SetInstance(HorizonClientInstanceName, false)
 
 		horizonURL := "https://horizon-testnet.stellar.org"
 		gotDependency, err := NewHorizonClient(ctx, horizonURL)

--- a/internal/dependencyinjection/horizon_client_test.go
+++ b/internal/dependencyinjection/horizon_client_test.go
@@ -1,0 +1,40 @@
+package dependencyinjection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_dependencyinjection_NewHorizonClient(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	ctx := context.Background()
+	t.Run("should create and return the same instance on the second call", func(t *testing.T) {
+		ClearInstancesTestHelper(t)
+
+		horizonURL := "https://horizon-testnet.stellar.org"
+		gotDependency, err := NewHorizonClient(ctx, horizonURL)
+		require.NoError(t, err)
+
+		gotDependencyDuplicate, err := NewHorizonClient(ctx, horizonURL)
+		require.NoError(t, err)
+
+		assert.Equal(t, &gotDependency, &gotDependencyDuplicate)
+	})
+
+	t.Run("should return an error if there's an invalid instance pre-stored", func(t *testing.T) {
+		ClearInstancesTestHelper(t)
+
+		SetInstance(horizonClientInstanceName, false)
+
+		horizonURL := "https://horizon-testnet.stellar.org"
+		gotDependency, err := NewHorizonClient(ctx, horizonURL)
+		assert.Nil(t, gotDependency)
+		assert.EqualError(t, err, "trying to cast an existing horizon client instance")
+	})
+}

--- a/internal/dependencyinjection/ledger_number_tracker.go
+++ b/internal/dependencyinjection/ledger_number_tracker.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 )
 
-const ledgerNumberTrackerInstanceName = "ledger_number_tracker_instance"
+const LedgerNumberTrackerInstanceName = "ledger_number_tracker_instance"
 
 // NewLedgerNumberTracker creates a new ledger number tracker instance, or retrives an instance that was already
 // created before.
 func NewLedgerNumberTracker(ctx context.Context, horizonClient horizonclient.ClientInterface) (engine.LedgerNumberTracker, error) {
-	instanceName := ledgerNumberTrackerInstanceName
+	instanceName := LedgerNumberTrackerInstanceName
 
 	// Already initialized
 	if instance, ok := GetInstance(instanceName); ok {

--- a/internal/dependencyinjection/ledger_number_tracker.go
+++ b/internal/dependencyinjection/ledger_number_tracker.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/support/log"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 )
 
@@ -14,7 +13,7 @@ const ledgerNumberTrackerInstanceName = "ledger_number_tracker_instance"
 
 // NewLedgerNumberTracker creates a new ledger number tracker instance, or retrives an instance that was already
 // created before.
-func NewLedgerNumberTracker(ctx context.Context, horizonURL string) (engine.LedgerNumberTracker, error) {
+func NewLedgerNumberTracker(ctx context.Context, horizonClient horizonclient.ClientInterface) (engine.LedgerNumberTracker, error) {
 	instanceName := ledgerNumberTrackerInstanceName
 
 	// Already initialized
@@ -27,10 +26,6 @@ func NewLedgerNumberTracker(ctx context.Context, horizonURL string) (engine.Ledg
 
 	// Setup a new instance
 	log.Ctx(ctx).Infof("⚙️ Setting up Ledger Number Tracker")
-	horizonClient := &horizonclient.Client{
-		HorizonURL: horizonURL,
-		HTTP:       httpclient.DefaultClient(),
-	}
 	newInstance, err := engine.NewLedgerNumberTracker(horizonClient)
 	if err != nil {
 		return nil, fmt.Errorf("creating a new ledger number tracker instance: %w", err)

--- a/internal/dependencyinjection/ledger_number_tracker.go
+++ b/internal/dependencyinjection/ledger_number_tracker.go
@@ -1,0 +1,42 @@
+package dependencyinjection
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
+)
+
+const ledgerNumberTrackerInstanceName = "ledger_number_tracker_instance"
+
+// NewLedgerNumberTracker creates a new ledger number tracker instance, or retrives an instance that was already
+// created before.
+func NewLedgerNumberTracker(ctx context.Context, horizonURL string) (engine.LedgerNumberTracker, error) {
+	instanceName := ledgerNumberTrackerInstanceName
+
+	// Already initialized
+	if instance, ok := GetInstance(instanceName); ok {
+		if castedInstance, ok2 := instance.(engine.LedgerNumberTracker); ok2 {
+			return castedInstance, nil
+		}
+		return nil, fmt.Errorf("trying to cast an existing ledger number tracker instance")
+	}
+
+	// Setup a new instance
+	log.Ctx(ctx).Infof("⚙️ Setting up Ledger Number Tracker")
+	horizonClient := &horizonclient.Client{
+		HorizonURL: horizonURL,
+		HTTP:       httpclient.DefaultClient(),
+	}
+	newInstance, err := engine.NewLedgerNumberTracker(horizonClient)
+	if err != nil {
+		return nil, fmt.Errorf("creating a new ledger number tracker instance: %w", err)
+	}
+
+	SetInstance(instanceName, newInstance)
+
+	return newInstance, nil
+}

--- a/internal/dependencyinjection/ledger_number_tracker_test.go
+++ b/internal/dependencyinjection/ledger_number_tracker_test.go
@@ -1,0 +1,40 @@
+package dependencyinjection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_dependencyinjection_NewLedgerNumberTracker(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	ctx := context.Background()
+	t.Run("should create and return the same instance on the second call", func(t *testing.T) {
+		ClearInstancesTestHelper(t)
+
+		horizonClient := &horizonclient.MockClient{}
+		gotDependency, err := NewLedgerNumberTracker(ctx, horizonClient)
+		require.NoError(t, err)
+
+		gotDependencyDuplicate, err := NewLedgerNumberTracker(ctx, horizonClient)
+		require.NoError(t, err)
+
+		assert.Equal(t, &gotDependency, &gotDependencyDuplicate)
+	})
+
+	t.Run("should return an error if there's an invalid instance pre-stored", func(t *testing.T) {
+		ClearInstancesTestHelper(t)
+
+		SetInstance(ledgerNumberTrackerInstanceName, false)
+
+		gotDependency, err := NewLedgerNumberTracker(ctx, &horizonclient.MockClient{})
+		assert.Nil(t, gotDependency)
+		assert.EqualError(t, err, "trying to cast an existing ledger number tracker instance")
+	})
+}

--- a/internal/dependencyinjection/ledger_number_tracker_test.go
+++ b/internal/dependencyinjection/ledger_number_tracker_test.go
@@ -31,7 +31,7 @@ func Test_dependencyinjection_NewLedgerNumberTracker(t *testing.T) {
 	t.Run("should return an error if there's an invalid instance pre-stored", func(t *testing.T) {
 		ClearInstancesTestHelper(t)
 
-		SetInstance(ledgerNumberTrackerInstanceName, false)
+		SetInstance(LedgerNumberTrackerInstanceName, false)
 
 		gotDependency, err := NewLedgerNumberTracker(ctx, &horizonclient.MockClient{})
 		assert.Nil(t, gotDependency)

--- a/internal/dependencyinjection/main.go
+++ b/internal/dependencyinjection/main.go
@@ -2,26 +2,16 @@ package dependencyinjection
 
 import "sync"
 
-var (
-	// dependenciesStoreMap var is the global map for all the service instances.
-	dependenciesStoreMap = make(map[string]interface{})
-	// dependenciesStoreMutex is the mutex for the global map, used to make sure the map is thread safe.
-	dependenciesStoreMutex sync.Mutex
-)
+// dependenciesStore is the global store for all the service instances.
+// sync.Map is safe for concurrent use by multiple goroutines without additional locking or coordination.
+var dependenciesStore sync.Map
 
-// SetInstance adds a new service instance to instances map.
+// SetInstance adds a new service instance to the store.
 func SetInstance(instanceName string, instance interface{}) {
-	dependenciesStoreMutex.Lock()
-	defer dependenciesStoreMutex.Unlock()
-
-	dependenciesStoreMap[instanceName] = instance
+	dependenciesStore.Store(instanceName, instance)
 }
 
-// GetInstance retrieves a service instance by name from the instances map.
+// GetInstance retrieves a service instance by name from the store.
 func GetInstance(instanceName string) (interface{}, bool) {
-	dependenciesStoreMutex.Lock()
-	defer dependenciesStoreMutex.Unlock()
-
-	instance, ok := dependenciesStoreMap[instanceName]
-	return instance, ok
+	return dependenciesStore.Load(instanceName)
 }

--- a/internal/dependencyinjection/main.go
+++ b/internal/dependencyinjection/main.go
@@ -1,9 +1,27 @@
 package dependencyinjection
 
-// dependenciesStoreMap var is the global map for all the service instances.
-var dependenciesStoreMap map[string]interface{} = map[string]interface{}{}
+import "sync"
+
+var (
+	// dependenciesStoreMap var is the global map for all the service instances.
+	dependenciesStoreMap = make(map[string]interface{})
+	// dependenciesStoreMutex is the mutex for the global map, used to make sure the map is thread safe.
+	dependenciesStoreMutex sync.Mutex
+)
 
 // SetInstance adds a new service instance to instances map.
 func SetInstance(instanceName string, instance interface{}) {
+	dependenciesStoreMutex.Lock()
+	defer dependenciesStoreMutex.Unlock()
+
 	dependenciesStoreMap[instanceName] = instance
+}
+
+// GetInstance retrieves a service instance by name from the instances map.
+func GetInstance(instanceName string) (interface{}, bool) {
+	dependenciesStoreMutex.Lock()
+	defer dependenciesStoreMutex.Unlock()
+
+	instance, ok := dependenciesStoreMap[instanceName]
+	return instance, ok
 }

--- a/internal/dependencyinjection/signature_service.go
+++ b/internal/dependencyinjection/signature_service.go
@@ -16,7 +16,7 @@ func NewSignatureService(ctx context.Context, opts engine.SignatureServiceOption
 	instanceName := signatureServiceInstanceName
 
 	// Already initialized
-	if instance, ok := dependenciesStoreMap[instanceName]; ok {
+	if instance, ok := GetInstance(instanceName); ok {
 		if signatureServiceInstance, ok2 := instance.(engine.SignatureService); ok2 {
 			return signatureServiceInstance, nil
 		}

--- a/internal/dependencyinjection/signature_service.go
+++ b/internal/dependencyinjection/signature_service.go
@@ -5,18 +5,10 @@ import (
 	"fmt"
 
 	"github.com/stellar/go/support/log"
-	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 )
 
 const signatureServiceInstanceName = "signature_service_instance"
-
-type SignatureServiceOptions struct {
-	NetworkPassphrase      string
-	DBConnectionPool       db.DBConnectionPool
-	DistributionPrivateKey string
-	EncryptionPassphrase   string
-}
 
 // NewSignatureService creates a new signature service instance, or retrives an instance that was already
 // created before.

--- a/internal/dependencyinjection/signature_service.go
+++ b/internal/dependencyinjection/signature_service.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 )
 
-const signatureServiceInstanceName = "signature_service_instance"
+const SignatureServiceInstanceName = "signature_service_instance"
 
 // NewSignatureService creates a new signature service instance, or retrives an instance that was already
 // created before.
 func NewSignatureService(ctx context.Context, opts engine.SignatureServiceOptions) (engine.SignatureService, error) {
-	instanceName := signatureServiceInstanceName
+	instanceName := SignatureServiceInstanceName
 
 	// Already initialized
 	if instance, ok := GetInstance(instanceName); ok {

--- a/internal/dependencyinjection/signature_service_test.go
+++ b/internal/dependencyinjection/signature_service_test.go
@@ -67,7 +67,7 @@ func Test_dependencyinjection_NewSignatureService(t *testing.T) {
 	t.Run("should return an error if there's an invalid instance pre-stored", func(t *testing.T) {
 		ClearInstancesTestHelper(t)
 
-		SetInstance(signatureServiceInstanceName, false)
+		SetInstance(SignatureServiceInstanceName, false)
 
 		opts := engine.SignatureServiceOptions{
 			NetworkPassphrase:      network.TestNetworkPassphrase,

--- a/internal/dependencyinjection/signature_service_test.go
+++ b/internal/dependencyinjection/signature_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
+	engineMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,6 +34,7 @@ func Test_dependencyinjection_NewSignatureService(t *testing.T) {
 			DistributionPrivateKey: distributionPrivateKey,
 			EncryptionPassphrase:   encryptionPassphrase,
 			Type:                   engine.SignatureServiceTypeDefault,
+			LedgerNumberTracker:    engineMocks.NewMockLedgerNumberTracker(t),
 		}
 
 		gotDependency, err := NewSignatureService(ctx, opts)

--- a/internal/dependencyinjection/sms_client.go
+++ b/internal/dependencyinjection/sms_client.go
@@ -33,7 +33,7 @@ func NewSMSClient(opts SMSClientOptions) (message.MessengerClient, error) {
 
 	// If there is already an instance of the service, we return the same instance
 	instanceName := buildSMSClientInstanceName(opts.MessengerOptions.MessengerType)
-	if instance, ok := dependenciesStoreMap[instanceName]; ok {
+	if instance, ok := GetInstance(instanceName); ok {
 		if smsClientInstance, ok := instance.(message.MessengerClient); ok {
 			return smsClientInstance, nil
 		}

--- a/internal/dependencyinjection/tss_db_connection_pool.go
+++ b/internal/dependencyinjection/tss_db_connection_pool.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
 )
 
-const tssDBConnectionPoolInstanceName = "tss_db_connection_pool_instance"
+const TSSDBConnectionPoolInstanceName = "tss_db_connection_pool_instance"
 
 type TSSDBConnectionPoolOptions struct {
 	DatabaseURL string
@@ -18,7 +18,7 @@ type TSSDBConnectionPoolOptions struct {
 // NewTSSDBConnectionPool creates a new TSS db connection pool instance, or retrives a instance that
 // was already created before.
 func NewTSSDBConnectionPool(ctx context.Context, opts TSSDBConnectionPoolOptions) (db.DBConnectionPool, error) {
-	instanceName := tssDBConnectionPoolInstanceName
+	instanceName := TSSDBConnectionPoolInstanceName
 
 	if instance, ok := GetInstance(instanceName); ok {
 		if dbConnectionPoolInstance, ok2 := instance.(db.DBConnectionPool); ok2 {

--- a/internal/dependencyinjection/tss_db_connection_pool.go
+++ b/internal/dependencyinjection/tss_db_connection_pool.go
@@ -20,7 +20,7 @@ type TSSDBConnectionPoolOptions struct {
 func NewTSSDBConnectionPool(ctx context.Context, opts TSSDBConnectionPoolOptions) (db.DBConnectionPool, error) {
 	instanceName := tssDBConnectionPoolInstanceName
 
-	if instance, ok := dependenciesStoreMap[instanceName]; ok {
+	if instance, ok := GetInstance(instanceName); ok {
 		if dbConnectionPoolInstance, ok2 := instance.(db.DBConnectionPool); ok2 {
 			return dbConnectionPoolInstance, nil
 		}

--- a/internal/dependencyinjection/tss_db_connection_pool_test.go
+++ b/internal/dependencyinjection/tss_db_connection_pool_test.go
@@ -41,7 +41,7 @@ func Test_dependencyinjection_NewTSSDBConnectionPool(t *testing.T) {
 	t.Run("should return an error if there's an invalid instance pre-stored", func(t *testing.T) {
 		ClearInstancesTestHelper(t)
 
-		SetInstance(tssDBConnectionPoolInstanceName, false)
+		SetInstance(TSSDBConnectionPoolInstanceName, false)
 
 		opts := TSSDBConnectionPoolOptions{DatabaseURL: dbt.DSN}
 		gotDependency, err := NewTSSDBConnectionPool(ctx, opts)

--- a/internal/dependencyinjection/tx_submitter_engine.go
+++ b/internal/dependencyinjection/tx_submitter_engine.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 )
 
-const txSubmitterEngineInstanceName = "tx_submitter_engine_instance"
+const TxSubmitterEngineInstanceName = "tx_submitter_engine_instance"
 
 type TxSubmitterEngineOptions struct {
 	HorizonURL              string
@@ -19,7 +19,7 @@ type TxSubmitterEngineOptions struct {
 // NewTxSubmitterEngine creates a new ledger number tracker instance, or retrives an instance that was already
 // created before.
 func NewTxSubmitterEngine(ctx context.Context, opts TxSubmitterEngineOptions) (engine.SubmitterEngine, error) {
-	instanceName := txSubmitterEngineInstanceName
+	instanceName := TxSubmitterEngineInstanceName
 
 	// Already initialized
 	if instance, ok := GetInstance(instanceName); ok {

--- a/internal/dependencyinjection/tx_submitter_engine.go
+++ b/internal/dependencyinjection/tx_submitter_engine.go
@@ -1,0 +1,62 @@
+package dependencyinjection
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
+)
+
+const txSubmitterEngineInstanceName = "tx_submitter_engine_instance"
+
+type TxSubmitterEngineOptions struct {
+	HorizonURL              string
+	SignatureServiceOptions engine.SignatureServiceOptions
+	MaxBaseFee              int
+}
+
+// NewTxSubmitterEngine creates a new ledger number tracker instance, or retrives an instance that was already
+// created before.
+func NewTxSubmitterEngine(ctx context.Context, opts TxSubmitterEngineOptions) (engine.SubmitterEngine, error) {
+	instanceName := txSubmitterEngineInstanceName
+
+	// Already initialized
+	if instance, ok := GetInstance(instanceName); ok {
+		if castedInstance, ok2 := instance.(engine.SubmitterEngine); ok2 {
+			return castedInstance, nil
+		}
+		return engine.SubmitterEngine{}, fmt.Errorf("trying to cast an existing ledger number tracker instance")
+	}
+
+	horizonClient, err := NewHorizonClient(ctx, opts.HorizonURL)
+	if err != nil {
+		return engine.SubmitterEngine{}, fmt.Errorf("grabbing horizon client instance: %w", err)
+	}
+
+	ledgerNumberTracker, err := NewLedgerNumberTracker(ctx, horizonClient)
+	if err != nil {
+		return engine.SubmitterEngine{}, fmt.Errorf("grabbing ledger number tracker instance: %w", err)
+	}
+
+	signatureService, err := NewSignatureService(ctx, opts.SignatureServiceOptions)
+	if err != nil {
+		return engine.SubmitterEngine{}, fmt.Errorf("grabbing signature service instance: %w", err)
+	}
+
+	// Setup a new instance
+	log.Ctx(ctx).Infof("⚙️ Setting up Tx Submitter Engine")
+	newInstance := engine.SubmitterEngine{
+		HorizonClient:       horizonClient,
+		LedgerNumberTracker: ledgerNumberTracker,
+		SignatureService:    signatureService,
+		MaxBaseFee:          opts.MaxBaseFee,
+	}
+	if err = newInstance.Validate(); err != nil {
+		return engine.SubmitterEngine{}, fmt.Errorf("validating new instance submitter engine: %w", err)
+	}
+
+	SetInstance(instanceName, newInstance)
+
+	return newInstance, nil
+}

--- a/internal/dependencyinjection/tx_submitter_engine.go
+++ b/internal/dependencyinjection/tx_submitter_engine.go
@@ -26,7 +26,7 @@ func NewTxSubmitterEngine(ctx context.Context, opts TxSubmitterEngineOptions) (e
 		if castedInstance, ok2 := instance.(engine.SubmitterEngine); ok2 {
 			return castedInstance, nil
 		}
-		return engine.SubmitterEngine{}, fmt.Errorf("trying to cast an existing ledger number tracker instance")
+		return engine.SubmitterEngine{}, fmt.Errorf("trying to cast an existing submitter engine instance")
 	}
 
 	horizonClient, err := NewHorizonClient(ctx, opts.HorizonURL)

--- a/internal/dependencyinjection/tx_submitter_engine.go
+++ b/internal/dependencyinjection/tx_submitter_engine.go
@@ -38,6 +38,7 @@ func NewTxSubmitterEngine(ctx context.Context, opts TxSubmitterEngineOptions) (e
 	if err != nil {
 		return engine.SubmitterEngine{}, fmt.Errorf("grabbing ledger number tracker instance: %w", err)
 	}
+	opts.SignatureServiceOptions.LedgerNumberTracker = ledgerNumberTracker
 
 	signatureService, err := NewSignatureService(ctx, opts.SignatureServiceOptions)
 	if err != nil {

--- a/internal/dependencyinjection/tx_submitter_engine_test.go
+++ b/internal/dependencyinjection/tx_submitter_engine_test.go
@@ -1,0 +1,45 @@
+package dependencyinjection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	engineMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/mocks"
+)
+
+func Test_dependencyinjection_NewTxSubmitterEngine(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	ctx := context.Background()
+	t.Run("should create and return the same instance on the second call", func(t *testing.T) {
+		ClearInstancesTestHelper(t)
+
+		mSigService := engineMocks.NewMockSignatureService(t)
+		SetInstance(signatureServiceInstanceName, mSigService)
+
+		opts := TxSubmitterEngineOptions{MaxBaseFee: 100}
+		gotDependency, err := NewTxSubmitterEngine(ctx, opts)
+		require.NoError(t, err)
+
+		gotDependencyDuplicate, err := NewTxSubmitterEngine(ctx, opts)
+		require.NoError(t, err)
+
+		assert.Equal(t, &gotDependency, &gotDependencyDuplicate)
+	})
+
+	t.Run("should return an error if there's an invalid instance pre-stored", func(t *testing.T) {
+		ClearInstancesTestHelper(t)
+
+		SetInstance(txSubmitterEngineInstanceName, false)
+
+		opts := TxSubmitterEngineOptions{}
+		gotDependency, err := NewTxSubmitterEngine(ctx, opts)
+		assert.Empty(t, gotDependency)
+		assert.EqualError(t, err, "trying to cast an existing submitter engine instance")
+	})
+}

--- a/internal/dependencyinjection/tx_submitter_engine_test.go
+++ b/internal/dependencyinjection/tx_submitter_engine_test.go
@@ -20,7 +20,7 @@ func Test_dependencyinjection_NewTxSubmitterEngine(t *testing.T) {
 		ClearInstancesTestHelper(t)
 
 		mSigService := engineMocks.NewMockSignatureService(t)
-		SetInstance(signatureServiceInstanceName, mSigService)
+		SetInstance(SignatureServiceInstanceName, mSigService)
 
 		opts := TxSubmitterEngineOptions{MaxBaseFee: 100}
 		gotDependency, err := NewTxSubmitterEngine(ctx, opts)
@@ -35,7 +35,7 @@ func Test_dependencyinjection_NewTxSubmitterEngine(t *testing.T) {
 	t.Run("should return an error if there's an invalid instance pre-stored", func(t *testing.T) {
 		ClearInstancesTestHelper(t)
 
-		SetInstance(txSubmitterEngineInstanceName, false)
+		SetInstance(TxSubmitterEngineInstanceName, false)
 
 		opts := TxSubmitterEngineOptions{}
 		gotDependency, err := NewTxSubmitterEngine(ctx, opts)

--- a/internal/serve/httphandler/assets_handler.go
+++ b/internal/serve/httphandler/assets_handler.go
@@ -26,17 +26,13 @@ import (
 	tssUtils "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/utils"
 )
 
-const (
-	feeMultiplierInStroops = 10_000
-	stellarNativeAssetCode = "XLM"
-)
+const stellarNativeAssetCode = "XLM"
 
 var errCouldNotRemoveTrustline = errors.New("could not remove trustline")
 
 type AssetsHandler struct {
-	Models             *data.Models
-	HorizonClient      horizonclient.ClientInterface
-	SignatureService   engine.SignatureService
+	Models *data.Models
+	engine.SubmitterEngine
 	GetPreconditionsFn func() txnbuild.Preconditions
 }
 
@@ -282,7 +278,7 @@ func (c AssetsHandler) submitChangeTrustTransaction(ctx context.Context, acc *ho
 			},
 			IncrementSequenceNum: true,
 			Operations:           operations,
-			BaseFee:              txnbuild.MinBaseFee * feeMultiplierInStroops,
+			BaseFee:              int64(c.MaxBaseFee),
 			Preconditions:        preconditions,
 		},
 	)

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/mocks"
 )
 
@@ -106,11 +107,16 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 	distributionKP := keypair.MustRandom()
 	horizonClientMock := &horizonclient.MockClient{}
 	signatureService := mocks.NewMockSignatureService(t)
+	mLedgerNumberTracker := mocks.NewMockLedgerNumberTracker(t)
 
 	handler := &AssetsHandler{
-		Models:             model,
-		SignatureService:   signatureService,
-		HorizonClient:      horizonClientMock,
+		Models: model,
+		SubmitterEngine: engine.SubmitterEngine{
+			SignatureService:    signatureService,
+			HorizonClient:       horizonClientMock,
+			LedgerNumberTracker: mLedgerNumberTracker,
+			MaxBaseFee:          200,
+		},
 		GetPreconditionsFn: func() txnbuild.Preconditions { return defaultPreconditions },
 	}
 
@@ -146,7 +152,7 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 						SourceAccount: distributionKP.Address(),
 					},
 				},
-				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
+				BaseFee:       200,
 				Preconditions: defaultPreconditions,
 			},
 		)
@@ -332,7 +338,7 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 						SourceAccount: distributionKP.Address(),
 					},
 				},
-				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
+				BaseFee:       200,
 				Preconditions: defaultPreconditions,
 			},
 		)
@@ -418,7 +424,7 @@ func Test_AssetHandler_CreateAsset(t *testing.T) {
 						SourceAccount: distributionKP.Address(),
 					},
 				},
-				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
+				BaseFee:       200,
 				Preconditions: defaultPreconditions,
 			},
 		)
@@ -497,11 +503,16 @@ func Test_AssetHandler_DeleteAsset(t *testing.T) {
 	distributionKP := keypair.MustRandom()
 	horizonClientMock := &horizonclient.MockClient{}
 	signatureService := mocks.NewMockSignatureService(t)
+	mLedgerNumberTracker := mocks.NewMockLedgerNumberTracker(t)
 
 	handler := &AssetsHandler{
-		Models:             model,
-		SignatureService:   signatureService,
-		HorizonClient:      horizonClientMock,
+		Models: model,
+		SubmitterEngine: engine.SubmitterEngine{
+			SignatureService:    signatureService,
+			HorizonClient:       horizonClientMock,
+			LedgerNumberTracker: mLedgerNumberTracker,
+			MaxBaseFee:          150,
+		},
 		GetPreconditionsFn: func() txnbuild.Preconditions { return defaultPreconditions },
 	}
 
@@ -538,7 +549,7 @@ func Test_AssetHandler_DeleteAsset(t *testing.T) {
 						SourceAccount: distributionKP.Address(),
 					},
 				},
-				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
+				BaseFee:       150,
 				Preconditions: defaultPreconditions,
 			},
 		)
@@ -702,10 +713,15 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 	distributionKP := keypair.MustRandom()
 	horizonClientMock := &horizonclient.MockClient{}
 	signatureService := mocks.NewMockSignatureService(t)
+	mLedgerNumberTracker := mocks.NewMockLedgerNumberTracker(t)
 
 	handler := &AssetsHandler{
-		SignatureService:   signatureService,
-		HorizonClient:      horizonClientMock,
+		SubmitterEngine: engine.SubmitterEngine{
+			SignatureService:    signatureService,
+			HorizonClient:       horizonClientMock,
+			LedgerNumberTracker: mLedgerNumberTracker,
+			MaxBaseFee:          300,
+		},
 		GetPreconditionsFn: func() txnbuild.Preconditions { return defaultPreconditions },
 	}
 
@@ -786,7 +802,7 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 						SourceAccount: distributionKP.Address(),
 					},
 				},
-				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
+				BaseFee:       300,
 				Preconditions: defaultPreconditions,
 			},
 		)
@@ -877,7 +893,7 @@ func Test_AssetHandler_handleUpdateAssetTrustlineForDistributionAccount(t *testi
 						SourceAccount: distributionKP.Address(),
 					},
 				},
-				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
+				BaseFee:       300,
 				Preconditions: defaultPreconditions,
 			},
 		)
@@ -1086,10 +1102,15 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 	distributionKP := keypair.MustRandom()
 	horizonClientMock := &horizonclient.MockClient{}
 	signatureService := mocks.NewMockSignatureService(t)
+	mLedgerNumberTracker := mocks.NewMockLedgerNumberTracker(t)
 
 	handler := &AssetsHandler{
-		SignatureService:   signatureService,
-		HorizonClient:      horizonClientMock,
+		SubmitterEngine: engine.SubmitterEngine{
+			SignatureService:    signatureService,
+			HorizonClient:       horizonClientMock,
+			LedgerNumberTracker: mLedgerNumberTracker,
+			MaxBaseFee:          txnbuild.MinBaseFee,
+		},
 		GetPreconditionsFn: func() txnbuild.Preconditions { return defaultPreconditions },
 	}
 
@@ -1150,7 +1171,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 						SourceAccount: distributionKP.Address(),
 					},
 				},
-				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
+				BaseFee:       txnbuild.MinBaseFee,
 				Preconditions: defaultPreconditions,
 			},
 		)
@@ -1196,7 +1217,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 						SourceAccount: distributionKP.Address(),
 					},
 				},
-				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
+				BaseFee:       txnbuild.MinBaseFee,
 				Preconditions: defaultPreconditions,
 			},
 		)
@@ -1263,7 +1284,7 @@ func Test_AssetHandler_submitChangeTrustTransaction(t *testing.T) {
 						SourceAccount: distributionKP.Address(),
 					},
 				},
-				BaseFee:       txnbuild.MinBaseFee * feeMultiplierInStroops,
+				BaseFee:       txnbuild.MinBaseFee,
 				Preconditions: defaultPreconditions,
 			},
 		)
@@ -1316,12 +1337,18 @@ func newAssetTestMock(t *testing.T, distributionAccountAddress string) *assetTes
 		On("DistributionAccount").
 		Return(distributionAccountAddress)
 
+	mLedgerNumberTracker := mocks.NewMockLedgerNumberTracker(t)
+
 	return &assetTestMock{
 		SignatureService:  signatureService,
 		HorizonClientMock: horizonClientMock,
 		Handler: AssetsHandler{
-			SignatureService: signatureService,
-			HorizonClient:    horizonClientMock,
+			SubmitterEngine: engine.SubmitterEngine{
+				SignatureService:    signatureService,
+				HorizonClient:       horizonClientMock,
+				LedgerNumberTracker: mLedgerNumberTracker,
+				MaxBaseFee:          txnbuild.MinBaseFee,
+			},
 		},
 	}
 }
@@ -1376,7 +1403,7 @@ func Test_AssetHandler_submitChangeTrustTransaction_makeSurePreconditionsAreSetA
 				SourceAccount: distributionKP.Address(),
 			},
 		},
-		BaseFee: txnbuild.MinBaseFee * feeMultiplierInStroops,
+		BaseFee: txnbuild.MinBaseFee,
 	}
 
 	// TODO: Fix this test that seems to be flaky locally [SDP-963]

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/network"
 	supporthttp "github.com/stellar/go/support/http"
 	"github.com/stellar/go/support/log"
@@ -70,8 +69,7 @@ type ServeOptions struct {
 	UIBaseURL                       string
 	ResetTokenExpirationHours       int
 	NetworkPassphrase               string
-	HorizonClient                   horizonclient.ClientInterface
-	SignatureService                engine.SignatureService
+	SubmitterEngine                 engine.SubmitterEngine
 	Sep10SigningPublicKey           string
 	Sep10SigningPrivateKey          string
 	AnchorPlatformBaseSepURL        string
@@ -80,7 +78,6 @@ type ServeOptions struct {
 	AnchorPlatformAPIService        anchorplatform.AnchorPlatformAPIServiceInterface
 	CrashTrackerClient              crashtracker.CrashTrackerClient
 	DistributionPublicKey           string
-	DistributionSeed                string
 	ReCAPTCHASiteKey                string
 	ReCAPTCHASiteSecretKey          string
 	EnableScheduler                 bool
@@ -280,9 +277,8 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 		r.Route("/assets", func(r chi.Router) {
 			assetsHandler := httphandler.AssetsHandler{
-				Models:           o.Models,
-				SignatureService: o.SignatureService,
-				HorizonClient:    o.HorizonClient,
+				Models:          o.Models,
+				SubmitterEngine: o.SubmitterEngine,
 			}
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -70,8 +70,7 @@ type ServeOptions struct {
 	UIBaseURL                       string
 	ResetTokenExpirationHours       int
 	NetworkPassphrase               string
-	HorizonURL                      string
-	horizonClient                   horizonclient.ClientInterface
+	HorizonClient                   horizonclient.ClientInterface
 	SignatureService                engine.SignatureService
 	Sep10SigningPublicKey           string
 	Sep10SigningPrivateKey          string
@@ -141,12 +140,6 @@ func (opts *ServeOptions) SetupDependencies() error {
 		return fmt.Errorf("error creating SEP-24 JWT manager: %w", err)
 	}
 	opts.sep24JWTManager = sep24JWTManager
-
-	// Setup Horizon Client
-	opts.horizonClient = &horizonclient.Client{
-		HorizonURL: opts.HorizonURL,
-		HTTP:       httpclient.DefaultClient(),
-	}
 
 	return nil
 }
@@ -289,7 +282,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			assetsHandler := httphandler.AssetsHandler{
 				Models:           o.Models,
 				SignatureService: o.SignatureService,
-				HorizonClient:    o.horizonClient,
+				HorizonClient:    o.HorizonClient,
 			}
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	supporthttp "github.com/stellar/go/support/http"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
@@ -76,7 +75,6 @@ func Test_Serve(t *testing.T) {
 		AnchorPlatformOutgoingJWTSecret: "jwt_secret_1234567890",
 		Version:                         "x.y.z",
 		NetworkPassphrase:               network.TestNetworkPassphrase,
-		DistributionSeed:                keypair.MustRandom().Seed(),
 	}
 
 	// Mock supportHTTPRun
@@ -223,7 +221,6 @@ func getServeOptionsForTests(t *testing.T, databaseDSN string) ServeOptions {
 		SMSMessengerClient:              &messengerClientMock,
 		Version:                         "x.y.z",
 		NetworkPassphrase:               network.TestNetworkPassphrase,
-		DistributionSeed:                keypair.MustRandom().Seed(),
 		EnableMultiTenantDB:             false,
 	}
 	err = serveOptions.SetupDependencies()

--- a/internal/transactionsubmission/engine/mocks/signature_service.go
+++ b/internal/transactionsubmission/engine/mocks/signature_service.go
@@ -5,8 +5,6 @@ package mocks
 import (
 	context "context"
 
-	keypair "github.com/stellar/go/keypair"
-
 	mock "github.com/stretchr/testify/mock"
 
 	txnbuild "github.com/stellar/go/txnbuild"
@@ -17,27 +15,39 @@ type MockSignatureService struct {
 	mock.Mock
 }
 
-// BatchInsert provides a mock function with given fields: ctx, kps, shouldEncryptSeed, currLedgerNumber
-func (_m *MockSignatureService) BatchInsert(ctx context.Context, kps []*keypair.Full, shouldEncryptSeed bool, currLedgerNumber int) error {
-	ret := _m.Called(ctx, kps, shouldEncryptSeed, currLedgerNumber)
+// BatchInsert provides a mock function with given fields: ctx, amount
+func (_m *MockSignatureService) BatchInsert(ctx context.Context, amount int) ([]string, error) {
+	ret := _m.Called(ctx, amount)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, []*keypair.Full, bool, int) error); ok {
-		r0 = rf(ctx, kps, shouldEncryptSeed, currLedgerNumber)
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int) ([]string, error)); ok {
+		return rf(ctx, amount)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int) []string); ok {
+		r0 = rf(ctx, amount)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, amount)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// Delete provides a mock function with given fields: ctx, publicKey, currLedgerNumber
-func (_m *MockSignatureService) Delete(ctx context.Context, publicKey string, currLedgerNumber int) error {
-	ret := _m.Called(ctx, publicKey, currLedgerNumber)
+// Delete provides a mock function with given fields: ctx, publicKey
+func (_m *MockSignatureService) Delete(ctx context.Context, publicKey string) error {
+	ret := _m.Called(ctx, publicKey)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, int) error); ok {
-		r0 = rf(ctx, publicKey, currLedgerNumber)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, publicKey)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/transactionsubmission/engine/signature_service.go
+++ b/internal/transactionsubmission/engine/signature_service.go
@@ -41,6 +41,7 @@ type SignatureServiceOptions struct {
 	DBConnectionPool       db.DBConnectionPool
 	DistributionPrivateKey string
 	EncryptionPassphrase   string
+	LedgerNumberTracker    LedgerNumberTracker
 	Type                   SignatureServiceType
 }
 
@@ -52,6 +53,7 @@ func NewSignatureService(opts SignatureServiceOptions) (SignatureService, error)
 			DBConnectionPool:       opts.DBConnectionPool,
 			DistributionPrivateKey: opts.DistributionPrivateKey,
 			EncryptionPassphrase:   opts.EncryptionPassphrase,
+			LedgerNumberTracker:    opts.LedgerNumberTracker,
 		})
 
 	default:
@@ -75,6 +77,7 @@ type DefaultSignatureServiceOptions struct {
 	DistributionPrivateKey string
 	EncryptionPassphrase   string
 	Encrypter              utils.PrivateKeyEncrypter
+	LedgerNumberTracker    LedgerNumberTracker
 }
 
 func (opts *DefaultSignatureServiceOptions) Validate() error {
@@ -94,6 +97,10 @@ func (opts *DefaultSignatureServiceOptions) Validate() error {
 		return fmt.Errorf("encryption passphrase is not a valid Ed25519 secret")
 	}
 
+	if opts.LedgerNumberTracker == nil {
+		return fmt.Errorf("ledger number tracker cannot be nil")
+	}
+
 	return nil
 }
 
@@ -105,6 +112,7 @@ type DefaultSignatureService struct {
 	chAccModel           store.ChannelAccountStore
 	encrypter            utils.PrivateKeyEncrypter
 	encryptionPassphrase string
+	ledgerNumberTracker  LedgerNumberTracker
 }
 
 // NewDefaultSignatureService returns a new DefaultSignatureService instance.
@@ -131,6 +139,7 @@ func NewDefaultSignatureService(opts DefaultSignatureServiceOptions) (*DefaultSi
 		chAccModel:           store.NewChannelAccountModel(opts.DBConnectionPool),
 		encrypter:            encrypter,
 		encryptionPassphrase: opts.EncryptionPassphrase,
+		ledgerNumberTracker:  opts.LedgerNumberTracker,
 	}, nil
 }
 

--- a/internal/transactionsubmission/engine/signature_service.go
+++ b/internal/transactionsubmission/engine/signature_service.go
@@ -245,7 +245,7 @@ func (ds *DefaultSignatureService) BatchInsert(ctx context.Context, amount int) 
 	lockedToLedgerNumber := currentLedgerNumber + IncrementForMaxLedgerBounds
 
 	batchInsertPayload := []*store.ChannelAccount{}
-	for range make([]interface{}, amount) {
+	for i := 0; i < amount; i++ {
 		kp, innerErr := keypair.Random()
 		if innerErr != nil {
 			return nil, fmt.Errorf("generating random keypair: %w", innerErr)

--- a/internal/transactionsubmission/engine/signature_service.go
+++ b/internal/transactionsubmission/engine/signature_service.go
@@ -25,14 +25,6 @@ func (t SignatureServiceType) All() []SignatureServiceType {
 	return []SignatureServiceType{SignatureServiceTypeDefault}
 }
 
-func (t SignatureServiceType) StringAll() []string {
-	strAll := []string{}
-	for _, t := range t.All() {
-		strAll = append(strAll, string(t))
-	}
-	return strAll
-}
-
 func ParseSignatureServiceType(sigServiceType string) (SignatureServiceType, error) {
 	sigServiceTypeStrUpper := strings.ToUpper(sigServiceType)
 	ctType := SignatureServiceType(sigServiceTypeStrUpper)

--- a/internal/transactionsubmission/engine/signature_service_test.go
+++ b/internal/transactionsubmission/engine/signature_service_test.go
@@ -579,35 +579,24 @@ func Test_DefaultSignatureService_BatchInsert(t *testing.T) {
 	distributionKP, err := keypair.Random()
 	require.NoError(t, err)
 
-	signerKP1 := keypair.MustRandom()
-	signerKP2 := keypair.MustRandom()
-
 	testCase := []struct {
-		name              string
-		shouldEncryptSeed bool
-		kps               []*keypair.Full
-		wantErrContains   string
+		name            string
+		amount          int
+		wantErrContains string
 	}{
 		{
-			name:            "if KPs is empty, return an error",
-			wantErrContains: "no keypairs provided",
+			name:            "if amount<=0, return an error",
+			wantErrContains: "the amnount of accounts to insert need to be greater than zero",
 		},
 		{
-			name:              "🎉 successfully bulk insert without encryption",
-			shouldEncryptSeed: false,
-			kps:               []*keypair.Full{signerKP1, signerKP2},
-		},
-		{
-			name:              "🎉 successfully bulk insert with encryption",
-			shouldEncryptSeed: true,
-			kps:               []*keypair.Full{signerKP1, signerKP2},
+			name:   "🎉 successfully bulk insert",
+			amount: 2,
 		},
 	}
 
-	type comparableChAccount struct {
-		PublicKey  string
-		PrivateKey string
-	}
+	mLedgerNumberTracker := mocks.NewMockLedgerNumberTracker(t)
+	mLedgerNumberTracker.On("GetLedgerNumber").Return(100, nil).Once()
+	defer mLedgerNumberTracker.AssertExpectations(t)
 
 	defaultEncrypter := &utils.DefaultPrivateKeyEncrypter{}
 	encrypterPass := distributionKP.Seed()
@@ -617,7 +606,7 @@ func Test_DefaultSignatureService_BatchInsert(t *testing.T) {
 		DistributionPrivateKey: distributionKP.Seed(),
 		EncryptionPassphrase:   encrypterPass,
 		Encrypter:              defaultEncrypter,
-		LedgerNumberTracker:    mocks.NewMockLedgerNumberTracker(t),
+		LedgerNumberTracker:    mLedgerNumberTracker,
 	})
 	require.NoError(t, err)
 
@@ -627,42 +616,33 @@ func Test_DefaultSignatureService_BatchInsert(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 0, count, "this test should have started with 0 channel accounts")
 
-			err = defaultSigService.BatchInsert(ctx, tc.kps, tc.shouldEncryptSeed, 0)
+			publicKeys, err := defaultSigService.BatchInsert(ctx, tc.amount)
 			if tc.wantErrContains != "" {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.wantErrContains)
+				assert.Nil(t, publicKeys)
 			} else {
 				require.NoError(t, err)
 
 				allChAccounts, err := chAccountStore.GetAll(ctx, dbConnectionPool, math.MaxInt32, 0)
 				require.NoError(t, err)
-				assert.Equal(t, len(tc.kps), len(allChAccounts))
+				assert.Equal(t, tc.amount, len(publicKeys))
+				assert.Equal(t, tc.amount, len(allChAccounts))
 
 				// compare the accounts
-				var allChAccountsComparable []comparableChAccount
+				var alChAccPublicKeys []string
 				for _, chAccount := range allChAccounts {
-					publicKey := chAccount.PublicKey
-					privateKey := chAccount.PrivateKey
+					alChAccPublicKeys = append(alChAccPublicKeys, chAccount.PublicKey)
 
-					if tc.shouldEncryptSeed {
-						privateKey, err = defaultEncrypter.Decrypt(privateKey, encrypterPass)
-						require.NoError(t, err)
-					}
-
-					allChAccountsComparable = append(allChAccountsComparable, comparableChAccount{
-						PublicKey:  publicKey,
-						PrivateKey: privateKey,
-					})
+					// Check if the private key is the actual seed for the public key
+					encryptedPrivateKey := chAccount.PrivateKey
+					privateKey, err := defaultEncrypter.Decrypt(encryptedPrivateKey, encrypterPass)
+					require.NoError(t, err)
+					kp := keypair.MustParseFull(privateKey)
+					assert.Equal(t, chAccount.PublicKey, kp.Address())
 				}
 
-				var tcChAccountsComparable []comparableChAccount
-				for _, kp := range tc.kps {
-					tcChAccountsComparable = append(tcChAccountsComparable, comparableChAccount{
-						PublicKey:  kp.Address(),
-						PrivateKey: kp.Seed(),
-					})
-				}
-				assert.ElementsMatch(t, tcChAccountsComparable, allChAccountsComparable)
+				assert.ElementsMatch(t, alChAccPublicKeys, publicKeys)
 			}
 
 			store.DeleteAllFromChannelAccounts(t, ctx, dbConnectionPool)
@@ -680,17 +660,16 @@ func Test_DefaultSignatureService_Delete(t *testing.T) {
 	ctx := context.Background()
 	chAccountStore := &store.ChannelAccountModel{DBConnectionPool: dbConnectionPool}
 
-	distributionKP, err := keypair.Random()
-	require.NoError(t, err)
-	defaultSigService, err := NewDefaultSignatureService(DefaultSignatureServiceOptions{
-		NetworkPassphrase:      network.TestNetworkPassphrase,
-		DBConnectionPool:       dbConnectionPool,
-		DistributionPrivateKey: distributionKP.Seed(),
-		EncryptionPassphrase:   distributionKP.Seed(),
-		Encrypter:              &utils.PrivateKeyEncrypterMock{},
-		LedgerNumberTracker:    mocks.NewMockLedgerNumberTracker(t),
-	})
-	require.NoError(t, err)
+	// current ledger number
+	currLedgerNumber := 0
+	lockUntilLedgerNumber := 10
+	mLedgerNumberTracker := mocks.NewMockLedgerNumberTracker(t)
+	mLedgerNumberTracker.
+		On("GetLedgerNumber").
+		Return(currLedgerNumber, nil).
+		Times(3)
+
+	defer mLedgerNumberTracker.AssertExpectations(t)
 
 	// at start: count=0
 	count, err := chAccountStore.Count(ctx)
@@ -703,29 +682,39 @@ func Test_DefaultSignatureService_Delete(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 
-	currLedgerNumber := 0
-	lockUntilLedgerNumber := 10
 	for _, chAcc := range channelAccounts {
 		_, err = chAccountStore.Lock(ctx, chAccountStore.DBConnectionPool, chAcc.PublicKey, int32(currLedgerNumber), int32(lockUntilLedgerNumber))
 		require.NoError(t, err)
 	}
 
+	distributionKP, err := keypair.Random()
+	require.NoError(t, err)
+	defaultSigService, err := NewDefaultSignatureService(DefaultSignatureServiceOptions{
+		NetworkPassphrase:      network.TestNetworkPassphrase,
+		DBConnectionPool:       dbConnectionPool,
+		DistributionPrivateKey: distributionKP.Seed(),
+		EncryptionPassphrase:   distributionKP.Seed(),
+		Encrypter:              &utils.PrivateKeyEncrypterMock{},
+		LedgerNumberTracker:    mLedgerNumberTracker,
+	})
+	require.NoError(t, err)
+
 	// delete one account: count=2->1
-	err = defaultSigService.Delete(ctx, channelAccounts[0].PublicKey, lockUntilLedgerNumber)
+	err = defaultSigService.Delete(ctx, channelAccounts[0].PublicKey)
 	require.NoError(t, err)
 	count, err = chAccountStore.Count(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 1, count)
 
 	// delete another account: count=1->0
-	err = defaultSigService.Delete(ctx, channelAccounts[1].PublicKey, lockUntilLedgerNumber)
+	err = defaultSigService.Delete(ctx, channelAccounts[1].PublicKey)
 	require.NoError(t, err)
 	count, err = chAccountStore.Count(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
 
 	// delete non-existing account: error expected
-	err = defaultSigService.Delete(ctx, "non-existent-account", 0)
+	err = defaultSigService.Delete(ctx, "non-existent-account")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, store.ErrRecordNotFound)
 }

--- a/internal/transactionsubmission/engine/submitter_engine_test.go
+++ b/internal/transactionsubmission/engine/submitter_engine_test.go
@@ -4,48 +4,70 @@ import (
 	"testing"
 
 	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_NewSubmitterEngine(t *testing.T) {
-	mockHorizonClient := &horizonclient.MockClient{}
+func Test_SubmitterEngine_Validate(t *testing.T) {
+	hMock := &horizonclient.MockClient{}
+	mLedgerNumberTracker := mocks.NewMockLedgerNumberTracker(t)
+	mSigService := mocks.NewMockSignatureService(t)
 
 	testCases := []struct {
 		name            string
-		hClient         horizonclient.ClientInterface
+		engine          SubmitterEngine
 		wantErrContains string
-		wantResult      *SubmitterEngine
 	}{
 		{
 			name:            "returns an error if the horizon client is nil",
-			hClient:         nil,
-			wantErrContains: "creating ledger keeper: horizon client cannot be nil",
+			wantErrContains: "horizon client cannot be nil",
 		},
 		{
-			name:    "🎉 successfully provides new SubmitterEngine",
-			hClient: mockHorizonClient,
-			wantResult: &SubmitterEngine{
-				HorizonClient:       mockHorizonClient,
-				LedgerNumberTracker: &DefaultLedgerNumberTracker{hClient: mockHorizonClient, maxLedgerAge: MaxLedgerAge},
+			name: "returns an error if the ledger number tracker is nil",
+			engine: SubmitterEngine{
+				HorizonClient: hMock,
+			},
+			wantErrContains: "ledger number tracker cannot be nil",
+		},
+		{
+			name: "returns an error if the signature service is nil",
+			engine: SubmitterEngine{
+				HorizonClient:       hMock,
+				LedgerNumberTracker: mLedgerNumberTracker,
+			},
+			wantErrContains: "signature service cannot be nil",
+		},
+		{
+			name: "returns an error if the max base fee is less than the minimum",
+			engine: SubmitterEngine{
+				HorizonClient:       hMock,
+				LedgerNumberTracker: mLedgerNumberTracker,
+				SignatureService:    mSigService,
+				MaxBaseFee:          99,
+			},
+			wantErrContains: "maxBaseFee must be greater than or equal to 100",
+		},
+		{
+			name: "🎉 successfully validates the SubmitterEngine",
+			engine: SubmitterEngine{
+				HorizonClient:       hMock,
+				LedgerNumberTracker: mLedgerNumberTracker,
+				SignatureService:    mSigService,
+				MaxBaseFee:          100,
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			submitterEngine, err := NewSubmitterEngine(tc.hClient)
+			err := tc.engine.Validate()
 			if tc.wantErrContains != "" {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.wantErrContains)
-				assert.Nil(t, submitterEngine)
 			} else {
 				require.NoError(t, err)
-				assert.NotNil(t, submitterEngine)
-				assert.Equal(t, tc.wantResult, submitterEngine)
 			}
 		})
 	}
-
-	mockHorizonClient.AssertExpectations(t)
 }

--- a/internal/transactionsubmission/horizon.go
+++ b/internal/transactionsubmission/horizon.go
@@ -137,7 +137,6 @@ func CreateChannelAccountsOnChain(ctx context.Context, submiterEngine engine.Sub
 }
 
 // DeleteChannelAccountOnChain creates, signs, and broadcasts a transaction to delete a channel account onchain.
-// TODO: apply engine here
 func DeleteChannelAccountOnChain(ctx context.Context, submiterEngine engine.SubmitterEngine, chAccAddress string) error {
 	distributionAccount := submiterEngine.SignatureService.DistributionAccount()
 	rootAccount, err := submiterEngine.HorizonClient.AccountDetail(horizonclient.AccountRequest{

--- a/internal/transactionsubmission/horizon_test.go
+++ b/internal/transactionsubmission/horizon_test.go
@@ -47,6 +47,7 @@ func Test_CreateChannelAccountsOnChain(t *testing.T) {
 		DistributionPrivateKey: distributionKP.Seed(),
 		EncryptionPassphrase:   encrypterPass,
 		Encrypter:              privateKeyEncrypterMock,
+		LedgerNumberTracker:    engineMocks.NewMockLedgerNumberTracker(t),
 	})
 	require.NoError(t, err)
 

--- a/internal/transactionsubmission/manager.go
+++ b/internal/transactionsubmission/manager.go
@@ -9,9 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/support/log"
-	"github.com/stellar/go/txnbuild"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
@@ -25,15 +23,13 @@ import (
 const serviceName = "Transaction Submission Service"
 
 type SubmitterOptions struct {
-	HorizonClient        horizonclient.ClientInterface
 	NumChannelAccounts   int
 	QueuePollingInterval int
-	MaxBaseFee           int
 	MonitorService       tssMonitor.TSSMonitorService
 	CrashTrackerClient   crashtracker.CrashTrackerClient
 	EventProducer        events.Producer
 
-	SignatureService engine.SignatureService
+	SubmitterEngine  engine.SubmitterEngine
 	DBConnectionPool db.DBConnectionPool
 }
 
@@ -42,12 +38,8 @@ func (so *SubmitterOptions) validate() error {
 		return fmt.Errorf("database connection pool cannot be nil")
 	}
 
-	if so.SignatureService == nil {
-		return fmt.Errorf("signature service cannot be nil")
-	}
-
-	if so.HorizonClient == nil {
-		return fmt.Errorf("horizon client cannot be nil")
+	if err := so.SubmitterEngine.Validate(); err != nil {
+		return fmt.Errorf("validating submitter engine: %w", err)
 	}
 
 	if so.NumChannelAccounts < MinNumberOfChannelAccounts || so.NumChannelAccounts > MaxNumberOfChannelAccounts {
@@ -56,10 +48,6 @@ func (so *SubmitterOptions) validate() error {
 
 	if so.QueuePollingInterval < 6 {
 		return fmt.Errorf("queue polling interval must be greater than 6 seconds")
-	}
-
-	if so.MaxBaseFee < txnbuild.MinBaseFee {
-		return fmt.Errorf("max base fee must be greater than or equal to %d", txnbuild.MinBaseFee)
 	}
 
 	if sdpUtils.IsEmpty(so.MonitorService) {
@@ -79,9 +67,7 @@ type Manager struct {
 	queueService        defaultQueueService
 	txProcessingLimiter *engine.TransactionProcessingLimiter
 	// transaction submission:
-	engine     *engine.SubmitterEngine
-	sigService engine.SignatureService
-	maxBaseFee int
+	engine *engine.SubmitterEngine
 	// crash & metrics monitoring:
 	monitorService     tssMonitor.TSSMonitorService
 	crashTrackerClient crashtracker.CrashTrackerClient
@@ -115,12 +101,6 @@ func NewManager(ctx context.Context, opts SubmitterOptions) (m *Manager, err err
 		return nil, fmt.Errorf("initializing channel transaction bundle model: %w", err)
 	}
 
-	// initialize SubmitterEngine
-	submitterEngine, err := engine.NewSubmitterEngine(opts.HorizonClient)
-	if err != nil {
-		return nil, fmt.Errorf("initializing submitter engine: %w", err)
-	}
-
 	// validate if we have any channel accounts in the DB.
 	chAccCount, err := chAccModel.Count(ctx)
 	if err != nil {
@@ -151,9 +131,7 @@ func NewManager(ctx context.Context, opts SubmitterOptions) (m *Manager, err err
 		queueService:        queueService,
 		txProcessingLimiter: txProcessingLimiter,
 
-		engine:     submitterEngine,
-		sigService: opts.SignatureService,
-		maxBaseFee: opts.MaxBaseFee,
+		engine: &opts.SubmitterEngine,
 
 		crashTrackerClient: crashTrackerClient,
 		monitorService:     opts.MonitorService,
@@ -212,8 +190,6 @@ func (m *Manager) ProcessTransactions(ctx context.Context) {
 					m.txModel,
 					m.chAccModel,
 					m.engine,
-					m.sigService,
-					m.maxBaseFee,
 					m.crashTrackerClient,
 					m.txProcessingLimiter,
 					m.monitorService,

--- a/internal/transactionsubmission/manager_test.go
+++ b/internal/transactionsubmission/manager_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	monitorMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/monitor/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/mocks"
 	engineMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/mocks"
 	tssMonitor "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/monitor"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/store"
@@ -421,7 +420,7 @@ func Test_Manager_ProcessTransactions(t *testing.T) {
 
 			// mock ledger number tracker
 			const currentLedgerNumber = 123
-			mockLedgerNumberTracker := &mocks.MockLedgerNumberTracker{}
+			mockLedgerNumberTracker := engineMocks.NewMockLedgerNumberTracker(t)
 			mockLedgerNumberTracker.On("GetLedgerNumber").Return(currentLedgerNumber, nil)
 			defer mockLedgerNumberTracker.AssertExpectations(t)
 

--- a/internal/transactionsubmission/manager_test.go
+++ b/internal/transactionsubmission/manager_test.go
@@ -415,6 +415,7 @@ func Test_Manager_ProcessTransactions(t *testing.T) {
 				DistributionPrivateKey: distributionKP.Seed(),
 				EncryptionPassphrase:   distributionKP.Seed(),
 				Encrypter:              &utils.PrivateKeyEncrypterMock{},
+				LedgerNumberTracker:    engineMocks.NewMockLedgerNumberTracker(t),
 			})
 			require.NoError(t, err)
 

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -42,8 +42,6 @@ type TransactionWorker struct {
 	txModel             store.TransactionStore
 	chAccModel          store.ChannelAccountStore
 	engine              *engine.SubmitterEngine
-	sigService          engine.SignatureService
-	maxBaseFee          int
 	crashTrackerClient  crashtracker.CrashTrackerClient
 	txProcessingLimiter *engine.TransactionProcessingLimiter
 	monitorSvc          tssMonitor.TSSMonitorService
@@ -55,8 +53,6 @@ func NewTransactionWorker(
 	txModel *store.TransactionModel,
 	chAccModel *store.ChannelAccountModel,
 	engine *engine.SubmitterEngine,
-	sigService engine.SignatureService,
-	maxBaseFee int,
 	crashTrackerClient crashtracker.CrashTrackerClient,
 	txProcessingLimiter *engine.TransactionProcessingLimiter,
 	monitorSvc tssMonitor.TSSMonitorService,
@@ -74,16 +70,11 @@ func NewTransactionWorker(
 		return TransactionWorker{}, fmt.Errorf("chAccModel cannot be nil")
 	}
 
-	if tssUtils.IsEmpty(engine) {
+	if engine == nil {
 		return TransactionWorker{}, fmt.Errorf("engine cannot be nil")
 	}
-
-	if tssUtils.IsEmpty(sigService) {
-		return TransactionWorker{}, fmt.Errorf("sigService cannot be nil")
-	}
-
-	if maxBaseFee < txnbuild.MinBaseFee {
-		return TransactionWorker{}, fmt.Errorf("maxBaseFee must be greater than or equal to %d", txnbuild.MinBaseFee)
+	if err := engine.Validate(); err != nil {
+		return TransactionWorker{}, fmt.Errorf("validating engine: %w", err)
 	}
 
 	if crashTrackerClient == nil {
@@ -103,8 +94,6 @@ func NewTransactionWorker(
 		txModel:             txModel,
 		chAccModel:          chAccModel,
 		engine:              engine,
-		sigService:          sigService,
-		maxBaseFee:          maxBaseFee,
 		crashTrackerClient:  crashTrackerClient,
 		txProcessingLimiter: txProcessingLimiter,
 		monitorSvc:          monitorSvc,
@@ -450,7 +439,7 @@ func (tw *TransactionWorker) prepareForSubmission(ctx context.Context, txJob *Tx
 	// Important: We need to save tx hash before submitting a transaction.
 	// If the script/server crashes after transaction is submitted but before the response
 	// is processed, we can easily determine whether tx was sent or not later using tx hash.
-	feeBumpTxHash, err := feeBumpTx.HashHex(tw.sigService.NetworkPassphrase())
+	feeBumpTxHash, err := feeBumpTx.HashHex(tw.engine.SignatureService.NetworkPassphrase())
 	if err != nil {
 		return nil, fmt.Errorf("hashing transaction for job %v: %w", txJob, err)
 	}
@@ -500,13 +489,13 @@ func (tw *TransactionWorker) buildAndSignTransaction(ctx context.Context, txJob 
 			},
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
-					SourceAccount: tw.sigService.DistributionAccount(),
+					SourceAccount: tw.engine.SignatureService.DistributionAccount(),
 					Amount:        strconv.FormatFloat(txJob.Transaction.Amount, 'f', 6, 32), // TODO find a better way to do this
 					Destination:   txJob.Transaction.Destination,
 					Asset:         asset,
 				},
 			},
-			BaseFee: int64(tw.maxBaseFee),
+			BaseFee: int64(tw.engine.MaxBaseFee),
 			Preconditions: txnbuild.Preconditions{
 				TimeBounds:   txnbuild.NewTimeout(300),                                                 // maximum 5 minutes
 				LedgerBounds: &txnbuild.LedgerBounds{MaxLedger: uint32(txJob.LockedUntilLedgerNumber)}, // currently, 8-10 ledgers in the future
@@ -518,7 +507,7 @@ func (tw *TransactionWorker) buildAndSignTransaction(ctx context.Context, txJob 
 		return nil, fmt.Errorf("building transaction for job %v: %w", txJob, err)
 	}
 
-	paymentTx, err = tw.sigService.SignStellarTransaction(ctx, paymentTx, tw.sigService.DistributionAccount(), txJob.ChannelAccount.PublicKey)
+	paymentTx, err = tw.engine.SignatureService.SignStellarTransaction(ctx, paymentTx, tw.engine.SignatureService.DistributionAccount(), txJob.ChannelAccount.PublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("signing transaction: for job %v: %w", txJob, err)
 	}
@@ -527,8 +516,8 @@ func (tw *TransactionWorker) buildAndSignTransaction(ctx context.Context, txJob 
 	feeBumpTx, err = txnbuild.NewFeeBumpTransaction(
 		txnbuild.FeeBumpTransactionParams{
 			Inner:      paymentTx,
-			FeeAccount: tw.sigService.DistributionAccount(),
-			BaseFee:    int64(tw.maxBaseFee),
+			FeeAccount: tw.engine.SignatureService.DistributionAccount(),
+			BaseFee:    int64(tw.engine.MaxBaseFee),
 		},
 	)
 	if err != nil {
@@ -536,7 +525,7 @@ func (tw *TransactionWorker) buildAndSignTransaction(ctx context.Context, txJob 
 	}
 
 	// generate a random number to use as the fee-bump transaction's sequence number
-	feeBumpTx, err = tw.sigService.SignFeeBumpStellarTransaction(ctx, feeBumpTx, tw.sigService.DistributionAccount())
+	feeBumpTx, err = tw.engine.SignatureService.SignFeeBumpStellarTransaction(ctx, feeBumpTx, tw.engine.SignatureService.DistributionAccount())
 	if err != nil {
 		return nil, fmt.Errorf("signing fee-bump transaction for job %v: %w", txJob, err)
 	}

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -62,6 +62,7 @@ func getTransactionWorkerInstance(t *testing.T, dbConnectionPool db.DBConnection
 		DistributionPrivateKey: distributionKP.Seed(),
 		EncryptionPassphrase:   distributionKP.Seed(),
 		Encrypter:              &utils.PrivateKeyEncrypterMock{},
+		LedgerNumberTracker:    engineMocks.NewMockLedgerNumberTracker(t),
 	})
 	require.NoError(t, err)
 
@@ -133,6 +134,7 @@ func Test_NewTransactionWorker(t *testing.T) {
 		DistributionPrivateKey: distributionKP.Seed(),
 		EncryptionPassphrase:   distributionKP.Seed(),
 		Encrypter:              &utils.PrivateKeyEncrypterMock{},
+		LedgerNumberTracker:    engineMocks.NewMockLedgerNumberTracker(t),
 	})
 	require.NoError(t, err)
 
@@ -956,6 +958,7 @@ func Test_TransactionWorker_buildAndSignTransaction(t *testing.T) {
 		DistributionPrivateKey: distributionKP.Seed(),
 		EncryptionPassphrase:   distributionKP.Seed(),
 		Encrypter:              &utils.PrivateKeyEncrypterMock{},
+		LedgerNumberTracker:    engineMocks.NewMockLedgerNumberTracker(t),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
### What

Move all objects related to Stellar transaction submission into a single object:
```go
type SubmitterEngine struct {
	HorizonClient horizonclient.ClientInterface
	LedgerNumberTracker
	SignatureService
	MaxBaseFee int
}
```

Also, refactor the SIgnatureService interface so it becomes more generic and safer:
1. It became safer by not receiving the full keypair for insertion but instead receiving the amount of accounts to be created. We don't want to pass secrets around, but instead rely on the sig service to create the secrets.
2. It became more generic by removing the currentLedgerNumber from the insert/delete method signatures. This was very implementation-specific.

### Why

So we can inject all the necessary services at once.

Also, to prepare the sig service for the VAULT implementation.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
