### PR TITLE
[SDP-1149] Fix bug when patching XLM with the Anchor Platform

### DIFF
--- a/internal/anchorplatform/object_schemas.go
+++ b/internal/anchorplatform/object_schemas.go
@@ -162,6 +162,8 @@ func NewStellarAssetInAIF(assetCode, assetIssuer string) string {
 	assetIssuer = strings.TrimSpace(assetIssuer)
 	if assetIssuer != "" {
 		assetIssuer = ":" + assetIssuer
+	} else if assetCode == "XLM" {
+		return "stellar:native"
 	}
 	return fmt.Sprintf("stellar:%s%s", strings.TrimSpace(assetCode), assetIssuer)
 }

--- a/internal/anchorplatform/object_schemas_test.go
+++ b/internal/anchorplatform/object_schemas_test.go
@@ -3,19 +3,52 @@ package anchorplatform
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_NewStellarAssetInAIF(t *testing.T) {
-	// USDC
-	assetCode := "USDC"
-	assetIssuer := "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
-	asset := NewStellarAssetInAIF(assetCode, assetIssuer)
-	require.Equal(t, "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", asset)
+	testCases := []struct {
+		name        string
+		assetCode   string
+		assetIssuer string
+		expected    string
+	}{
+		{
+			name:        "issued 'USDC'",
+			assetCode:   "USDC",
+			assetIssuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+			expected:    "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+		},
+		{
+			name:        "issued 'XLM'",
+			assetCode:   "XLM",
+			assetIssuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+			expected:    "stellar:XLM:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+		},
+		{
+			name:        "issued 'native'",
+			assetCode:   "native",
+			assetIssuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+			expected:    "stellar:native:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+		},
+		{
+			name:        "native asset represented as 'native'",
+			assetCode:   "native",
+			assetIssuer: "",
+			expected:    "stellar:native",
+		},
+		{
+			name:        "native asset represented as 'XLM'",
+			assetCode:   "XLM",
+			assetIssuer: "",
+			expected:    "stellar:native",
+		},
+	}
 
-	// XLM
-	assetCode = "XLM"
-	assetIssuer = ""
-	asset = NewStellarAssetInAIF(assetCode, assetIssuer)
-	require.Equal(t, "stellar:XLM", asset)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			aifAsset := NewStellarAssetInAIF(tc.assetCode, tc.assetIssuer)
+			assert.Equal(t, tc.expected, aifAsset)
+		})
+	}
 }

