### PR TITLE
[Chore] Rename methods, as suggested in PR #207

### DIFF
--- a/cmd/channel_accounts.go
+++ b/cmd/channel_accounts.go
@@ -156,8 +156,8 @@ func (c *ChannelAccountsCommand) Command(cmdService ChAccCmdServiceInterface) *c
 			}
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			di.DeleteAndCloseInstanceByValue(cmd.Context(), c.TSSDBConnectionPool)
-			di.DeleteAndCloseInstanceByKey(cmd.Context(), di.AdminDBConnectionPoolInstanceName)
+			di.CleanupInstanceByValue(cmd.Context(), c.TSSDBConnectionPool)
+			di.CleanupInstanceByKey(cmd.Context(), di.AdminDBConnectionPoolInstanceName)
 		},
 	}
 	err := configOpts.Init(channelAccountsCmd)

--- a/cmd/db/db.go
+++ b/cmd/db/db.go
@@ -41,7 +41,7 @@ func (c *DatabaseCommand) Command(globalOptions *utils.GlobalOptionsType) *cobra
 		},
 		RunE: utils.CallHelpCommand,
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			di.DeleteAndCloseInstanceByValue(cmd.Context(), c.adminDBConnectionPool)
+			di.CleanupInstanceByValue(cmd.Context(), c.adminDBConnectionPool)
 		},
 	}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -452,7 +452,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 				log.Ctx(ctx).Fatalf("error getting Admin DB connection pool: %v", err)
 			}
 			defer func() {
-				di.DeleteAndCloseInstanceByValue(ctx, adminDBConnectionPool)
+				di.CleanupInstanceByValue(ctx, adminDBConnectionPool)
 			}()
 			serveOpts.AdminDBConnectionPool = adminDBConnectionPool
 			adminServeOpts.AdminDBConnectionPool = adminDBConnectionPool
@@ -463,7 +463,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 				log.Ctx(ctx).Fatalf("error getting Multi-tenant DB connection pool: %v", err)
 			}
 			defer func() {
-				di.DeleteAndCloseInstanceByValue(ctx, serveOpts.MtnDBConnectionPool)
+				di.CleanupInstanceByValue(ctx, serveOpts.MtnDBConnectionPool)
 			}()
 
 			// Setup the TSSDBConnectionPool
@@ -472,7 +472,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 				log.Ctx(ctx).Fatalf("error getting TSS DB connection pool: %v", err)
 			}
 			defer func() {
-				di.DeleteAndCloseInstanceByValue(ctx, tssDBConnectionPool)
+				di.CleanupInstanceByValue(ctx, tssDBConnectionPool)
 			}()
 
 			// Setup the Crash Tracker client

--- a/cmd/transaction_submitter.go
+++ b/cmd/transaction_submitter.go
@@ -217,8 +217,8 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 			submitterService.StartSubmitter(ctx, tssOpts)
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			di.DeleteAndCloseInstanceByValue(cmd.Context(), tssOpts.DBConnectionPool)
-			di.DeleteAndCloseInstanceByKey(cmd.Context(), di.AdminDBConnectionPoolInstanceName)
+			di.CleanupInstanceByValue(cmd.Context(), tssOpts.DBConnectionPool)
+			di.CleanupInstanceByKey(cmd.Context(), di.AdminDBConnectionPoolInstanceName)
 		},
 	}
 	err := configOpts.Init(cmd)

--- a/internal/dependencyinjection/container.go
+++ b/internal/dependencyinjection/container.go
@@ -30,9 +30,9 @@ func GetInstance(instanceName string) (interface{}, bool) {
 	return instance, ok
 }
 
