### PR TITLE
SDP-1105: Add demo-wallet to docker-compose for testing sep24 multi-tenant registration

### DIFF
--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -222,6 +222,13 @@ services:
         kafka-topics.sh --create --if-not-exists --topic events.payment.payment_completed --bootstrap-server kafka:9092
         kafka-topics.sh --create --if-not-exists --topic events.payment.ready_to_pay --bootstrap-server kafka:9092
       "
+  
+  demo-wallet:
+    image: 
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./env-config-demo-wallet.js:/usr/share/nginx/html/settings/env-config.js
 
 volumes:
   postgres-db:

--- a/dev/env-config-demo-wallet.js
+++ b/dev/env-config-demo-wallet.js
@@ -1,0 +1,8 @@
+window._env_ = {
+    AMPLITUDE_API_KEY: "",
+    SENTRY_API_KEY: "",
+    HORIZON_PASSPHRASE: "",
+    HORIZON_URL: "",
+    CLIENT_DOMAIN: "demo-wallet-server.stellar.org",
+    WALLET_BACKEND_ENDPOINT: "http://demo-wallet-server.stellar.org",
+};


### PR DESCRIPTION
### What

- We need to add a demo-wallet client to the current docker compose used for development
- We don’t need to run the server, we can just run the client yarn start:client 
- Configuration for env-config.js
- SDP Frontend customizes env-config.js by mounting it as a volume. This approach can be used here too if possible.


### Why

- In multi-tenant SDP, we rely on the hostname prefix to determine the tenant we’re targeting during sep24 flow
- Locally, that host would look like http://redcorp.stellar.local and http://bluecorp.stellar.local. 
- Deployed demo-wallet doesn’t only allows localhost on http. Any other URL would require https. This prevents us from testing using custom hostnames locally.

### Known limitations

demo-wallet image

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
