### PR TITLE
chore: stop running e2e on mtn docker push

### DIFF
--- a/.github/workflows/docker_image_public_release.yml
+++ b/.github/workflows/docker_image_public_release.yml
@@ -22,7 +22,7 @@ jobs:
     secrets: inherit # pass all secrets
 
   e2e_integration_test:
-    if: github.ref == 'refs/heads/develop' # TODO: re-enable in SDP-968
+    if: github.ref != 'refs/heads/sdp-multitenant' # TODO: re-enable in SDP-968
     uses: ./.github/workflows/e2e_integration_test.yml # execute the callable e2e_integration_test.yml
     needs:
       - tests

--- a/.github/workflows/docker_image_public_release.yml
+++ b/.github/workflows/docker_image_public_release.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit # pass all secrets
 
   e2e_integration_test:
+    if: github.ref == 'refs/heads/develop' # TODO: re-enable in SDP-968
     uses: ./.github/workflows/e2e_integration_test.yml # execute the callable e2e_integration_test.yml
     needs:
       - tests
@@ -101,6 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tests
+      - anchor_platform_integration_check
     steps:
       - uses: actions/checkout@v3
 
@@ -122,6 +124,7 @@ jobs:
     needs:
       - build_and_push_docker_image_on_release
       - build_and_push_docker_image_on_dev_push
+      - build_and_push_docker_image_on_multitenant
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
### What
Not run e2e when releasing sdp-multitenant docker image. 
This will be re-enabled as part of https://stellarorg.atlassian.net/browse/SDP-968


### Why
Docker image release for sdp-multitenant is marked as failed. 
<img width="1285" alt="Screenshot 2024-02-14 at 3 27 25 PM" src="https://github.com/stellar/stellar-disbursement-platform-backend/assets/4129193/d5d768e6-bf83-4267-a585-0ba23708ed79">

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
