### PR TITLE
[Chore] Update logs usage to include the request info and use the context in all log calls

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -66,7 +66,7 @@ func (a *AuthCommand) Command() *cobra.Command {
 			authCmdConfigOpts.Require()
 			err := authCmdConfigOpts.SetValues()
 			if err != nil {
-				log.Fatalf("error setting values of config options: %s", err.Error())
+				log.Ctx(ctx).Fatalf("error setting values of config options: %s", err.Error())
 			}
 
 			if cmd.Name() == addUserSubcommand.Name() && !viper.GetBool("password") {
@@ -79,7 +79,7 @@ func (a *AuthCommand) Command() *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {
-				log.Fatalf("Error calling auth command: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error calling auth command: %s", err.Error())
 			}
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
@@ -141,7 +141,7 @@ func (a *AuthCommand) Command() *cobra.Command {
 	}
 
 	if err := authCmdConfigOpts.Init(authCmd); err != nil {
-		log.Fatalf("error initializing authCmd config options: %s", err.Error())
+		log.Ctx(authCmd.Context()).Fatalf("error initializing authCmd config options: %s", err.Error())
 	}
 
 	authCmd.AddCommand(addUserSubcommand)

--- a/cmd/channel_accounts.go
+++ b/cmd/channel_accounts.go
@@ -162,7 +162,7 @@ func (c *ChannelAccountsCommand) Command(cmdService ChAccCmdServiceInterface) *c
 	}
 	err := configOpts.Init(channelAccountsCmd)
 	if err != nil {
-		log.Fatalf("Error initializing %s command: %v", channelAccountsCmd.Name(), err)
+		log.Ctx(channelAccountsCmd.Context()).Fatalf("Error initializing %s command: %v", channelAccountsCmd.Name(), err)
 	}
 
 	channelAccountsCmd.AddCommand(c.ViewCommand(cmdService))
@@ -203,7 +203,7 @@ func (c *ChannelAccountsCommand) CreateCommand(cmdService ChAccCmdServiceInterfa
 		},
 	}
 	if err := configOpts.Init(createCmd); err != nil {
-		log.Fatalf("Error initializing %s command: %v", createCmd.Name(), err)
+		log.Ctx(createCmd.Context()).Fatalf("Error initializing %s command: %v", createCmd.Name(), err)
 	}
 
 	return createCmd
@@ -241,7 +241,7 @@ func (c *ChannelAccountsCommand) VerifyCommand(cmdService ChAccCmdServiceInterfa
 		},
 	}
 	if err := configOpts.Init(verifyCmd); err != nil {
-		log.Fatalf("Error initializing %s command: %v", verifyCmd.Name(), err)
+		log.Ctx(verifyCmd.Context()).Fatalf("Error initializing %s command: %v", verifyCmd.Name(), err)
 	}
 
 	return verifyCmd
@@ -278,7 +278,7 @@ func (c *ChannelAccountsCommand) EnsureCommand(cmdService ChAccCmdServiceInterfa
 		},
 	}
 	if err := configOpts.Init(ensureCmd); err != nil {
-		log.Fatalf("Error initializing %s command: %v", ensureCmd.Name(), err)
+		log.Ctx(ensureCmd.Context()).Fatalf("Error initializing %s command: %v", ensureCmd.Name(), err)
 	}
 
 	return ensureCmd
@@ -325,7 +325,7 @@ func (c *ChannelAccountsCommand) DeleteCommand(cmdService ChAccCmdServiceInterfa
 		},
 	}
 	if err := configOpts.Init(deleteCmd); err != nil {
-		log.Fatalf("Error initializing %s command: %v", deleteCmd.Name(), err)
+		log.Ctx(deleteCmd.Context()).Fatalf("Error initializing %s command: %v", deleteCmd.Name(), err)
 	}
 
 	deleteCmd.MarkFlagsMutuallyExclusive("channel-account-id", "delete-all-accounts")

--- a/cmd/integration_tests.go
+++ b/cmd/integration_tests.go
@@ -53,13 +53,14 @@ func (c *IntegrationTestsCommand) Command() *cobra.Command {
 		Use:   "integration-tests",
 		Short: "Integration tests related commands",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			cmdUtils.PropagatePersistentPreRun(cmd, args)
+			ctx := cmd.Context()
 
 			// Validate & ingest input parameters
 			configOpts.Require()
 			err := configOpts.SetValues()
 			if err != nil {
-				log.Fatalf("Error setting values of config options: %s", err.Error())
+				log.Ctx(ctx).Fatalf("Error setting values of config options: %s", err.Error())
 			}
 
 			// inject database url to integration tests opts
@@ -67,13 +68,13 @@ func (c *IntegrationTestsCommand) Command() *cobra.Command {
 
 			c.Service, err = integrationtests.NewIntegrationTestsService(*integrationTestsOpts)
 			if err != nil {
-				log.Fatalf("error creating integration tests service: %s", err.Error())
+				log.Ctx(ctx).Fatalf("error creating integration tests service: %s", err.Error())
 			}
 		},
 	}
 	err := configOpts.Init(integrationTestsCmd)
 	if err != nil {
-		log.Fatalf("Error initializing a config option: %s", err.Error())
+		log.Ctx(integrationTestsCmd.Context()).Fatalf("Error initializing a config option: %s", err.Error())
 	}
 
 	startIntegrationTestsCmd := c.StartIntegrationTestsCommand(integrationTestsOpts)
@@ -188,14 +189,14 @@ func (c *IntegrationTestsCommand) StartIntegrationTestsCommand(integrationTestsO
 
 			err := c.Service.StartIntegrationTests(ctx, *integrationTestsOpts)
 			if err != nil {
-				log.Fatalf("Error starting integration tests: %s", err.Error())
+				log.Ctx(ctx).Fatalf("Error starting integration tests: %s", err.Error())
 			}
 		},
 	}
 
 	err := configOpts.Init(startIntegrationTestsCmd)
 	if err != nil {
-		log.Fatalf("Error initializing startIntegrationTestsCmd: %s", err.Error())
+		log.Ctx(startIntegrationTestsCmd.Context()).Fatalf("Error initializing startIntegrationTestsCmd: %s", err.Error())
 	}
 
 	return startIntegrationTestsCmd
