### PR TITLE
[SDP-1142] simplify docker-compose by splitting monitoring containers

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -46,8 +46,13 @@ cp .env.example .env
 
 4. Execute the following command to create all the necessary Docker containers needed to run SDP:
 ```sh
-docker-compose up
+./main.sh
 ```
+
+5. In order to start the sdp containers with monitoring services, run the following command:
+```sh
+docker-compose -f docker-compose.yml -f docker-compose-monitoring.yml up
+````
 
 This will spin up the following services:
 

--- a/dev/docker-compose-monitoring.yml
+++ b/dev/docker-compose-monitoring.yml
@@ -1,0 +1,44 @@
+version: '3'
+services:
+  db-conduktor:
+    image: postgres:14
+    hostname: postgresql
+    volumes:
+      - db-conduktor-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: "conduktor-platform"
+      POSTGRES_USER: "conduktor"
+      POSTGRES_PASSWORD: "change_me"
+      POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
+
+  conduktor-platform:
+    image: conduktor/conduktor-platform:1.19.2
+    ports:
+      - "9090:8080"
+    volumes:
+      - conduktor-platform-data:/var/conduktor
+    environment:
+      CDK_DATABASE_URL: "postgresql://conduktor:change_me@db-conduktor:5432/conduktor-platform"
+      CDK_MONITORING_CORTEX-URL: http://conduktor-monitoring:9009/
+      CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-monitoring:9010/
+      CDK_MONITORING_CALLBACK-URL: http://conduktor-platform:9090/monitoring/api/
+      CDK_MONITORING_NOTIFICATIONS-CALLBACK-URL: http://localhost:9090
+    healthcheck:
+      test: curl -f http://localhost:9090/platform/api/modules/health/live || exit 1
+      interval: 10s
+      start_period: 10s
+      timeout: 5s
+      retries: 3
+    depends_on:
+      - db-conduktor
+
+  conduktor-monitoring:
+    image: conduktor/conduktor-platform-cortex:1.19.2
+    environment:
+      CDK_CONSOLE-URL: "http://conduktor-platform:9090"
+
+volumes:
+  db-conduktor-data:
+    driver: local
+  conduktor-platform-data:
+    driver: local

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -223,49 +223,10 @@ services:
         kafka-topics.sh --create --if-not-exists --topic events.payment.ready_to_pay --bootstrap-server kafka:9092
       "
 
-  db-conduktor:
-    image: postgres:14
-    hostname: postgresql
-    volumes:
-      - db-conduktor-data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_DB: "conduktor-platform"
-      POSTGRES_USER: "conduktor"
-      POSTGRES_PASSWORD: "change_me"
-      POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
-
-  conduktor-platform:
-    image: conduktor/conduktor-platform:1.19.2
-    ports:
-      - "9090:8080"
-    volumes:
-      - conduktor-platform-data:/var/conduktor
-    environment:
-      CDK_DATABASE_URL: "postgresql://conduktor:change_me@db-conduktor:5432/conduktor-platform"
-      CDK_MONITORING_CORTEX-URL: http://conduktor-monitoring:9009/
-      CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-monitoring:9010/
-      CDK_MONITORING_CALLBACK-URL: http://conduktor-platform:9090/monitoring/api/
-      CDK_MONITORING_NOTIFICATIONS-CALLBACK-URL: http://localhost:9090
-    healthcheck:
-      test: curl -f http://localhost:9090/platform/api/modules/health/live || exit 1
-      interval: 10s
-      start_period: 10s
-      timeout: 5s
-      retries: 3
-
-  conduktor-monitoring:
-    image: conduktor/conduktor-platform-cortex:1.19.2
-    environment:
-      CDK_CONSOLE-URL: "http://conduktor-platform:9090"
-
 volumes:
   postgres-db:
     driver: local
   postgres-ap-db:
     driver: local
   kafka-data:
-    driver: local
-  db-conduktor-data:
-    driver: local
-  conduktor-platform-data:
     driver: local

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -59,24 +59,6 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
-  conduktor-platform:
-    extends:
-      file: docker-compose-sdp-anchor.yml
-      service: conduktor-platform
-    volumes:
-      - conduktor-platform-data:/var/conduktor
-    depends_on:
-      - db-conduktor
-  db-conduktor:
-    extends:
-      file: docker-compose-sdp-anchor.yml
-      service: db-conduktor
-    volumes:
-      - db-conduktor-data:/var/lib/postgresql/data
-  conduktor-monitoring:
-    extends:
-      file: docker-compose-sdp-anchor.yml
-      service: conduktor-monitoring
 
 volumes:
   postgres-db:
@@ -85,8 +67,3 @@ volumes:
     driver: local
   kafka-data:
     driver: local
-  db-conduktor-data:
-    driver: local
-  conduktor-platform-data:
-    driver: local
-


### PR DESCRIPTION
### What
simplify the main docker-compose to reduce the number of containers started. 

### Why
Currently we’re starting 11 containers: 

- 1 init container
- 7 containers needed for running the SDP
     - Kafka, sdp db, sdp frontend, sdp api, anchor db, anchor, tss. 
- 3 containers for monitoring kafka (conduktor)

We’re splitting the 3 containers for monitoring kafka into their own docker-compose that we’re calling docker-compose-monitoring. We can add containers like Grafana and Prometheus here for optionally starting a monitoring stack for the SDP.
https://stellarorg.atlassian.net/browse/SDP-1142

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
