### PR TITLE
[SDP-1119] fix the domain value used to produce the invitation link for MTN

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -98,7 +98,6 @@ func (s *ServerService) GetSchedulerJobRegistrars(
 			scheduler.WithPaymentFromSubmitterJobOption(schedulerOptions.PaymentJobIntervalSeconds, models, tssDBConnectionPool),
 			scheduler.WithPatchAnchorPlatformTransactionsCompletionJobOption(schedulerOptions.PaymentJobIntervalSeconds, apAPIService, models),
 			scheduler.WithSendReceiverWalletsSMSInvitationJobOption(jobs.SendReceiverWalletsSMSInvitationJobOptions{
-				AnchorPlatformBaseSepURL:       serveOpts.AnchorPlatformBaseSepURL,
 				Models:                         models,
 				MessengerClient:                serveOpts.SMSMessengerClient,
 				MaxInvitationSMSResendAttempts: int64(serveOpts.MaxInvitationSMSResendAttempts),

--- a/internal/events/eventhandlers/send_receiver_wallets_sms_invitation_event_handler.go
+++ b/internal/events/eventhandlers/send_receiver_wallets_sms_invitation_event_handler.go
@@ -47,7 +47,6 @@ func NewSendReceiverWalletsSMSInvitationEventHandler(options SendReceiverWallets
 	s, err := services.NewSendReceiverWalletInviteService(
 		models,
 		options.MessengerClient,
-		options.AnchorPlatformBaseSepURL,
 		options.Sep10SigningPrivateKey,
 		options.MaxInvitationSMSResendAttempts,
 		options.CrashTrackerClient,

--- a/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job.go
+++ b/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job.go
@@ -17,7 +17,6 @@ const (
 )
 
 type SendReceiverWalletsSMSInvitationJobOptions struct {
-	AnchorPlatformBaseSepURL       string
 	Models                         *data.Models
 	MessengerClient                message.MessengerClient
 	MaxInvitationSMSResendAttempts int64
@@ -60,7 +59,6 @@ func NewSendReceiverWalletsSMSInvitationJob(options SendReceiverWalletsSMSInvita
 	s, err := services.NewSendReceiverWalletInviteService(
 		options.Models,
 		options.MessengerClient,
-		options.AnchorPlatformBaseSepURL,
 		options.Sep10SigningPrivateKey,
 		options.MaxInvitationSMSResendAttempts,
 		options.CrashTrackerClient,

--- a/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
+++ b/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 
@@ -31,8 +34,6 @@ func Test_NewSendReceiverWalletsSMSInvitationJob(t *testing.T) {
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 
-	anchorPlatformBaseSepURL := "http://localhost:8000"
-
 	messageDryRunClient, err := message.NewDryRunClient()
 	require.NoError(t, err)
 
@@ -40,7 +41,6 @@ func Test_NewSendReceiverWalletsSMSInvitationJob(t *testing.T) {
 		if os.Getenv("TEST_FATAL") == "1" {
 			o := SendReceiverWalletsSMSInvitationJobOptions{
 				Models:                         models,
-				AnchorPlatformBaseSepURL:       anchorPlatformBaseSepURL,
 				MaxInvitationSMSResendAttempts: 3,
 			}
 
@@ -67,7 +67,6 @@ func Test_NewSendReceiverWalletsSMSInvitationJob(t *testing.T) {
 			o := SendReceiverWalletsSMSInvitationJobOptions{
 				Models:                         models,
 				MessengerClient:                messageDryRunClient,
-				AnchorPlatformBaseSepURL:       "",
 				MaxInvitationSMSResendAttempts: 3,
 			}
 
@@ -93,7 +92,6 @@ func Test_NewSendReceiverWalletsSMSInvitationJob(t *testing.T) {
 		o := SendReceiverWalletsSMSInvitationJobOptions{
 			Models:                         models,
 			MessengerClient:                messageDryRunClient,
-			AnchorPlatformBaseSepURL:       anchorPlatformBaseSepURL,
 			MaxInvitationSMSResendAttempts: 3,
 			JobIntervalSeconds:             DefaultMinimumJobIntervalSeconds,
 		}
@@ -124,11 +122,16 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 
-	anchorPlatformBaseSepURL := "http://localhost:8000"
+	tenantBaseURL := "http://localhost:8000"
+	tenantInfo := &tenant.Tenant{
+		ID:      uuid.NewString(),
+		Name:    "TestTenant",
+		BaseURL: &tenantBaseURL,
+	}
+	ctx := tenant.SaveTenantInContext(context.Background(), tenantInfo)
+
 	stellarSecretKey := "SBUSPEKAZKLZSWHRSJ2HWDZUK6I3IVDUWA7JJZSGBLZ2WZIUJI7FPNB5"
 	var maxInvitationSMSResendAttempts int64 = 3
-
-	ctx := context.Background()
 
 	t.Run("executes the service successfully", func(t *testing.T) {
 		messengerClientMock := &message.MessengerClientMock{}
@@ -137,7 +140,6 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 		s, err := services.NewSendReceiverWalletInviteService(
 			models,
 			messengerClientMock,
-			anchorPlatformBaseSepURL,
 			stellarSecretKey,
 			maxInvitationSMSResendAttempts,
 			crashTrackerClientMock,
@@ -199,22 +201,22 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 		})
 
 		walletDeepLink1 := services.WalletDeepLink{
-			DeepLink:                 wallet1.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset1.Code,
-			AssetIssuer:              asset1.Issuer,
+			DeepLink:         wallet1.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset1.Code,
+			AssetIssuer:      asset1.Issuer,
 		}
 		deepLink1, err := walletDeepLink1.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
 		contentWallet1 := fmt.Sprintf("You have a payment waiting for you from the MyCustomAid. Click %s to register.", deepLink1)
 
 		walletDeepLink2 := services.WalletDeepLink{
-			DeepLink:                 wallet2.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset2.Code,
-			AssetIssuer:              asset2.Issuer,
+			DeepLink:         wallet2.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset2.Code,
+			AssetIssuer:      asset2.Issuer,
 		}
 		deepLink2, err := walletDeepLink2.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)

--- a/internal/services/send_receiver_wallets_invite_service_test.go
+++ b/internal/services/send_receiver_wallets_invite_service_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
@@ -21,29 +24,29 @@ import (
 
 func Test_GetSignedRegistrationLink_SchemelessDeepLink(t *testing.T) {
 	wdl := WalletDeepLink{
-		DeepLink:                 "api-dev.vibrantapp.com/sdp-dev",
-		AnchorPlatformBaseSepURL: "https://ap.localhost.com",
-		OrganizationName:         "FOO Org",
-		AssetCode:                "USDC",
-		AssetIssuer:              "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+		DeepLink:         "api-dev.vibrantapp.com/sdp-dev",
+		OrganizationName: "FOO Org",
+		AssetCode:        "USDC",
+		AssetIssuer:      "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+		TenantBaseURL:    "https://tenant.localhost.com",
 	}
 
 	registrationLink, err := wdl.GetSignedRegistrationLink("SCTOVDWM3A7KLTXXIV6YXL6QRVUIIG4HHHIDDKPR4JUB3DGDIKI5VGA2")
 	require.NoError(t, err)
-	wantRegistrationLink := "https://api-dev.vibrantapp.com/sdp-dev?asset=USDC-GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&domain=ap.localhost.com&name=FOO+Org&signature=b40479041eea534a029c6aadf36f3bf6696aba9ff64684b558b9a412150b31fa8480ac7babcdef17cb445c1d105a761dbaa3599361c2d9e1d526fd4a5bac370a"
+	wantRegistrationLink := "https://api-dev.vibrantapp.com/sdp-dev?asset=USDC-GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&domain=tenant.localhost.com&name=FOO+Org&signature=c6695a52ba8cc0ae2174023b116d4f726bc3d2c6d8d75a34336902ecbfa7eca07a059f44be503e3c4a71627aca66b05280b187e6614a0b130cf371328319ce0a"
 	require.Equal(t, wantRegistrationLink, registrationLink)
 
 	wdl = WalletDeepLink{
-		DeepLink:                 "https://www.beansapp.com/disbursements/registration?redirect=true",
-		AnchorPlatformBaseSepURL: "https://ap.localhost.com",
-		OrganizationName:         "FOO Org",
-		AssetCode:                "USDC",
-		AssetIssuer:              "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+		DeepLink:         "https://www.beansapp.com/disbursements/registration?redirect=true",
+		TenantBaseURL:    "https://tenant.localhost.com",
+		OrganizationName: "FOO Org",
+		AssetCode:        "USDC",
+		AssetIssuer:      "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
 	}
 
 	registrationLink, err = wdl.GetSignedRegistrationLink("SCTOVDWM3A7KLTXXIV6YXL6QRVUIIG4HHHIDDKPR4JUB3DGDIKI5VGA2")
 	require.NoError(t, err)
-	wantRegistrationLink = "https://www.beansapp.com/disbursements/registration?asset=USDC-GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&domain=ap.localhost.com&name=FOO+Org&redirect=true&signature=8dd0a570bf5590a8e1a4983d413b5429ed504659543cf180fbf1b3ffbf0ea90083789a7c0c615d9cbddbe0c59f7555e6fd33fb5ca8f4685c821fc23ad7cd2f0d"
+	wantRegistrationLink = "https://www.beansapp.com/disbursements/registration?asset=USDC-GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&domain=tenant.localhost.com&name=FOO+Org&redirect=true&signature=ab27744802e712716cc2c282cb08cb327f1ed75c334152879dd2b2d880eb0c5cf250deb8ae11510e1d4db00ee1f8c15bf940760464ae27a4140ecdc32304780d"
 	require.Equal(t, wantRegistrationLink, registrationLink)
 }
 
@@ -55,7 +58,10 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
 
-	anchorPlatformBaseSepURL := "http://localhost:8000"
+	tenantBaseURL := "http://localhost:8000"
+	tenantInfo := &tenant.Tenant{ID: uuid.NewString(), Name: "TestTenant", BaseURL: &tenantBaseURL}
+	ctx := tenant.SaveTenantInContext(context.Background(), tenantInfo)
+
 	stellarSecretKey := "SBUSPEKAZKLZSWHRSJ2HWDZUK6I3IVDUWA7JJZSGBLZ2WZIUJI7FPNB5"
 	messengerClientMock := &message.MessengerClientMock{}
 	messengerClientMock.
@@ -64,8 +70,6 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		Maybe()
 
 	mockCrashTrackerClient := &crashtracker.MockCrashTrackerClient{}
-
-	ctx := context.Background()
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
@@ -96,15 +100,12 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 	})
 
 	t.Run("returns error when service has wrong setup", func(t *testing.T) {
-		_, err := NewSendReceiverWalletInviteService(models, nil, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		_, err := NewSendReceiverWalletInviteService(models, nil, stellarSecretKey, 3, mockCrashTrackerClient)
 		assert.EqualError(t, err, "invalid service setup: messenger client can't be nil")
-
-		_, err = NewSendReceiverWalletInviteService(models, messengerClientMock, "", stellarSecretKey, 3, mockCrashTrackerClient)
-		assert.EqualError(t, err, "invalid service setup: anchorPlatformBaseSepURL can't be empty")
 	})
 
 	t.Run("inserts the failed sent message", func(t *testing.T) {
-		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, stellarSecretKey, 3, mockCrashTrackerClient)
 		require.NoError(t, err)
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -133,22 +134,22 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		})
 
 		walletDeepLink1 := WalletDeepLink{
-			DeepLink:                 wallet1.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset1.Code,
-			AssetIssuer:              asset1.Issuer,
+			DeepLink:         wallet1.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset1.Code,
+			AssetIssuer:      asset1.Issuer,
 		}
 		deepLink1, err := walletDeepLink1.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
 		contentWallet1 := fmt.Sprintf("You have a payment waiting for you from the MyCustomAid. Click %s to register.", deepLink1)
 
 		walletDeepLink2 := WalletDeepLink{
-			DeepLink:                 wallet2.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset2.Code,
-			AssetIssuer:              asset2.Issuer,
+			DeepLink:         wallet2.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset2.Code,
+			AssetIssuer:      asset2.Issuer,
 		}
 		deepLink2, err := walletDeepLink2.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
@@ -244,7 +245,7 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 	})
 
 	t.Run("send invite successfully", func(t *testing.T) {
-		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, stellarSecretKey, 3, mockCrashTrackerClient)
 		require.NoError(t, err)
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -273,22 +274,22 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		})
 
 		walletDeepLink1 := WalletDeepLink{
-			DeepLink:                 wallet1.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset1.Code,
-			AssetIssuer:              asset1.Issuer,
+			DeepLink:         wallet1.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset1.Code,
+			AssetIssuer:      asset1.Issuer,
 		}
 		deepLink1, err := walletDeepLink1.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
 		contentWallet1 := fmt.Sprintf("You have a payment waiting for you from the MyCustomAid. Click %s to register.", deepLink1)
 
 		walletDeepLink2 := WalletDeepLink{
-			DeepLink:                 wallet2.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset2.Code,
-			AssetIssuer:              asset2.Issuer,
+			DeepLink:         wallet2.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset2.Code,
+			AssetIssuer:      asset2.Issuer,
 		}
 		deepLink2, err := walletDeepLink2.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
@@ -375,7 +376,7 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 	})
 
 	t.Run("send invite successfully with custom invite message", func(t *testing.T) {
-		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, stellarSecretKey, 3, mockCrashTrackerClient)
 		require.NoError(t, err)
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -408,22 +409,22 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		})
 
 		walletDeepLink1 := WalletDeepLink{
-			DeepLink:                 wallet1.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset1.Code,
-			AssetIssuer:              asset1.Issuer,
+			DeepLink:         wallet1.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset1.Code,
+			AssetIssuer:      asset1.Issuer,
 		}
 		deepLink1, err := walletDeepLink1.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
 		contentWallet1 := fmt.Sprintf("%s %s", customInvitationMessage, deepLink1)
 
 		walletDeepLink2 := WalletDeepLink{
-			DeepLink:                 wallet2.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset2.Code,
-			AssetIssuer:              asset2.Issuer,
+			DeepLink:         wallet2.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset2.Code,
+			AssetIssuer:      asset2.Issuer,
 		}
 		deepLink2, err := walletDeepLink2.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
@@ -510,7 +511,7 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 	})
 
 	t.Run("doesn't resend the invitation SMS when organization's SMS Resend Interval is nil and the invitation was already sent", func(t *testing.T) {
-		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, stellarSecretKey, 3, mockCrashTrackerClient)
 		require.NoError(t, err)
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -555,7 +556,7 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 	})
 
 	t.Run("doesn't resend the invitation SMS when receiver reached the maximum number of resend attempts", func(t *testing.T) {
-		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, stellarSecretKey, 3, mockCrashTrackerClient)
 		require.NoError(t, err)
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -635,7 +636,7 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 	})
 
 	t.Run("doesn't resend invitation SMS when receiver is not in the resend period", func(t *testing.T) {
-		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, stellarSecretKey, 3, mockCrashTrackerClient)
 		require.NoError(t, err)
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -682,7 +683,7 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 	})
 
 	t.Run("successfully resend the invitation SMS", func(t *testing.T) {
-		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, stellarSecretKey, 3, mockCrashTrackerClient)
 		require.NoError(t, err)
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -712,11 +713,11 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		require.NoError(t, err)
 
 		walletDeepLink1 := WalletDeepLink{
-			DeepLink:                 wallet1.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset1.Code,
-			AssetIssuer:              asset1.Issuer,
+			DeepLink:         wallet1.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset1.Code,
+			AssetIssuer:      asset1.Issuer,
 		}
 		deepLink1, err := walletDeepLink1.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
@@ -790,7 +791,7 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 			SMSRegistrationMessageTemplate: "SMS Registration Message template test disbursement 4:",
 		})
 
-		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, stellarSecretKey, 3, mockCrashTrackerClient)
 		require.NoError(t, err)
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -819,22 +820,22 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		})
 
 		walletDeepLink1 := WalletDeepLink{
-			DeepLink:                 wallet1.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset1.Code,
-			AssetIssuer:              asset1.Issuer,
+			DeepLink:         wallet1.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset1.Code,
+			AssetIssuer:      asset1.Issuer,
 		}
 		deepLink1, err := walletDeepLink1.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
 		contentDisbursement3 := fmt.Sprintf("%s %s", disbursement3.SMSRegistrationMessageTemplate, deepLink1)
 
 		walletDeepLink2 := WalletDeepLink{
-			DeepLink:                 wallet2.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset2.Code,
-			AssetIssuer:              asset2.Issuer,
+			DeepLink:         wallet2.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset2.Code,
+			AssetIssuer:      asset2.Issuer,
 		}
 		deepLink2, err := walletDeepLink2.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
@@ -929,7 +930,7 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 			SMSRegistrationMessageTemplate: "SMS Registration Message template test disbursement:",
 		})
 
-		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, anchorPlatformBaseSepURL, stellarSecretKey, 3, mockCrashTrackerClient)
+		s, err := NewSendReceiverWalletInviteService(models, messengerClientMock, stellarSecretKey, 3, mockCrashTrackerClient)
 		require.NoError(t, err)
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -959,11 +960,11 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		require.NoError(t, err)
 
 		walletDeepLink1 := WalletDeepLink{
-			DeepLink:                 wallet1.DeepLinkSchema,
-			AnchorPlatformBaseSepURL: anchorPlatformBaseSepURL,
-			OrganizationName:         "MyCustomAid",
-			AssetCode:                asset1.Code,
-			AssetIssuer:              asset1.Issuer,
+			DeepLink:         wallet1.DeepLinkSchema,
+			TenantBaseURL:    tenantBaseURL,
+			OrganizationName: "MyCustomAid",
+			AssetCode:        asset1.Code,
+			AssetIssuer:      asset1.Issuer,
 		}
 		deepLink1, err := walletDeepLink1.GetSignedRegistrationLink(stellarSecretKey)
 		require.NoError(t, err)
@@ -1412,7 +1413,7 @@ func Test_WalletDeepLink_TomlFileDomain(t *testing.T) {
 		{
 			link:       "",
 			wantResult: "",
-			wantErr:    fmt.Errorf("AnchorPlatformBaseSepURL can't be empty"),
+			wantErr:    fmt.Errorf("base URL for tenant can't be empty"),
 		},
 		{
 			link:       "test.com",
@@ -1429,7 +1430,7 @@ func Test_WalletDeepLink_TomlFileDomain(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.link, func(t *testing.T) {
 			wdl := WalletDeepLink{
-				AnchorPlatformBaseSepURL: tc.link,
+				TenantBaseURL: tc.link,
 			}
 
 			result, err := wdl.TomlFileDomain()
@@ -1453,16 +1454,16 @@ func Test_WalletDeepLink_validate(t *testing.T) {
 	// toml file domain can't be empty
 	wdl.DeepLink = "wallet://sdp"
 	err = wdl.validate()
-	require.EqualError(t, err, "toml file domain can't be empty")
+	require.EqualError(t, err, "tenant base URL can't be empty")
 
 	// toml file domain can't be empty (different setup)
 	wdl.DeepLink = "wallet://"
 	wdl.Route = "sdp"
 	err = wdl.validate()
-	require.EqualError(t, err, "toml file domain can't be empty")
+	require.EqualError(t, err, "tenant base URL can't be empty")
 
 	// organization name can't be empty
-	wdl.AnchorPlatformBaseSepURL = "foo.bar"
+	wdl.TenantBaseURL = "foo.bar"
 	err = wdl.validate()
 	require.EqualError(t, err, "organization name can't be empty")
 
@@ -1507,33 +1508,33 @@ func Test_WalletDeepLink_GetUnsignedRegistrationLink(t *testing.T) {
 		{
 			name: "🎉 successful for non-native assets",
 			walletDeepLink: WalletDeepLink{
-				DeepLink:                 "wallet://",
-				Route:                    "sdp", // route added separated from the deep link
-				AnchorPlatformBaseSepURL: "foo.bar",
-				OrganizationName:         "Foo Bar Org",
-				AssetCode:                "FOO",
-				AssetIssuer:              "GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX",
+				DeepLink:         "wallet://",
+				Route:            "sdp", // route added separated from the deep link
+				TenantBaseURL:    "foo.bar",
+				OrganizationName: "Foo Bar Org",
+				AssetCode:        "FOO",
+				AssetIssuer:      "GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX",
 			},
 			wantResult: "wallet://sdp?asset=FOO-GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX&domain=foo.bar&name=Foo+Bar+Org",
 		},
 		{
 			name: "🎉 successful for native (XLM) assets",
 			walletDeepLink: WalletDeepLink{
-				DeepLink:                 "wallet://sdp", // route added directly to the deep link
-				AnchorPlatformBaseSepURL: "foo.bar",
-				OrganizationName:         "Foo Bar Org",
-				AssetCode:                "XLM",
+				DeepLink:         "wallet://sdp", // route added directly to the deep link
+				TenantBaseURL:    "foo.bar",
+				OrganizationName: "Foo Bar Org",
+				AssetCode:        "XLM",
 			},
 			wantResult: "wallet://sdp?asset=native&domain=foo.bar&name=Foo+Bar+Org",
 		},
 		{
 			name: "🎉 successful for deeplink with query params",
 			walletDeepLink: WalletDeepLink{
-				DeepLink:                 "wallet://sdp?custom=true",
-				AnchorPlatformBaseSepURL: "foo.bar",
-				OrganizationName:         "Foo Bar Org",
-				AssetCode:                "FOO",
-				AssetIssuer:              "GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX",
+				DeepLink:         "wallet://sdp?custom=true",
+				TenantBaseURL:    "foo.bar",
+				OrganizationName: "Foo Bar Org",
+				AssetCode:        "FOO",
+				AssetIssuer:      "GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX",
 			},
 			wantResult: "wallet://sdp?asset=FOO-GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX&custom=true&domain=foo.bar&name=Foo+Bar+Org",
 		},
@@ -1566,12 +1567,12 @@ func Test_WalletDeepLink_GetSignedRegistrationLink(t *testing.T) {
 
 	t.Run("fails if the private key is invalid", func(t *testing.T) {
 		wdl := WalletDeepLink{
-			DeepLink:                 "wallet://",
-			Route:                    "sdp",
-			AnchorPlatformBaseSepURL: "foo.bar",
-			OrganizationName:         "Foo Bar Org",
-			AssetCode:                "FOO",
-			AssetIssuer:              "GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX",
+			DeepLink:         "wallet://",
+			Route:            "sdp",
+			TenantBaseURL:    "foo.bar",
+			OrganizationName: "Foo Bar Org",
+			AssetCode:        "FOO",
+			AssetIssuer:      "GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX",
 		}
 
 		actual, err := wdl.GetSignedRegistrationLink("invalid-secret-key")
@@ -1581,11 +1582,11 @@ func Test_WalletDeepLink_GetSignedRegistrationLink(t *testing.T) {
 
 	t.Run("Successful for non-native assets 🎉", func(t *testing.T) {
 		wdl := WalletDeepLink{
-			DeepLink:                 "wallet://sdp",
-			AnchorPlatformBaseSepURL: "foo.bar",
-			OrganizationName:         "Foo Bar Org",
-			AssetCode:                "FOO",
-			AssetIssuer:              "GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX",
+			DeepLink:         "wallet://sdp",
+			TenantBaseURL:    "foo.bar",
+			OrganizationName: "Foo Bar Org",
+			AssetCode:        "FOO",
+			AssetIssuer:      "GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX",
 		}
 
 		expected := "wallet://sdp?asset=FOO-GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX&domain=foo.bar&name=Foo+Bar+Org&signature=361b0c0e6094dc35e0baa8ccae99bac1bdddc099e8bf6f68f4045e15b99c96d1a39c5343bb010a0b34f29a3490d233d43e3e2f5e537cf52d85f62deb75b2150d"
@@ -1600,11 +1601,11 @@ func Test_WalletDeepLink_GetSignedRegistrationLink(t *testing.T) {
 
 	t.Run("Successful for native (XLM) assets 🎉", func(t *testing.T) {
 		wdl := WalletDeepLink{
-			DeepLink:                 "wallet://",
-			Route:                    "sdp",
-			AnchorPlatformBaseSepURL: "foo.bar",
-			OrganizationName:         "Foo Bar Org",
-			AssetCode:                "XLM",
+			DeepLink:         "wallet://",
+			Route:            "sdp",
+			TenantBaseURL:    "foo.bar",
+			OrganizationName: "Foo Bar Org",
+			AssetCode:        "XLM",
 		}
 
 		expected := "wallet://sdp?asset=native&domain=foo.bar&name=Foo+Bar+Org&signature=972a3012e18f107e0bf951f5acc757df953c3bbbe668a2d2652bf2445a759132f6af303df063f69d1a862b7ab419813554b201837795648f6175c9d9d72cf60f"
@@ -1617,12 +1618,12 @@ func Test_WalletDeepLink_GetSignedRegistrationLink(t *testing.T) {
 		require.True(t, isValid)
 	})
 
-	t.Run("Successful for native (XLM) assets and AnchorPlatformBaseSepURL with https:// schema 🎉", func(t *testing.T) {
+	t.Run("Successful for native (XLM) assets and TenantBaseURL with https:// schema 🎉", func(t *testing.T) {
 		wdl := WalletDeepLink{
-			DeepLink:                 "wallet://sdp",
-			AnchorPlatformBaseSepURL: "https://foo.bar",
-			OrganizationName:         "Foo Bar Org",
-			AssetCode:                "XLM",
+			DeepLink:         "wallet://sdp",
+			TenantBaseURL:    "https://foo.bar",
+			OrganizationName: "Foo Bar Org",
+			AssetCode:        "XLM",
 		}
 
 		expected := "wallet://sdp?asset=native&domain=foo.bar&name=Foo+Bar+Org&signature=972a3012e18f107e0bf951f5acc757df953c3bbbe668a2d2652bf2445a759132f6af303df063f69d1a862b7ab419813554b201837795648f6175c9d9d72cf60f"


### PR DESCRIPTION
### What
* change invitation links for receiver to contain the multi-tenant domain for the tenant. 

**Before:**
`You have a payment waiting for you from the bluecorp. 
Click https://demo-wallet.stellar.org?asset=USDC-GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&domain=localhost&name=bluecorp&signature=ad1a6a70a80068d046e0e30937ed043a23dafea30e616cbc949a52586578a1a499933f5662f85fc636cc104cffd3281ce63022cbe4e84971207f3a521f11ae07 to register.`

**After:**
`Content: You have a payment waiting for you from the bluecorp. 
Click https://demo-wallet.stellar.org?asset=USDC-GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&domain=bluecorp.stellar.local&name=bluecorp&signature=fb1b5cdd446820d3aa02823c993d9fc1e05cd86a0764dc93bb9b37a8e701b4c8ff6eda368699ab5faeabdb07f012937e33210bfecc631e89457a9c34beb09a0c to register.`

### Why
https://stellarorg.atlassian.net/browse/SDP-1119

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