-// DeleteAndCloseInstanceByKey removes a service instance from the store by key and test if it is a dbConnectionPool, in which
-// case, the pool is closed.
-func DeleteAndCloseInstanceByKey(ctx context.Context, instanceName string) {
+// CleanupInstanceByKey removes a service instance from the store by key and test if it is closeable, in which case, its
+// Close() method is called.
+func CleanupInstanceByKey(ctx context.Context, instanceName string) {
 	m.Lock()
 	defer m.Unlock()
 
@@ -44,14 +44,14 @@ func DeleteAndCloseInstanceByKey(ctx context.Context, instanceName string) {
 
 	if closeableInstance, ok := instanceToDelete.(io.Closer); ok {
 		if err := closeableInstance.Close(); err != nil {
-			log.Ctx(ctx).Errorf("error closing instance=%s in DeleteAndCloseInstanceByKey: %v", instanceName, err)
+			log.Ctx(ctx).Errorf("error closing instance=%s in CleanupInstanceByKey: %v", instanceName, err)
 		}
 	}
 }
 
-// DeleteAndCloseInstanceByValue removes a service instance from the store by value and checks if it is a dbConnectionPool, in which
-// case, the pool is closed.
-func DeleteAndCloseInstanceByValue(ctx context.Context, instance interface{}) {
+// CleanupInstanceByValue removes a service instance from the store by value and checks if it is closeable, in which
+// case, its Close() method is called.
+func CleanupInstanceByValue(ctx context.Context, instance interface{}) {
 	m.Lock()
 	defer m.Unlock()
 
@@ -71,7 +71,7 @@ func DeleteAndCloseInstanceByValue(ctx context.Context, instance interface{}) {
 
 		if closeableInstance, ok2 := instanceToDelete.(io.Closer); ok2 {
 			if err := closeableInstance.Close(); err != nil {
-				log.Ctx(ctx).Errorf("error closing instance=%s in DeleteAndCloseInstanceByValue: %v", k, err)
+				log.Ctx(ctx).Errorf("error closing instance=%s in CleanupInstanceByValue: %v", k, err)
 			}
 		}
 	}

--- a/internal/dependencyinjection/container_test.go
+++ b/internal/dependencyinjection/container_test.go
@@ -35,14 +35,14 @@ func Test_GetInstance(t *testing.T) {
 	assert.Nil(t, instance)
 }
 
-func Test_DeleteAndCloseInstanceByKey(t *testing.T) {
+func Test_CleanupInstanceByKey(t *testing.T) {
 	defer ClearInstancesTestHelper(t)
 	ctx := context.Background()
 
 	t.Run("attempting to delete a non-existing key should not panic", func(t *testing.T) {
 		defer ClearInstancesTestHelper(t)
 
-		assert.NotPanics(t, func() { DeleteAndCloseInstanceByKey(ctx, "testKey") })
+		assert.NotPanics(t, func() { CleanupInstanceByKey(ctx, "testKey") })
 	})
 
 	t.Run("deleting something that's not a dbConnectionPool", func(t *testing.T) {
@@ -52,7 +52,7 @@ func Test_DeleteAndCloseInstanceByKey(t *testing.T) {
 		_, ok := GetInstance("testKey")
 		assert.True(t, ok)
 
-		DeleteAndCloseInstanceByKey(ctx, "testKey")
+		CleanupInstanceByKey(ctx, "testKey")
 		_, ok = GetInstance("testKey")
 		assert.False(t, ok)
 	})
@@ -70,7 +70,7 @@ func Test_DeleteAndCloseInstanceByKey(t *testing.T) {
 		_, ok := GetInstance("dbKey")
 		assert.True(t, ok)
 
-		DeleteAndCloseInstanceByKey(ctx, "dbKey")
+		CleanupInstanceByKey(ctx, "dbKey")
 		_, ok = GetInstance("dbKey")
 		assert.False(t, ok)
 		err = dbConnectionPool.Ping(ctx)
@@ -78,7 +78,7 @@ func Test_DeleteAndCloseInstanceByKey(t *testing.T) {
 	})
 }
 
-func Test_DeleteAndCloseInstanceByValue(t *testing.T) {
+func Test_CleanupInstanceByValue(t *testing.T) {
 	defer ClearInstancesTestHelper(t)
 
 	ctx := context.Background()
@@ -86,7 +86,7 @@ func Test_DeleteAndCloseInstanceByValue(t *testing.T) {
 	t.Run("attempting to delete a non-existing value should not panic", func(t *testing.T) {
 		defer ClearInstancesTestHelper(t)
 
-		assert.NotPanics(t, func() { DeleteAndCloseInstanceByValue(ctx, "testValue") })
+		assert.NotPanics(t, func() { CleanupInstanceByValue(ctx, "testValue") })
 	})
 
 	t.Run("deleting something that's not a dbConnectionPool", func(t *testing.T) {
@@ -96,7 +96,7 @@ func Test_DeleteAndCloseInstanceByValue(t *testing.T) {
 		_, ok := GetInstance("testKey")
 		assert.True(t, ok)
 
-		DeleteAndCloseInstanceByValue(ctx, "testValue")
+		CleanupInstanceByValue(ctx, "testValue")
 		_, ok = GetInstance("testKey")
 		assert.False(t, ok)
 	})
@@ -121,7 +121,7 @@ func Test_DeleteAndCloseInstanceByValue(t *testing.T) {
 			require.Truef(t, ok, "instance missing for index %d", i)
 		}
 
-		DeleteAndCloseInstanceByValue(ctx, dbConnectionPool1)
+		CleanupInstanceByValue(ctx, dbConnectionPool1)
 		for i, keyName := range keyNames {
 			_, ok := GetInstance(keyName)
 			require.Falsef(t, ok, "instance %d should have been deleted", i)

--- a/internal/dependencyinjection/fixtures.go
+++ b/internal/dependencyinjection/fixtures.go
@@ -10,6 +10,6 @@ func ClearInstancesTestHelper(t *testing.T) {
 
 	// Range over the map and delete each entry.
 	for instanceName := range dependenciesStore {
-		DeleteAndCloseInstanceByKey(context.Background(), instanceName)
+		CleanupInstanceByKey(context.Background(), instanceName)
 	}
 }

--- a/stellar-multitenant/pkg/cli/add_tenants.go
+++ b/stellar-multitenant/pkg/cli/add_tenants.go
@@ -122,7 +122,7 @@ func AddTenantsCmd() *cobra.Command {
 				log.Fatalf("getting TSS DBConnectionPool: %v", err)
 			}
 			defer func() {
-				di.DeleteAndCloseInstanceByValue(ctx, tssDBConnectionPool)
+				di.CleanupInstanceByValue(ctx, tssDBConnectionPool)
 			}()
 
 			// Get Admin DB connection pool
@@ -131,7 +131,7 @@ func AddTenantsCmd() *cobra.Command {
 				log.Fatalf("getting Admin database connection pool: %v", err)
 			}
 			defer func() {
-				di.DeleteAndCloseInstanceByValue(ctx, adminDBConnectionPool)
+				di.CleanupInstanceByValue(ctx, adminDBConnectionPool)
 			}()
 
 			tenantName, userFirstName, userLastName, userEmail, organizationName := args[0], args[1], args[2], args[3], args[4]

--- a/stellar-multitenant/pkg/cli/config_tenant.go
+++ b/stellar-multitenant/pkg/cli/config_tenant.go
@@ -96,7 +96,7 @@ func ConfigTenantCmd() *cobra.Command {
 			}
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			di.DeleteAndCloseInstanceByValue(cmd.Context(), adminDBConnectionPool)
+			di.CleanupInstanceByValue(cmd.Context(), adminDBConnectionPool)
 		},
 	}
 


### PR DESCRIPTION
### What

Rename dependency injection methods:
- `DeleteAndCloseInstanceByKey` -> `CleanupInstanceByKey`
- `DeleteAndCloseInstanceByValue` -> `DeleteAndCloseInstanceByValue`

### Why

As suggested in PR #207.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
