### PR TITLE
[SDP-1089] Add rate-limiters both in the application and the k8s deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           go-version: 1.19
 
       - name: Run tests
-        run: go test -race -coverpkg=./... -coverprofile=c.out ./...
+        run: go test -race -timeout 3m -coverpkg=./... -coverprofile=c.out ./...
 
       - name: Validate Test Coverage Threshold
         env:

--- a/go.list
+++ b/go.list
@@ -70,6 +70,7 @@ github.com/gin-contrib/sse v0.1.0
 github.com/gin-gonic/gin v1.8.1
 github.com/go-chi/chi v4.1.2+incompatible
 github.com/go-chi/chi/v5 v5.0.10
+github.com/go-chi/httprate v0.8.0
 github.com/go-errors/errors v1.5.1
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/getsentry/sentry-go v0.23.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/chi/v5 v5.0.10
+	github.com/go-chi/httprate v0.8.0
 	github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyN
 github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
 github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/httprate v0.8.0 h1:CyKng28yhGnlGXH9EDGC/Qizj29afJQSNW15W/yj34o=
+github.com/go-chi/httprate v0.8.0/go.mod h1:6GOYBSwnpra4CQfAKXu8sQZg+nZ0M1g9QnyFvxrAB8A=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/helmchart/sdp/values.yaml
+++ b/helmchart/sdp/values.yaml
@@ -202,6 +202,8 @@ sdp:
     className: "nginx"
     annotations:
       nginx.ingress.kubernetes.io/custom-response-headers: "X-XSS-Protection: 1; mode=block || X-Frame-Options: DENY || X-Content-Type-Options: nosniff || Strict-Transport-Security: max-age=31536000; includeSubDomains"
+      nginx.ingress.kubernetes.io/limit-rpm: "120"
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
     tls:
       - hosts:
           - '{{ include "sdp.domain" . }}'
@@ -345,6 +347,8 @@ anchorPlatform:
     className: "nginx"
     annotations:
       nginx.ingress.kubernetes.io/custom-response-headers: "X-XSS-Protection: 1; mode=block || X-Frame-Options: DENY || X-Content-Type-Options: nosniff || Strict-Transport-Security: max-age=31536000; includeSubDomains"
+      nginx.ingress.kubernetes.io/limit-rpm: "120"
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
     tls:
       - hosts:
           - '{{ include "sdp.ap.domain" . }}'

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -218,6 +218,8 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	mux.Use(middleware.RecoverHandler)
 	mux.Use(middleware.MetricsRequestHandler(o.MonitorService))
 	mux.Use(middleware.CSPMiddleware())
+	mux.Use(chimiddleware.CleanPath)
+	mux.Use(chimiddleware.Compress(5))
 
 	// Create a route along /static that will serve contents from the ./public_files folder.
 	staticFileServer(mux, publicfiles.PublicFiles)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/httprate"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/network"
 	supporthttp "github.com/stellar/go/support/http"
@@ -207,6 +208,11 @@ func Serve(opts ServeOptions, httpServer HTTPServerInterface) error {
 	return nil
 }
 
+const (
+	rateLimitPer20Seconds = 30
+	rateLimitWindow       = 20 * time.Second
+)
+
 func handleHTTP(o ServeOptions) *chi.Mux {
 	mux := chi.NewMux()
 
@@ -214,6 +220,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	mux.Use(middleware.CorsMiddleware(o.CorsAllowedOrigins))
 	mux.Use(chimiddleware.RequestID)
 	mux.Use(chimiddleware.RealIP)
+	mux.Use(httprate.LimitAll(rateLimitPer20Seconds, rateLimitWindow))
 	mux.Use(supporthttp.LoggingMiddleware)
 	mux.Use(middleware.RecoverHandler)
 	mux.Use(middleware.MetricsRequestHandler(o.MonitorService))


### PR DESCRIPTION
### What

Implement in-memory rate-limiting in the server, sensitive to the pair {IP, endpoint}. It's configured to a max of 10 requests every 20 seconds, which translates to a maximum of 30 requests per minute per IP, segregated per endpoint.

Also, add rate-limit to the k8s Ingress manifest.

### Why

For increased security against bots.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
