### PR TITLE
fix: ensure verification field order

### DIFF
--- a/internal/data/receiver_verification.go
+++ b/internal/data/receiver_verification.go
@@ -107,7 +107,8 @@ func (m *ReceiverVerificationModel) GetLatestByPhoneNumber(ctx context.Context, 
 		WHERE 
 		    r.phone_number = $1
 		ORDER BY
-		    rv.updated_at DESC
+		    rv.updated_at DESC,
+			rv.verification_field ASC
 		LIMIT 1
 	`
 

--- a/internal/data/receiver_verification.go
+++ b/internal/data/receiver_verification.go
@@ -100,14 +100,14 @@ func (m *ReceiverVerificationModel) GetLatestByPhoneNumber(ctx context.Context, 
 	receiverVerification := ReceiverVerification{}
 	query := `
 		SELECT 
-		    rv.*
+			rv.*
 		FROM 
-		    receiver_verifications rv
+			receiver_verifications rv
 		JOIN receivers r ON rv.receiver_id = r.id
 		WHERE 
-		    r.phone_number = $1
+			r.phone_number = $1
 		ORDER BY
-		    rv.updated_at DESC,
+			rv.updated_at DESC,
 			rv.verification_field ASC
 		LIMIT 1
 	`


### PR DESCRIPTION
### What

The order should be by `updated_at` and then by `verification_field` in alphabetical order.

### Why

SDP-1106

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
