### PR TITLE
[SDP-1132] serve: Multi-tenant instance breaks when user is logged in using the base domain.

### DIFF
--- a/internal/serve/middleware/middleware.go
+++ b/internal/serve/middleware/middleware.go
@@ -84,7 +84,7 @@ func MetricsRequestHandler(monitorService monitor.MonitorServiceInterface) func(
 
 // AuthenticateMiddleware is a middleware that validates the Authorization header for
 // authenticated endpoints.
-func AuthenticateMiddleware(authManager auth.AuthManager) func(http.Handler) http.Handler {
+func AuthenticateMiddleware(authManager auth.AuthManager, tenantManager tenant.ManagerInterface) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			authHeader := req.Header.Get("Authorization")
@@ -113,6 +113,15 @@ func AuthenticateMiddleware(authManager auth.AuthManager) func(http.Handler) htt
 
 			// Add the token to the request context
 			ctx = context.WithValue(ctx, TokenContextKey, token)
+
+			// Attempt fetching tenant ID from token
+			tenantID, err := authManager.GetTenantID(ctx, token)
+			if err == nil && tenantID != "" {
+				currentTenant, tenantErr := tenantManager.GetTenantByID(ctx, tenantID)
+				if tenantErr == nil && currentTenant != nil {
+					ctx = tenant.SaveTenantInContext(ctx, currentTenant)
+				}
+			}
 
 			// Add the user ID to the request context logger
 			ctx = log.Set(ctx, log.Ctx(ctx).WithField("user_id", userID))
@@ -274,26 +283,18 @@ func CSPMiddleware() func(http.Handler) http.Handler {
 	}
 }
 
-// InjectTenantMiddleware is a middleware that injects the tenant into the request context, if it can be found in either
-// the authentication token, the request HEADER, or the hostname prefix.
-func InjectTenantMiddleware(tenantManager tenant.ManagerInterface, authManager auth.AuthManager) func(http.Handler) http.Handler {
+// ResolveTenantFromRequestMiddleware is a middleware that injects the tenant into the request context, if it can be found in
+// the request HEADER, or the hostname prefix.
+func ResolveTenantFromRequestMiddleware(tenantManager tenant.ManagerInterface) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
 
 			var currentTenant *tenant.Tenant
-			// Attempt 1. Attempt fetching tenant ID from token
-			if token, ok := ctx.Value(TokenContextKey).(string); ok {
-				if tenantID, err := authManager.GetTenantID(ctx, token); err == nil {
-					currentTenant, _ = tenantManager.GetTenantByID(ctx, tenantID)
-				}
-			}
 
-			// Attempt 2. Attempt fetching tenant name from request
-			if currentTenant == nil {
-				if tenantName, err := extractTenantNameFromRequest(req); err == nil && tenantName != "" {
-					currentTenant, _ = tenantManager.GetTenantByName(ctx, tenantName)
-				}
+			// Attempt fetching tenant name from request
+			if tenantName, err := extractTenantNameFromRequest(req); err == nil && tenantName != "" {
+				currentTenant, _ = tenantManager.GetTenantByName(ctx, tenantName)
 			}
 
 			if currentTenant != nil {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -204,7 +204,6 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	))
 	mux.Use(chimiddleware.RequestID)
 	mux.Use(chimiddleware.RealIP)
-	mux.Use(middleware.InjectTenantMiddleware(o.tenantManager, o.authManager))
 	mux.Use(middleware.LoggingMiddleware)
 	mux.Use(middleware.RecoverHandler)
 	mux.Use(middleware.MetricsRequestHandler(o.MonitorService))
@@ -219,6 +218,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	authManager := o.authManager
 	mux.Group(func(r chi.Router) {
 		r.Use(middleware.AuthenticateMiddleware(authManager))
+		r.Use(middleware.InjectTenantMiddleware(o.tenantManager, o.authManager))
 		r.Use(middleware.EnsureTenantMiddleware)
 
 		r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).Route("/statistics", func(r chi.Router) {
@@ -373,6 +373,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 	// Public routes that are tenant aware (they need to know the tenant ID)
 	mux.Group(func(r chi.Router) {
+		r.Use(middleware.InjectTenantMiddleware(o.tenantManager, o.authManager))
 		r.Use(middleware.EnsureTenantMiddleware)
 
 		r.Post("/login", httphandler.LoginHandler{
@@ -404,6 +405,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 	// SEP-24 and miscellaneous endpoints that are tenant-unaware
 	mux.Group(func(r chi.Router) {
+		r.Use(middleware.InjectTenantMiddleware(o.tenantManager, o.authManager))
 		r.Get("/health", httphandler.HealthHandler{
 			ReleaseID: o.GitCommit,
 			ServiceID: ServiceID,


### PR DESCRIPTION
### What

Multi-tenant instance breaks when the user is logged in using the base domain. 

### Why

`InjectTenantMiddleware` was trying to fetch tenant ID from the token, but `AuthenticateMiddleware` only added the token to the request context later.

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