@@ -240,14 +241,14 @@ func (c *IntegrationTestsCommand) CreateIntegrationTestsDataCommand(integrationT
 
 			err := c.Service.CreateTestData(ctx, *integrationTestsOpts)
 			if err != nil {
-				log.Fatalf("Error creating integration tests data: %s", err.Error())
+				log.Ctx(ctx).Fatalf("Error creating integration tests data: %s", err.Error())
 			}
 		},
 	}
 
 	err := configOpts.Init(createIntegrationTestsDataCmd)
 	if err != nil {
-		log.Fatalf("Error initializing createIntegrationTestsDataCmd: %s", err.Error())
+		log.Ctx(createIntegrationTestsDataCmd.Context()).Fatalf("Error initializing createIntegrationTestsDataCmd: %s", err.Error())
 	}
 
 	return createIntegrationTestsDataCmd

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -70,7 +70,7 @@ func (s *MessageCommand) Command(messengerService MessengerServiceInterface) *co
 				log.Fatalf("Error calling help command: %s", err.Error())
 			}
 
-			log.Infof("🎉 Successfully mounted messenger client for type %s", opts.MessengerType)
+			log.Ctx(cmd.Context()).Infof("🎉 Successfully mounted messenger client for type %s", opts.MessengerType)
 		},
 	}
 	err := messageCmdConfigOpts.Init(messageCmd)

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -53,7 +53,7 @@ func (s *MessageCommand) Command(messengerService MessengerServiceInterface) *co
 		Use:   "message",
 		Short: "Messenger related commands",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			cmdUtils.PropagatePersistentPreRun(cmd, args)
 			// Inject dependencies:
 			opts.Environment = globalOptions.Environment
 
@@ -61,21 +61,22 @@ func (s *MessageCommand) Command(messengerService MessengerServiceInterface) *co
 			messageCmdConfigOpts.Require()
 			err := messageCmdConfigOpts.SetValues()
 			if err != nil {
-				log.Fatalf("Error setting values of config options: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error setting values of config options: %s", err.Error())
 			}
 		},
 		Run: func(cmd *cobra.Command, _ []string) {
+			ctx := cmd.Context()
 			_, err := messengerService.GetClient(opts)
 			if err != nil {
-				log.Fatalf("Error calling help command: %s", err.Error())
+				log.Ctx(ctx).Fatalf("Error calling help command: %s", err.Error())
 			}
 
-			log.Ctx(cmd.Context()).Infof("🎉 Successfully mounted messenger client for type %s", opts.MessengerType)
+			log.Ctx(ctx).Infof("🎉 Successfully mounted messenger client for type %s", opts.MessengerType)
 		},
 	}
 	err := messageCmdConfigOpts.Init(messageCmd)
 	if err != nil {
-		log.Fatalf("Error initializing messageCmd config option: %s", err.Error())
+		log.Ctx(messageCmd.Context()).Fatalf("Error initializing messageCmd config option: %s", err.Error())
 	}
 
 	sendMessageCmd := s.sendMessageCommand(messengerService, &opts)
@@ -121,25 +122,25 @@ func (s *MessageCommand) sendMessageCommand(messengerService MessengerServiceInt
 		Use:   "send",
 		Short: "Send a message",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			cmdUtils.PropagatePersistentPreRun(cmd, args)
 
 			// Validate & ingest input parameters
 			sendMessageCmdConfigOpts.Require()
 			err := sendMessageCmdConfigOpts.SetValues()
 			if err != nil {
-				log.Fatalf("Error setting values of config options: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error setting values of config options: %s", err.Error())
 			}
 		},
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			err := messengerService.SendMessage(*messageOptions, msg)
 			if err != nil {
-				log.Fatalf("Error sending message: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error sending message: %s", err.Error())
 			}
 		},
 	}
 	err := sendMessageCmdConfigOpts.Init(sendMessageCmd)
 	if err != nil {
-		log.Fatalf("Error initializing a sendMessageCmd option: %s", err.Error())
+		log.Ctx(sendMessageCmd.Context()).Fatalf("Error initializing a sendMessageCmd option: %s", err.Error())
 	}
 
 	return sendMessageCmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,13 +66,14 @@ func rootCmd() *cobra.Command {
 		Long:    "The Stellar Disbursement Platform (SDP) enables organizations to disburse bulk payments to recipients using Stellar.",
 		Version: globalOptions.Version,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			ctx := cmd.Context()
 			configOpts.Require()
 			err := configOpts.SetValues()
 			if err != nil {
 				log.Fatalf("Error setting values of config options: %s", err.Error())
 			}
-			log.Info("Version: ", globalOptions.Version)
-			log.Info("GitCommit: ", globalOptions.GitCommit)
+			log.Ctx(ctx).Info("Version: ", globalOptions.Version)
+			log.Ctx(ctx).Info("GitCommit: ", globalOptions.GitCommit)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			err := cmd.Help()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,7 +70,7 @@ func rootCmd() *cobra.Command {
 			configOpts.Require()
 			err := configOpts.SetValues()
 			if err != nil {
-				log.Fatalf("Error setting values of config options: %s", err.Error())
+				log.Ctx(ctx).Fatalf("Error setting values of config options: %s", err.Error())
 			}
 			log.Ctx(ctx).Info("Version: ", globalOptions.Version)
 			log.Ctx(ctx).Info("GitCommit: ", globalOptions.GitCommit)
@@ -78,14 +78,14 @@ func rootCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := cmd.Help()
 			if err != nil {
-				log.Fatalf("Error calling help command: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error calling help command: %s", err.Error())
 			}
 		},
 	}
 
 	err := configOpts.Init(rootCmd)
 	if err != nil {
-		log.Fatalf("Error initializing a config option: %s", err.Error())
+		log.Ctx(rootCmd.Context()).Fatalf("Error initializing a config option: %s", err.Error())
 	}
 
 	return rootCmd

--- a/cmd/transaction_submitter.go
+++ b/cmd/transaction_submitter.go
@@ -49,7 +49,7 @@ func (t *TxSubmitterService) StartSubmitter(ctx context.Context, opts txSub.Subm
 	tssManager, err := txSub.NewManager(ctx, opts)
 	if err != nil {
 		opts.CrashTrackerClient.LogAndReportErrors(ctx, err, "Cannot start submitter service")
-		log.Fatalf("Error starting transaction submission service: %s", err.Error())
+		log.Ctx(ctx).Fatalf("Error starting transaction submission service: %s", err.Error())
 	}
 
 	tssManager.ProcessTransactions(ctx)
@@ -59,7 +59,7 @@ func (s *TxSubmitterService) StartMetricsServe(ctx context.Context, opts serve.M
 	err := serve.MetricsServe(opts, httpServer)
 	if err != nil {
 		crashTrackerClient.LogAndReportErrors(ctx, err, "Cannot start metrics service")
-		log.Fatalf("Error starting metrics server: %s", err.Error())
+		log.Ctx(ctx).Fatalf("Error starting metrics server: %s", err.Error())
 	}
 }
 
@@ -223,7 +223,7 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 	}
 	err := configOpts.Init(cmd)
 	if err != nil {
-		log.Fatalf("Error initializing a config option: %s", err.Error())
+		log.Ctx(cmd.Context()).Fatalf("Error initializing a config option: %s", err.Error())
 	}
 
 	return cmd

