### PR TITLE
[SDP-1156] Remove `email_sender_type` and `sms_sender_type` from tenant config

### DIFF
--- a/db/migrations/admin-migrations/2024-04-16-alter-tenants-table-drop-sms-email-type.sql
+++ b/db/migrations/admin-migrations/2024-04-16-alter-tenants-table-drop-sms-email-type.sql
@@ -1,0 +1,16 @@
+-- +migrate Up
+ALTER TABLE public.tenants
+    DROP COLUMN email_sender_type,
+    DROP COLUMN sms_sender_type;
+
+DROP TYPE public.email_sender_type;
+DROP TYPE public.sms_sender_type;
+
+-- +migrate Down
+
+CREATE TYPE public.email_sender_type AS ENUM ('AWS_EMAIL', 'DRY_RUN');
+CREATE TYPE public.sms_sender_type AS ENUM ('TWILIO_SMS', 'AWS_SMS', 'DRY_RUN');
+
+ALTER TABLE public.tenants
+    ADD COLUMN email_sender_type email_sender_type DEFAULT 'DRY_RUN'::email_sender_type,
+    ADD COLUMN sms_sender_type sms_sender_type DEFAULT 'DRY_RUN'::sms_sender_type;

--- a/dev/main.sh
+++ b/dev/main.sh
@@ -66,8 +66,6 @@ for tenant in "${tenants[@]}"; do
         -d '{
                 "name": "'"$tenant"'",
                 "organization_name": "'"$tenant"'",
-                "email_sender_type": "DRY_RUN",
-                "sms_sender_type": "DRY_RUN",
                 "base_url": "'"$baseURL"'",
                 "sdp_ui_base_url": "'"$sdpUIBaseURL"'",
                 "owner_email": "'"$ownerEmail"'",

