### PR TITLE
[SDP-1118] Hotfix: sanitize disbursement instructions

### DIFF
--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -434,16 +434,19 @@ func parseInstructionsFromCSV(file io.Reader, verificationField data.Verificatio
 		return nil, validator
 	}
 
+	var sanitizedInstructions []*data.DisbursementInstruction
 	for i, instruction := range instructions {
+		sanitizedInstruction := validator.SanitizeInstruction(instruction)
 		lineNumber := i + 2 // +1 for header row, +1 for 0-index
-		validator.ValidateInstruction(instruction, lineNumber)
+		validator.ValidateInstruction(sanitizedInstruction, lineNumber)
+		sanitizedInstructions = append(sanitizedInstructions, sanitizedInstruction)
 	}
 
-	validator.Check(len(instructions) > 0, "instructions", "no valid instructions found")
+	validator.Check(len(sanitizedInstructions) > 0, "instructions", "no valid instructions found")
 
 	if validator.HasErrors() {
 		return nil, validator
 	}
 
-	return instructions, nil
+	return sanitizedInstructions, nil
 }

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -855,17 +855,6 @@ func Test_DisbursementHandler_PostDisbursementInstructions(t *testing.T) {
 			expectedMessage: "File uploaded successfully",
 		},
 		{
-			name:           "valid input",
-			disbursementID: draftDisbursement.ID,
-			csvRecords: [][]string{
-				{"phone", "id", "amount", "verification"},
-				{"+380445555555", "123456789", "100.5", "1990-01-01"},
-				{"+380445555555", "123456789", "100.5", "1990-01-01"},
-			},
-			expectedStatus:  http.StatusOK,
-			expectedMessage: "File uploaded successfully",
-		},
-		{
 			name:           "invalid date of birth",
 			disbursementID: draftDisbursement.ID,
 			csvRecords: [][]string{

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -855,6 +855,17 @@ func Test_DisbursementHandler_PostDisbursementInstructions(t *testing.T) {
 			expectedMessage: "File uploaded successfully",
 		},
 		{
+			name:           "valid input",
+			disbursementID: draftDisbursement.ID,
+			csvRecords: [][]string{
+				{"phone", "id", "amount", "verification"},
+				{"+380445555555", "123456789", "100.5", "1990-01-01"},
+				{"+380445555555", "123456789", "100.5", "1990-01-01"},
+			},
+			expectedStatus:  http.StatusOK,
+			expectedMessage: "File uploaded successfully",
+		},
+		{
 			name:           "invalid date of birth",
 			disbursementID: draftDisbursement.ID,
 			csvRecords: [][]string{

--- a/internal/serve/validators/disbursement_instructions_validator.go
+++ b/internal/serve/validators/disbursement_instructions_validator.go
@@ -30,10 +30,10 @@ func NewDisbursementInstructionsValidator(verificationField data.VerificationFie
 }
 
 func (iv *DisbursementInstructionsValidator) ValidateInstruction(instruction *data.DisbursementInstruction, lineNumber int) {
-	phone := strings.TrimSpace(instruction.Phone)
-	id := strings.TrimSpace(instruction.ID)
-	amount := strings.TrimSpace(instruction.Amount)
-	verification := strings.TrimSpace(instruction.VerificationValue)
+	phone := instruction.Phone
+	id := instruction.ID
+	amount := instruction.Amount
+	verification := instruction.VerificationValue
 
 	// validate phone field
 	iv.CheckError(utils.ValidatePhoneNumber(phone), fmt.Sprintf("line %d - phone", lineNumber), "invalid phone format. Correct format: +380445555555")
@@ -64,4 +64,18 @@ func (iv *DisbursementInstructionsValidator) ValidateInstruction(instruction *da
 	} else {
 		log.Warnf("Verification field %v is not being validated for ValidateReceiver", iv)
 	}
+}
+
+func (iv *DisbursementInstructionsValidator) SanitizeInstruction(instruction *data.DisbursementInstruction) *data.DisbursementInstruction {
+	var sanitizedInstruction data.DisbursementInstruction
+	sanitizedInstruction.Phone = strings.TrimSpace(instruction.Phone)
+	sanitizedInstruction.ID = strings.TrimSpace(instruction.ID)
+	sanitizedInstruction.Amount = strings.TrimSpace(instruction.Amount)
+	sanitizedInstruction.VerificationValue = strings.TrimSpace(instruction.VerificationValue)
+
+	if instruction.ExternalPaymentId != nil {
+		externalPaymentId := strings.TrimSpace(*instruction.ExternalPaymentId)
+		sanitizedInstruction.ExternalPaymentId = &externalPaymentId
+	}
+	return &sanitizedInstruction
 }


### PR DESCRIPTION
### What
* Trim spaces for all fields in disbursement instructions

### Why
Resolve https://stellarorg.atlassian.net/browse/SDP-1118
Phone number with extra spaces especially, may result in creation of duplicate receivers. 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