--- a/internal/anchorplatform/platform_api_service.go
+++ b/internal/anchorplatform/platform_api_service.go
@@ -113,28 +113,28 @@ func (a *AnchorPlatformAPIService) updateAnchorTransactions(ctx context.Context,
 
 	recordsJSON, err := json.Marshal(records)
 	if err != nil {
-		return fmt.Errorf("error marshaling records: %w", err)
+		return fmt.Errorf("marshaling records: %w", err)
 	}
 
 	u, err := url.JoinPath(a.AnchorPlatformBasePlatformURL, "transactions")
 	if err != nil {
-		return fmt.Errorf("error creating url: %w", err)
+		return fmt.Errorf("creating url: %w", err)
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodPatch, u, strings.NewReader(string(recordsJSON)))
 	if err != nil {
-		return fmt.Errorf("error creating new request: %w", err)
+		return fmt.Errorf("creating new request: %w", err)
 	}
 	request.Header.Set("Content-Type", "application/json")
 
 	token, err := a.GetJWTToken(apTxPatch...)
 	if err != nil {
-		return fmt.Errorf("getting jwt token in updateAnchorTransactions: %w", err)
+		return fmt.Errorf("getting a jwt token: %w", err)
 	}
 	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
 	response, err := a.HttpClient.Do(request)
 	if err != nil {
-		return fmt.Errorf("error making request to anchor platform: %w", err)
+		return fmt.Errorf("making request to anchor platform: %w", err)
 	}
 
 	body, err := io.ReadAll(response.Body)
@@ -144,7 +144,7 @@ func (a *AnchorPlatformAPIService) updateAnchorTransactions(ctx context.Context,
 	defer response.Body.Close()
 
 	if response.StatusCode/100 != 2 {
-		return fmt.Errorf("error updating transaction on anchor platform, response.StatusCode=%d, response.body=%v", response.StatusCode, string(body))
+		return fmt.Errorf("updating transaction on anchor platform, response.StatusCode=%d, response.body=%v", response.StatusCode, string(body))
 	}
 
 	return nil

--- a/internal/anchorplatform/platform_api_service_test.go
+++ b/internal/anchorplatform/platform_api_service_test.go
@@ -112,9 +112,9 @@ func Test_updateAnchorTransactions(t *testing.T) {
 	}
 
 	t.Run("error calling httpClient.Do", func(t *testing.T) {
-		httpClientMock.On("Do", mock.MatchedBy(mockMatchedByFn)).Return(nil, fmt.Errorf("error calling the request")).Once()
+		httpClientMock.On("Do", mock.MatchedBy(mockMatchedByFn)).Return(nil, fmt.Errorf("calling the request")).Once()
 		err := anchorPlatformAPIService.updateAnchorTransactions(ctx, apTxPatch)
-		require.EqualError(t, err, "error making request to anchor platform: error calling the request")
+		require.EqualError(t, err, "making request to anchor platform: calling the request")
 
 		httpClientMock.AssertExpectations(t)
 	})
@@ -128,7 +128,7 @@ func Test_updateAnchorTransactions(t *testing.T) {
 		httpClientMock.On("Do", mock.MatchedBy(mockMatchedByFn)).Return(response, nil).Once()
 
 		err := anchorPlatformAPIService.updateAnchorTransactions(ctx, apTxPatch)
-		wantErr := fmt.Errorf("error updating transaction on anchor platform, response.StatusCode=%d, response.body=%v", http.StatusBadRequest, transactionResponse)
+		wantErr := fmt.Errorf("updating transaction on anchor platform, response.StatusCode=%d, response.body=%v", http.StatusBadRequest, transactionResponse)
 		require.Equal(t, wantErr, err)
 
 		httpClientMock.AssertExpectations(t)

--- a/internal/data/assets_test.go
+++ b/internal/data/assets_test.go
@@ -246,7 +246,7 @@ func Test_AssetModelGetByWalletID(t *testing.T) {
 	})
 }
 
-func Test_AssetModel_Ensure(t *testing.T) {
+func Test_AssetModel_Insert(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 

--- a/internal/events/eventhandlers/patch_anchor_platform_transaction_completion_event_handler.go
+++ b/internal/events/eventhandlers/patch_anchor_platform_transaction_completion_event_handler.go
@@ -76,7 +76,7 @@ func (h *PatchAnchorPlatformTransactionCompletionEventHandler) Handle(ctx contex
 	ctx = tenant.SaveTenantInContext(ctx, tnt)
 
 	if err := h.service.PatchAPTransactionForPaymentEvent(ctx, payment); err != nil {
-		h.crashTrackerClient.LogAndReportErrors(ctx, err, fmt.Sprintf("[%s] patching anchor platform transaction", h.Name()))
+		h.crashTrackerClient.LogAndReportErrors(ctx, err, fmt.Sprintf("[%s] patching anchor platform transaction for payment event", h.Name()))
 		return
 	}
 }

--- a/internal/events/eventhandlers/patch_anchor_platform_transaction_completion_event_handler_test.go
+++ b/internal/events/eventhandlers/patch_anchor_platform_transaction_completion_event_handler_test.go
@@ -83,7 +83,7 @@ func Test_PatchAnchorPlatformTransactionCompletionEventHandler(t *testing.T) {
 			Once()
 
 		crashTrackerClient.
-			On("LogAndReportErrors", mock.Anything, errors.New("unexpected error"), "[PatchAnchorPlatformTransactionCompletionEventHandler] patching anchor platform transaction").
+			On("LogAndReportErrors", mock.Anything, errors.New("unexpected error"), "[PatchAnchorPlatformTransactionCompletionEventHandler] patching anchor platform transaction for payment event").
 			Return().
 			Once()
 

--- a/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
+++ b/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
@@ -193,8 +193,8 @@ func Test_PatchAnchorPlatformTransactionsCompletionJob_Execute(t *testing.T) {
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 1 payments to process", entries[0].Message)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] got 1 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
 	})
 
 	apAPISvcMock.AssertExpectations(t)

--- a/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
+++ b/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
@@ -8,17 +8,17 @@ import (
 	"testing"
 	"time"
 
-	servicesMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/lib/pq"
 	"github.com/stellar/go/support/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/anchorplatform"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	servicesMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 )
 
 func Test_NewPatchAnchorPlatformTransactionCompletionJob(t *testing.T) {
@@ -193,8 +193,8 @@ func Test_PatchAnchorPlatformTransactionsCompletionJob_Execute(t *testing.T) {
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: got 1 payments to process", entries[0].Message)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 1 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
 	})
 
 	apAPISvcMock.AssertExpectations(t)

--- a/internal/serve/httphandler/assets_handler.go
+++ b/internal/serve/httphandler/assets_handler.go
@@ -75,7 +75,6 @@ func (c AssetsHandler) CreateAsset(w http.ResponseWriter, r *http.Request) {
 	v.Check(assetCode != "", "code", "code is required")
 	if assetCode != stellarNativeAssetCode {
 		v.Check(strkey.IsValidEd25519PublicKey(assetIssuer), "issuer", "issuer is invalid")
-		v.Check(assetIssuer != "", "issuer", "issuer is required")
 	}
 
 	if v.HasErrors() {

--- a/internal/serve/httphandler/assets_handler.go
+++ b/internal/serve/httphandler/assets_handler.go
@@ -2,7 +2,6 @@ package httphandler
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -69,12 +68,14 @@ func (c AssetsHandler) CreateAsset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	assetCode := strings.TrimSpace(strings.ToUpper(assetRequest.Code))
+	assetIssuer := strings.TrimSpace(assetRequest.Issuer)
+
 	v := validators.NewValidator()
-	v.Check(assetRequest.Code != "", "code", "code is required")
-	if strings.ToUpper(assetRequest.Code) != stellarNativeAssetCode {
-		v.Check(assetRequest.Issuer != "", "issuer", "issuer is required")
-		assetRequest.Issuer = strings.TrimSpace(assetRequest.Issuer)
-		v.Check(strkey.IsValidEd25519PublicKey(assetRequest.Issuer), "issuer", "issuer is invalid")
+	v.Check(assetCode != "", "code", "code is required")
+	if assetCode != stellarNativeAssetCode {
+		v.Check(strkey.IsValidEd25519PublicKey(assetIssuer), "issuer", "issuer is invalid")
+		v.Check(assetIssuer != "", "issuer", "issuer is required")
 	}
 
 	if v.HasErrors() {
@@ -85,27 +86,21 @@ func (c AssetsHandler) CreateAsset(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	asset, err := db.RunInTransactionWithResult(ctx, c.Models.DBConnectionPool, nil, func(dbTx db.DBTransaction) (*data.Asset, error) {
-		insertedAsset, insertErr := c.Models.Assets.Insert(
-			ctx,
-			dbTx,
-			assetRequest.Code,
-			assetRequest.Issuer,
-		)
+		insertedAsset, insertErr := c.Models.Assets.Insert(ctx, dbTx, assetCode, assetIssuer)
 		if insertErr != nil {
-			return nil, fmt.Errorf("error inserting new asset: %w", insertErr)
+			return nil, fmt.Errorf("inserting new asset: %w", insertErr)
 		}
 
-		trustlineErr := c.handleUpdateAssetTrustlineForDistributionAccount(ctx, &txnbuild.CreditAsset{
-			Code:   assetRequest.Code,
-			Issuer: assetRequest.Issuer,
-		}, nil)
+		assetToAdd := &txnbuild.CreditAsset{Code: assetCode, Issuer: assetIssuer}
+		trustlineErr := c.handleUpdateAssetTrustlineForDistributionAccount(ctx, assetToAdd, nil)
 		if trustlineErr != nil {
-			return nil, fmt.Errorf("error adding trustline for the distribution account: %w", trustlineErr)
+			return nil, fmt.Errorf("adding trustline for the distribution account: %w", trustlineErr)
 		}
 
 		return insertedAsset, nil
 	})
 	if err != nil {
+		err = fmt.Errorf("creating asset in AssetHandler: %w", err)
 		httperror.InternalError(ctx, "Cannot create new asset", err, nil).Render(w)
 		return
 	}

--- a/internal/serve/httphandler/assets_handler.go
+++ b/internal/serve/httphandler/assets_handler.go
@@ -106,11 +106,6 @@ func (c AssetsHandler) CreateAsset(w http.ResponseWriter, r *http.Request) {
 		return insertedAsset, nil
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			httperror.Conflict("asset already exists", err, nil).Render(w)
-			return
-		}
-
 		httperror.InternalError(ctx, "Cannot create new asset", err, nil).Render(w)
 		return
 	}

--- a/internal/services/patch_anchor_platform_transactions_completion.go
+++ b/internal/services/patch_anchor_platform_transactions_completion.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/stellar/go/support/log"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/anchorplatform"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
@@ -77,10 +78,6 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchAPTransactionsFor
 		payments, err := s.sdpModels.Payment.GetAllReadyToPatchCompletionAnchorTransactions(ctx, dbTx)
 		if err != nil {
 			return fmt.Errorf("getting payments: %w", err)
-		}
-
-		if err != nil {
-			return fmt.Errorf("getting payments from database transaction: %w", err)
 		}
 
 		log.Ctx(ctx).Debugf("PatchAnchorPlatformTransactionService: got %d payments to process", len(payments))

--- a/internal/services/patch_anchor_platform_transactions_completion.go
+++ b/internal/services/patch_anchor_platform_transactions_completion.go
@@ -80,7 +80,7 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchAPTransactionsFor
 			return fmt.Errorf("getting payments: %w", err)
 		}
 
-		log.Ctx(ctx).Debugf("PatchAnchorPlatformTransactionService: got %d payments to process", len(payments))
+		log.Ctx(ctx).Debugf("[PatchAnchorPlatformTransactionService] got %d payments to process", len(payments))
 
 		// successfulPaymentsForAPTransactionID has its keys as the AP Transaction ID. Here we store the transaction IDs
 		// from the transactions patched to the AP with the "Completed" anchor status. So we avoid concurrency errors like, a receiver having
@@ -94,7 +94,7 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchAPTransactionsFor
 			// Step 3: Check if the AP transaction was already patched as completed. If it's true we don't need to report it anymore.
 			if _, ok := successfulPaymentsForAPTransactionID[payment.ReceiverWallet.AnchorPlatformTransactionID]; ok {
 				log.Ctx(ctx).Debugf(
-					"PatchAnchorPlatformTransactionService: anchor platform transaction ID %q already patched as completed. No action needed",
+					"[PatchAnchorPlatformTransactionService] anchor platform transaction ID %q already patched as completed. No action needed",
 					payment.ReceiverWallet.AnchorPlatformTransactionID,
 				)
 				continue
@@ -107,7 +107,7 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchAPTransactionsFor
 			}
 			patchErr := s.patchAnchorPaymentTransaction(ctx, payment, statusMessage)
 			if patchErr != nil {
-				log.Ctx(ctx).Errorf("PatchAnchorPlatformTransactionService: error patching anchor transaction: %v", patchErr)
+				log.Ctx(ctx).Errorf("[PatchAnchorPlatformTransactionService] patching anchor transaction: %v", patchErr)
 				continue
 			}
 			if payment.Status == data.SuccessPaymentStatus {
@@ -118,7 +118,7 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchAPTransactionsFor
 			receiverWalletIDs = append(receiverWalletIDs, payment.ReceiverWallet.ID)
 		}
 
-		log.Ctx(ctx).Debugf("PatchAnchorPlatformTransactionService: updating anchor platform transaction synced at for %d receiver wallet(s)", len(receiverWalletIDs))
+		log.Ctx(ctx).Debugf("[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for %d receiver wallet(s)", len(receiverWalletIDs))
 
 		// Step 6: we update the receiver_wallets table saying that the AP transaction associated with the user registration
 		// was successfully patched/synced.
@@ -168,7 +168,7 @@ func (s *PatchAnchorPlatformTransactionCompletionService) patchAnchorPaymentTran
 			},
 		})
 		if err != nil {
-			err = fmt.Errorf("PatchAnchorPlatformTransactionService: error patching anchor transaction ID %q with status %q: %w", payment.ReceiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted, err)
+			err = fmt.Errorf("[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: %w", payment.ReceiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted, err)
 			log.Ctx(ctx).Error(err)
 			return err
 		}
@@ -185,12 +185,12 @@ func (s *PatchAnchorPlatformTransactionCompletionService) patchAnchorPaymentTran
 			Status:  anchorplatform.APTransactionStatusError,
 		})
 		if err != nil {
-			err = fmt.Errorf("PatchAnchorPlatformTransactionService: error patching anchor transaction ID %q with status %q: %w", payment.ReceiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusError, err)
+			err = fmt.Errorf("[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: %w", payment.ReceiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusError, err)
 			log.Ctx(ctx).Error(err)
 			return err
 		}
 	} else {
-		err := fmt.Errorf("PatchAnchorPlatformTransactionService: invalid payment status to patch to anchor platform. Payment ID: %s - Status: %s", payment.ID, payment.Status)
+		err := fmt.Errorf("[PatchAnchorPlatformTransactionService] invalid payment status to patch to anchor platform (paymentID=%s, status=%s)", payment.ID, payment.Status)
 		log.Ctx(ctx).Error(err)
 		return err
 	}