--- a/internal/crashtracker/sentry_client.go
+++ b/internal/crashtracker/sentry_client.go
@@ -54,7 +54,7 @@ type sentryClient struct {
 func (s *sentryClient) LogAndReportErrors(ctx context.Context, err error, msg string) {
 	// check if error is context canceled:
 	if errors.Is(err, context.Canceled) {
-		log.Warn("context canceled, not reporting error to sentry")
+		log.Ctx(ctx).Warn("context canceled, not reporting error to sentry")
 		return
 	}
 

--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -669,7 +669,7 @@ func (p *PaymentModel) CancelPaymentsWithinPeriodDays(ctx context.Context, sqlEx
 		return fmt.Errorf("error getting number of rows affected: %w", err)
 	}
 	if numRowsAffected == 0 {
-		log.Debug("No payments were canceled")
+		log.Ctx(ctx).Debug("No payments were canceled")
 	}
 
 	return nil

--- a/internal/serve/httphandler/reset_password_handler.go
+++ b/internal/serve/httphandler/reset_password_handler.go
@@ -73,7 +73,7 @@ func (h ResetPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	log.Infof("[ResetUserPassword] - Reset password for user with token %s",
+	log.Ctx(ctx).Infof("[ResetUserPassword] - Reset password for user with token %s",
 		utils.TruncateString(resetPasswordRequest.ResetToken, len(resetPasswordRequest.ResetToken)/4))
 	httpjson.RenderStatus(w, http.StatusOK, nil, httpjson.JSON)
 }

--- a/internal/serve/httphandler/stellar_toml_handler.go
+++ b/internal/serve/httphandler/stellar_toml_handler.go
@@ -42,7 +42,7 @@ func (s *StellarTomlHandler) horizonURL() string {
 func (s *StellarTomlHandler) buildGeneralInformation(ctx context.Context, req *http.Request) string {
 	distributionPublicKey, err := s.DistributionAccountResolver.DistributionAccountFromContext(ctx)
 	if err != nil {
-		log.Warnf("Couldn't get distribution account from context in %s%s", req.Host, req.URL.Path)
+		log.Ctx(ctx).Warnf("Couldn't get distribution account from context in %s%s", req.Host, req.URL.Path)
 		distributionPublicKey = s.DistributionAccountResolver.HostDistributionAccount()
 	}
 

--- a/internal/serve/httphandler/wallets_handler.go
+++ b/internal/serve/httphandler/wallets_handler.go
@@ -51,7 +51,7 @@ func (h WalletsHandler) PostWallets(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	validator := validators.NewWalletValidator()
-	reqBody = validator.ValidateCreateWalletRequest(reqBody)
+	reqBody = validator.ValidateCreateWalletRequest(ctx, reqBody)
 	if validator.HasErrors() {
 		httperror.BadRequest("invalid request body", nil, validator.Errors).Render(rw)
 		return

--- a/internal/serve/middleware/middleware.go
+++ b/internal/serve/middleware/middleware.go
@@ -76,7 +76,7 @@ func MetricsRequestHandler(monitorService monitor.MonitorServiceInterface) func(
 
 			err := monitorService.MonitorHttpRequestDuration(duration, labels)
 			if err != nil {
-				log.Errorf("Error trying to monitor request time: %s", err)
+				log.Ctx(req.Context()).Errorf("Error trying to monitor request time: %s", err)
 			}
 		})
 	}

--- a/internal/serve/middleware/middleware.go
+++ b/internal/serve/middleware/middleware.go
@@ -187,7 +187,9 @@ func LoggingMiddleware() func(http.Handler) http.Handler {
 
 			reqCtx := req.Context()
 			logFields := log.F{
-				"req": middleware.GetReqID(reqCtx),
+				"method": req.Method,
+				"path":   req.URL.String(),
+				"req":    middleware.GetReqID(reqCtx),
 			}
 			logCtx := log.Set(reqCtx, log.Ctx(reqCtx).WithFields(logFields))
 
@@ -219,8 +221,6 @@ func logRequestStart(req *http.Request) {
 	l := log.Ctx(req.Context()).WithFields(
 		log.F{
 			"subsys":    "http",
-			"path":      req.URL.String(),
-			"method":    req.Method,
 			"ip":        req.RemoteAddr,
 			"host":      req.Host,
 			"useragent": req.Header.Get("User-Agent"),
@@ -233,8 +233,6 @@ func logRequestStart(req *http.Request) {
 func logRequestEnd(req *http.Request, mw mutil.WriterProxy, duration time.Duration) {
 	l := log.Ctx(req.Context()).WithFields(log.F{
 		"subsys":   "http",
-		"path":     req.URL.String(),
-		"method":   req.Method,
 		"status":   mw.Status(),
 		"bytes":    mw.BytesWritten(),
 		"duration": duration,

--- a/internal/serve/middleware/middleware_test.go
+++ b/internal/serve/middleware/middleware_test.go
@@ -158,16 +158,16 @@ func Test_MetricsRequestHandler(t *testing.T) {
 func Test_AuthenticateMiddleware(t *testing.T) {
 	r := chi.NewRouter()
 
-	jwtManagerMock := &auth.JWTManagerMock{}
-	authManager := auth.NewAuthManager(auth.WithCustomJWTManagerOption(jwtManagerMock))
+	mAuthManager := &auth.AuthManagerMock{}
 
 	r.Group(func(r chi.Router) {
-		r.Use(AuthenticateMiddleware(authManager))
+		r.Use(AuthenticateMiddleware(mAuthManager))
 
 		r.Get("/authenticated", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write(json.RawMessage(`{"status":"ok"}`))
 			require.NoError(t, err)
+			log.Ctx(r.Context()).Info("authenticated route")
 		})
 	})
 
@@ -232,9 +232,9 @@ func Test_AuthenticateMiddleware(t *testing.T) {
 
 		req.Header.Set("Authorization", "Bearer token")
 
-		jwtManagerMock.
-			On("ValidateToken", mock.Anything, "token").
-			Return(false, errors.New("unexpected error")).
+		mAuthManager.
+			On("GetUserID", mock.Anything, "token").
+			Return("", errors.New("unexpected error")).
 			Once()
 
 		getEntries := log.DefaultLogger.StartTest(log.ErrorLevel)
@@ -251,7 +251,7 @@ func Test_AuthenticateMiddleware(t *testing.T) {
 
 		entries := getEntries()
 		assert.NotEmpty(t, entries)
-		assert.Equal(t, `error validating auth token: validating token: unexpected error`, entries[0].Message)
+		assert.Equal(t, `error validating auth token: unexpected error`, entries[0].Message)
 	})
 
 	t.Run("returns Unauthorized when the token is invalid", func(t *testing.T) {
@@ -260,9 +260,9 @@ func Test_AuthenticateMiddleware(t *testing.T) {
 
 		req.Header.Set("Authorization", "Bearer token")
 
-		jwtManagerMock.
-			On("ValidateToken", mock.Anything, "token").
-			Return(false, nil).
+		mAuthManager.
+			On("GetUserID", mock.Anything, "token").
+			Return("", auth.ErrInvalidToken).
 			Once()
 
 		w := httptest.NewRecorder()
@@ -282,10 +282,12 @@ func Test_AuthenticateMiddleware(t *testing.T) {
 
 		req.Header.Set("Authorization", "Bearer token")
 
-		jwtManagerMock.
-			On("ValidateToken", mock.Anything, "token").
-			Return(true, nil).
+		mAuthManager.
+			On("GetUserID", mock.Anything, "token").
+			Return("test_user_id", nil).
 			Once()
+
+		getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
 
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
@@ -296,6 +298,12 @@ func Test_AuthenticateMiddleware(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.JSONEq(t, `{"status":"ok"}`, string(respBody))
+
+		// assert if user_id is in the logs:
+		entries := getEntries()
+		assert.NotEmpty(t, entries)
+		assert.Contains(t, entries[0].Message, "authenticated route")
+		assert.Equal(t, entries[0].Data["user_id"], "test_user_id")
 	})
 
 	t.Run("doesn't return Unauthorized for unauthenticated routes", func(t *testing.T) {

--- a/internal/serve/middleware/middleware_test.go
+++ b/internal/serve/middleware/middleware_test.go
@@ -643,7 +643,7 @@ func Test_LoggingMiddleware(t *testing.T) {
 		}, nil).Once()
 
 		r.Use(TenantMiddleware(mTenantManager, mAuthManager))
-		r.Use(LoggingMiddleware())
+		r.Use(LoggingMiddleware)
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte(expectedRespBody))
 			require.NoError(t, err)
@@ -689,7 +689,7 @@ func Test_LoggingMiddleware(t *testing.T) {
 
 		debugEntries := log.DefaultLogger.StartTest(log.DebugLevel)
 
-		r.Use(LoggingMiddleware())
+		r.Use(LoggingMiddleware)
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte(expectedRespBody))
 			require.NoError(t, err)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -218,7 +218,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	mux.Group(func(r chi.Router) {
 		r.Use(middleware.AuthenticateMiddleware(authManager))
 		r.Use(middleware.TenantMiddleware(o.tenantManager, o.authManager))
-		r.Use(middleware.LoggingMiddleware())
+		r.Use(middleware.LoggingMiddleware)
 
 		r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).Route("/statistics", func(r chi.Router) {
 			statisticsHandler := httphandler.StatisticsHandler{DBConnectionPool: o.MtnDBConnectionPool}
@@ -373,7 +373,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	// Public routes that are tenant aware (they need to know the tenant ID)
 	mux.Group(func(r chi.Router) {
 		r.Use(middleware.TenantMiddleware(o.tenantManager, o.authManager))
-		r.Use(middleware.LoggingMiddleware())
+		r.Use(middleware.LoggingMiddleware)
 
 		r.Post("/login", httphandler.LoginHandler{
 			AuthManager:        authManager,
@@ -410,7 +410,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 	// SEP-24 and miscellaneous endpoints that are tenant-unaware
 	mux.Group(func(r chi.Router) {
-		r.Use(middleware.LoggingMiddleware())
+		r.Use(middleware.LoggingMiddleware)
 
 		r.Get("/health", httphandler.HealthHandler{
 			ReleaseID: o.GitCommit,

--- a/internal/serve/validators/disbursement_instructions_validator.go
+++ b/internal/serve/validators/disbursement_instructions_validator.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
@@ -46,22 +45,21 @@ func (iv *DisbursementInstructionsValidator) ValidateInstruction(instruction *da
 	iv.CheckError(utils.ValidateAmount(amount), fmt.Sprintf("line %d - amount", lineNumber), "invalid amount. Amount must be a positive number")
 
 	// validate verification field
-	// date of birth with format 2006-01-02
-	if iv.verificationField == data.VerificationFieldDateOfBirth {
+	switch iv.verificationField {
+	case data.VerificationFieldDateOfBirth:
+		// date of birth with format 2006-01-02
 		dob, err := time.Parse("2006-01-02", verification)
 		iv.CheckError(err, fmt.Sprintf("line %d - birthday", lineNumber), "invalid date of birth format. Correct format: 1990-01-01")
 
 		// check if date of birth is in the past
 		iv.Check(dob.Before(time.Now()), fmt.Sprintf("line %d - birthday", lineNumber), "date of birth cannot be in the future")
-	} else if iv.verificationField == data.VerificationFieldPin {
+	case data.VerificationFieldPin:
 		if len(verification) < VERIFICATION_FIELD_PIN_MIN_LENGTH || len(verification) > VERIFICATION_FIELD_PIN_MAX_LENGTH {
 			iv.addError(fmt.Sprintf("line %d - pin", lineNumber), "invalid pin. Cannot have less than 4 or more than 8 characters in pin")
 		}
-	} else if iv.verificationField == data.VerificationFieldNationalID {
+	case data.VerificationFieldNationalID:
 		if len(verification) > VERIFICATION_FIELD_MAX_ID_LENGTH {
 			iv.addError(fmt.Sprintf("line %d - national id", lineNumber), "invalid national id. Cannot have more than 50 characters in national id")
 		}
-	} else {
-		log.Warnf("Verification field %v is not being validated for ValidateReceiver", iv)
 	}
 }

--- a/internal/serve/validators/receiver_registration_validator.go
+++ b/internal/serve/validators/receiver_registration_validator.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
@@ -39,25 +38,23 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 	rv.Check(verificationType != "", "verification_type", "verification type cannot be empty")
 	vt := rv.validateAndGetVerificationType(verificationType)
 
-	// validate verification field
-	// date of birth with format 2006-01-02
-	if vt == data.VerificationFieldDateOfBirth {
+	// validate verification fields
+	switch vt {
+	case data.VerificationFieldDateOfBirth:
+		// date of birth with format 2006-01-02
 		dob, err := time.Parse("2006-01-02", verification)
 		rv.CheckError(err, "verification", "invalid date of birth format. Correct format: 1990-01-01")
 
 		// check if date of birth is in the past
 		rv.Check(dob.Before(time.Now()), "verification", "date of birth cannot be in the future")
-	} else if vt == data.VerificationFieldPin {
+	case data.VerificationFieldPin:
 		if len(verification) < VERIFICATION_FIELD_PIN_MIN_LENGTH || len(verification) > VERIFICATION_FIELD_PIN_MAX_LENGTH {
 			rv.addError("verification", "invalid pin. Cannot have less than 4 or more than 8 characters in pin")
 		}
-	} else if vt == data.VerificationFieldNationalID {
+	case data.VerificationFieldNationalID:
 		if len(verification) > VERIFICATION_FIELD_MAX_ID_LENGTH {
 			rv.addError("verification", "invalid national id. Cannot have more than 50 characters in national id")
 		}
-	} else {
-		// TODO: validate other VerificationField types.
-		log.Warnf("Verification type %v is not being validated for ValidateReceiver", vt)
 	}
 
 	receiverInfo.PhoneNumber = phone

--- a/internal/serve/validators/wallet_validator.go
+++ b/internal/serve/validators/wallet_validator.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"context"
 	"net/url"
 	"strings"
 
@@ -27,7 +28,7 @@ func NewWalletValidator() *WalletValidator {
 	return &WalletValidator{Validator: NewValidator()}
 }
 
-func (wv *WalletValidator) ValidateCreateWalletRequest(reqBody *WalletRequest) *WalletRequest {
+func (wv *WalletValidator) ValidateCreateWalletRequest(ctx context.Context, reqBody *WalletRequest) *WalletRequest {
 	wv.Check(reqBody != nil, "body", "request body is empty")
 
 	if wv.HasErrors() {
@@ -51,19 +52,19 @@ func (wv *WalletValidator) ValidateCreateWalletRequest(reqBody *WalletRequest) *
 
 	homepageURL, err := url.ParseRequestURI(homepage)
 	if err != nil {
-		log.Errorf("parsing homepage URL: %v", err)
+		log.Ctx(ctx).Errorf("parsing homepage URL: %v", err)
 		wv.Check(false, "homepage", "invalid homepage URL provided")
 	}
 
 	deepLinkSchemaURL, err := url.ParseRequestURI(deepLinkSchema)
 	if err != nil {
-		log.Errorf("parsing deep link schema: %v", err)
+		log.Ctx(ctx).Errorf("parsing deep link schema: %v", err)
 		wv.Check(false, "deep_link_schema", "invalid deep link schema provided")
 	}
 
 	sep10URL, err := url.Parse(sep10ClientDomain)
 	if err != nil {
-		log.Errorf("parsing SEP-10 client domain URL: %v", err)
+		log.Ctx(ctx).Errorf("parsing SEP-10 client domain URL: %v", err)
 		wv.Check(false, "sep_10_client_domain", "invalid SEP-10 client domain URL provided")
 	}
 

--- a/internal/serve/validators/wallet_validator_test.go
+++ b/internal/serve/validators/wallet_validator_test.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stellar/go/support/log"
@@ -9,9 +10,11 @@ import (
 )
 
 func TestWalletValidator_ValidateCreateWalletRequest(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("returns error when request body is empty", func(t *testing.T) {
 		wv := NewWalletValidator()
-		wv.ValidateCreateWalletRequest(nil)
+		wv.ValidateCreateWalletRequest(ctx, nil)
 		assert.True(t, wv.HasErrors())
 		assert.Equal(t, map[string]interface{}{"body": "request body is empty"}, wv.Errors)
 	})
@@ -20,7 +23,7 @@ func TestWalletValidator_ValidateCreateWalletRequest(t *testing.T) {
 		wv := NewWalletValidator()
 		reqBody := &WalletRequest{}
 
-		wv.ValidateCreateWalletRequest(reqBody)
+		wv.ValidateCreateWalletRequest(ctx, reqBody)
 		assert.True(t, wv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
 			"deep_link_schema":     "deep_link_schema is required",
@@ -32,7 +35,7 @@ func TestWalletValidator_ValidateCreateWalletRequest(t *testing.T) {
 
 		reqBody.Name = "Wallet Provider"
 		wv.Errors = map[string]interface{}{}
-		wv.ValidateCreateWalletRequest(reqBody)
+		wv.ValidateCreateWalletRequest(ctx, reqBody)
 		assert.True(t, wv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
 			"deep_link_schema":     "deep_link_schema is required",
@@ -54,7 +57,7 @@ func TestWalletValidator_ValidateCreateWalletRequest(t *testing.T) {
 			AssetsIDs:         []string{"asset-id"},
 		}
 
-		wv.ValidateCreateWalletRequest(reqBody)
+		wv.ValidateCreateWalletRequest(ctx, reqBody)
 
 		assert.True(t, wv.HasErrors())
 
@@ -80,11 +83,11 @@ func TestWalletValidator_ValidateCreateWalletRequest(t *testing.T) {
 			AssetsIDs:         []string{"asset-id"},
 		}
 
-		wv.ValidateCreateWalletRequest(reqBody)
+		wv.ValidateCreateWalletRequest(ctx, reqBody)
 		assert.False(t, wv.HasErrors())
 
 		reqBody.Homepage = "http://homepage.com/sdp?redirect=true"
-		wv.ValidateCreateWalletRequest(reqBody)
+		wv.ValidateCreateWalletRequest(ctx, reqBody)
 		assert.False(t, wv.HasErrors())
 		assert.Equal(t, map[string]interface{}{}, wv.Errors)
 	})
@@ -99,11 +102,11 @@ func TestWalletValidator_ValidateCreateWalletRequest(t *testing.T) {
 			AssetsIDs:         []string{"asset-id"},
 		}
 
-		wv.ValidateCreateWalletRequest(reqBody)
+		wv.ValidateCreateWalletRequest(ctx, reqBody)
 		assert.False(t, wv.HasErrors())
 
 		reqBody.DeepLinkSchema = "https://deeplinkschema.com/sdp?redirect=true"
-		wv.ValidateCreateWalletRequest(reqBody)
+		wv.ValidateCreateWalletRequest(ctx, reqBody)
 		assert.False(t, wv.HasErrors())
 	})
 
@@ -117,26 +120,28 @@ func TestWalletValidator_ValidateCreateWalletRequest(t *testing.T) {
 			AssetsIDs:         []string{"asset-id"},
 		}
 
-		reqBody = wv.ValidateCreateWalletRequest(reqBody)
+		reqBody = wv.ValidateCreateWalletRequest(ctx, reqBody)
 		assert.False(t, wv.HasErrors())
 		assert.Equal(t, "sep-10-client-domain.com", reqBody.SEP10ClientDomain)
 
 		reqBody.SEP10ClientDomain = "https://sep-10-client-domain.com/sdp?redirect=true"
-		reqBody = wv.ValidateCreateWalletRequest(reqBody)
+		reqBody = wv.ValidateCreateWalletRequest(ctx, reqBody)
 		assert.False(t, wv.HasErrors())
 		assert.Equal(t, "sep-10-client-domain.com", reqBody.SEP10ClientDomain)
 
 		reqBody.SEP10ClientDomain = "http://localhost:8000"
-		reqBody = wv.ValidateCreateWalletRequest(reqBody)
+		reqBody = wv.ValidateCreateWalletRequest(ctx, reqBody)
 		assert.False(t, wv.HasErrors())
 		assert.Equal(t, "localhost:8000", reqBody.SEP10ClientDomain)
 	})
 }
 
 func TestWalletValidator_ValidatePatchWalletRequest(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("returns error when request body is empty", func(t *testing.T) {
 		wv := NewWalletValidator()
-		wv.ValidateCreateWalletRequest(nil)
+		wv.ValidateCreateWalletRequest(ctx, nil)
 		assert.True(t, wv.HasErrors())
 		assert.Equal(t, map[string]interface{}{"body": "request body is empty"}, wv.Errors)
 	})

--- a/internal/services/ready_payments_cancellation_service.go
+++ b/internal/services/ready_payments_cancellation_service.go
@@ -32,7 +32,7 @@ func (s ReadyPaymentsCancellationService) CancelReadyPayments(ctx context.Contex
 	}
 
 	if organization.PaymentCancellationPeriodDays == nil {
-		log.Debug("automatic ready payment cancellation is deactivated. Set a valid value to the organization's payment_cancellation_period_days to activate it.")
+		log.Ctx(ctx).Debug("automatic ready payment cancellation is deactivated. Set a valid value to the organization's payment_cancellation_period_days to activate it.")
 		return nil
 	}
 

--- a/stellar-auth/cmd/stellarauth/main.go
+++ b/stellar-auth/cmd/stellarauth/main.go
@@ -19,6 +19,6 @@ func main() {
 
 	cmd := cli.SetupCLI(Version, GitCommit)
 	if err := cmd.Execute(); err != nil {
-		log.Fatalf("error executing: %s", err.Error())
+		log.Ctx(cmd.Context()).Fatalf("error executing: %s", err.Error())
 	}
 }

--- a/stellar-auth/pkg/cli/add_user.go
+++ b/stellar-auth/pkg/cli/add_user.go
@@ -103,30 +103,30 @@ func AddUserCmd(databaseURLFlagName string, passwordPrompt PasswordPromptInterfa
 			if passwordFlag {
 				result, err := passwordPrompt.Run()
 				if err != nil {
-					log.Fatalf("add-user error prompting password: %s", err)
+					log.Ctx(ctx).Fatalf("add-user error prompting password: %s", err)
 				}
 
 				pwValidator, err := utils.GetPasswordValidatorInstance()
 				if err != nil {
-					log.Fatalf("cannot initialize password validator: %s", err)
+					log.Ctx(ctx).Fatalf("cannot initialize password validator: %s", err)
 				}
 				err = pwValidator.ValidatePassword(result)
 				if err != nil {
-					log.Fatalf("password is not valid: %v", err)
+					log.Ctx(ctx).Fatalf("password is not valid: %v", err)
 				}
 				password = result
 			}
 
 			err := execAddUser(ctx, dbUrl, email, firstName, lastName, password, isOwner, rolesConfigKey)
 			if err != nil {
-				log.Fatalf("add-user command error: %s", err)
+				log.Ctx(ctx).Fatalf("add-user command error: %s", err)
 			}
 			log.Ctx(ctx).Infof("user inserted: %s", args[0])
 		},
 	}
 	err := addUserCmdConfigOpts.Init(addUser)
 	if err != nil {
-		log.Fatalf("error initializing addUserCmd config option: %s", err.Error())
+		log.Ctx(addUser.Context()).Fatalf("error initializing addUserCmd config option: %s", err.Error())
 	}
 
 	return addUser

--- a/stellar-auth/pkg/cli/add_user.go
+++ b/stellar-auth/pkg/cli/add_user.go
@@ -121,7 +121,7 @@ func AddUserCmd(databaseURLFlagName string, passwordPrompt PasswordPromptInterfa
 			if err != nil {
 				log.Fatalf("add-user command error: %s", err)
 			}
-			log.Infof("user inserted: %s", args[0])
+			log.Ctx(ctx).Infof("user inserted: %s", args[0])
 		},
 	}
 	err := addUserCmdConfigOpts.Init(addUser)

--- a/stellar-auth/pkg/cli/migrate.go
+++ b/stellar-auth/pkg/cli/migrate.go
@@ -18,7 +18,7 @@ func MigrateCmd(databaseFlagName string) *cobra.Command {
 		Short: "Apply Stellar Auth database migrations",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {
-				log.Fatalf("Error calling help command: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error calling help command: %s", err.Error())
 			}
 		},
 	}
@@ -28,12 +28,13 @@ func MigrateCmd(databaseFlagName string) *cobra.Command {
 		Short: "Migrates database up [count] migrations",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			var count int
 			if len(args) > 0 {
 				var err error
 				count, err = strconv.Atoi(args[0])
 				if err != nil {
-					log.Fatalf("Invalid [count] argument: %s", args[0])
+					log.Ctx(ctx).Fatalf("Invalid [count] argument: %s", args[0])
 				}
 			}
 
@@ -45,7 +46,7 @@ func MigrateCmd(databaseFlagName string) *cobra.Command {
 
 			err := runMigration(dbURL, migrate.Up, count)
 			if err != nil {
-				log.Fatalf("Error migrating database Up: %s", err.Error())
+				log.Ctx(ctx).Fatalf("Error migrating database Up: %s", err.Error())
 			}
 		},
 	}
@@ -56,9 +57,10 @@ func MigrateCmd(databaseFlagName string) *cobra.Command {
 		Short: "Migrates database down [count] migrations",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			count, err := strconv.Atoi(args[0])
 			if err != nil {
-				log.Fatalf("Invalid [count] argument: %s", args[0])
+				log.Ctx(ctx).Fatalf("Invalid [count] argument: %s", args[0])
 			}
 
 			dbURL := globalOptions.databaseURL
@@ -68,7 +70,7 @@ func MigrateCmd(databaseFlagName string) *cobra.Command {
 
 			err = runMigration(dbURL, migrate.Down, count)
 			if err != nil {
-				log.Fatalf("Error migrating database Down: %s", err.Error())
+				log.Ctx(ctx).Fatalf("Error migrating database Down: %s", err.Error())
 			}
 		},
 	}

--- a/stellar-auth/pkg/cli/root.go
+++ b/stellar-auth/pkg/cli/root.go
@@ -43,18 +43,19 @@ func rootCmd() *cobra.Command {
 		Use:   "stellarauth",
 		Short: "Stellar Auth handles JWT management.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			configOptions.Require()
 			err := configOptions.SetValues()
 			if err != nil {
 				log.Fatalf("Error setting values of config options: %s", err.Error())
 			}
 
-			log.Info("Version: ", globalOptions.version)
-			log.Info("GitCommit: ", globalOptions.gitCommit)
+			log.Ctx(ctx).Info("Version: ", globalOptions.version)
+			log.Ctx(ctx).Info("GitCommit: ", globalOptions.gitCommit)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {
-				log.Fatalf("Error calling help command: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error calling help command: %s", err.Error())
 			}
 		},
 	}

--- a/stellar-auth/pkg/cli/root.go
+++ b/stellar-auth/pkg/cli/root.go
@@ -47,7 +47,7 @@ func rootCmd() *cobra.Command {
 			configOptions.Require()
 			err := configOptions.SetValues()
 			if err != nil {
-				log.Fatalf("Error setting values of config options: %s", err.Error())
+				log.Ctx(ctx).Fatalf("Error setting values of config options: %s", err.Error())
 			}
 
 			log.Ctx(ctx).Info("Version: ", globalOptions.version)
@@ -61,7 +61,7 @@ func rootCmd() *cobra.Command {
 	}
 
 	if err := configOptions.Init(cmd); err != nil {
-		log.Fatalf("Error initializing a config option: %s", err.Error())
+		log.Ctx(cmd.Context()).Fatalf("Error initializing a config option: %s", err.Error())
 	}
 
 	return cmd

--- a/stellar-multitenant/cmd/stellarmultitenant/main.go
+++ b/stellar-multitenant/cmd/stellarmultitenant/main.go
@@ -19,6 +19,6 @@ func main() {
 
 	cmd := cli.SetupCLI(Version, GitCommit)
 	if err := cmd.Execute(); err != nil {
-		log.Fatalf("error executing: %s", err.Error())
+		log.Ctx(cmd.Context()).Fatalf("error executing: %s", err.Error())
 	}
 }

--- a/stellar-multitenant/pkg/cli/add_tenants.go
+++ b/stellar-multitenant/pkg/cli/add_tenants.go
@@ -95,11 +95,11 @@ func AddTenantsCmd() *cobra.Command {
 			validateTenantNameArg,
 		),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			cmdUtils.PropagatePersistentPreRun(cmd, args)
 			configOptions.Require()
 			err := configOptions.SetValues()
 			if err != nil {
-				log.Fatalf("Error setting values of config options: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error setting values of config options: %s", err.Error())
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -111,7 +111,7 @@ func AddTenantsCmd() *cobra.Command {
 				MessengerOptions: &tenantsOpts.MessengerOptions,
 			})
 			if err != nil {
-				log.Fatalf("creating email client: %v", err)
+				log.Ctx(ctx).Fatalf("creating email client: %v", err)
 			}
 
 			// Get TSS DB connection pool
@@ -119,7 +119,7 @@ func AddTenantsCmd() *cobra.Command {
 			dbcpOptions := di.DBConnectionPoolOptions{DatabaseURL: globalOptions.multitenantDbURL}
 			tssDBConnectionPool, err := di.NewTSSDBConnectionPool(ctx, dbcpOptions)
 			if err != nil {
-				log.Fatalf("getting TSS DBConnectionPool: %v", err)
+				log.Ctx(ctx).Fatalf("getting TSS DBConnectionPool: %v", err)
 			}
 			defer func() {
 				di.CleanupInstanceByValue(ctx, tssDBConnectionPool)
@@ -128,7 +128,7 @@ func AddTenantsCmd() *cobra.Command {
 			// Get Admin DB connection pool
 			adminDBConnectionPool, err := di.NewAdminDBConnectionPool(ctx, dbcpOptions)
 			if err != nil {
-				log.Fatalf("getting Admin database connection pool: %v", err)
+				log.Ctx(ctx).Fatalf("getting Admin database connection pool: %v", err)
 			}
 			defer func() {
 				di.CleanupInstanceByValue(ctx, adminDBConnectionPool)
@@ -150,7 +150,7 @@ func AddTenantsCmd() *cobra.Command {
 	}
 
 	if err := configOptions.Init(&cmd); err != nil {
-		log.Fatalf("initializing config options: %v", err)
+		log.Ctx(cmd.Context()).Fatalf("initializing config options: %v", err)
 	}
 
 	return &cmd

--- a/stellar-multitenant/pkg/cli/config_tenant.go
+++ b/stellar-multitenant/pkg/cli/config_tenant.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/log"
 
+	cmdUtils "github.com/stellar/stellar-disbursement-platform-backend/cmd/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	di "github.com/stellar/stellar-disbursement-platform-backend/internal/dependencyinjection"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/cli/utils"
@@ -74,11 +75,11 @@ func ConfigTenantCmd() *cobra.Command {
 		Long:    "Configure an existing tenant by updating their existing configuration",
 		Aliases: []string{"ct"},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+			cmdUtils.PropagatePersistentPreRun(cmd, args)
 			configOptions.Require()
 			err := configOptions.SetValues()
 			if err != nil {
-				log.Fatalf("Error setting values of config options: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error setting values of config options: %s", err.Error())
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/stellar-multitenant/pkg/cli/config_tenant.go
+++ b/stellar-multitenant/pkg/cli/config_tenant.go
@@ -120,7 +120,7 @@ func executeConfigTenant(ctx context.Context, to *tenantOptions, dbConnectionPoo
 		return fmt.Errorf("updating tenant config: %w", err)
 	}
 
-	log.Infof("tenant ID %s configuration updated successfully", to.ID)
+	log.Ctx(ctx).Infof("tenant ID %s configuration updated successfully", to.ID)
 
 	return nil
 }

--- a/stellar-multitenant/pkg/cli/root.go
+++ b/stellar-multitenant/pkg/cli/root.go
@@ -36,7 +36,7 @@ func rootCmd() *cobra.Command {
 			configOptions.Require()
 			err := configOptions.SetValues()
 			if err != nil {
-				log.Fatalf("Error setting values of config options: %s", err.Error())
+				log.Ctx(ctx).Fatalf("Error setting values of config options: %s", err.Error())
 			}
 
 			log.Ctx(ctx).Info("Version: ", globalOptions.version)
@@ -44,13 +44,13 @@ func rootCmd() *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {
-				log.Fatalf("Error calling help command: %s", err.Error())
+				log.Ctx(cmd.Context()).Fatalf("Error calling help command: %s", err.Error())
 			}
 		},
 	}
 
 	if err := configOptions.Init(cmd); err != nil {
-		log.Fatalf("Error initializing a config option: %s", err.Error())
+		log.Ctx(cmd.Context()).Fatalf("Error initializing a config option: %s", err.Error())
 	}
 
 	return cmd

--- a/stellar-multitenant/pkg/cli/root.go
+++ b/stellar-multitenant/pkg/cli/root.go
@@ -32,14 +32,15 @@ func rootCmd() *cobra.Command {
 		Use:   "mtn",
 		Short: "Stellar Disbursement Platform Multi-tenant Configuration.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			configOptions.Require()
 			err := configOptions.SetValues()
 			if err != nil {
 				log.Fatalf("Error setting values of config options: %s", err.Error())
 			}
 
-			log.Info("Version: ", globalOptions.version)
-			log.Info("GitCommit: ", globalOptions.gitCommit)
+			log.Ctx(ctx).Info("Version: ", globalOptions.version)
+			log.Ctx(ctx).Info("GitCommit: ", globalOptions.gitCommit)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {

--- a/stellar-multitenant/pkg/internal/provisioning/manager.go
+++ b/stellar-multitenant/pkg/internal/provisioning/manager.go
@@ -34,13 +34,13 @@ func (m *Manager) ProvisionNewTenant(
 	organizationName, uiBaseURL, networkType string,
 ) (*tenant.Tenant, error) {
 	// TODO (SDP-1107): Run this in a database transaction.
-	log.Infof("adding tenant %s", name)
+	log.Ctx(ctx).Infof("adding tenant %s", name)
 	t, err := m.tenantManager.AddTenant(ctx, name)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Infof("creating tenant %s database schema", t.Name)
+	log.Ctx(ctx).Infof("creating tenant %s database schema", t.Name)
 	schemaName := fmt.Sprintf("sdp_%s", t.Name)
 	_, err = m.db.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA %s", pq.QuoteIdentifier(schemaName)))
 	if err != nil {
@@ -53,13 +53,13 @@ func (m *Manager) ProvisionNewTenant(
 	}
 
 	// Applying migrations
-	log.Infof("applying SDP migrations on the tenant %s schema", t.Name)
+	log.Ctx(ctx).Infof("applying SDP migrations on the tenant %s schema", t.Name)
 	err = m.RunMigrationsForTenant(ctx, t, u, migrate.Up, 0, sdpmigrations.FS, db.StellarPerTenantSDPMigrationsTableName)
 	if err != nil {
 		return nil, fmt.Errorf("applying SDP migrations: %w", err)
 	}
 
-	log.Infof("applying stellar-auth migrations on the tenant %s schema", t.Name)
+	log.Ctx(ctx).Infof("applying stellar-auth migrations on the tenant %s schema", t.Name)
 	err = m.RunMigrationsForTenant(ctx, t, u, migrate.Up, 0, authmigrations.FS, db.StellarPerTenantAuthMigrationsTableName)
 	if err != nil {
 		return nil, fmt.Errorf("applying stellar-auth migrations: %w", err)
@@ -167,7 +167,7 @@ func (m *Manager) RunMigrationsForTenant(
 	if err != nil {
 		return fmt.Errorf("applying SDP migrations: %w", err)
 	}
-	log.Infof("successful applied %d migrations", n)
+	log.Ctx(ctx).Infof("successful applied %d migrations", n)
 	return nil
 }
 


### PR DESCRIPTION
### What

Update logs usage to include the request info and use the context in all log calls. Basically, the changes are:
- `log.Debug(...)` -> `log.Ctx(ctx).Debug(...)`
- `log.Info(...)` -> `log.Ctx(ctx).Info(...)`
- `log.Warn(...)` -> `log.Ctx(ctx).Warn(...)`
- `log.Error(...)` -> `log.Ctx(ctx).Error(...)`
- `log.Fatal(...)` -> `log.Ctx(ctx).Fatal(...)`

And also, updated the Logging middleware to inject the `method` and `path` into the context, so they show up whenever we call `log.Ctx(ctx)...`:
https://github.com/stellar/stellar-disbursement-platform-backend/blob/d7efea6923d6cc029f2955c93fc1cf80d554db13/internal/serve/middleware/middleware.go#L191-L192

Additionally, updated the AuthenticateMiddleware to inject the `user_id` into the context:

https://github.com/stellar/stellar-disbursement-platform-backend/blob/50972ca1d03a514a4c42b8fd05a869d86263b76d/internal/serve/middleware/middleware.go#L117-L118

### Why

This will provide more info when logging anything that comes through an API call. Here's the new format:
```log
WARN[2024-03-06T13:40:07.577-08:00] Couldn't get distribution account from context in bluecorp.stellar.local:8000/.well-known/stellar.toml  method=GET path=/.well-known/stellar.toml pid=85201 req=Marcelos-MacBook-Pro.local/ak6SxvKlKb-000001
```

by comparison, here's the old format (without the `method` and `path` fields).
```log
WARN[2024-03-06T11:33:47.294-08:00] Couldn't get distribution account from context in localhost:8000/.well-known/stellar.toml  pid=36195
```

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
