### PR TITLE
[SDP-1095] Add Authentication to GET `/organization/logo` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Install github.com/nishanths/exhaustive and golang.org/x/tools/cmd/deadcode@latest
         run: |
-          go install github.com/nishanths/exhaustive/cmd/exhaustive@latest
-          go install golang.org/x/tools/cmd/deadcode@latest
+          go install github.com/nishanths/exhaustive/cmd/exhaustive@v0.12.0
+          go install golang.org/x/tools/cmd/deadcode@v0.18.0
 
       - name: Run `exhaustive`
         run: exhaustive -default-signifies-exhaustive ./...

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -344,6 +344,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			BaseURL:               o.BaseURL,
 			DistributionPublicKey: o.DistributionPublicKey,
 			PasswordValidator:     o.PasswordValidator,
+			PublicFilesFS:         publicfiles.PublicFiles,
 		}
 		r.Route("/profile", func(r chi.Router) {
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
@@ -362,6 +363,9 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
 				Get("/", profileHandler.GetOrganizationInfo)
+
+			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
+				Get("/logo", profileHandler.GetOrganizationLogo)
 		})
 	})
 
@@ -370,10 +374,6 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	// Public routes that are tenant aware (they need to know the tenant ID)
 	mux.Group(func(r chi.Router) {
 		r.Use(middleware.TenantMiddleware(o.tenantManager, o.authManager))
-
-		// Even if the logo URL is under the public endpoints, it'll be authenticated. The `auth token` should be
-		// added in the URL's query params. Example: https://...?token=mytoken
-		r.Get("/organization/logo", httphandler.ProfileHandler{Models: o.Models, PublicFilesFS: publicfiles.PublicFiles}.GetOrganizationLogo)
 
 		r.Post("/login", httphandler.LoginHandler{
 			AuthManager:        authManager,

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -327,7 +327,9 @@ func Test_handleHTTP_unauthenticatedEndpoints(t *testing.T) {
 		path   string
 	}{
 		{http.MethodGet, "/health"},
+		{http.MethodGet, "/.well-known/stellar.toml"},
 		{http.MethodPost, "/login"},
+		{http.MethodPost, "/mfa"},
 		{http.MethodPost, "/forgot-password"},
 		{http.MethodPost, "/reset-password"},
 	}
@@ -410,6 +412,7 @@ func Test_handleHTTP_authenticatedEndpoints(t *testing.T) {
 		// Organization
 		{http.MethodGet, "/organization"},
 		{http.MethodPatch, "/organization"},
+		{http.MethodGet, "/organization/logo"},
 	}
 
 	// Expect 401 as a response:


### PR DESCRIPTION
### What
Adding authentication to `GET /organization/logo` 

### Why
Logos need to be able to resolve the tenant name. Making the endpoint authenticated solves this issue as we can reliably resolve the tenant id from the jwt token. 

FE PR: https://github.com/stellar/stellar-disbursement-platform-frontend/pull/79
Jira: https://stellarorg.atlassian.net/browse/SDP-1095

![Screenshot 2024-03-04 at 11 54 52 AM](https://github.com/stellar/stellar-disbursement-platform-backend/assets/4129193/06f65e50-b1b5-41d7-8031-eff0486931fb)
![Screenshot 2024-03-04 at 11 55 00 AM](https://github.com/stellar/stellar-disbursement-platform-backend/assets/4129193/6547f1b6-6c25-42db-bc5f-2dceaa27564a)


### Known limitations
n/a

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