--- a/internal/services/patch_anchor_platform_transactions_completion.go
+++ b/internal/services/patch_anchor_platform_transactions_completion.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/anchorplatform"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
 const MaxErrorMessageLength = 255
@@ -77,10 +78,10 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchAPTransactionsFor
 		// Step 1: Get all Success and Failed payments from receivers for their respective wallets.
 		payments, err := s.sdpModels.Payment.GetAllReadyToPatchCompletionAnchorTransactions(ctx, dbTx)
 		if err != nil {
-			return fmt.Errorf("getting payments: %w", err)
+			return fmt.Errorf("[%s] getting payments ready to patch completion: %w", utils.GetTypeName(s), err)
 		}
 
-		log.Ctx(ctx).Debugf("[PatchAnchorPlatformTransactionService] got %d payments to process", len(payments))
+		log.Ctx(ctx).Debugf("[%s] got %d payments to process", utils.GetTypeName(s), len(payments))
 
 		// successfulPaymentsForAPTransactionID has its keys as the AP Transaction ID. Here we store the transaction IDs
 		// from the transactions patched to the AP with the "Completed" anchor status. So we avoid concurrency errors like, a receiver having
@@ -94,7 +95,8 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchAPTransactionsFor
 			// Step 3: Check if the AP transaction was already patched as completed. If it's true we don't need to report it anymore.
 			if _, ok := successfulPaymentsForAPTransactionID[payment.ReceiverWallet.AnchorPlatformTransactionID]; ok {
 				log.Ctx(ctx).Debugf(
-					"[PatchAnchorPlatformTransactionService] anchor platform transaction ID %q already patched as completed. No action needed",
+					"[%s] anchor platform transaction ID %q already patched as completed. No action needed",
+					utils.GetTypeName(s),
 					payment.ReceiverWallet.AnchorPlatformTransactionID,
 				)
 				continue
@@ -107,7 +109,7 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchAPTransactionsFor
 			}
 			patchErr := s.patchAnchorPaymentTransaction(ctx, payment, statusMessage)
 			if patchErr != nil {
-				log.Ctx(ctx).Errorf("[PatchAnchorPlatformTransactionService] patching anchor transaction: %v", patchErr)
+				log.Ctx(ctx).Errorf("[%s] patching anchor transaction: %v", utils.GetTypeName(s), patchErr)
 				continue
 			}
 			if payment.Status == data.SuccessPaymentStatus {
@@ -118,13 +120,13 @@ func (s *PatchAnchorPlatformTransactionCompletionService) PatchAPTransactionsFor
 			receiverWalletIDs = append(receiverWalletIDs, payment.ReceiverWallet.ID)
 		}
 
