### PR TITLE
[SDP-1064] serve/httphandlers/cmd: use tenants SDPUIBaseURL when sending messages

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -274,15 +274,6 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 			Required:  true,
 		},
 		{
-			Name:           "sdp-ui-base-url",
-			Usage:          "The SDP UI/dashboard Base URL.",
-			OptType:        types.String,
-			ConfigKey:      &serveOpts.UIBaseURL,
-			FlagDefault:    "http://localhost:3000",
-			CustomSetValue: cmdUtils.SetConfigOptionURLString,
-			Required:       true,
-		},
-		{
 			Name:        "enable-scheduler",
 			Usage:       "Enable Scheduler for SDP Backend Jobs",
 			OptType:     types.Bool,

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -138,7 +138,6 @@ func Test_serve(t *testing.T) {
 		CorsAllowedOrigins:              []string{"*"},
 		SEP24JWTSecret:                  "jwt_secret_1234567890",
 		BaseURL:                         "https://sdp.com",
-		UIBaseURL:                       "http://localhost:3000",
 		ResetTokenExpirationHours:       24,
 		NetworkPassphrase:               network.TestNetworkPassphrase,
 		Sep10SigningPublicKey:           "GAX46JJZ3NPUM2EUBTTGFM6ITDF7IGAFNBSVWDONPYZJREHFPP2I5U7S",

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -27,7 +27,6 @@ const forgotPasswordMessageTitle = "Reset Account Password"
 type ForgotPasswordHandler struct {
 	AuthManager        auth.AuthManager
 	MessengerClient    message.MessengerClient
-	UIBaseURL          string
 	Models             *data.Models
 	ReCAPTCHAValidator validators.ReCAPTCHAValidator
 }
@@ -107,7 +106,7 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		resetPasswordLink, err := url.JoinPath(h.UIBaseURL, "reset-password")
+		resetPasswordLink, err := url.JoinPath(*tnt.SDPUIBaseURL, "reset-password")
 		if err != nil {
 			err = fmt.Errorf("error getting reset password link: %w", err)
 			log.Ctx(ctx).Error(err)

--- a/internal/serve/httphandler/user_handler.go
+++ b/internal/serve/httphandler/user_handler.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type UserHandler struct {
 	AuthManager     auth.AuthManager
 	MessengerClient message.MessengerClient
-	UIBaseURL       string
 	Models          *data.Models
 }
 
@@ -157,6 +157,13 @@ func (h UserHandler) UserActivation(rw http.ResponseWriter, req *http.Request) {
 func (h UserHandler) CreateUser(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
+	tnt, err := tenant.GetTenantFromContext(ctx)
+	if err != nil {
+		err = fmt.Errorf("getting tenant from context: %w", err)
+		httperror.Unauthorized("", err, nil).Render(rw)
+		return
+	}
+
 	var reqBody CreateUserRequest
 	if err := httpdecode.DecodeJSON(req, &reqBody); err != nil {
 		err = fmt.Errorf("decoding the request body: %w", err)
@@ -178,7 +185,7 @@ func (h UserHandler) CreateUser(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	s := services.NewCreateUserService(h.Models, h.Models.DBConnectionPool, h.AuthManager, h.MessengerClient)
-	u, err := s.CreateUser(ctx, newUser, h.UIBaseURL)
+	u, err := s.CreateUser(ctx, newUser, *tnt.SDPUIBaseURL)
 	if err != nil {
 		if errors.Is(err, auth.ErrUserEmailAlreadyExists) {
 			httperror.BadRequest(auth.ErrUserEmailAlreadyExists.Error(), err, nil).Render(rw)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -66,7 +66,6 @@ type ServeOptions struct {
 	SEP24JWTSecret                  string
 	sep24JWTManager                 *anchorplatform.JWTManager
 	BaseURL                         string
-	UIBaseURL                       string
 	ResetTokenExpirationHours       int
 	NetworkPassphrase               string
 	SubmitterEngine                 engine.SubmitterEngine
@@ -206,7 +205,6 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			userHandler := httphandler.UserHandler{
 				AuthManager:     authManager,
 				MessengerClient: o.EmailMessengerClient,
-				UIBaseURL:       o.UIBaseURL,
 				Models:          o.Models,
 			}
 
@@ -354,7 +352,6 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		r.Post("/forgot-password", httphandler.ForgotPasswordHandler{
 			AuthManager:        authManager,
 			MessengerClient:    o.EmailMessengerClient,
-			UIBaseURL:          o.UIBaseURL,
 			Models:             o.Models,
 			ReCAPTCHAValidator: reCAPTCHAValidator,
 		}.ServeHTTP)


### PR DESCRIPTION
### What

This PR uses the tenants `SDPUIBaseURL` wherever the UI Base URL is needed. Also, the global UI base URL was removed.

### Why

Now, this value is configured per tenant.

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
