### PR TITLE
[SDP-1073] Enable TSS for multi-tenant SDP

### DIFF
--- a/dev/docker-compose-frontend.yml
+++ b/dev/docker-compose-frontend.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   sdp-frontend:
-    container_name: sdp-frontend
+    container_name: sdp-frontend-mtn
     image: stellar/stellar-disbursement-platform-frontend:multitenant-alpha
     ports:
       - "3000:80"

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -13,7 +13,7 @@ services:
       - postgres-db:/data/postgres
 
   sdp-api:
-    container_name: sdp-api
+    container_name: sdp-api-mtn
     image: stellar/sdp-v2:latest
     build:
       context: ../
@@ -81,7 +81,7 @@ services:
         ./stellar-disbursement-platform serve
 
   db-anchor-platform:
-    container_name: anchor-platform-postgres-db
+    container_name: anchor-platform-postgres-db-mtn
     image: postgres:14-alpine
     environment:
       POSTGRES_USER: postgres
@@ -116,7 +116,7 @@ services:
       METRICS_ENABLED: "false"  # Metrics would be available at port 8082
       METRICS_EXTRAS_ENABLED: "false"
       SEP10_ENABLED: "true"
-      SEP10_HOME_DOMAINS: "localhost:8000, *.stellar.local" # Comma separated list of home domains
+      SEP10_HOME_DOMAINS: "localhost:8000, redcorp.stellar.local:8000, bluecorp.stellar.local:8000" # Comma separated list of home domains
       SEP10_HOME_DOMAIN: ""
       SEP10_WEB_AUTH_DOMAIN: "localhost:8080"
       # SEP10_CLIENT_ATTRIBUTION_REQUIRED: true  # RECOMMENDED

--- a/dev/docker-compose-tss.yml
+++ b/dev/docker-compose-tss.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   sdp-tss:
-    container_name: sdp-tss
+    container_name: sdp-tss-mtn
     image: stellar/sdp-v2:latest
     build:
       context: ../

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -27,14 +27,14 @@ services:
       service: anchor-platform
     depends_on:
       - db-anchor-platform
-#  sdp-tss:
-#    extends:
-#      file: docker-compose-tss.yml
-#      service: sdp-tss
-#    depends_on:
-#      - db
-#      - sdp-api
-#      - kafka
+  sdp-tss:
+    extends:
+      file: docker-compose-tss.yml
+      service: sdp-tss
+    depends_on:
+      - db
+      - sdp-api
+      - kafka
   sdp-frontend:
     extends:
       file: docker-compose-frontend.yml


### PR DESCRIPTION
### What
* Enable TSS in docker-compose for SDP multi-tenant
* Rename containers for SDP multi-tenant so that developers can run both mtn and single tenant versions side-by-side. 
* Fix `SEP10_HOME_DOMAINS` for anchor configuration 

### Why

https://stellarorg.atlassian.net/browse/SDP-1073

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
