### PR TITLE
[SDP-1059] Make `ready_payments_cancellation` job multi-tenant

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -62,7 +62,7 @@ func (s *ServerService) StartAdminServe(opts serveadmin.ServeOptions, httpServer
 }
 
 func (s *ServerService) GetSchedulerJobRegistrars(ctx context.Context, serveOpts serve.ServeOptions, schedulerOptions scheduler.SchedulerOptions, apAPIService anchorplatform.AnchorPlatformAPIServiceInterface) ([]scheduler.SchedulerJobRegisterOption, error) {
-	// TODO: in SEP-1111, inject the remaining dbConnectionPools needed here.
+	// TODO: in SDP-1111, inject the remaining dbConnectionPools needed here.
 	models, err := data.NewModels(serveOpts.MtnDBConnectionPool)
 	if err != nil {
 		log.Ctx(ctx).Fatalf("error creating models in Job Scheduler: %s", err.Error())
@@ -550,7 +550,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 				if innerErr != nil {
 					log.Ctx(ctx).Fatalf("Error getting scheduler job registrars: %v", innerErr)
 				}
-				go scheduler.StartScheduler(crashTrackerClient.Clone(), schedulerJobRegistrars...)
+				go scheduler.StartScheduler(serveOpts.AdminDBConnectionPool, crashTrackerClient.Clone(), schedulerJobRegistrars...)
 			} else {
 				log.Ctx(ctx).Warn("Scheduler Service is disabled.")
 			}

--- a/internal/scheduler/jobs/anchor_platform_auth_enforcement_job.go
+++ b/internal/scheduler/jobs/anchor_platform_auth_enforcement_job.go
@@ -75,4 +75,8 @@ func (job AnchorPlatformAuthMonitoringJob) Execute(ctx context.Context) error {
 	return nil
 }
 
+func (job AnchorPlatformAuthMonitoringJob) IsJobMultiTenant() bool {
+	return false
+}
+
 var _ Job = new(AnchorPlatformAuthMonitoringJob)

--- a/internal/scheduler/jobs/job.go
+++ b/internal/scheduler/jobs/job.go
@@ -9,4 +9,5 @@ type Job interface {
 	Execute(context.Context) error
 	GetInterval() time.Duration
 	GetName() string
+	IsJobMultiTenant() bool
 }

--- a/internal/scheduler/jobs/mocks.go
+++ b/internal/scheduler/jobs/mocks.go
@@ -1,0 +1,88 @@
+package jobs
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+)
+
+// MockJob is a mock job created for testing purposes
+type MockJob struct {
+	Name       string
+	Interval   time.Duration
+	Executions int
+	mu         sync.Mutex
+}
+
+func (m *MockJob) GetName() string {
+	return m.Name
+}
+
+func (m *MockJob) GetInterval() time.Duration {
+	return m.Interval
+}
+
+func (m *MockJob) Execute(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Executions++
+	return nil
+}
+
+func (m *MockJob) GetExecutions() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.Executions
+}
+
+func (m *MockJob) IsJobMultiTenant() bool {
+	return false
+}
+
+// verify that MockJob implements the Job interface
+var _ Job = (*MockJob)(nil)
+
+// MockMultiTenantJob is a mock multi-tenant job created for testing purposes
+type MockMultiTenantJob struct {
+	Name       string
+	Interval   time.Duration
+	Executions sync.Map
+}
+
+func (m *MockMultiTenantJob) GetName() string {
+	return m.Name
+}
+
+func (m *MockMultiTenantJob) GetInterval() time.Duration {
+	return m.Interval
+}
+
+func (m *MockMultiTenantJob) Execute(ctx context.Context) error {
+	tnt, err := tenant.GetTenantFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	execs, ok := m.Executions.Load(tnt.ID)
+	if !ok {
+		execs = 0
+	}
+	m.Executions.Store(tnt.ID, execs.(int)+1)
+	return nil
+}
+
+func (m *MockMultiTenantJob) GetExecutions(id string) int {
+	value, ok := m.Executions.Load(id)
+	if !ok {
+		return 0
+	}
+	return value.(int)
+}
+
+func (m *MockMultiTenantJob) IsJobMultiTenant() bool {
+	return true
+}
+
+// verify that MockMultiTenantJob implements the Job interface
+var _ Job = (*MockMultiTenantJob)(nil)

