### PR TITLE
[Hot-fix] TSS amount precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 None
 
+## [1.1.1](https://github.com/stellar/stellar-disbursement-platform-backend/compare/1.1.0...1.1.1)
+
+### Fixed
+
+- TSS amount precision [#176](https://github.com/stellar/stellar-disbursement-platform-backend/pull/176)
+
 ## [1.1.0](https://github.com/stellar/stellar-disbursement-platform-backend/compare/1.0.1...1.1.0)
 
 ### Changed

--- a/internal/db/migrations/2023-07-05.0-tss-transactions-table-constraints.sql
+++ b/internal/db/migrations/2023-07-05.0-tss-transactions-table-constraints.sql
@@ -6,7 +6,7 @@ ALTER TABLE public.submitter_transactions
     ADD COLUMN xdr_received TEXT UNIQUE,
     ALTER COLUMN external_id SET NOT NULL,
     ALTER COLUMN status SET DEFAULT 'PENDING',
-    ALTER COLUMN amount TYPE numeric(10,7),
+    ALTER COLUMN amount TYPE NUMERIC(19,7),
     ADD CONSTRAINT unique_stellar_transaction_hash UNIQUE (stellar_transaction_hash),
     ADD CONSTRAINT check_retry_count CHECK (retry_count >= 0);
 

--- a/internal/db/migrations/2024-02-05.0-tss-transactions-table-amount-constraing.sql
+++ b/internal/db/migrations/2024-02-05.0-tss-transactions-table-amount-constraing.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+
+ALTER TABLE public.submitter_transactions
+    ALTER COLUMN amount TYPE NUMERIC(19,7);
+
+-- +migrate Down

--- a/internal/transactionsubmission/store/transactions_test.go
+++ b/internal/transactionsubmission/store/transactions_test.go
@@ -124,14 +124,16 @@ func Test_TransactionModel_BulkInsert(t *testing.T) {
 			ExternalID:  "external-id-1",
 			AssetCode:   "USDC",
 			AssetIssuer: keypair.MustRandom().Address(),
-			Amount:      1,
+			// Lowest number in the Stellar network (ref: https://developers.stellar.org/docs/fundamentals-and-concepts/stellar-data-structures/assets#amount-precision):
+			Amount:      0.0000001,
 			Destination: keypair.MustRandom().Address(),
 		}
 		incomingTx2 := Transaction{
 			ExternalID:  "external-id-2",
 			AssetCode:   "USDC",
 			AssetIssuer: keypair.MustRandom().Address(),
-			Amount:      2,
+			// Largest number in the Stellar network (ref: https://developers.stellar.org/docs/fundamentals-and-concepts/stellar-data-structures/assets#amount-precision):
+			Amount:      922337203685.4775807,
 			Destination: keypair.MustRandom().Address(),
 		}
 		insertedTransactions, err := txModel.BulkInsert(ctx, dbConnectionPool, []Transaction{incomingTx1, incomingTx2})


### PR DESCRIPTION
### What

Fix TSS's database amount precision to be compliant with the Stellar network amount precision.

### Why

The database amount was configured to NUMERIC(10,7), which allows the maximum value of 999.9999999. This is not compliant with the Stellar network amounts though, which according with the [docs](https://developers.stellar.org/docs/fundamentals-and-concepts/stellar-data-structures/assets#amount-precision) supports numbers from 0.0000001 to 922,337,203,685.4775807.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