-		log.Ctx(ctx).Debugf("[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for %d receiver wallet(s)", len(receiverWalletIDs))
+		log.Ctx(ctx).Debugf("[%s] updating anchor platform transaction synced at for %d receiver wallet(s)", utils.GetTypeName(s), len(receiverWalletIDs))
 
 		// Step 6: we update the receiver_wallets table saying that the AP transaction associated with the user registration
 		// was successfully patched/synced.
 		_, err = s.sdpModels.ReceiverWallet.UpdateAnchorPlatformTransactionSyncedAt(ctx, dbTx, receiverWalletIDs...)
 		if err != nil {
-			return fmt.Errorf("updating receiver wallet anchor platform transaction synced at: %w", err)
+			return fmt.Errorf("[%s] updating receiver wallet anchor platform transaction synced at: %w", utils.GetTypeName(s), err)
 		}
 
 		return nil
@@ -168,7 +170,7 @@ func (s *PatchAnchorPlatformTransactionCompletionService) patchAnchorPaymentTran
 			},
 		})
 		if err != nil {
-			err = fmt.Errorf("[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: %w", payment.ReceiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted, err)
+			err = fmt.Errorf("[%s] patching anchor transaction ID %q with status %q: %w", utils.GetTypeName(s), payment.ReceiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted, err)
 			log.Ctx(ctx).Error(err)
 			return err
 		}