--- a/internal/scheduler/jobs/ready_payments_cancellation_job.go
+++ b/internal/scheduler/jobs/ready_payments_cancellation_job.go
@@ -36,9 +36,15 @@ func (j ReadyPaymentsCancellationJob) Execute(ctx context.Context) error {
 	return nil
 }
 
+func (j ReadyPaymentsCancellationJob) IsJobMultiTenant() bool {
+	return true
+}
+
 func NewReadyPaymentsCancellationJob(models *data.Models) *ReadyPaymentsCancellationJob {
 	s := services.NewReadyPaymentsCancellationService(models)
 	return &ReadyPaymentsCancellationJob{
 		service: s,
 	}
 }
+
+var _ Job = new(ReadyPaymentsCancellationJob)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -136,7 +136,7 @@ func worker(ctx context.Context, workerID int, crashTrackerClient crashtracker.C
 		case job := <-jobQueue:
 			executeJob(ctx, job, workerID, crashTrackerClient, tenantManager)
 		case <-ctx.Done():
-			log.Infof("Worker %d stopping...", workerID)
+			log.Ctx(ctx).Infof("Worker %d stopping...", workerID)
 			return
 		}
 	}
@@ -154,7 +154,7 @@ func executeJob(ctx context.Context, job jobs.Job, workerID int, crashTrackerCli
 		}
 		for _, t := range tenants {
 			log.Ctx(ctx).Debugf("Processing job %s for tenant %s on worker %d", job.GetName(), t.ID, workerID)
-			tenantCtx := tenant.SaveTenantInContext(ctx, &t)
+			tenantCtx := tenant.SaveTenantInContext(context.Background(), &t)
 			if jobErr := job.Execute(tenantCtx); jobErr != nil {
 				msg := fmt.Sprintf("error processing job %s for tenant %s on worker %d", job.GetName(), t.ID, workerID)
 				crashTrackerClient.LogAndReportErrors(tenantCtx, err, msg)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -8,6 +8,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/anchorplatform"
@@ -24,6 +27,7 @@ type Scheduler struct {
 	cancel             context.CancelFunc
 	jobQueue           chan jobs.Job
 	crashTrackerClient crashtracker.CrashTrackerClient
+	tenantManager      tenant.ManagerInterface
 }
 
 type SchedulerOptions struct{}
@@ -34,7 +38,7 @@ type SchedulerJobRegisterOption func(*Scheduler)
 const SchedulerWorkerCount = 5
 
 // StartScheduler initializes and starts the scheduler. This method blocks until the scheduler is stopped.
-func StartScheduler(crashTrackerClient crashtracker.CrashTrackerClient, schedulerJobRegisters ...SchedulerJobRegisterOption) {
+func StartScheduler(adminDBConnectionPool db.DBConnectionPool, crashTrackerClient crashtracker.CrashTrackerClient, schedulerJobRegisters ...SchedulerJobRegisterOption) {
 	// Call crash tracker FlushEvents to flush buffered events before the scheduler terminates
 	defer crashTrackerClient.FlushEvents(2 * time.Second)
 	// Call crash tracker Recover for recover from unhandled panics
@@ -51,6 +55,7 @@ func StartScheduler(crashTrackerClient crashtracker.CrashTrackerClient, schedule
 	scheduler := newScheduler(cancel)
 	// add crashTrackerClient to scheduler object
 	scheduler.crashTrackerClient = crashTrackerClient
+	scheduler.tenantManager = tenant.NewManager(tenant.WithDatabase(adminDBConnectionPool))
 
 	// Registering jobs
 	for _, schedulerJobRegister := range schedulerJobRegisters {
@@ -91,7 +96,7 @@ func (s *Scheduler) start(ctx context.Context) {
 	// 1. We start all the workers that will process jobs from the job queue.
 	for i := 1; i <= SchedulerWorkerCount; i++ {
 		// start a new worker passing a CrashTrackerClient clone to report errors when the job is executed
-		go worker(ctx, i, s.crashTrackerClient.Clone(), s.jobQueue)
+		go worker(ctx, i, s.crashTrackerClient.Clone(), s.tenantManager, s.jobQueue)
 	}
 
 	// 2. Enqueue jobs to jobQueue.
@@ -120,7 +125,7 @@ func (s *Scheduler) stop() {
 }
 
 // worker is a goroutine that processes jobs from the job queue.
-func worker(ctx context.Context, workerID int, crashTrackerClient crashtracker.CrashTrackerClient, jobQueue <-chan jobs.Job) {
+func worker(ctx context.Context, workerID int, crashTrackerClient crashtracker.CrashTrackerClient, tenantManager tenant.ManagerInterface, jobQueue <-chan jobs.Job) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Ctx(ctx).Errorf("Worker %d encountered a panic while processing a job: %v", workerID, r)
@@ -129,15 +134,37 @@ func worker(ctx context.Context, workerID int, crashTrackerClient crashtracker.C
 	for {
 		select {
 		case job := <-jobQueue:
-			log.Ctx(ctx).Debugf("Worker %d processing job: %s", workerID, job.GetName())
-			if err := job.Execute(ctx); err != nil {
-				msg := fmt.Sprintf("error processing job %s on worker %d", job.GetName(), workerID)
-				// call crash tracker client to log and report error
-				crashTrackerClient.LogAndReportErrors(ctx, err, msg)
-			}
+			executeJob(ctx, job, workerID, crashTrackerClient, tenantManager)
 		case <-ctx.Done():
-			log.Ctx(ctx).Infof("Worker %d stopping...", workerID)
+			log.Infof("Worker %d stopping...", workerID)
 			return
+		}
+	}
+}
+
+// executeJob executes a job and reports any errors to the crash tracker.
+func executeJob(ctx context.Context, job jobs.Job, workerID int, crashTrackerClient crashtracker.CrashTrackerClient, tenantManager tenant.ManagerInterface) {
+	// Handle multi-tenant jobs.
+	if job.IsJobMultiTenant() {
+		tenants, err := tenantManager.GetAllTenants(ctx)
+		if err != nil {
+			msg := fmt.Sprintf("error getting all tenants for job %s on worker %d", job.GetName(), workerID)
+			crashTrackerClient.LogAndReportErrors(ctx, err, msg)
+			return
+		}
+		for _, t := range tenants {
+			log.Ctx(ctx).Debugf("Processing job %s for tenant %s on worker %d", job.GetName(), t.ID, workerID)
+			tenantCtx := tenant.SaveTenantInContext(ctx, &t)
+			if jobErr := job.Execute(tenantCtx); jobErr != nil {
+				msg := fmt.Sprintf("error processing job %s for tenant %s on worker %d", job.GetName(), t.ID, workerID)
+				crashTrackerClient.LogAndReportErrors(tenantCtx, err, msg)
+			}
+		}
+	} else {
+		log.Ctx(ctx).Debugf("Processing job %s on worker %d", job.GetName(), workerID)
+		if err := job.Execute(ctx); err != nil {
+			msg := fmt.Sprintf("error processing job %s on worker %d", job.GetName(), workerID)
+			crashTrackerClient.LogAndReportErrors(ctx, err, msg)
 		}
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestScheduler(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	t.Parallel()
+
+	_, cancel := context.WithCancel(context.Background())
 	scheduler := newScheduler(cancel)
 
 	mockCrashTrackerClient := &crashtracker.MockCrashTrackerClient{}
@@ -42,7 +44,7 @@ func TestScheduler(t *testing.T) {
 	scheduler.addJob(mockJob2)
 
 	// Start the scheduler and wait for a short period to let the job run
-	scheduler.start(ctx)
+	scheduler.start(context.Background())
 	time.Sleep(2 * time.Second)
 
 	job1Executions := mockJob1.GetExecutions()
@@ -59,7 +61,9 @@ func TestScheduler(t *testing.T) {
 }
 
 func TestMultiTenantScheduler(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	t.Parallel()
+
+	_, cancel := context.WithCancel(context.Background())
 	scheduler := newScheduler(cancel)
 
 	mockCrashTrackerClient := &crashtracker.MockCrashTrackerClient{}
@@ -86,7 +90,7 @@ func TestMultiTenantScheduler(t *testing.T) {
 	scheduler.addJob(mockJob)
 
 	// Start the scheduler and wait for a short period to let the job run
-	scheduler.start(ctx)
+	scheduler.start(context.Background())
 	time.Sleep(2 * time.Second)
 
 	tenant1Executions := mockJob.GetExecutions(tenant1.ID)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,42 +2,19 @@ package scheduler
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/scheduler/jobs"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	"github.com/stretchr/testify/require"
 )
-
-// MockJob is a mock job created for testing purposes
-type MockJob struct {
-	name       string
-	interval   time.Duration
-	executions int
-	mu         sync.Mutex
-}
-
-func (m *MockJob) GetName() string {
-	return m.name
-}
-
-func (m *MockJob) GetInterval() time.Duration {
-	return m.interval
-}
-
-func (m *MockJob) Execute(ctx context.Context) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.executions++
-	return nil
-}
-
-func (m *MockJob) GetExecutions() int {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.executions
-}
 
 func TestScheduler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -49,16 +26,16 @@ func TestScheduler(t *testing.T) {
 	clone := crashtracker.MockCrashTrackerClient{}
 	mockCrashTrackerClient.On("Clone").Return(&clone).Times(5)
 
-	mockJob1 := &MockJob{
-		name:       "mock_job_1",
-		interval:   1 * time.Second,
-		executions: 0,
+	mockJob1 := &jobs.MockJob{
+		Name:       "mock_job_1",
+		Interval:   1 * time.Second,
+		Executions: 0,
 	}
 
-	mockJob2 := &MockJob{
-		name:       "mock_job_2",
-		interval:   20 * time.Second,
-		executions: 0,
+	mockJob2 := &jobs.MockJob{
+		Name:       "mock_job_2",
+		Interval:   20 * time.Second,
+		Executions: 0,
 	}
 
 	scheduler.addJob(mockJob1)
@@ -79,4 +56,49 @@ func TestScheduler(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	mockCrashTrackerClient.AssertExpectations(t)
+}
+
+func TestMultiTenantScheduler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	scheduler := newScheduler(cancel)
+
+	mockCrashTrackerClient := &crashtracker.MockCrashTrackerClient{}
+	scheduler.crashTrackerClient = mockCrashTrackerClient
+
+	clone := crashtracker.MockCrashTrackerClient{}
+	mockCrashTrackerClient.On("Clone").Return(&clone).Times(5)
+
+	mockTenantManager := &tenant.TenantManagerMock{}
+	scheduler.tenantManager = mockTenantManager
+
+	tenant1 := tenant.Tenant{ID: "tenant1", Name: "Tenant 1"}
+	tenant2 := tenant.Tenant{ID: "tenant2", Name: "Tenant 2"}
+
+	mockTenantManager.On("GetAllTenants", mock.Anything).
+		Return([]tenant.Tenant{tenant1, tenant2}, nil).
+		Once()
+
+	mockJob := &jobs.MockMultiTenantJob{
+		Name:     "mock_job_1",
+		Interval: 1 * time.Second,
+	}
+
+	scheduler.addJob(mockJob)
+
+	// Start the scheduler and wait for a short period to let the job run
+	scheduler.start(ctx)
+	time.Sleep(2 * time.Second)
+
+	tenant1Executions := mockJob.GetExecutions(tenant1.ID)
+	assert.True(t, tenant1Executions > 0, "Expected job to be executed at least once, but it was executed %d times", tenant1Executions)
+
+	tenant2Executions := mockJob.GetExecutions(tenant2.ID)
+	assert.Equal(t, tenant1Executions, tenant2Executions, "Expected both tenants to have the same number of executions, but tenant1 had %d and tenant2 had %d", tenant1Executions, tenant2Executions)
+
+	// Test stopping the scheduler
+	cancel()
+	time.Sleep(1 * time.Second)
+
+	mockCrashTrackerClient.AssertExpectations(t)
+	mockTenantManager.AssertExpectations(t)
 }

--- a/internal/services/ready_payments_cancelation_service_test.go
+++ b/internal/services/ready_payments_cancelation_service_test.go
@@ -78,7 +78,7 @@ func Test_ReadyPaymentsCancellationService_CancelReadyPaymentsService(t *testing
 		require.Len(t, entries, 1)
 		assert.Equal(
 			t,
-			"automatic ready payment cancellation is deactivated. Set a valid value to the organization's payment_cancellation_period_days to activate it.",
+			"automatic ready payment cancellation is deactivated for MyCustomAid. Set a valid value to the organization's payment_cancellation_period_days to activate it.",
 			entries[0].Message,
 		)
 	})

--- a/internal/services/ready_payments_cancellation_service.go
+++ b/internal/services/ready_payments_cancellation_service.go
@@ -32,11 +32,11 @@ func (s ReadyPaymentsCancellationService) CancelReadyPayments(ctx context.Contex
 	}
 
 	if organization.PaymentCancellationPeriodDays == nil {
-		log.Ctx(ctx).Debug("automatic ready payment cancellation is deactivated. Set a valid value to the organization's payment_cancellation_period_days to activate it.")
+		log.Ctx(ctx).Debugf("automatic ready payment cancellation is deactivated for %s. Set a valid value to the organization's payment_cancellation_period_days to activate it.", organization.Name)
 		return nil
 	}
 
-	if err := s.sdpModels.Payment.CancelPaymentsWithinPeriodDays(ctx, s.sdpModels.DBConnectionPool, *organization.PaymentCancellationPeriodDays); err != nil {
+	if err = s.sdpModels.Payment.CancelPaymentsWithinPeriodDays(ctx, s.sdpModels.DBConnectionPool, *organization.PaymentCancellationPeriodDays); err != nil {
 		return fmt.Errorf("canceling ready payments after %d days: %w", int(*organization.PaymentCancellationPeriodDays), err)
 	}
 	return nil


### PR DESCRIPTION
### What
* Make `ready_payments_cancellation` job multi-tenant
* Introduce a framework for running schedule jobs in a multi-tenant fashion. 

#### How does it work ? 
* Jobs have a new method `IsMultiTenant()` that's used to determine is a job is multi-tenant or not. 
* When the worker is about to process a multi-tenant job, it fetches the list of tenants and runs the job once for every tenant. 

```
DEBU[2024-03-11T13:42:22.310-07:00] Enqueuing job: ready_payments_cancellation    pid=15992
DEBU[2024-03-11T13:42:22.330-07:00] Processing job ready_payments_cancellation for tenant aee4b490-953c-45d9-b7f4-20cecb71d1de on worker 3  pid=15992
DEBU[2024-03-11T13:42:22.350-07:00] automatic ready payment cancellation is deactivated for bluecorp. Set a valid value to the organization's payment_cancellation_period_days to activate it.  pid=15992
DEBU[2024-03-11T13:42:22.350-07:00] Processing job ready_payments_cancellation for tenant 96808121-94a2-444e-b707-41c911b382cc on worker 3  pid=15992
DEBU[2024-03-11T13:42:22.364-07:00] automatic ready payment cancellation is deactivated for redcorp. Set a valid value to the organization's payment_cancellation_period_days to activate it. 
```

### Why
https://stellarorg.atlassian.net/browse/SDP-1059

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
