### PR TITLE
[SDP-1088] Fix distribution account balance validation that fails when the intended asset is XLM

### DIFF
--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lib/pq"
 	"golang.org/x/exp/slices"
 
+	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 )
 
@@ -35,6 +36,14 @@ func (a Asset) Equals(other Asset) bool {
 		return true
 	}
 	return strings.EqualFold(a.Code, other.Code) && strings.EqualFold(a.Issuer, other.Issuer)
+}
+
+func (a Asset) EqualsHorizonAsset(horizonAsset base.Asset) bool {
+	if a.IsNative() && horizonAsset.Type == "native" {
+		return true
+	}
+
+	return strings.EqualFold(a.Code, horizonAsset.Code) && strings.EqualFold(a.Issuer, horizonAsset.Issuer)
 }
 
 type AssetModel struct {

--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"golang.org/x/exp/slices"
+	"strings"
 	"time"
 
 	"github.com/lib/pq"
@@ -18,6 +20,21 @@ type Asset struct {
 	CreatedAt *time.Time `json:"created_at,omitempty" db:"created_at"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty" db:"updated_at"`
 	DeletedAt *time.Time `json:"deleted_at" db:"deleted_at"`
+}
+
+// IsNative returns true if the asset is the native asset (XLM).
+func (a Asset) IsNative() bool {
+	return strings.TrimSpace(a.Issuer) == "" &&
+		slices.Contains([]string{"XLM", "NATIVE"}, strings.ToUpper(a.Code))
+}
+
+// Equals returns true if the asset is the same as the other asset. Case-insensitive.
+func (a Asset) Equals(other Asset) bool {
+	if a.IsNative() && other.IsNative() {
+		return true
+	}
+	return strings.ToUpper(a.Code) == strings.ToUpper(other.Code) &&
+		strings.ToUpper(a.Issuer) == strings.ToUpper(other.Issuer)
 }
 
 type AssetModel struct {

--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -34,8 +34,7 @@ func (a Asset) Equals(other Asset) bool {
 	if a.IsNative() && other.IsNative() {
 		return true
 	}
-	return strings.ToUpper(a.Code) == strings.ToUpper(other.Code) &&
-		strings.ToUpper(a.Issuer) == strings.ToUpper(other.Issuer)
+	return strings.EqualFold(a.Code, other.Code) && strings.EqualFold(a.Issuer, other.Issuer)
 }
 
 type AssetModel struct {

--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -5,11 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"strings"
 	"time"
 
 	"github.com/lib/pq"
+	"golang.org/x/exp/slices"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 )
 

--- a/internal/data/assets_test.go
+++ b/internal/data/assets_test.go
@@ -12,6 +12,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_Asset_IsNative(t *testing.T) {
+	cases := []struct {
+		asset    Asset
+		isNative bool
+	}{
+		{Asset{Code: "XLM"}, true},
+		{Asset{Code: "NATIVE"}, true},
+		{Asset{Code: "ABC"}, false},
+		{Asset{Issuer: "Issuer1", Code: "XLM"}, false},
+		{Asset{Issuer: "Issuer1", Code: "NATIVE"}, false},
+		{Asset{Issuer: "Issuer2", Code: "XYZ"}, false},
+	}
+
+	for _, c := range cases {
+		got := c.asset.IsNative()
+		if got != c.isNative {
+			t.Errorf("Asset{%q, %q}.IsNative() == %t, want %t", c.asset.Issuer, c.asset.Code, got, c.isNative)
+		}
+	}
+}
+
+func Test_Asset_Equals(t *testing.T) {
+	cases := []struct {
+		asset1 Asset
+		asset2 Asset
+		equals bool
+	}{
+		{Asset{Code: "XLM"}, Asset{Code: "XLM"}, true},
+		{Asset{Code: "XLM"}, Asset{Code: "ABC"}, false},
+		{Asset{Issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", Code: "USDC"}, Asset{Issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", Code: "usdc"}, true},
+		{Asset{Issuer: "Issuer1", Code: "ABC"}, Asset{Issuer: "Issuer2", Code: "ABC"}, false},
+		{Asset{Issuer: "Issuer1", Code: "ABC"}, Asset{Issuer: "Issuer1", Code: "XYZ"}, false},
+	}
+
+	for _, c := range cases {
+		got := c.asset1.Equals(c.asset2)
+		if got != c.equals {
+			t.Errorf("Asset{%q, %q}.Equals(Asset{%q, %q}) == %t, want %t", c.asset1.Issuer, c.asset1.Code, c.asset2.Issuer, c.asset2.Code, got, c.equals)
+		}
+	}
+}
+
 func Test_AssetModelGet(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()

--- a/internal/data/assets_test.go
+++ b/internal/data/assets_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -35,22 +36,26 @@ func Test_Asset_IsNative(t *testing.T) {
 
 func Test_Asset_Equals(t *testing.T) {
 	cases := []struct {
-		asset1 Asset
-		asset2 Asset
-		equals bool
+		asset1         Asset
+		asset2         Asset
+		expectedResult bool
 	}{
 		{Asset{Code: "XLM"}, Asset{Code: "XLM"}, true},
+		{Asset{Code: "XLM"}, Asset{Code: "xlm"}, true},
 		{Asset{Code: "XLM"}, Asset{Code: "ABC"}, false},
 		{Asset{Issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", Code: "USDC"}, Asset{Issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", Code: "usdc"}, true},
+		{Asset{Issuer: "gbbD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", Code: "USDC"}, Asset{Issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", Code: "usdc"}, true},
 		{Asset{Issuer: "Issuer1", Code: "ABC"}, Asset{Issuer: "Issuer2", Code: "ABC"}, false},
 		{Asset{Issuer: "Issuer1", Code: "ABC"}, Asset{Issuer: "Issuer1", Code: "XYZ"}, false},
 	}
 
-	for _, c := range cases {
-		got := c.asset1.Equals(c.asset2)
-		if got != c.equals {
-			t.Errorf("Asset{%q, %q}.Equals(Asset{%q, %q}) == %t, want %t", c.asset1.Issuer, c.asset1.Code, c.asset2.Issuer, c.asset2.Code, got, c.equals)
-		}
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
+			got := c.asset1.Equals(c.asset2)
+			if got != c.expectedResult {
+				t.Errorf("Asset{%q, %q}.Equals(Asset{%q, %q}) == %t, want %t", c.asset1.Issuer, c.asset1.Code, c.asset2.Issuer, c.asset2.Code, got, c.expectedResult)
+			}
+		})
 	}
 }
 

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -370,6 +370,7 @@ func (d DisbursementHandler) PatchDisbursementStatus(w http.ResponseWriter, r *h
 		err = services.ErrDisbursementStatusCantBeChanged
 	}
 
+	var insufficientBalanceErr services.InsufficientBalanceError
 	if err != nil {
 		switch {
 		case errors.Is(err, services.ErrDisbursementNotFound):
@@ -384,8 +385,9 @@ func (d DisbursementHandler) PatchDisbursementStatus(w http.ResponseWriter, r *h
 			httperror.Forbidden("Disbursement can't be started by its creator. Approval by another user is required.", err, nil).Render(w)
 		case errors.Is(err, services.ErrDisbursementWalletDisabled):
 			httperror.BadRequest(services.ErrDisbursementWalletDisabled.Error(), err, nil).Render(w)
-		case errors.Is(err, services.ErrDisbursementWalletInsufficientBalance):
-			httperror.Conflict(services.ErrDisbursementWalletInsufficientBalance.Error(), err, nil).Render(w)
+		case errors.As(err, &insufficientBalanceErr):
+			log.Ctx(ctx).Error(insufficientBalanceErr)
+			httperror.Conflict(insufficientBalanceErr.Error(), err, nil).Render(w)
 		default:
 			msg := fmt.Sprintf("Cannot update disbursement ID %s with status: %s", disbursementID, toStatus)
 			httperror.InternalError(ctx, msg, err, nil).Render(w)

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -50,6 +50,7 @@ var (
 
 type InsufficientBalanceError struct {
 	DisbursementID     string
+	DisbursementAsset  data.Asset
 	AvailableBalance   float64
 	DisbursementAmount float64
 	TotalPendingAmount float64
@@ -57,12 +58,13 @@ type InsufficientBalanceError struct {
 
 func (e InsufficientBalanceError) Error() string {
 	return fmt.Sprintf(
-		"disbursement %s failed with insufficient distribution account balance %.2f to fulfill new amount (%.2f) along with the pending amount (%.2f). Total pending amount: %.2f",
+		"the disbursement %s failed due to an account balance (%.2f) that was insufficient to fulfill new amount (%.2f) along with the pending amount (%.2f). To complete this action, your distribution account needs to be recharged with at least %.2f %s",
 		e.DisbursementID,
 		e.AvailableBalance,
 		e.DisbursementAmount,
 		e.TotalPendingAmount,
 		(e.DisbursementAmount+e.TotalPendingAmount)-e.AvailableBalance,
+		e.DisbursementAsset.Code,
 	)
 }
 
@@ -294,6 +296,7 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 
 		if (availableBalance - (disbursementAmount + totalPendingAmount)) < 0 {
 			err = InsufficientBalanceError{
+				DisbursementAsset:  *disbursement.Asset,
 				DisbursementID:     disbursementID,
 				AvailableBalance:   availableBalance,
 				DisbursementAmount: disbursementAmount,

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
@@ -231,13 +230,7 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 
 		var distributionBalance float64
 		for _, b := range rootAccount.Balances {
-			var rootAsset data.Asset
-			if b.Asset.Type == "native" {
-				rootAsset = assets.XLMAsset
-			} else {
-				rootAsset = data.Asset{Code: b.Asset.Code, Issuer: b.Asset.Issuer}
-			}
-			if disbursement.Asset.Equals(rootAsset) {
+			if disbursement.Asset.EqualsHorizonAsset(b.Asset) {
 				distributionBalance, err = strconv.ParseFloat(b.Balance, 64)
 				if err != nil {
 					return fmt.Errorf("cannot convert Horizon distribution account balance %s into float: %w", b.Balance, err)

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -57,7 +57,7 @@ type InsufficientBalanceError struct {
 
 func (e InsufficientBalanceError) Error() string {
 	return fmt.Sprintf(
-		"disbursement %s failed with insufficient distribution account balance %f to fulfill new amount (%f) along with the pending amount (%f). Total pending amount: %f",
+		"disbursement %s failed with insufficient distribution account balance %.2f to fulfill new amount (%.2f) along with the pending amount (%.2f). Total pending amount: %.2f",
 		e.DisbursementID,
 		e.AvailableBalance,
 		e.DisbursementAmount,

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	"strconv"
 
 	"github.com/stellar/go/clients/horizonclient"
@@ -230,7 +231,13 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 
 		var distributionBalance float64
 		for _, b := range rootAccount.Balances {
-			if b.Asset.Code == disbursement.Asset.Code && b.Asset.Issuer == disbursement.Asset.Issuer {
+			var rootAsset data.Asset
+			if b.Asset.Type == "native" {
+				rootAsset = assets.XLMAsset
+			} else {
+				rootAsset = data.Asset{Code: b.Asset.Code, Issuer: b.Asset.Issuer}
+			}
+			if disbursement.Asset.Equals(rootAsset) {
 				distributionBalance, err = strconv.ParseFloat(b.Balance, 64)
 				if err != nil {
 					return fmt.Errorf("cannot convert Horizon distribution account balance %s into float: %w", b.Balance, err)

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	"strconv"
 
 	"github.com/stellar/go/clients/horizonclient"
@@ -15,6 +14,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -479,7 +479,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		).Return(horizon.Account{
 			Balances: []horizon.Balance{
 				{
-					Balance: "10000",
+					Balance: "11111",
 					Asset: base.Asset{
 						Code:   asset.Code,
 						Issuer: asset.Issuer,
@@ -499,33 +499,26 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			ReceiverWallet: rwReady,
 			Disbursement:   disbursement,
 			Asset:          *asset,
-			Amount:         "10001",
+			Amount:         "22222",
 			Status:         data.ReadyPaymentStatus,
 		})
 
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 
+		expectedErr := InsufficientBalanceError{
+			DisbursementID:     disbursement.ID,
+			AvailableBalance:   11111.0,
+			DisbursementAmount: 22222.0,
+			TotalPendingAmount: 1100.0,
+		}
 		err = service.StartDisbursement(ctx, disbursement.ID, distributionPubKey)
-		require.EqualError(
-			t,
-			err,
-			fmt.Sprintf(
-				"running atomic function in RunInTransactionWithResult: %s",
-				ErrDisbursementWalletInsufficientBalance.Error(),
-			),
-		)
+		require.EqualError(t, err, fmt.Sprintf("running atomic function in RunInTransactionWithResult: %v", expectedErr))
 
 		// PendingTotal includes payments associated with 'readyDisbursement' that were moved from the draft to ready status
-		assert.Contains(
-			t,
-			buf.String(),
-			fmt.Sprintf("Insufficient distribution account balance %f to fulfill amount %f for disbursement id %s and total pending amount %f",
-				10000.0,
-				10001.0,
-				disbursement.ID,
-				1100.0),
-		)
+		expectedErrStr := fmt.Sprintf("disbursement %s failed with insufficient distribution account balance 11111.000000 to fulfill new amount (22222.000000) along with the pending amount (1100.000000). Total pending amount: 12211.000000", disbursement.ID)
+		t.Log(expectedErr.Error())
+		assert.Contains(t, buf.String(), expectedErrStr)
 	})
 
 	authManagerMock.AssertExpectations(t)

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -516,7 +516,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		require.EqualError(t, err, fmt.Sprintf("running atomic function in RunInTransactionWithResult: %v", expectedErr))
 
 		// PendingTotal includes payments associated with 'readyDisbursement' that were moved from the draft to ready status
-		expectedErrStr := fmt.Sprintf("disbursement %s failed with insufficient distribution account balance 11111.000000 to fulfill new amount (22222.000000) along with the pending amount (1100.000000). Total pending amount: 12211.000000", disbursement.ID)
+		expectedErrStr := fmt.Sprintf("disbursement %s failed with insufficient distribution account balance 11111.00 to fulfill new amount (22222.00) along with the pending amount (1100.00). Total pending amount: 12211.00", disbursement.ID)
 		t.Log(expectedErr.Error())
 		assert.Contains(t, buf.String(), expectedErrStr)
 	})

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -507,6 +507,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		log.DefaultLogger.SetOutput(buf)
 
 		expectedErr := InsufficientBalanceError{
+			DisbursementAsset:  *asset,
 			DisbursementID:     disbursement.ID,
 			AvailableBalance:   11111.0,
 			DisbursementAmount: 22222.0,
@@ -516,8 +517,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		require.EqualError(t, err, fmt.Sprintf("running atomic function in RunInTransactionWithResult: %v", expectedErr))
 
 		// PendingTotal includes payments associated with 'readyDisbursement' that were moved from the draft to ready status
-		expectedErrStr := fmt.Sprintf("disbursement %s failed with insufficient distribution account balance 11111.00 to fulfill new amount (22222.00) along with the pending amount (1100.00). Total pending amount: 12211.00", disbursement.ID)
-		t.Log(expectedErr.Error())
+		expectedErrStr := fmt.Sprintf("the disbursement %s failed due to an account balance (11111.00) that was insufficient to fulfill new amount (22222.00) along with the pending amount (1100.00). To complete this action, your distribution account needs to be recharged with at least 12211.00 USDC", disbursement.ID)
 		assert.Contains(t, buf.String(), expectedErrStr)
 	})
 


### PR DESCRIPTION
### What

Fix Distribution account balance validation that fails when the intended asset is XLM.

Also, improve the error message when the validation fails to the following format:

XLM:
![Screenshot 2024-02-09 at 12 35 24 PM](https://github.com/stellar/stellar-disbursement-platform-backend/assets/1952597/9dcaa4fd-5208-4a53-bc24-defdbc53c78f)

USDC:
![Screenshot 2024-02-09 at 12 42 26 PM](https://github.com/stellar/stellar-disbursement-platform-backend/assets/1952597/b8e2ec63-6280-4762-a609-a557e60f0185)


### Tested with:

- [x] XLM low amount  (native)
- [x] XLM high amount (native)
- [x] USDC low amount
- [x] USDC high amount.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