@@ -185,12 +187,12 @@ func (s *PatchAnchorPlatformTransactionCompletionService) patchAnchorPaymentTran
 			Status:  anchorplatform.APTransactionStatusError,
 		})
 		if err != nil {
-			err = fmt.Errorf("[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: %w", payment.ReceiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusError, err)
+			err = fmt.Errorf("[%s] patching anchor transaction ID %q with status %q: %w", utils.GetTypeName(s), payment.ReceiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusError, err)
 			log.Ctx(ctx).Error(err)
 			return err
 		}
 	} else {
-		err := fmt.Errorf("[PatchAnchorPlatformTransactionService] invalid payment status to patch to anchor platform (paymentID=%s, status=%s)", payment.ID, payment.Status)
+		err := fmt.Errorf("[%s] invalid payment status to patch to anchor platform (paymentID=%s, status=%s)", utils.GetTypeName(s), payment.ID, payment.Status)
 		log.Ctx(ctx).Error(err)
 		return err
 	}

--- a/internal/services/patch_anchor_platform_transactions_completion_test.go
+++ b/internal/services/patch_anchor_platform_transactions_completion_test.go
@@ -97,7 +97,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			PaymentStatusMessage: "",
 			StellarTransactionID: "tx-hash",
 		})
-		assert.ErrorContains(t, sErr, fmt.Sprintf("[PatchAnchorPlatformTransactionService] invalid payment status to patch to anchor platform (paymentID=%s, status=PENDING)", payment.ID))
+		assert.ErrorContains(t, sErr, fmt.Sprintf("[PatchAnchorPlatformTransactionCompletionService] invalid payment status to patch to anchor platform (paymentID=%s, status=PENDING)", payment.ID))
 	})
 
 	t.Run("doesn't mark as synced when fails patching anchor platform transaction when payment is success", func(t *testing.T) {
@@ -161,14 +161,14 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			Once()
 
 		sErr := svc.PatchAPTransactionForPaymentEvent(ctx, tx)
-		assert.ErrorContains(t, sErr, fmt.Sprintf(`[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted))
+		assert.ErrorContains(t, sErr, fmt.Sprintf(`[PatchAnchorPlatformTransactionCompletionService] patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted))
 
 		syncedAt := getAPTransactionSyncedAt(t, ctx, dbConnectionPool, receiverWallet.ID)
 		assert.True(t, syncedAt.IsZero())
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, fmt.Sprintf(`[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted), entries[0].Message)
+		assert.Equal(t, fmt.Sprintf(`[PatchAnchorPlatformTransactionCompletionService] patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted), entries[0].Message)
 	})
 
 	t.Run("mark as synced when patch anchor platform transaction successfully and payment is failed", func(t *testing.T) {
@@ -435,8 +435,8 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 0 payments to process", entries[0].Message)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 0 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] got 0 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] updating anchor platform transaction synced at for 0 receiver wallet(s)", entries[1].Message)
 	})
 
 	t.Run("doesn't mark as synced when fails patching anchor platform transaction when payment is success", func(t *testing.T) {
@@ -498,9 +498,9 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 4)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 1 payments to process", entries[0].Message)
-		assert.Equal(t, fmt.Sprintf(`[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted), entries[1].Message)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 0 receiver wallet(s)", entries[3].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] got 1 payments to process", entries[0].Message)
+		assert.Equal(t, fmt.Sprintf(`[PatchAnchorPlatformTransactionCompletionService] patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted), entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] updating anchor platform transaction synced at for 0 receiver wallet(s)", entries[3].Message)
 	})
 
 	t.Run("mark as synced when patch anchor platform transaction successfully and payment is failed", func(t *testing.T) {
@@ -559,8 +559,8 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 1 payments to process", entries[0].Message)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] got 1 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
 	})
 
 	t.Run("marks as synced when patch anchor platform transaction successfully and payment is success", func(t *testing.T) {
@@ -622,8 +622,8 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 1 payments to process", entries[0].Message)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] got 1 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
 	})
 
 	t.Run("doesn't patch the transaction when it's already patch as completed", func(t *testing.T) {
@@ -703,11 +703,11 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 3)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 2 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] got 2 payments to process", entries[0].Message)
 		assert.Equal(t,
-			fmt.Sprintf(`[PatchAnchorPlatformTransactionService] anchor platform transaction ID %q already patched as completed. No action needed`, receiverWallet.AnchorPlatformTransactionID),
+			fmt.Sprintf(`[PatchAnchorPlatformTransactionCompletionService] anchor platform transaction ID %q already patched as completed. No action needed`, receiverWallet.AnchorPlatformTransactionID),
 			entries[1].Message)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[2].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[2].Message)
 	})
 
 	t.Run("patches the transactions successfully if the other payments were failed", func(t *testing.T) {
@@ -837,8 +837,8 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 3 payments to process", entries[0].Message)
-		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 3 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] got 3 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionCompletionService] updating anchor platform transaction synced at for 3 receiver wallet(s)", entries[1].Message)
 	})
 
 	apAPISvcMock.AssertExpectations(t)

