### PR TITLE
[SDP-1129] TSS tweaks from the TSS review call, and small improvements in the MonitorPayment method

### DIFF
--- a/internal/transactionsubmission/monitor/monitor_service.go
+++ b/internal/transactionsubmission/monitor/monitor_service.go
@@ -47,8 +47,9 @@ func (ms *TSSMonitorService) Start(opts sdpMonitor.MetricOptions) error {
 	return nil
 }
 
-// MonitorPayment sends a metric about a payment tx to the observer, linking it to a entry in the logs that contains specific metadata about said tx.
-func (ms *TSSMonitorService) MonitorPayment(ctx context.Context, tx store.Transaction, metricTag sdpMonitor.MetricTag, txMetadata TxMetadata) {
+// LogAndMonitorPayment sends a metric about a payment tx to the observer, and logs the event and some additional data.
+// The event and the log can be correlated through the event_id field.
+func (ms *TSSMonitorService) LogAndMonitorPayment(ctx context.Context, tx store.Transaction, metricTag sdpMonitor.MetricTag, txMetadata TxMetadata) {
 	eventID := uuid.New().String()
 	paymentLogMessage := paymentLogMessage(eventID, metricTag)
 

--- a/internal/transactionsubmission/monitor/monitor_service.go
+++ b/internal/transactionsubmission/monitor/monitor_service.go
@@ -55,20 +55,23 @@ func (ms *TSSMonitorService) LogAndMonitorPayment(ctx context.Context, tx store.
 	paymentLogMessage := paymentLogMessage(eventID, metricTag)
 
 	labels := map[string]string{
-		"event_id":        eventID,
-		"event_type":      txMetadata.PaymentEventType,
-		"tx_id":           tx.ID,
-		"tenant_id":       tx.TenantID,
-		"event_time":      time.Now().String(),
+		// Instance info
 		"app_version":     ms.Version,
 		"git_commit_hash": ms.GitCommitHash,
+		// Event info
+		"event_id":   eventID,
+		"event_type": txMetadata.PaymentEventType,
+		"event_time": time.Now().String(),
+		// Transaction info
+		"tx_id":           tx.ID,
+		"tenant_id":       tx.TenantID,
+		"channel_account": txMetadata.SrcChannelAcc,
 	}
 	paymentLog := log.Ctx(ctx).WithFields(log.F{
+		"asset":               tx.AssetCode,
+		"destination_account": tx.Destination,
 		"created_at":          tx.CreatedAt.String(),
 		"updated_at":          tx.UpdatedAt.String(),
-		"asset":               tx.AssetCode,
-		"channel_account":     txMetadata.SrcChannelAcc,
-		"destination_account": tx.Destination,
 	})
 	for key, value := range labels {
 		paymentLog = paymentLog.WithField(key, value)

--- a/internal/transactionsubmission/monitor/monitor_service.go
+++ b/internal/transactionsubmission/monitor/monitor_service.go
@@ -48,9 +48,9 @@ func (ms *TSSMonitorService) Start(opts sdpMonitor.MetricOptions) error {
 	return nil
 }
 
-// LogAndMonitorPayment sends a metric about a payment tx to the observer, and logs the event and some additional data.
+// LogAndMonitorTransaction sends a metric about a payment tx to the observer, and logs the event and some additional data.
 // The event and the log can be correlated through the event_id field.
-func (ms *TSSMonitorService) LogAndMonitorPayment(ctx context.Context, tx store.Transaction, metricTag sdpMonitor.MetricTag, txMetadata TxMetadata) {
+func (ms *TSSMonitorService) LogAndMonitorTransaction(ctx context.Context, tx store.Transaction, metricTag sdpMonitor.MetricTag, txMetadata TxMetadata) {
 	eventID := uuid.New().String()
 	paymentLogMessage := paymentLogMessage(eventID, metricTag)
 

--- a/internal/transactionsubmission/monitor/monitor_service_test.go
+++ b/internal/transactionsubmission/monitor/monitor_service_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/store"
 )
 
-func Test_TSSMonitorService_MonitorPayment(t *testing.T) {
+func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
 	mMonitorClient := sdpMonitorMocks.MockMonitorClient{}
 	tssMonitorSvc := TSSMonitorService{
 		Client:        &mMonitorClient,
@@ -129,7 +129,7 @@ func Test_TSSMonitorService_MonitorPayment(t *testing.T) {
 			ctx := context.Background()
 
 			mMonitorClient.On("MonitorCounters", tc.metricTag, mock.Anything).Return(nil).Once()
-			tssMonitorSvc.MonitorPayment(ctx, tc.txModel, tc.metricTag, tc.txMetadata)
+			tssMonitorSvc.LogAndMonitorPayment(ctx, tc.txModel, tc.metricTag, tc.txMetadata)
 
 			logEntries := getLogEntries()
 			assert.NotEmpty(t, logEntries[0])

--- a/internal/transactionsubmission/monitor/monitor_service_test.go
+++ b/internal/transactionsubmission/monitor/monitor_service_test.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"database/sql"
+	"slices"
 	"testing"
 	"time"
 
@@ -30,6 +31,8 @@ func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
 	destAcc := "0xDEST"
 	xdr := sql.NullString{String: "AAAAAAAAAMgAAAAAAAAAAgAAAAAAAAAGAAAAAAAAAAAAAAAFAAAAAAAAAAA=", Valid: true}
 	txHash := "0xSUCCESS"
+	tenantID := "test_tenant_id"
+	txID := "test_tx_id"
 	errStr := "error!"
 
 	testCases := []struct {
@@ -39,7 +42,7 @@ func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
 		txMetadata TxMetadata
 		eventType  string
 		logLevel   logrus.Level
-		fieldsMap  map[string]string
+		fieldsMap  map[string]interface{}
 	}{
 		{
 			name:      "monitor payment_processing_started",
@@ -49,18 +52,25 @@ func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
 				SrcChannelAcc:    srcChannelAcc,
 			},
 			txModel: store.Transaction{
+				ID:          "test_tx_id",
 				CreatedAt:   &time,
 				UpdatedAt:   &time,
 				AssetCode:   assetCode,
 				Destination: destAcc,
+				TenantID:    "test_tenant_id",
 			},
 			logLevel: log.DebugLevel,
-			fieldsMap: map[string]string{
-				"created_at":          time.String(),
-				"updated_at":          time.String(),
+			fieldsMap: map[string]interface{}{
+				"app_version":         tssMonitorSvc.Version,
 				"asset":               assetCode,
 				"channel_account":     srcChannelAcc,
+				"created_at":          time.String(),
 				"destination_account": destAcc,
+				"event_type":          sdpMonitor.PaymentProcessingStartedLabel,
+				"git_commit_hash":     tssMonitorSvc.GitCommitHash,
+				"tenant_id":           tenantID,
+				"tx_id":               txID,
+				"updated_at":          time.String(),
 			},
 		},
 		{
@@ -71,6 +81,8 @@ func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
 				SrcChannelAcc:    srcChannelAcc,
 			},
 			txModel: store.Transaction{
+				ID:                     txID,
+				TenantID:               tenantID,
 				CreatedAt:              &time,
 				UpdatedAt:              &time,
 				CompletedAt:            &time,
@@ -81,16 +93,21 @@ func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
 				StellarTransactionHash: sql.NullString{String: txHash, Valid: true},
 			},
 			logLevel: log.InfoLevel,
-			fieldsMap: map[string]string{
-				"created_at":          time.String(),
-				"updated_at":          time.String(),
+			fieldsMap: map[string]interface{}{
+				"app_version":         tssMonitorSvc.Version,
 				"asset":               assetCode,
 				"channel_account":     srcChannelAcc,
-				"destination_account": destAcc,
-				"xdr_sent":            xdr.String,
-				"xdr_received":        xdr.String,
 				"completed_at":        time.String(),
+				"created_at":          time.String(),
+				"destination_account": destAcc,
+				"event_type":          sdpMonitor.PaymentReconciliationTransactionSuccessfulLabel,
+				"git_commit_hash":     tssMonitorSvc.GitCommitHash,
+				"tenant_id":           tenantID,
+				"tx_id":               txID,
 				"tx_hash":             txHash,
+				"updated_at":          time.String(),
+				"xdr_received":        xdr.String,
+				"xdr_sent":            xdr.String,
 			},
 		},
 		{
@@ -103,21 +120,31 @@ func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
 				ErrStack:         errStr,
 			},
 			txModel: store.Transaction{
-				CreatedAt:   &time,
-				UpdatedAt:   &time,
-				AssetCode:   assetCode,
-				Destination: destAcc,
-				XDRSent:     xdr,
+				ID:                     txID,
+				TenantID:               tenantID,
+				CreatedAt:              &time,
+				UpdatedAt:              &time,
+				AssetCode:              assetCode,
+				Destination:            destAcc,
+				XDRSent:                xdr,
+				StellarTransactionHash: sql.NullString{String: txHash, Valid: true},
 			},
 			logLevel: log.InfoLevel,
-			fieldsMap: map[string]string{
-				"created_at":          time.String(),
-				"updated_at":          time.String(),
+			fieldsMap: map[string]interface{}{
+				"app_version":         tssMonitorSvc.Version,
 				"asset":               assetCode,
 				"channel_account":     srcChannelAcc,
+				"created_at":          time.String(),
 				"destination_account": destAcc,
-				"xdr_sent":            xdr.String,
 				"error":               errStr,
+				"event_type":          sdpMonitor.PaymentFailedLabel,
+				"git_commit_hash":     tssMonitorSvc.GitCommitHash,
+				"horizon_error?":      true,
+				"tenant_id":           tenantID,
+				"tx_hash":             txHash,
+				"tx_id":               txID,
+				"updated_at":          time.String(),
+				"xdr_sent":            xdr.String,
 			},
 		},
 	}
@@ -134,9 +161,14 @@ func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
 			logEntries := getLogEntries()
 			assert.NotEmpty(t, logEntries[0])
 
-			data := logEntries[0].Data
-			for k, v := range tc.fieldsMap {
-				assert.Equal(t, v, data[k])
+			logFieldsThatCannotBeAsserted := []string{"event_id", "event_time", "pid"}
+			assert.Len(t, logEntries[0].Data, len(tc.fieldsMap)+len(logFieldsThatCannotBeAsserted))
+
+			for k, v := range logEntries[0].Data {
+				if slices.Contains(logFieldsThatCannotBeAsserted, k) {
+					continue
+				}
+				assert.Equal(t, v, tc.fieldsMap[k], "failed value comparison for key: %s", k)
 			}
 
 			assert.Contains(t, logEntries[0].Message, string(tc.metricTag))

--- a/internal/transactionsubmission/monitor/monitor_service_test.go
+++ b/internal/transactionsubmission/monitor/monitor_service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/store"
 )
 
-func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
+func Test_TSSMonitorService_LogAndMonitorTransaction(t *testing.T) {
 	mMonitorClient := sdpMonitorMocks.MockMonitorClient{}
 	tssMonitorSvc := TSSMonitorService{
 		Client:        &mMonitorClient,
@@ -156,7 +156,7 @@ func Test_TSSMonitorService_LogAndMonitorPayment(t *testing.T) {
 			ctx := context.Background()
 
 			mMonitorClient.On("MonitorCounters", tc.metricTag, mock.Anything).Return(nil).Once()
-			tssMonitorSvc.LogAndMonitorPayment(ctx, tc.txModel, tc.metricTag, tc.txMetadata)
+			tssMonitorSvc.LogAndMonitorTransaction(ctx, tc.txModel, tc.metricTag, tc.txMetadata)
 
 			logEntries := getLogEntries()
 			assert.NotEmpty(t, logEntries[0])

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -167,6 +167,8 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 			//   - 504: Timeout
 			//   - 429: Too Many Requests
 			//   - 400: with any of the codes: [tx_insufficient_fee, tx_too_late, tx_bad_seq]
+			//   - 5xx
+			// 	 - random network errors
 			if hErrWrapper.ShouldMarkAsError() {
 				var updatedTx *store.Transaction
 				updatedTx, err = tw.txModel.UpdateStatusToError(ctx, txJob.Transaction, hErrWrapper.Error())
@@ -326,7 +328,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 			ErrStack:         hWrapperErr.Error(),
 			PaymentEventType: sdpMonitor.PaymentReconciliationUnexpectedErrorLabel,
 		})
-		// TODO: review if we're covering 429s here.
+
 		return fmt.Errorf("unexpected error: %w", hWrapperErr)
 	}
 

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -158,10 +158,9 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 	}()
 
 	if errors.As(hErr, &hErrWrapper) {
-		// TODO: are we logging the error that we save in the DB?
 		tw.txProcessingLimiter.AdjustLimitIfNeeded(hErrWrapper)
 
-		if hErrWrapper.ResultCodes != nil {
+		if hErrWrapper.IsHorizonError() {
 			isHorizonErr = true
 
 			// Errors that are not marked as definitive errors: 504: Timeouts, 429: Too Many Requests, 400's with error code tx_insufficient_fee, tx_too_late, tx_bad_seq

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -168,7 +168,7 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 			//   - 429: Too Many Requests
 			//   - 400: with any of the codes: [tx_insufficient_fee, tx_too_late, tx_bad_seq]
 			//   - 5xx
-			// 	 - random network errors
+			//   - random network errors
 			if hErrWrapper.ShouldMarkAsError() {
 				var updatedTx *store.Transaction
 				updatedTx, err = tw.txModel.UpdateStatusToError(ctx, txJob.Transaction, hErrWrapper.Error())

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -163,7 +163,10 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 		if hErrWrapper.IsHorizonError() {
 			isHorizonErr = true
 
-			// Errors that are not marked as definitive errors: 504: Timeouts, 429: Too Many Requests, 400's with error code tx_insufficient_fee, tx_too_late, tx_bad_seq
+			// Errors that are not marked as definitive errors:
+			//   - 504: Timeout
+			//   - 429: Too Many Requests
+			//   - 400: with any of the codes: [tx_insufficient_fee, tx_too_late, tx_bad_seq]
 			if hErrWrapper.ShouldMarkAsError() {
 				var updatedTx *store.Transaction
 				updatedTx, err = tw.txModel.UpdateStatusToError(ctx, txJob.Transaction, hErrWrapper.Error())

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -145,7 +145,7 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 			eventType = sdpMonitor.PaymentMarkedForReprocessingLabel
 		}
 
-		tw.monitorSvc.MonitorPayment(
+		tw.monitorSvc.LogAndMonitorPayment(
 			ctx,
 			txJob.Transaction,
 			metricTag,
@@ -300,7 +300,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 	if err == nil && txDetail.Successful {
 		err = tw.handleSuccessfulTransaction(ctx, txJob, txDetail)
 		if err != nil {
-			tw.monitorSvc.MonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationFailureTag, tssMonitor.TxMetadata{
+			tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationFailureTag, tssMonitor.TxMetadata{
 				SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 				IsHorizonErr:     false,
 				ErrStack:         err.Error(),
@@ -309,7 +309,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 			return fmt.Errorf("handling successful transaction: %w", err)
 		}
 
-		tw.monitorSvc.MonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationSuccessfulTag, tssMonitor.TxMetadata{
+		tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationSuccessfulTag, tssMonitor.TxMetadata{
 			SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 			PaymentEventType: sdpMonitor.PaymentReconciliationTransactionSuccessfulLabel,
 		})
@@ -317,7 +317,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 	} else if (err != nil || txDetail.Successful) && !hWrapperErr.IsNotFound() {
 		log.Ctx(ctx).Warnf("received unexpected horizon error: %v", hWrapperErr)
 
-		tw.monitorSvc.MonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationFailureTag, tssMonitor.TxMetadata{
+		tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationFailureTag, tssMonitor.TxMetadata{
 			SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 			IsHorizonErr:     true,
 			ErrStack:         hWrapperErr.Error(),
@@ -339,7 +339,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 		return fmt.Errorf("unlocking job: %w", err)
 	}
 
-	tw.monitorSvc.MonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationSuccessfulTag, tssMonitor.TxMetadata{
+	tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationSuccessfulTag, tssMonitor.TxMetadata{
 		SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 		PaymentEventType: sdpMonitor.PaymentReconciliationMarkedForReprocessingLabel,
 	})
@@ -382,7 +382,7 @@ func (tw *TransactionWorker) producePaymentCompletedEvent(ctx context.Context, e
 func (tw *TransactionWorker) processTransactionSubmission(ctx context.Context, txJob *TxJob) error {
 	log.Ctx(ctx).Infof("🚧 Processing transaction submission for job %v...", txJob)
 
-	tw.monitorSvc.MonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentProcessingStartedTag, tssMonitor.TxMetadata{
+	tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentProcessingStartedTag, tssMonitor.TxMetadata{
 		SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 		PaymentEventType: sdpMonitor.PaymentProcessingStartedLabel,
 	})
@@ -564,7 +564,7 @@ func (tw *TransactionWorker) submit(ctx context.Context, txJob *TxJob, feeBumpTx
 			eventType = sdpMonitor.PaymentReprocessingSuccessfulLabel
 		}
 
-		tw.monitorSvc.MonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentTransactionSuccessfulTag, tssMonitor.TxMetadata{
+		tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentTransactionSuccessfulTag, tssMonitor.TxMetadata{
 			SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 			IsHorizonErr:     false,
 			PaymentEventType: eventType,

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -145,7 +145,7 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 			eventType = sdpMonitor.PaymentMarkedForReprocessingLabel
 		}
 
-		tw.monitorSvc.LogAndMonitorPayment(
+		tw.monitorSvc.LogAndMonitorTransaction(
 			ctx,
 			txJob.Transaction,
 			metricTag,
@@ -305,7 +305,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 	if err == nil && txDetail.Successful {
 		err = tw.handleSuccessfulTransaction(ctx, txJob, txDetail)
 		if err != nil {
-			tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationFailureTag, tssMonitor.TxMetadata{
+			tw.monitorSvc.LogAndMonitorTransaction(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationFailureTag, tssMonitor.TxMetadata{
 				SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 				IsHorizonErr:     false,
 				ErrStack:         err.Error(),
@@ -314,7 +314,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 			return fmt.Errorf("handling successful transaction: %w", err)
 		}
 
-		tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationSuccessfulTag, tssMonitor.TxMetadata{
+		tw.monitorSvc.LogAndMonitorTransaction(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationSuccessfulTag, tssMonitor.TxMetadata{
 			SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 			PaymentEventType: sdpMonitor.PaymentReconciliationTransactionSuccessfulLabel,
 		})
@@ -322,7 +322,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 	} else if (err != nil || txDetail.Successful) && !hWrapperErr.IsNotFound() {
 		log.Ctx(ctx).Warnf("received unexpected horizon error: %v", hWrapperErr)
 
-		tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationFailureTag, tssMonitor.TxMetadata{
+		tw.monitorSvc.LogAndMonitorTransaction(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationFailureTag, tssMonitor.TxMetadata{
 			SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 			IsHorizonErr:     true,
 			ErrStack:         hWrapperErr.Error(),
@@ -344,7 +344,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 		return fmt.Errorf("unlocking job: %w", err)
 	}
 
-	tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationSuccessfulTag, tssMonitor.TxMetadata{
+	tw.monitorSvc.LogAndMonitorTransaction(ctx, txJob.Transaction, sdpMonitor.PaymentReconciliationSuccessfulTag, tssMonitor.TxMetadata{
 		SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 		PaymentEventType: sdpMonitor.PaymentReconciliationMarkedForReprocessingLabel,
 	})
@@ -387,7 +387,7 @@ func (tw *TransactionWorker) producePaymentCompletedEvent(ctx context.Context, e
 func (tw *TransactionWorker) processTransactionSubmission(ctx context.Context, txJob *TxJob) error {
 	log.Ctx(ctx).Infof("🚧 Processing transaction submission for job %v...", txJob)
 
-	tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentProcessingStartedTag, tssMonitor.TxMetadata{
+	tw.monitorSvc.LogAndMonitorTransaction(ctx, txJob.Transaction, sdpMonitor.PaymentProcessingStartedTag, tssMonitor.TxMetadata{
 		SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 		PaymentEventType: sdpMonitor.PaymentProcessingStartedLabel,
 	})
@@ -569,7 +569,7 @@ func (tw *TransactionWorker) submit(ctx context.Context, txJob *TxJob, feeBumpTx
 			eventType = sdpMonitor.PaymentReprocessingSuccessfulLabel
 		}
 
-		tw.monitorSvc.LogAndMonitorPayment(ctx, txJob.Transaction, sdpMonitor.PaymentTransactionSuccessfulTag, tssMonitor.TxMetadata{
+		tw.monitorSvc.LogAndMonitorTransaction(ctx, txJob.Transaction, sdpMonitor.PaymentTransactionSuccessfulTag, tssMonitor.TxMetadata{
 			SrcChannelAcc:    txJob.ChannelAccount.PublicKey,
 			IsHorizonErr:     false,
 			PaymentEventType: eventType,

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -709,8 +709,9 @@ func Test_TransactionWorker_reconcileSubmittedTransaction(t *testing.T) {
 		shouldBePushedBackToQueue  bool
 	}{
 		{
-			name:              "🎉 successfully verifies the tx went through and marks it as successful",
-			horizonTxResponse: horizon.Transaction{Successful: true, ResultXdr: resultXDR},
+			name:                      "🎉 successfully verifies the tx went through and marks it as successful",
+			horizonTxResponse:         horizon.Transaction{Successful: true, ResultXdr: resultXDR},
+			shouldBePushedBackToQueue: false,
 		},
 		{
 			name:                      "🎉 successfully verifies the tx failed and mark it for resubmission",


### PR DESCRIPTION
### What

* Renamed `MonitorPayment` to `LogAndMonitorTransaction` for improved clarity.
* Started using the updated paymentLog in LogAndMonitorTransaction earlier than before, for a more complete debugging
* Added more fields to `LogAndMonitorTransaction`
* Validate info previously raised in the TSS review call

### Why

Address https://stellarorg.atlassian.net/browse/SDP-1129.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
