### PR TITLE
stellar-multitenant: remove distribution account from admin api handlers

### DIFF
--- a/stellar-multitenant/pkg/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/pkg/internal/httphandler/tenants_handler.go
@@ -118,13 +118,12 @@ func (t TenantsHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	tenantID := chi.URLParam(r, "id")
 
 	tnt, err := t.Manager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
-		ID:                  tenantID,
-		EmailSenderType:     reqBody.EmailSenderType,
-		SMSSenderType:       reqBody.SMSSenderType,
-		BaseURL:             reqBody.BaseURL,
-		SDPUIBaseURL:        reqBody.SDPUIBaseURL,
-		Status:              reqBody.Status,
-		DistributionAccount: reqBody.DistributionAccount,
+		ID:              tenantID,
+		EmailSenderType: reqBody.EmailSenderType,
+		SMSSenderType:   reqBody.SMSSenderType,
+		BaseURL:         reqBody.BaseURL,
+		SDPUIBaseURL:    reqBody.SDPUIBaseURL,
+		Status:          reqBody.Status,
 	})
 	if err != nil {
 		if errors.Is(tenant.ErrEmptyUpdateTenant, err) {

--- a/stellar-multitenant/pkg/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/pkg/internal/httphandler/tenants_handler_test.go
@@ -631,28 +631,13 @@ func Test_TenantHandler_Patch(t *testing.T) {
 		runSuccessfulRequestPatchTest(t, r, ctx, dbConnectionPool, handler, reqBody, expectedRespBody)
 	})
 
-	t.Run("successfully updates Distribution Account of a tenant", func(t *testing.T) {
-		reqBody := `{"distribution_account": "GAAFQ2NZRRELBKLNLRZ5CT5RENLQGJPHDM6YY5UKV5UDAFNZ6KD6J4W7"}`
-		expectedRespBody := `
-			"email_sender_type": "DRY_RUN",
-			"sms_sender_type": "DRY_RUN",
-			"base_url": null,
-			"sdp_ui_base_url": null,
-			"status": "TENANT_CREATED",
-			"distribution_account": "GAAFQ2NZRRELBKLNLRZ5CT5RENLQGJPHDM6YY5UKV5UDAFNZ6KD6J4W7",
-		`
-
-		runSuccessfulRequestPatchTest(t, r, ctx, dbConnectionPool, handler, reqBody, expectedRespBody)
-	})
-
 	t.Run("successfully updates all fields of a tenant", func(t *testing.T) {
 		reqBody := `{
 			"email_sender_type": "AWS_EMAIL",
 			"sms_sender_type": "AWS_SMS",
 			"base_url": "http://valid.com",
 			"sdp_ui_base_url": "http://valid.com",
-			"status": "TENANT_ACTIVATED",
-			"distribution_account": "GAAFQ2NZRRELBKLNLRZ5CT5RENLQGJPHDM6YY5UKV5UDAFNZ6KD6J4W7"
+			"status": "TENANT_ACTIVATED"
 		}`
 
 		expectedRespBody := `
@@ -661,7 +646,7 @@ func Test_TenantHandler_Patch(t *testing.T) {
 			"base_url": "http://valid.com",
 			"sdp_ui_base_url": "http://valid.com",
 			"status": "TENANT_ACTIVATED",
-			"distribution_account": "GAAFQ2NZRRELBKLNLRZ5CT5RENLQGJPHDM6YY5UKV5UDAFNZ6KD6J4W7",
+			"distribution_account": "GCTNUNQVX7BNIP5AUWW2R4YC7G6R3JGUDNMGT7H62BGBUY4A4V6ROAAH",
 		`
 
 		runSuccessfulRequestPatchTest(t, r, ctx, dbConnectionPool, handler, reqBody, expectedRespBody)

--- a/stellar-multitenant/pkg/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/pkg/internal/validators/tenant_validator.go
@@ -5,8 +5,6 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/stellar/go/strkey"
-
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -14,25 +12,23 @@ import (
 var validTenantName *regexp.Regexp = regexp.MustCompile(`^[a-z-]+$`)
 
 type TenantRequest struct {
-	Name                string                 `json:"name"`
-	OwnerEmail          string                 `json:"owner_email"`
-	OwnerFirstName      string                 `json:"owner_first_name"`
-	OwnerLastName       string                 `json:"owner_last_name"`
-	OrganizationName    string                 `json:"organization_name"`
-	EmailSenderType     tenant.EmailSenderType `json:"email_sender_type"`
-	SMSSenderType       tenant.SMSSenderType   `json:"sms_sender_type"`
-	BaseURL             string                 `json:"base_url"`
-	SDPUIBaseURL        string                 `json:"sdp_ui_base_url"`
-	DistributionAccount string                 `json:"distribution_account"`
+	Name             string                 `json:"name"`
+	OwnerEmail       string                 `json:"owner_email"`
+	OwnerFirstName   string                 `json:"owner_first_name"`
+	OwnerLastName    string                 `json:"owner_last_name"`
+	OrganizationName string                 `json:"organization_name"`
+	EmailSenderType  tenant.EmailSenderType `json:"email_sender_type"`
+	SMSSenderType    tenant.SMSSenderType   `json:"sms_sender_type"`
+	BaseURL          string                 `json:"base_url"`
+	SDPUIBaseURL     string                 `json:"sdp_ui_base_url"`
 }
 
 type UpdateTenantRequest struct {
-	EmailSenderType     *tenant.EmailSenderType `json:"email_sender_type"`
-	SMSSenderType       *tenant.SMSSenderType   `json:"sms_sender_type"`
-	BaseURL             *string                 `json:"base_url"`
-	SDPUIBaseURL        *string                 `json:"sdp_ui_base_url"`
-	Status              *tenant.TenantStatus    `json:"status"`
-	DistributionAccount *string                 `json:"distribution_account"`
+	EmailSenderType *tenant.EmailSenderType `json:"email_sender_type"`
+	SMSSenderType   *tenant.SMSSenderType   `json:"sms_sender_type"`
+	BaseURL         *string                 `json:"base_url"`
+	SDPUIBaseURL    *string                 `json:"sdp_ui_base_url"`
+	Status          *tenant.TenantStatus    `json:"status"`
 }
 
 type TenantValidator struct {
@@ -68,10 +64,6 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 
 	if _, err = url.ParseRequestURI(reqBody.SDPUIBaseURL); err != nil {
 		tv.Check(false, "sdp_ui_base_url", "invalid SDP UI base URL value")
-	}
-
-	if reqBody.DistributionAccount != "" {
-		tv.Check(strkey.IsValidEd25519PublicKey(reqBody.DistributionAccount), "distribution_account", "invalid distribution account value")
 	}
 
 	if tv.HasErrors() {
@@ -128,10 +120,6 @@ func (tv *TenantValidator) ValidateUpdateTenantRequest(reqBody *UpdateTenantRequ
 
 	if reqBody.Status != nil {
 		tv.Check((*reqBody.Status).IsValid(), "status", "invalid status value")
-	}
-
-	if reqBody.DistributionAccount != nil {
-		tv.Check(strkey.IsValidEd25519PublicKey(*reqBody.DistributionAccount), "distribution_account", "invalid distribution account value")
 	}
 
 	if tv.HasErrors() {


### PR DESCRIPTION
### What

This PR removes the `distribution_account` field from the requests of `POST` and `PATCH` of the Admin API.

### Why

This field should not be changed externally.

### Known limitations

N/A

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