--- a/internal/services/patch_anchor_platform_transactions_completion_test.go
+++ b/internal/services/patch_anchor_platform_transactions_completion_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/stellar/go/support/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/anchorplatform"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_NewPatchAnchorPlatformTransactionCompletionService(t *testing.T) {
@@ -96,7 +97,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			PaymentStatusMessage: "",
 			StellarTransactionID: "tx-hash",
 		})
-		assert.ErrorContains(t, sErr, fmt.Sprintf("PatchAnchorPlatformTransactionService: invalid payment status to patch to anchor platform. Payment ID: %s - Status: PENDING", payment.ID))
+		assert.ErrorContains(t, sErr, fmt.Sprintf("[PatchAnchorPlatformTransactionService] invalid payment status to patch to anchor platform (paymentID=%s, status=PENDING)", payment.ID))
 	})
 
 	t.Run("doesn't mark as synced when fails patching anchor platform transaction when payment is success", func(t *testing.T) {
@@ -160,14 +161,14 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			Once()
 
 		sErr := svc.PatchAPTransactionForPaymentEvent(ctx, tx)
-		assert.ErrorContains(t, sErr, fmt.Sprintf(`PatchAnchorPlatformTransactionService: error patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted))
+		assert.ErrorContains(t, sErr, fmt.Sprintf(`[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted))
 
 		syncedAt := getAPTransactionSyncedAt(t, ctx, dbConnectionPool, receiverWallet.ID)
 		assert.True(t, syncedAt.IsZero())
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, fmt.Sprintf(`PatchAnchorPlatformTransactionService: error patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted), entries[0].Message)
+		assert.Equal(t, fmt.Sprintf(`[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted), entries[0].Message)
 	})
 
 	t.Run("mark as synced when patch anchor platform transaction successfully and payment is failed", func(t *testing.T) {
@@ -434,8 +435,8 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: got 0 payments to process", entries[0].Message)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: updating anchor platform transaction synced at for 0 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 0 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 0 receiver wallet(s)", entries[1].Message)
 	})
 
 	t.Run("doesn't mark as synced when fails patching anchor platform transaction when payment is success", func(t *testing.T) {
@@ -497,9 +498,9 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 4)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: got 1 payments to process", entries[0].Message)
-		assert.Equal(t, fmt.Sprintf(`PatchAnchorPlatformTransactionService: error patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted), entries[1].Message)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: updating anchor platform transaction synced at for 0 receiver wallet(s)", entries[3].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 1 payments to process", entries[0].Message)
+		assert.Equal(t, fmt.Sprintf(`[PatchAnchorPlatformTransactionService] patching anchor transaction ID %q with status %q: invalid token`, receiverWallet.AnchorPlatformTransactionID, anchorplatform.APTransactionStatusCompleted), entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 0 receiver wallet(s)", entries[3].Message)
 	})
 
 	t.Run("mark as synced when patch anchor platform transaction successfully and payment is failed", func(t *testing.T) {
@@ -558,8 +559,8 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: got 1 payments to process", entries[0].Message)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 1 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
 	})
 
 	t.Run("marks as synced when patch anchor platform transaction successfully and payment is success", func(t *testing.T) {
@@ -621,8 +622,8 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: got 1 payments to process", entries[0].Message)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 1 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[1].Message)
 	})
 
 	t.Run("doesn't patch the transaction when it's already patch as completed", func(t *testing.T) {
@@ -702,11 +703,11 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 3)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: got 2 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 2 payments to process", entries[0].Message)
 		assert.Equal(t,
-			fmt.Sprintf(`PatchAnchorPlatformTransactionService: anchor platform transaction ID %q already patched as completed. No action needed`, receiverWallet.AnchorPlatformTransactionID),
+			fmt.Sprintf(`[PatchAnchorPlatformTransactionService] anchor platform transaction ID %q already patched as completed. No action needed`, receiverWallet.AnchorPlatformTransactionID),
 			entries[1].Message)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[2].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 1 receiver wallet(s)", entries[2].Message)
 	})
 
 	t.Run("patches the transactions successfully if the other payments were failed", func(t *testing.T) {
@@ -836,8 +837,8 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 
 		entries := getEntries()
 		require.Len(t, entries, 2)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: got 3 payments to process", entries[0].Message)
-		assert.Equal(t, "PatchAnchorPlatformTransactionService: updating anchor platform transaction synced at for 3 receiver wallet(s)", entries[1].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] got 3 payments to process", entries[0].Message)
+		assert.Equal(t, "[PatchAnchorPlatformTransactionService] updating anchor platform transaction synced at for 3 receiver wallet(s)", entries[1].Message)
 	})
 
 	apAPISvcMock.AssertExpectations(t)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -66,4 +67,19 @@ func ConvertType[S any, D any](src S) (D, error) {
 	}
 
 	return dst, nil
+}
+
+// GetTypeName receives any value and returns the name of its type without the package prefix.
+func GetTypeName(v interface{}) string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	fullTypeName := fmt.Sprintf("%T", v)
+
+	if dotIndex := strings.LastIndex(fullTypeName, "."); dotIndex != -1 {
+		return fullTypeName[dotIndex+1:]
+	}
+
+	return fullTypeName
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -174,3 +174,71 @@ func Test_ConvertType(t *testing.T) {
 		assert.Equal(t, wantDst, dst)
 	})
 }
+
+func Test_GetTypeName(t *testing.T) {
+	type MyType struct{}
+
+	testCases := []struct {
+		name           string
+		instance       interface{}
+		expectedResult string
+	}{
+		{
+			name:           "nil",
+			instance:       nil,
+			expectedResult: "<nil>",
+		},
+		{
+			name:           "Integer",
+			instance:       42,
+			expectedResult: "int",
+		},
+		{
+			name:           "Pointer to int",
+			instance:       new(int),
+			expectedResult: "*int",
+		},
+		{
+			name:           "String",
+			instance:       "test",
+			expectedResult: "string",
+		},
+		{
+			name:           "Pointer to string",
+			instance:       new(string),
+			expectedResult: "*string",
+		},
+		{
+			name:           "Empty struct",
+			instance:       struct{}{},
+			expectedResult: "struct {}",
+		},
+		{
+			name:           "Slice of strings",
+			instance:       []string{},
+			expectedResult: "[]string",
+		},
+		{
+			name:           "Map",
+			instance:       map[string]int{},
+			expectedResult: "map[string]int",
+		},
+		{
+			name:           "Custom type",
+			instance:       MyType{},
+			expectedResult: "MyType",
+		},
+		{
+			name:           "Pointer to custom type",
+			instance:       new(MyType),
+			expectedResult: "MyType",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualResult := GetTypeName(tc.instance)
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
+	}
+}


### PR DESCRIPTION
### What

Fix bug when patching XLM with the Anchor Platform by making sure the native asset is represented as `stellar:native`.

### Why

To address the error https://stellarorg.sentry.io/issues/5043465348/events/9639627a676f4b4e8a0a0043d5b0b5ab/?project=4505189092556800.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
