### PR TITLE
[SDP-1106] data/httphandler: upsert receivers' verification info

### DIFF
--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -263,8 +263,8 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 	getReceiverVerificationHashedValue := func(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, receiverID string, verificationField VerificationField) string {
 		const q = "SELECT hashed_value FROM receiver_verifications WHERE receiver_id = $1 AND verification_field = $2"
 		var hashedValue string
-		err := dbConnectionPool.GetContext(ctx, &hashedValue, q, receiverID, verificationField)
-		require.NoError(t, err)
+		qErr := dbConnectionPool.GetContext(ctx, &hashedValue, q, receiverID, verificationField)
+		require.NoError(t, qErr)
 		return hashedValue
 	}
 

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -249,6 +249,92 @@ func Test_ReceiverVerificationModel_UpdateVerificationValue(t *testing.T) {
 	assert.True(t, verified)
 }
 
+func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{})
+	receiverVerificationModel := ReceiverVerificationModel{}
+	getReceiverVerificationHashedValue := func(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, receiverID string, verificationField VerificationField) string {
+		const q = "SELECT hashed_value FROM receiver_verifications WHERE receiver_id = $1 AND verification_field = $2"
+		var hashedValue string
+		err := dbConnectionPool.GetContext(ctx, &hashedValue, q, receiverID, verificationField)
+		require.NoError(t, err)
+		return hashedValue
+	}
+
+	t.Run("upserts the verification value successfully", func(t *testing.T) {
+		// Inserts the verification value
+		firstVerificationValue := "123456"
+		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldPin, firstVerificationValue)
+		require.NoError(t, err)
+
+		currentHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationFieldPin)
+		assert.NotEmpty(t, currentHashedValue)
+		verified := CompareVerificationValue(currentHashedValue, firstVerificationValue)
+		assert.True(t, verified)
+
+		// Updates the verification value
+		newVerificationValue := "654321"
+		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldPin, newVerificationValue)
+		require.NoError(t, err)
+
+		afterUpdateHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationFieldPin)
+		assert.NotEmpty(t, afterUpdateHashedValue)
+
+		// Checking if the hashed value is NOT the first one.
+		verified = CompareVerificationValue(afterUpdateHashedValue, firstVerificationValue)
+		assert.False(t, verified)
+		// Checking if the hashed value is equal the updated verification value
+		verified = CompareVerificationValue(afterUpdateHashedValue, newVerificationValue)
+		assert.True(t, verified)
+	})
+
+	t.Run("doesn't update the verification value when it was confirmed by the receiver", func(t *testing.T) {
+		// Inserts the verification value
+		firstVerificationValue := "0301016957187"
+		err := receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldNationalID, firstVerificationValue)
+		require.NoError(t, err)
+
+		currentHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationFieldNationalID)
+		assert.NotEmpty(t, currentHashedValue)
+		verified := CompareVerificationValue(currentHashedValue, firstVerificationValue)
+		assert.True(t, verified)
+
+		// Receiver confirmed the verification value
+		now := time.Now()
+		err = receiverVerificationModel.UpdateReceiverVerification(ctx, ReceiverVerification{
+			ReceiverID:        receiver.ID,
+			VerificationField: VerificationFieldNationalID,
+			Attempts:          0,
+			ConfirmedAt:       &now,
+			FailedAt:          nil,
+		}, dbConnectionPool)
+		require.NoError(t, err)
+
+		newVerificationValue := "0301017821085"
+		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldNationalID, newVerificationValue)
+		require.NoError(t, err)
+
+		afterUpdateHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationFieldNationalID)
+		assert.NotEmpty(t, currentHashedValue)
+
+		// Checking if the hashed value is NOT the new one.
+		verified = CompareVerificationValue(afterUpdateHashedValue, newVerificationValue)
+		assert.False(t, verified)
+		// Checking if the hashed value is equal the first verification value
+		verified = CompareVerificationValue(afterUpdateHashedValue, firstVerificationValue)
+		assert.True(t, verified)
+
+		assert.Equal(t, currentHashedValue, afterUpdateHashedValue)
+	})
+}
+
 func Test_ReceiverVerificationModel_UpdateReceiverVerification(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()


### PR DESCRIPTION
### What

Now we upsert the receivers' verification info.

*Note:* Only *NOT* confirmed verification info will be updated.

### Why

The caller will be able to update/insert these entries.

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
