### PR TITLE
SDP-575: [data] Improve receiver verification error messaging for disbursement instructions

### DIFF
--- a/internal/data/disbursement_instructions.go
+++ b/internal/data/disbursement_instructions.go
@@ -25,6 +25,11 @@ type DisbursementInstructionModel struct {
 	disbursementModel         *DisbursementModel
 }
 
+type InstructionLine struct {
+	line                    int
+	disbursementInstruction *DisbursementInstruction
+}
+
 const MaxInstructionsPerDisbursement = 10000 // TODO: update this number with load testing results [SDP-524]
 
 // NewDisbursementInstructionModel creates a new DisbursementInstructionModel.
@@ -85,9 +90,12 @@ func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, userID st
 			receiverMap[receiver.PhoneNumber] = receiver
 		}
 
-		instructionMap := make(map[string]*DisbursementInstruction)
-		for _, instruction := range instructions {
-			instructionMap[instruction.Phone] = instruction
+		instructionMap := make(map[string]InstructionLine)
+		for line, instruction := range instructions {
+			instructionMap[instruction.Phone] = InstructionLine{
+				line:                    line+1,
+				disbursementInstruction: instruction,
+			}
 		}
 
 		for _, instruction := range instructions {
@@ -126,7 +134,7 @@ func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, userID st
 			if !verificationExists {
 				verificationInsert := ReceiverVerificationInsert{
 					ReceiverID:        receiver.ID,
-					VerificationValue: instruction.VerificationValue,
+					VerificationValue: instruction.disbursementInstruction.VerificationValue,
 					VerificationField: disbursement.VerificationField,
 				}
 				hashedVerification, insertError := di.receiverVerificationModel.Insert(ctx, dbTx, verificationInsert)
@@ -140,11 +148,11 @@ func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, userID st
 				}
 
 			} else {
-				if verified := CompareVerificationValue(verification.HashedValue, instruction.VerificationValue); !verified {
+				if verified := CompareVerificationValue(verification.HashedValue, instruction.disbursementInstruction.VerificationValue); !verified {
 					if verification.ConfirmedAt != nil {
-						return fmt.Errorf("%w: receiver verification for %s doesn't match", ErrReceiverVerificationMismatch, receiver.PhoneNumber)
+						return fmt.Errorf("%w: receiver verification for %s doesn't match. Check line %d on CSV file - Internal ID %s.", ErrReceiverVerificationMismatch, receiver.PhoneNumber, instruction.line, instruction.disbursementInstruction.ID)
 					}
-					err = di.receiverVerificationModel.UpdateVerificationValue(ctx, dbTx, verification.ReceiverID, verification.VerificationField, instruction.VerificationValue)
+					err = di.receiverVerificationModel.UpdateVerificationValue(ctx, dbTx, verification.ReceiverID, verification.VerificationField, instruction.disbursementInstruction.VerificationValue)
 
 					if err != nil {
 						return fmt.Errorf("error updating receiver verification for disbursement id %s: %w", disbursement.ID, err)

--- a/internal/data/disbursement_instructions.go
+++ b/internal/data/disbursement_instructions.go
@@ -93,7 +93,7 @@ func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, userID st
 		instructionMap := make(map[string]InstructionLine)
 		for line, instruction := range instructions {
 			instructionMap[instruction.Phone] = InstructionLine{
-				line:                    line+1,
+				line:                    line + 1,
 				disbursementInstruction: instruction,
 			}
 		}

--- a/internal/data/disbursement_instructions_test.go
+++ b/internal/data/disbursement_instructions_test.go
@@ -253,7 +253,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		instruction1.VerificationValue = "1990-01-07"
 		err = di.ProcessAll(ctx, "user-id", instructions, disbursement, disbursementUpdate, MaxInstructionsPerDisbursement)
 		require.Error(t, err)
-		assert.EqualError(t, err, "running atomic function in RunInTransactionWithResult: receiver verification mismatch: receiver verification for +380-12-345-671 doesn't match")
+		assert.EqualError(t, err, "running atomic function in RunInTransactionWithResult: receiver verification mismatch: receiver verification for +380-12-345-671 doesn't match. Check line 1 on CSV file - Internal ID 123456781.")
 	})
 }
 

--- a/internal/data/disbursement_instructions_test.go
+++ b/internal/data/disbursement_instructions_test.go
@@ -235,7 +235,6 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 	})
 
 	t.Run("failure - Confirmed Verification Value not matching", func(t *testing.T) {
-		//created new instructions to verify that the correct line number is returned in the error message
 		instruction4 := DisbursementInstruction{
 			Phone:             "+380-12-345-674",
 			Amount:            "100.04",

--- a/internal/data/disbursement_instructions_test.go
+++ b/internal/data/disbursement_instructions_test.go
@@ -235,11 +235,35 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 	})
 
 	t.Run("failure - Confirmed Verification Value not matching", func(t *testing.T) {
+		//created new instructions to verify that the correct line number is returned in the error message
+		instruction4 := DisbursementInstruction{
+			Phone:             "+380-12-345-674",
+			Amount:            "100.04",
+			ID:                "123456784",
+			VerificationValue: "1990-01-04",
+			ExternalPaymentId: &externalPaymentID,
+		}
+
+		instruction5 := DisbursementInstruction{
+			Phone:             "+380-12-345-675",
+			Amount:            "100.05",
+			ID:                "123456785",
+			VerificationValue: "1990-01-05",
+			ExternalPaymentId: &externalPaymentID,
+		}
+
+		instruction6 := DisbursementInstruction{
+			Phone:             "+380-12-345-676",
+			Amount:            "100.06",
+			ID:                "123456786",
+			VerificationValue: "1990-01-06",
+			ExternalPaymentId: &externalPaymentID,
+		}
 		// process instructions for the first time
 		err := di.ProcessAll(ctx, "user-id", instructions, disbursement, disbursementUpdate, MaxInstructionsPerDisbursement)
 		require.NoError(t, err)
 
-		receivers, err := di.receiverModel.GetByPhoneNumbers(ctx, dbConnectionPool, []string{instruction1.Phone, instruction2.Phone, instruction3.Phone})
+		receivers, err := di.receiverModel.GetByPhoneNumbers(ctx, dbConnectionPool, []string{instruction1.Phone, instruction2.Phone, instruction3.Phone, instruction4.Phone, instruction5.Phone, instruction6.Phone})
 		require.NoError(t, err)
 		receiversMap := make(map[string]*Receiver)
 		for _, receiver := range receivers {
@@ -247,13 +271,13 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		}
 
 		// confirm a verification
-		ConfirmVerificationForRecipient(t, ctx, dbConnectionPool, receiversMap[instruction1.Phone].ID)
+		ConfirmVerificationForRecipient(t, ctx, dbConnectionPool, receiversMap[instruction3.Phone].ID)
 
 		// process instructions with mismatched verification values
-		instruction1.VerificationValue = "1990-01-07"
+		instruction3.VerificationValue = "1990-01-07"
 		err = di.ProcessAll(ctx, "user-id", instructions, disbursement, disbursementUpdate, MaxInstructionsPerDisbursement)
 		require.Error(t, err)
-		assert.EqualError(t, err, "running atomic function in RunInTransactionWithResult: receiver verification mismatch: receiver verification for +380-12-345-671 doesn't match. Check line 1 on CSV file - Internal ID 123456781.")
+		assert.EqualError(t, err, "running atomic function in RunInTransactionWithResult: receiver verification mismatch: receiver verification for +380-12-345-673 doesn't match. Check line 3 on CSV file - Internal ID 123456783.")
 	})
 }
 


### PR DESCRIPTION
### What

Clear error message about which receiver (line in CSV & phone number / internal id) that has a mis-matching verification. 

### Why

If the user doesn't know which record is causing the error, they won't know where to check to find the original value.

### Known limitations

 N/A

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