--- a/internal/integrationtests/admin_api.go
+++ b/internal/integrationtests/admin_api.go
@@ -31,8 +31,6 @@ type CreateTenantRequest struct {
 	OwnerFirstName      string `json:"owner_first_name"`
 	OwnerLastName       string `json:"owner_last_name"`
 	OrganizationName    string `json:"organization_name"`
-	EmailSenderType     string `json:"email_sender_type"`
-	SMSSenderType       string `json:"sms_sender_type"`
 	BaseURL             string `json:"base_url"`
 	SDPUIBaseURL        string `json:"sdp_ui_base_url"`
 	DistributionAccount string `json:"distribution_account"`

--- a/internal/integrationtests/integration_tests.go
+++ b/internal/integrationtests/integration_tests.go
@@ -313,8 +313,6 @@ func (it *IntegrationTestsService) CreateTestData(ctx context.Context, opts Inte
 		OwnerFirstName:   "John",
 		OwnerLastName:    "Doe",
 		OrganizationName: "Integration Tests Organization",
-		EmailSenderType:  "DRY_RUN",
-		SMSSenderType:    "DRY_RUN",
 		BaseURL:          "http://localhost:8000",
 		SDPUIBaseURL:     "http://localhost:3000",
 	})

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -88,10 +88,8 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	tnt, err = h.Manager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
-		ID:              tnt.ID,
-		EmailSenderType: &reqBody.EmailSenderType,
-		SMSSenderType:   &reqBody.SMSSenderType,
-		BaseURL:         &reqBody.BaseURL,
+		ID:      tnt.ID,
+		BaseURL: &reqBody.BaseURL,
 	})
 	if err != nil {
 		httperror.InternalError(ctx, "Could not update tenant config", err, nil).Render(rw)
@@ -122,12 +120,10 @@ func (t TenantsHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	tenantID := chi.URLParam(r, "id")
 
 	tnt, err := t.Manager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
-		ID:              tenantID,
-		EmailSenderType: reqBody.EmailSenderType,
-		SMSSenderType:   reqBody.SMSSenderType,
-		BaseURL:         reqBody.BaseURL,
-		SDPUIBaseURL:    reqBody.SDPUIBaseURL,
-		Status:          reqBody.Status,
+		ID:           tenantID,
+		BaseURL:      reqBody.BaseURL,
+		SDPUIBaseURL: reqBody.SDPUIBaseURL,
+		Status:       reqBody.Status,
 	})
 	if err != nil {
 		if errors.Is(tenant.ErrEmptyUpdateTenant, err) {

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -138,8 +138,6 @@ func Test_TenantHandler_Get(t *testing.T) {
 				{
 					"id": %q,
 					"name": %q,
-					"email_sender_type": "DRY_RUN",
-					"sms_sender_type": "DRY_RUN",
 					"base_url": null,
 					"sdp_ui_base_url": null,
 					"status": "TENANT_CREATED",
@@ -151,8 +149,6 @@ func Test_TenantHandler_Get(t *testing.T) {
 				{
 					"id": %q,
 					"name": %q,
-					"email_sender_type": "DRY_RUN",
-					"sms_sender_type": "DRY_RUN",
 					"base_url": null,
 					"sdp_ui_base_url": null,
 					"status": "TENANT_CREATED",
@@ -187,8 +183,6 @@ func Test_TenantHandler_Get(t *testing.T) {
 			{
 				"id": %q,
 				"name": %q,
-				"email_sender_type": "DRY_RUN",
-				"sms_sender_type": "DRY_RUN",
 				"base_url": null,
 				"sdp_ui_base_url": null,
 				"status": "TENANT_CREATED",
@@ -220,8 +214,6 @@ func Test_TenantHandler_Get(t *testing.T) {
 			{
 				"id": %q,
 				"name": %q,
-				"email_sender_type": "DRY_RUN",
-				"sms_sender_type": "DRY_RUN",
 				"base_url": null,
 				"sdp_ui_base_url": null,
 				"status": "TENANT_CREATED",
@@ -317,8 +309,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 					"owner_last_name": "owner_last_name is required",
 					"organization_name": "organization_name is required",
 					"base_url": "invalid base URL value",
-					"email_sender_type": "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
-					"sms_sender_type": "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
 					"sdp_ui_base_url": "invalid SDP UI base URL value"
 				}
 			}
@@ -357,8 +347,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org",
-				"email_sender_type": "DRY_RUN",
-				"sms_sender_type": "DRY_RUN",
 				"base_url": "https://backend.sdp.org",
 				"sdp_ui_base_url": "https://aid-org.sdp.org",
 				"is_default": false
@@ -384,8 +372,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 			{
 				"id": %q,
 				"name": "aid-org",
-				"email_sender_type": "DRY_RUN",
-				"sms_sender_type": "DRY_RUN",
 				"base_url": "https://backend.sdp.org",
 				"sdp_ui_base_url": "https://aid-org.sdp.org",
 				"status": "TENANT_PROVISIONED",
@@ -463,8 +449,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org",
-				"email_sender_type": "DRY_RUN",
-				"sms_sender_type": "DRY_RUN",
 				"base_url": "https://backend.sdp.org",
 				"sdp_ui_base_url": "https://aid-org.sdp.org"
 			}
@@ -543,7 +527,7 @@ func Test_TenantHandler_Patch(t *testing.T) {
 
 	t.Run("returns NotFound when tenant does not exist", func(t *testing.T) {
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPatch, "/tenants/unknown", strings.NewReader(`{"email_sender_type": "AWS_EMAIL"}`))
+		req, err := http.NewRequest(http.MethodPatch, "/tenants/unknown", strings.NewReader(`{"base_url": "http://localhost"}`))
 		require.NoError(t, err)
 		r.ServeHTTP(rr, req)
 
@@ -558,14 +542,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 		assert.JSONEq(t, expectedRespBody, string(respBody))
 	})
 
-	t.Run("returns BadRequest when EmailSenderType is not valid", func(t *testing.T) {
-		runBadRequestPatchTest(t, r, url, "email_sender_type", "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]")
-	})
-
-	t.Run("returns BadRequest when SMSSenderType is not valid", func(t *testing.T) {
-		runBadRequestPatchTest(t, r, url, "sms_sender_type", "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]")
-	})
-
 	t.Run("returns BadRequest when BaseURL is not valid", func(t *testing.T) {
 		runBadRequestPatchTest(t, r, url, "base_url", "invalid base URL value")
 	})
@@ -578,41 +554,9 @@ func Test_TenantHandler_Patch(t *testing.T) {
 		runBadRequestPatchTest(t, r, url, "status", "invalid status value")
 	})
 
-	t.Run("successfully updates EmailSenderType of a tenant", func(t *testing.T) {
-		reqBody := `{"email_sender_type": "AWS_EMAIL"}`
-		expectedRespBody := `
-			"email_sender_type": "AWS_EMAIL",
-			"sms_sender_type": "DRY_RUN",
-			"base_url": null,
-			"sdp_ui_base_url": null,
-			"status": "TENANT_CREATED",
-			"distribution_account": "GCTNUNQVX7BNIP5AUWW2R4YC7G6R3JGUDNMGT7H62BGBUY4A4V6ROAAH",
-			"is_default": false,
-		`
-
-		runSuccessfulRequestPatchTest(t, r, ctx, dbConnectionPool, handler, reqBody, expectedRespBody)
-	})
-
-	t.Run("successfully updates SMSSenderType of a tenant", func(t *testing.T) {
-		reqBody := `{"SMS_sender_type": "TWILIO_SMS"}`
-		expectedRespBody := `
-			"email_sender_type": "DRY_RUN",
-			"sms_sender_type": "TWILIO_SMS",
-			"base_url": null,
-			"sdp_ui_base_url": null,
-			"status": "TENANT_CREATED",
-			"distribution_account": "GCTNUNQVX7BNIP5AUWW2R4YC7G6R3JGUDNMGT7H62BGBUY4A4V6ROAAH",
-			"is_default": false,
-		`
-
-		runSuccessfulRequestPatchTest(t, r, ctx, dbConnectionPool, handler, reqBody, expectedRespBody)
-	})
-
 	t.Run("successfully updates BaseURL of a tenant", func(t *testing.T) {
 		reqBody := `{"base_url": "http://valid.com"}`
 		expectedRespBody := `
-			"email_sender_type": "DRY_RUN",
-			"sms_sender_type": "DRY_RUN",
 			"base_url": "http://valid.com",
 			"sdp_ui_base_url": null,
 			"status": "TENANT_CREATED",
@@ -626,8 +570,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 	t.Run("successfully updates SDPUIBaseURL of a tenant", func(t *testing.T) {
 		reqBody := `{"sdp_ui_base_url": "http://valid.com"}`
 		expectedRespBody := `
-			"email_sender_type": "DRY_RUN",
-			"sms_sender_type": "DRY_RUN",
 			"base_url": null,
 			"sdp_ui_base_url": "http://valid.com",
 			"status": "TENANT_CREATED",
@@ -641,8 +583,6 @@ func Test_TenantHandler_Patch(t *testing.T) {
 	t.Run("successfully updates Status of a tenant", func(t *testing.T) {
 		reqBody := `{"status": "TENANT_ACTIVATED"}`
 		expectedRespBody := `
-			"email_sender_type": "DRY_RUN",
-			"sms_sender_type": "DRY_RUN",
 			"base_url": null,
 			"sdp_ui_base_url": null,
 			"status": "TENANT_ACTIVATED",
@@ -655,16 +595,12 @@ func Test_TenantHandler_Patch(t *testing.T) {
 
 	t.Run("successfully updates all fields of a tenant", func(t *testing.T) {
 		reqBody := `{
-			"email_sender_type": "AWS_EMAIL",
-			"sms_sender_type": "AWS_SMS",
 			"base_url": "http://valid.com",
 			"sdp_ui_base_url": "http://valid.com",
 			"status": "TENANT_ACTIVATED"
 		}`
 
 		expectedRespBody := `
-			"email_sender_type": "AWS_EMAIL",
-			"sms_sender_type": "AWS_SMS",
 			"base_url": "http://valid.com",
 			"sdp_ui_base_url": "http://valid.com",
 			"status": "TENANT_ACTIVATED",

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -13,23 +13,19 @@ import (
 var validTenantName *regexp.Regexp = regexp.MustCompile(`^[a-z-]+$`)
 
 type TenantRequest struct {
-	Name             string                 `json:"name"`
-	OwnerEmail       string                 `json:"owner_email"`
-	OwnerFirstName   string                 `json:"owner_first_name"`
-	OwnerLastName    string                 `json:"owner_last_name"`
-	OrganizationName string                 `json:"organization_name"`
-	EmailSenderType  tenant.EmailSenderType `json:"email_sender_type"`
-	SMSSenderType    tenant.SMSSenderType   `json:"sms_sender_type"`
-	BaseURL          string                 `json:"base_url"`
-	SDPUIBaseURL     string                 `json:"sdp_ui_base_url"`
+	Name             string `json:"name"`
+	OwnerEmail       string `json:"owner_email"`
+	OwnerFirstName   string `json:"owner_first_name"`
+	OwnerLastName    string `json:"owner_last_name"`
+	OrganizationName string `json:"organization_name"`
+	BaseURL          string `json:"base_url"`
+	SDPUIBaseURL     string `json:"sdp_ui_base_url"`
 }
 
 type UpdateTenantRequest struct {
-	EmailSenderType *tenant.EmailSenderType `json:"email_sender_type"`
-	SMSSenderType   *tenant.SMSSenderType   `json:"sms_sender_type"`
-	BaseURL         *string                 `json:"base_url"`
-	SDPUIBaseURL    *string                 `json:"sdp_ui_base_url"`
-	Status          *tenant.TenantStatus    `json:"status"`
+	BaseURL      *string              `json:"base_url"`
+	SDPUIBaseURL *string              `json:"sdp_ui_base_url"`
+	Status       *tenant.TenantStatus `json:"status"`
 }
 
 type DefaultTenantRequest struct {
@@ -65,12 +61,6 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 	tv.Check(reqBody.OrganizationName != "", "organization_name", "organization_name is required")
 
 	var err error
-	reqBody.EmailSenderType, err = tenant.ParseEmailSenderType(string(reqBody.EmailSenderType))
-	tv.CheckError(err, "email_sender_type", fmt.Sprintf("invalid email sender type. Expected one of these values: %s", []tenant.EmailSenderType{tenant.AWSEmailSenderType, tenant.DryRunEmailSenderType}))
-
-	reqBody.SMSSenderType, err = tenant.ParseSMSSenderType(string(reqBody.SMSSenderType))
-	tv.CheckError(err, "sms_sender_type", fmt.Sprintf("invalid sms sender type. Expected one of these values: %s", []tenant.SMSSenderType{tenant.TwilioSMSSenderType, tenant.AWSSMSSenderType, tenant.DryRunSMSSenderType}))
-
 	if _, err = url.ParseRequestURI(reqBody.BaseURL); err != nil {
 		tv.Check(false, "base_url", "invalid base URL value")
 	}
@@ -93,18 +83,6 @@ func (tv *TenantValidator) ValidateUpdateTenantRequest(reqBody *UpdateTenantRequ
 	}
 
 	var err error
-	if reqBody.EmailSenderType != nil {
-		emailSenderType, emailErr := tenant.ParseEmailSenderType(string(*reqBody.EmailSenderType))
-		tv.CheckError(emailErr, "email_sender_type", fmt.Sprintf("invalid email sender type. Expected one of these values: %s", []tenant.EmailSenderType{tenant.AWSEmailSenderType, tenant.DryRunEmailSenderType}))
-		reqBody.EmailSenderType = &emailSenderType
-	}
-
-	if reqBody.SMSSenderType != nil {
-		SMSSenderType, smsErr := tenant.ParseSMSSenderType(string(*reqBody.SMSSenderType))
-		tv.CheckError(smsErr, "sms_sender_type", fmt.Sprintf("invalid sms sender type. Expected one of these values: %s", []tenant.SMSSenderType{tenant.TwilioSMSSenderType, tenant.AWSSMSSenderType, tenant.DryRunSMSSenderType}))
-		reqBody.SMSSenderType = &SMSSenderType
-	}
-
 	if reqBody.BaseURL != nil {
 		if _, err = url.ParseRequestURI(*reqBody.BaseURL); err != nil {
 			tv.Check(false, "base_url", "invalid base URL value")

--- a/stellar-multitenant/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/internal/validators/tenant_validator_test.go
@@ -3,7 +3,6 @@ package validators
 import (
 	"testing"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,8 +27,6 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			"owner_last_name":   "owner_last_name is required",
 			"organization_name": "organization_name is required",
 			"base_url":          "invalid base URL value",
-			"email_sender_type": "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
-			"sms_sender_type":   "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
 			"sdp_ui_base_url":   "invalid SDP UI base URL value",
 		}, tv.Errors)
 
@@ -43,8 +40,6 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			"owner_last_name":   "owner_last_name is required",
 			"organization_name": "organization_name is required",
 			"base_url":          "invalid base URL value",
-			"email_sender_type": "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
-			"sms_sender_type":   "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
 			"sdp_ui_base_url":   "invalid SDP UI base URL value",
 		}, tv.Errors)
 	})
@@ -57,8 +52,6 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			OwnerFirstName:   "Owner",
 			OwnerLastName:    "Owner",
 			OrganizationName: "Aid Org",
-			EmailSenderType:  tenant.AWSEmailSenderType,
-			SMSSenderType:    tenant.TwilioSMSSenderType,
 			SDPUIBaseURL:     "http://localhost:3000",
 			BaseURL:          "http://localhost:8000",
 		}
@@ -78,8 +71,6 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			OwnerFirstName:   "",
 			OwnerLastName:    "",
 			OrganizationName: "",
-			EmailSenderType:  tenant.AWSEmailSenderType,
-			SMSSenderType:    tenant.TwilioSMSSenderType,
 			BaseURL:          "http://localhost:8000",
 			SDPUIBaseURL:     "http://localhost:3000",
 		}
@@ -103,58 +94,6 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		assert.Equal(t, map[string]interface{}{}, tv.Errors)
 	})
 
-	t.Run("validates the email sender type successfully", func(t *testing.T) {
-		tv := NewTenantValidator()
-		reqBody := &TenantRequest{
-			Name:             "aid-org",
-			OwnerEmail:       "owner@email.org",
-			OwnerFirstName:   "Owner",
-			OwnerLastName:    "Owner",
-			OrganizationName: "Aid Org",
-			EmailSenderType:  "invalid",
-			SMSSenderType:    tenant.TwilioSMSSenderType,
-			SDPUIBaseURL:     "http://localhost:3000",
-			BaseURL:          "http://localhost:8000",
-		}
-
-		tv.ValidateCreateTenantRequest(reqBody)
-		assert.True(t, tv.HasErrors())
-		assert.Equal(t, map[string]interface{}{
-			"email_sender_type": "invalid email sender type. Expected one of these values: [AWS_EMAIL DRY_RUN]",
-		}, tv.Errors)
-
-		reqBody.EmailSenderType = tenant.DryRunEmailSenderType
-		tv.Errors = map[string]interface{}{}
-		tv.ValidateCreateTenantRequest(reqBody)
-		assert.False(t, tv.HasErrors())
-	})
-
-	t.Run("validates the sms sender type successfully", func(t *testing.T) {
-		tv := NewTenantValidator()
-		reqBody := &TenantRequest{
-			Name:             "aid-org",
-			OwnerEmail:       "owner@email.org",
-			OwnerFirstName:   "Owner",
-			OwnerLastName:    "Owner",
-			OrganizationName: "Aid Org",
-			EmailSenderType:  tenant.AWSEmailSenderType,
-			SMSSenderType:    "invalid",
-			SDPUIBaseURL:     "http://localhost:3000",
-			BaseURL:          "http://localhost:8000",
-		}
-
-		tv.ValidateCreateTenantRequest(reqBody)
-		assert.True(t, tv.HasErrors())
-		assert.Equal(t, map[string]interface{}{
-			"sms_sender_type": "invalid sms sender type. Expected one of these values: [TWILIO_SMS AWS_SMS DRY_RUN]",
-		}, tv.Errors)
-
-		reqBody.SMSSenderType = tenant.DryRunSMSSenderType
-		tv.Errors = map[string]interface{}{}
-		tv.ValidateCreateTenantRequest(reqBody)
-		assert.False(t, tv.HasErrors())
-	})
-
 	t.Run("validates the URLs successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
@@ -163,8 +102,6 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			OwnerFirstName:   "Owner",
 			OwnerLastName:    "Owner",
 			OrganizationName: "Aid Org",
-			EmailSenderType:  tenant.AWSEmailSenderType,
-			SMSSenderType:    tenant.TwilioSMSSenderType,
 			SDPUIBaseURL:     "%invalid%",
 			BaseURL:          "%invalid%",
 		}
@@ -210,10 +147,8 @@ func TestTenantValidator_ValidateUpdateTenantRequest(t *testing.T) {
 		tv := NewTenantValidator()
 		url := "valid.com:3000"
 		reqBody := &UpdateTenantRequest{
-			EmailSenderType: &tenant.AWSEmailSenderType,
-			SMSSenderType:   &tenant.AWSSMSSenderType,
-			BaseURL:         &url,
-			SDPUIBaseURL:    &url,
+			BaseURL:      &url,
+			SDPUIBaseURL: &url,
 		}
 		tv.ValidateUpdateTenantRequest(reqBody)
 		assert.False(t, tv.HasErrors())

--- a/stellar-multitenant/pkg/tenant/fixtures.go
+++ b/stellar-multitenant/pkg/tenant/fixtures.go
@@ -43,7 +43,6 @@ func ResetTenantConfigFixture(t *testing.T, ctx context.Context, dbConnectionPoo
 	const q = `
 		UPDATE tenants
 		SET
-			email_sender_type = DEFAULT, sms_sender_type = DEFAULT,
 			base_url = NULL, sdp_ui_base_url = NULL
 		WHERE
 			id = $1

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -225,15 +225,6 @@ func (m *Manager) UpdateTenantConfig(ctx context.Context, tu *TenantUpdate) (*Te
 
 	fields := make([]string, 0)
 	args := make([]interface{}, 0)
-	if tu.EmailSenderType != nil {
-		fields = append(fields, "email_sender_type = ?")
-		args = append(args, *tu.EmailSenderType)
-	}
-
-	if tu.SMSSenderType != nil {
-		fields = append(fields, "sms_sender_type = ?")
-		args = append(args, *tu.SMSSenderType)
-	}
 
 	if tu.BaseURL != nil {
 		fields = append(fields, "base_url = ?")

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -78,40 +78,33 @@ func Test_Manager_UpdateTenantConfig(t *testing.T) {
 	})
 
 	t.Run("returns error when the tenant ID does not exist", func(t *testing.T) {
-		tnt, err := m.UpdateTenantConfig(ctx, &TenantUpdate{ID: "abc", EmailSenderType: &AWSEmailSenderType})
+		baseURL := "https://myorg.backend.io"
+		tnt, err := m.UpdateTenantConfig(ctx, &TenantUpdate{ID: "abc", BaseURL: &baseURL})
 		assert.Equal(t, ErrTenantDoesNotExist, err)
 		assert.Nil(t, tnt)
 	})
 
 	t.Run("updates tenant config successfully", func(t *testing.T) {
 		tntDB = ResetTenantConfigFixture(t, ctx, dbConnectionPool, tntDB.ID)
-		assert.Equal(t, tntDB.EmailSenderType, DryRunEmailSenderType)
-		assert.Equal(t, tntDB.SMSSenderType, DryRunSMSSenderType)
 		assert.Nil(t, tntDB.BaseURL)
 		assert.Nil(t, tntDB.SDPUIBaseURL)
 
 		// Partial Update
 		tnt, err := m.UpdateTenantConfig(ctx, &TenantUpdate{
-			ID:              tntDB.ID,
-			EmailSenderType: &AWSEmailSenderType,
-			SDPUIBaseURL:    &[]string{"https://myorg.frontend.io"}[0],
+			ID:           tntDB.ID,
+			SDPUIBaseURL: &[]string{"https://myorg.frontend.io"}[0],
 		})
 		require.NoError(t, err)
 
-		assert.Equal(t, tnt.EmailSenderType, AWSEmailSenderType)
-		assert.Equal(t, tnt.SMSSenderType, DryRunSMSSenderType)
 		assert.Nil(t, tnt.BaseURL)
 		assert.Equal(t, "https://myorg.frontend.io", *tnt.SDPUIBaseURL)
 
 		tnt, err = m.UpdateTenantConfig(ctx, &TenantUpdate{
-			ID:            tntDB.ID,
-			SMSSenderType: &TwilioSMSSenderType,
-			BaseURL:       &[]string{"https://myorg.backend.io"}[0],
+			ID:      tntDB.ID,
+			BaseURL: &[]string{"https://myorg.backend.io"}[0],
 		})
 		require.NoError(t, err)
 
-		assert.Equal(t, tnt.EmailSenderType, AWSEmailSenderType)
-		assert.Equal(t, tnt.SMSSenderType, TwilioSMSSenderType)
 		assert.Equal(t, "https://myorg.backend.io", *tnt.BaseURL)
 		assert.Equal(t, "https://myorg.frontend.io", *tnt.SDPUIBaseURL)
 	})

--- a/stellar-multitenant/pkg/tenant/tenant.go
+++ b/stellar-multitenant/pkg/tenant/tenant.go
@@ -9,61 +9,24 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-type EmailSenderType string
-
-var (
-	AWSEmailSenderType    EmailSenderType = "AWS_EMAIL"
-	DryRunEmailSenderType EmailSenderType = "DRY_RUN"
-)
-
-func ParseEmailSenderType(emailSenderTypeStr string) (EmailSenderType, error) {
-	validTypes := []EmailSenderType{AWSEmailSenderType, DryRunEmailSenderType}
-	esType := EmailSenderType(emailSenderTypeStr)
-	if slices.Contains(validTypes, esType) {
-		return esType, nil
-	}
-	return "", fmt.Errorf("invalid email sender type %q", emailSenderTypeStr)
-}
-
-type SMSSenderType string
-
-var (
-	TwilioSMSSenderType SMSSenderType = "TWILIO_SMS"
-	AWSSMSSenderType    SMSSenderType = "AWS_SMS"
-	DryRunSMSSenderType SMSSenderType = "DRY_RUN"
-)
-
-func ParseSMSSenderType(smsSenderTypeStr string) (SMSSenderType, error) {
-	validTypes := []SMSSenderType{TwilioSMSSenderType, AWSSMSSenderType, DryRunSMSSenderType}
-	smsSenderType := SMSSenderType(smsSenderTypeStr)
-	if slices.Contains(validTypes, smsSenderType) {
-		return smsSenderType, nil
-	}
-	return "", fmt.Errorf("invalid sms sender type %q", smsSenderTypeStr)
-}
-
 type Tenant struct {
-	ID                  string          `json:"id" db:"id"`
-	Name                string          `json:"name" db:"name"`
-	EmailSenderType     EmailSenderType `json:"email_sender_type" db:"email_sender_type"`
-	SMSSenderType       SMSSenderType   `json:"sms_sender_type" db:"sms_sender_type"`
-	BaseURL             *string         `json:"base_url" db:"base_url"`
-	SDPUIBaseURL        *string         `json:"sdp_ui_base_url" db:"sdp_ui_base_url"`
-	Status              TenantStatus    `json:"status" db:"status"`
-	DistributionAccount *string         `json:"distribution_account" db:"distribution_account"`
-	IsDefault           bool            `json:"is_default" db:"is_default"`
-	CreatedAt           time.Time       `json:"created_at" db:"created_at"`
-	UpdatedAt           time.Time       `json:"updated_at" db:"updated_at"`
+	ID                  string       `json:"id" db:"id"`
+	Name                string       `json:"name" db:"name"`
+	BaseURL             *string      `json:"base_url" db:"base_url"`
+	SDPUIBaseURL        *string      `json:"sdp_ui_base_url" db:"sdp_ui_base_url"`
+	Status              TenantStatus `json:"status" db:"status"`
+	DistributionAccount *string      `json:"distribution_account" db:"distribution_account"`
+	IsDefault           bool         `json:"is_default" db:"is_default"`
+	CreatedAt           time.Time    `json:"created_at" db:"created_at"`
+	UpdatedAt           time.Time    `json:"updated_at" db:"updated_at"`
 }
 
 type TenantUpdate struct {
-	ID                  string           `db:"id"`
-	EmailSenderType     *EmailSenderType `db:"email_sender_type"`
-	SMSSenderType       *SMSSenderType   `db:"sms_sender_type"`
-	BaseURL             *string          `db:"base_url"`
-	SDPUIBaseURL        *string          `db:"sdp_ui_base_url"`
-	Status              *TenantStatus    `db:"status"`
-	DistributionAccount *string          `db:"distribution_account"`
+	ID                  string        `db:"id"`
+	BaseURL             *string       `db:"base_url"`
+	SDPUIBaseURL        *string       `db:"sdp_ui_base_url"`
+	Status              *TenantStatus `db:"status"`
+	DistributionAccount *string       `db:"distribution_account"`
 }
 
 type TenantStatus string
@@ -89,18 +52,6 @@ func (tu *TenantUpdate) Validate() error {
 		return ErrEmptyUpdateTenant
 	}
 
-	if tu.EmailSenderType != nil {
-		if _, err := ParseEmailSenderType(string(*tu.EmailSenderType)); err != nil {
-			return fmt.Errorf("invalid email sender type: %w", err)
-		}
-	}
-
-	if tu.SMSSenderType != nil {
-		if _, err := ParseSMSSenderType(string(*tu.SMSSenderType)); err != nil {
-			return fmt.Errorf("invalid SMS sender type: %w", err)
-		}
-	}
-
 	if tu.BaseURL != nil && !isValidURL(*tu.BaseURL) {
 		return fmt.Errorf("invalid base URL")
 	}
@@ -121,12 +72,10 @@ func (tu *TenantUpdate) Validate() error {
 }
 
 func (tu *TenantUpdate) areAllFieldsEmpty() bool {
-	return (tu.EmailSenderType == nil &&
-		tu.SMSSenderType == nil &&
-		tu.BaseURL == nil &&
+	return tu.BaseURL == nil &&
 		tu.SDPUIBaseURL == nil &&
 		tu.Status == nil &&
-		tu.DistributionAccount == nil)
+		tu.DistributionAccount == nil
 }
 
 func isValidURL(u string) bool {

--- a/stellar-multitenant/pkg/tenant/tenant_test.go
+++ b/stellar-multitenant/pkg/tenant/tenant_test.go
@@ -18,29 +18,6 @@ func Test_TenantUpdate_Validate(t *testing.T) {
 		err = tu.Validate()
 		assert.EqualError(t, err, "provide at least one field to be updated")
 
-		esType := EmailSenderType("invalid")
-		tu.EmailSenderType = &esType
-		err = tu.Validate()
-		assert.EqualError(t, err, `invalid email sender type: invalid email sender type "invalid"`)
-
-		tu.EmailSenderType = nil
-		smsSenderType := SMSSenderType("invalid")
-		tu.SMSSenderType = &smsSenderType
-		err = tu.Validate()
-		assert.EqualError(t, err, `invalid SMS sender type: invalid sms sender type "invalid"`)
-
-		tu.SMSSenderType = nil
-		u := "inv@lid$"
-		tu.BaseURL = &u
-		err = tu.Validate()
-		assert.EqualError(t, err, "invalid base URL")
-
-		tu.SMSSenderType = nil
-		tu.BaseURL = nil
-		tu.SDPUIBaseURL = &u
-		err = tu.Validate()
-		assert.EqualError(t, err, "invalid SDP UI base URL")
-
 		tu.SDPUIBaseURL = nil
 		tenantStatus := TenantStatus("invalid")
 		tu.Status = &tenantStatus
@@ -50,12 +27,10 @@ func Test_TenantUpdate_Validate(t *testing.T) {
 
 	t.Run("valid values", func(t *testing.T) {
 		tu := TenantUpdate{
-			ID:              "abc",
-			EmailSenderType: &AWSEmailSenderType,
-			SMSSenderType:   &TwilioSMSSenderType,
-			BaseURL:         &[]string{"https://myorg.backend.io"}[0],
-			SDPUIBaseURL:    &[]string{"https://myorg.frontend.io"}[0],
-			Status:          &[]TenantStatus{ProvisionedTenantStatus}[0],
+			ID:           "abc",
+			BaseURL:      &[]string{"https://myorg.backend.io"}[0],
+			SDPUIBaseURL: &[]string{"https://myorg.frontend.io"}[0],
+			Status:       &[]TenantStatus{ProvisionedTenantStatus}[0],
 		}
 		err := tu.Validate()
 		assert.NoError(t, err)
@@ -67,34 +42,6 @@ func Test_TenantUpdate_areAllFieldsEmpty(t *testing.T) {
 	assert.True(t, tu.areAllFieldsEmpty())
 	tu.SDPUIBaseURL = &[]string{"https://myorg.backend.io"}[0]
 	assert.False(t, tu.areAllFieldsEmpty())
-}
-
-func Test_ParseEmailSenderType(t *testing.T) {
-	est, err := ParseEmailSenderType("invalid")
-	assert.EqualError(t, err, `invalid email sender type "invalid"`)
-	assert.Empty(t, est)
-
-	est, err = ParseEmailSenderType("aws_email")
-	assert.EqualError(t, err, `invalid email sender type "aws_email"`)
-	assert.Empty(t, est)
-
-	est, err = ParseEmailSenderType("AWS_EMAIL")
-	assert.NoError(t, err)
-	assert.Equal(t, AWSEmailSenderType, est)
-}
-
-func Test_ParseSMSSenderType(t *testing.T) {
-	sst, err := ParseSMSSenderType("invalid")
-	assert.EqualError(t, err, `invalid sms sender type "invalid"`)
-	assert.Empty(t, sst)
-
-	sst, err = ParseSMSSenderType("twilio_sms")
-	assert.EqualError(t, err, `invalid sms sender type "twilio_sms"`)
-	assert.Empty(t, sst)
-
-	sst, err = ParseSMSSenderType("TWILIO_SMS")
-	assert.NoError(t, err)
-	assert.Equal(t, TwilioSMSSenderType, sst)
 }
 
 func Test_TenantStatus_IsValid(t *testing.T) {


### PR DESCRIPTION
### What 

- Remove `email_sender_type` and `sms_sender_type` from tenant configuration

### Why 

- We decided not to wire those configurations. 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml