### PR TITLE
[SDP-1060] Fix TSS Configmap labels

### DIFF
--- a/helmchart/sdp/templates/01.3-configmap-tss.yaml
+++ b/helmchart/sdp/templates/01.3-configmap-tss.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "sdp.fullname" . }}-tss
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "sdp.labels" . | nindent 4 }}
+    {{- include "sdp.labelsWithSuffix" (list . "-tss") | nindent 4 }}
 
   {{- if .Values.tss.configMap.annotations }}
   annotations:


### PR DESCRIPTION
### What
TSS configmap also had the wrong labels. 

