### PR TITLE
SDP-1141 - Using ENABLE_SCHEDULER throws an error when producing a message

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -587,7 +587,8 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 					log.Fatalf("error setting up consumers: %v", kafkaErr)
 				}
 			} else {
-				log.Ctx(ctx).Warn("Event Broker Type is NONE.")
+				log.Ctx(ctx).Warn("Event Broker Type is NONE. Using Noop producer for logging events")
+				serveOpts.EventProducer = events.NoopProducer{}
 			}
 
 			// Starting Scheduler Service (background job) if enabled

--- a/internal/events/mocks.go
+++ b/internal/events/mocks.go
@@ -1,0 +1,48 @@
+package events
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockConsumer struct {
+	mock.Mock
+}
+
+var _ Consumer = new(MockConsumer)
+
+func (c *MockConsumer) ReadMessage(ctx context.Context) error {
+	args := c.Called(ctx)
+	return args.Error(0)
+}
+
+func (c *MockConsumer) RegisterEventHandler(ctx context.Context, eventHandlers ...EventHandler) error {
+	args := c.Called(ctx, eventHandlers)
+	return args.Error(0)
+}
+
+func (c *MockConsumer) Topic() string {
+	return c.Called().String(0)
+}
+
+func (c *MockConsumer) Close() error {
+	args := c.Called()
+	return args.Error(0)
+}
+
+type MockProducer struct {
+	mock.Mock
+}
+
+var _ Producer = new(MockProducer)
+
+func (c *MockProducer) WriteMessages(ctx context.Context, messages ...Message) error {
+	args := c.Called(ctx, messages)
+	return args.Error(0)
+}
+
+func (c *MockProducer) Close() error {
+	args := c.Called()
+	return args.Error(0)
+}

--- a/internal/scheduler/jobs/payment_from_submitter_job.go
+++ b/internal/scheduler/jobs/payment_from_submitter_job.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
@@ -47,7 +49,11 @@ func (d paymentFromSubmitterJob) IsJobMultiTenant() bool {
 }
 
 func (d paymentFromSubmitterJob) Execute(ctx context.Context) error {
-	err := d.service.SyncBatchTransactions(ctx, paymentFromSubmitterBatchSize)
+	t, err := tenant.GetTenantFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting tenant from context for %s: %w", paymentFromSubmitterJobName, err)
+	}
+	err = d.service.SyncBatchTransactions(ctx, paymentFromSubmitterBatchSize, t.ID)
 	if err != nil {
 		return fmt.Errorf("error executing paymentFromSubmitterJob: %w", err)
 	}

--- a/internal/services/mocks/payment_from_submitter_service.go
+++ b/internal/services/mocks/payment_from_submitter_service.go
@@ -19,7 +19,7 @@ func (s *MockPaymentFromSubmitterService) SyncTransaction(ctx context.Context, t
 	return args.Error(0)
 }
 
