### PR TITLE
Chore: attempt to fix intermittent error in `transactionsubmission/utils/utils_test.go:47`

### DIFF
--- a/internal/transactionsubmission/utils/utils_test.go
+++ b/internal/transactionsubmission/utils/utils_test.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"context"
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db/dbtest"
@@ -17,7 +19,9 @@ func TestAdvisoryLockAndRelease(t *testing.T) {
 	defer dbt.Close()
 
 	// Creates a database pool
-	lockKey := rand.Intn(100000)
+	randBigInt, err := rand.Int(rand.Reader, big.NewInt(90000))
+	require.NoError(t, err)
+	lockKey := int(randBigInt.Int64())
 
 	dbConnectionPool1, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
@@ -38,7 +42,11 @@ func TestAdvisoryLockAndRelease(t *testing.T) {
 	require.False(t, lockAcquired2)
 
 	// Close the original connection which releases the lock
+	sqlQuery := "SELECT pg_advisory_unlock($1)"
+	_, err = dbConnectionPool1.ExecContext(ctx, sqlQuery, lockKey)
+	require.NoError(t, err)
 	dbConnectionPool1.Close()
+	time.Sleep(200 * time.Millisecond)
 
 	// try to acquire the lock again
 	lockAcquired3, err := AcquireAdvisoryLock(ctx, dbConnectionPool2, lockKey)


### PR DESCRIPTION
### What

Attempt to fix intermittent error in `transactionsubmission/utils/utils_test.go:47`

### Why

There are intermittent errors happening when acquiring the advisory lock, like https://github.com/stellar/stellar-disbursement-platform-backend/actions/runs/7790057714/job/21243057987?pr=172 for instance:

![Screenshot 2024-02-05 at 12 17 17 PM](https://github.com/stellar/stellar-disbursement-platform-backend/assets/1952597/bf37732f-033d-48d4-a796-af6cc2442c2c)


### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