-func (s *MockPaymentFromSubmitterService) SyncBatchTransactions(ctx context.Context, batchSize int) error {
-	args := s.Called(ctx, batchSize)
+func (s *MockPaymentFromSubmitterService) SyncBatchTransactions(ctx context.Context, batchSize int, tenantID string) error {
+	args := s.Called(ctx, batchSize, tenantID)
 	return args.Error(0)
 }

--- a/internal/services/payment_from_submitter_service.go
+++ b/internal/services/payment_from_submitter_service.go
@@ -15,7 +15,7 @@ import (
 
 type PaymentFromSubmitterServiceInterface interface {
 	SyncTransaction(ctx context.Context, tx *schemas.EventPaymentCompletedData) error
-	SyncBatchTransactions(ctx context.Context, batchSize int) error
+	SyncBatchTransactions(ctx context.Context, batchSize int, tenantID string) error
 }
 
 // PaymentFromSubmitterService is a service that monitors TSS transactions that were complete and sync their completion
@@ -36,10 +36,10 @@ func NewPaymentFromSubmitterService(models *data.Models, tssDBConnectionPool db.
 }
 
 // SyncBatchTransactions monitors TSS transactions that were complete and sync their completion state with the SDP payments.
-func (s PaymentFromSubmitterService) SyncBatchTransactions(ctx context.Context, batchSize int) error {
+func (s PaymentFromSubmitterService) SyncBatchTransactions(ctx context.Context, batchSize int, tenantID string) error {
 	err := db.RunInTransaction(ctx, s.sdpModels.DBConnectionPool, nil, func(sdpDBTx db.DBTransaction) error {
 		return db.RunInTransaction(ctx, s.tssModel.DBConnectionPool, nil, func(tssDBTx db.DBTransaction) error {
-			transactions, err := s.tssModel.GetTransactionBatchForUpdate(ctx, tssDBTx, batchSize)
+			transactions, err := s.tssModel.GetTransactionBatchForUpdate(ctx, tssDBTx, batchSize, tenantID)
 			if err != nil {
 				return fmt.Errorf("getting transactions for update: %w", err)
 			}

--- a/internal/transactionsubmission/store/mocks/transaction_store.go
+++ b/internal/transactionsubmission/store/mocks/transaction_store.go
@@ -95,24 +95,24 @@ func (_m *MockTransactionStore) GetAllByPaymentIDs(ctx context.Context, paymentI
 }
 
 // GetTransactionBatchForUpdate provides a mock function with given fields: ctx, dbTx, batchSize
-func (_m *MockTransactionStore) GetTransactionBatchForUpdate(ctx context.Context, dbTx db.DBTransaction, batchSize int) ([]*store.Transaction, error) {
-	ret := _m.Called(ctx, dbTx, batchSize)
+func (_m *MockTransactionStore) GetTransactionBatchForUpdate(ctx context.Context, dbTx db.DBTransaction, batchSize int, tenantID string) ([]*store.Transaction, error) {
+	ret := _m.Called(ctx, dbTx, batchSize, tenantID)
 
 	var r0 []*store.Transaction
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, db.DBTransaction, int) ([]*store.Transaction, error)); ok {
-		return rf(ctx, dbTx, batchSize)
+	if rf, ok := ret.Get(0).(func(context.Context, db.DBTransaction, int, string) ([]*store.Transaction, error)); ok {
+		return rf(ctx, dbTx, batchSize, tenantID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, db.DBTransaction, int) []*store.Transaction); ok {
-		r0 = rf(ctx, dbTx, batchSize)
+	if rf, ok := ret.Get(0).(func(context.Context, db.DBTransaction, int, string) []*store.Transaction); ok {
+		r0 = rf(ctx, dbTx, batchSize, tenantID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*store.Transaction)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, db.DBTransaction, int) error); ok {
-		r1 = rf(ctx, dbTx, batchSize)
+	if rf, ok := ret.Get(1).(func(context.Context, db.DBTransaction, int, string) error); ok {
+		r1 = rf(ctx, dbTx, batchSize, tenantID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/transactionsubmission/store/store.go
+++ b/internal/transactionsubmission/store/store.go
@@ -40,7 +40,7 @@ type TransactionStore interface {
 	Unlock(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) (*Transaction, error)
 	// Queue management:
 	PrepareTransactionForReprocessing(ctx context.Context, sqlExec db.SQLExecuter, transactionID string) (*Transaction, error)
-	GetTransactionBatchForUpdate(ctx context.Context, dbTx db.DBTransaction, batchSize int) (transactions []*Transaction, err error)
+	GetTransactionBatchForUpdate(ctx context.Context, dbTx db.DBTransaction, batchSize int, tenantID string) (transactions []*Transaction, err error)
 	GetTransactionPendingUpdateByID(ctx context.Context, sqlExec db.SQLExecuter, txID string) (transaction *Transaction, err error)
 	UpdateSyncedTransactions(ctx context.Context, sqlExec db.SQLExecuter, txIDs []string) error
 }

--- a/internal/transactionsubmission/store/transactions_test.go
+++ b/internal/transactionsubmission/store/transactions_test.go
@@ -729,6 +729,7 @@ func Test_TransactionModel_GetTransactionBatchForUpdate(t *testing.T) {
 				require.NoError(t, err)
 			}()
 
+			tenantID := uuid.NewString()
 			var transactions []*Transaction
 			if tc.transactionStatus != "" {
 				transactions = CreateTransactionFixturesNew(t, ctx, dbTx, txCount, TransactionFixture{
@@ -737,7 +738,7 @@ func Test_TransactionModel_GetTransactionBatchForUpdate(t *testing.T) {
 					DestinationAddress: "GBHNIYGWZUAVZX7KTLVSMILBXJMUACVO6XBEKIN6RW7AABDFH6S7GK2Y",
 					Status:             tc.transactionStatus,
 					Amount:             1.2,
-					TenantID:           uuid.NewString(),
+					TenantID:           tenantID,
 				})
 			}
 			var txIDs []string
@@ -745,7 +746,7 @@ func Test_TransactionModel_GetTransactionBatchForUpdate(t *testing.T) {
 				txIDs = append(txIDs, tx.ID)
 			}
 
-			foundTransactions, err := txModel.GetTransactionBatchForUpdate(ctx, dbTx, tc.batchSize)
+			foundTransactions, err := txModel.GetTransactionBatchForUpdate(ctx, dbTx, tc.batchSize, tenantID)
 			if tc.wantErrContains == "" {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
### What
There are two issues fixed in this PR, both were not causing functional changes but were causing errors in the logs. 

1. Introduce a `NoopProducer` that logs events - in the case where `EVENT_BROKER_TYPE=NONE` 
2. Add `tenant-id` as a parameter to `payments_from_submitter` job. Given that this jobs goes from TSS -> SDP, we need to determine which tenant to use to fetch the txs from submitter_tx 



### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
