### PR TITLE
[SDP-1148] Add `base_url` and `sdp_ui_base_url` default values

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -5,11 +5,6 @@ import (
 	"go/types"
 	"net/url"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/db"
-	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
-
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stellar/go/support/config"
@@ -17,29 +12,22 @@ import (
 
 	cmdDB "github.com/stellar/stellar-disbursement-platform-backend/cmd/db"
 	cmdUtils "github.com/stellar/stellar-disbursement-platform-backend/cmd/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	di "github.com/stellar/stellar-disbursement-platform-backend/internal/dependencyinjection"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/cli"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type AuthCommand struct{}
 
 func (a *AuthCommand) Command() *cobra.Command {
-	var uiBaseURL string
 	messengerOptions := message.MessengerOptions{}
 
 	authCmdConfigOpts := config.ConfigOptions{
-		{
-			Name:           "sdp-ui-base-url",
-			Usage:          "The SDP UI/dashboard Base URL used to send the invitation link when a new user is created.",
-			OptType:        types.String,
-			ConfigKey:      &uiBaseURL,
-			FlagDefault:    "http://localhost:3000",
-			CustomSetValue: cmdUtils.SetConfigOptionURLString,
-			Required:       true,
-		},
 		{
 			Name:           "email-sender-type",
 			Usage:          fmt.Sprintf("The messenger type used to send invitations to new dashboard users. Options: %+v", message.MessengerType("").ValidEmailTypes()),
@@ -102,7 +90,7 @@ func (a *AuthCommand) Command() *cobra.Command {
 					log.Ctx(ctx).Fatalf("tenant-id is required")
 				}
 
-				forgotPasswordLink, err := url.JoinPath(uiBaseURL, "forgot-password")
+				forgotPasswordLink, err := url.JoinPath(globalOptions.SDPUIBaseURL, "forgot-password")
 				if err != nil {
 					log.Ctx(ctx).Fatalf("error getting forgot password link: %s", err.Error())
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,12 +57,19 @@ func rootCmd() *cobra.Command {
 			FlagDefault: "http://localhost:8000",
 			Required:    true,
 		},
+		{
+			Name:        "sdp-ui-base-url",
+			Usage:       "The SDP UI server's base URL.",
+			OptType:     types.String,
+			ConfigKey:   &globalOptions.SDPUIBaseURL,
+			FlagDefault: "http://localhost:3000",
+			Required:    true,
+		},
 		cmdUtils.NetworkPassphrase(&globalOptions.NetworkPassphrase),
 	}
 
 	rootCmd := &cobra.Command{
 		Use:     "stellar-disbursement-platform",
-		Short:   "Stellar Disbursement Platform",
 		Long:    "The Stellar Disbursement Platform (SDP) enables organizations to disburse bulk payments to recipients using Stellar.",
 		Version: globalOptions.Version,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,6 +70,7 @@ func rootCmd() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:     "stellar-disbursement-platform",
+		Short:   "Stellar Disbursement Platform",
 		Long:    "The Stellar Disbursement Platform (SDP) enables organizations to disburse bulk payments to recipients using Stellar.",
 		Version: globalOptions.Version,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -486,6 +486,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 			adminServeOpts.GitCommit = globalOptions.GitCommit
 			adminServeOpts.Version = globalOptions.Version
 			adminServeOpts.NetworkPassphrase = globalOptions.NetworkPassphrase
+			adminServeOpts.BaseURL = globalOptions.BaseURL
 		},
 		Run: func(cmd *cobra.Command, _ []string) {
 			ctx := cmd.Context()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -487,6 +487,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 			adminServeOpts.Version = globalOptions.Version
 			adminServeOpts.NetworkPassphrase = globalOptions.NetworkPassphrase
 			adminServeOpts.BaseURL = globalOptions.BaseURL
+			adminServeOpts.SDPUIBaseURL = globalOptions.SDPUIBaseURL
 		},
 		Run: func(cmd *cobra.Command, _ []string) {
 			ctx := cmd.Context()

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -216,6 +216,7 @@ func Test_serve(t *testing.T) {
 		AdminAccount:                            "admin-account",
 		AdminApiKey:                             "admin-api-key",
 		BaseURL:                                 "https://sdp.com",
+		SDPUIBaseURL:                            "http://sdp-ui.com",
 	}
 
 	eventBrokerOptions := cmdUtils.EventBrokerOptions{
@@ -278,6 +279,7 @@ func Test_serve(t *testing.T) {
 	t.Setenv("DISABLE_RECAPTCHA", fmt.Sprintf("%t", serveOpts.DisableMFA))
 	t.Setenv("DISTRIBUTION_SEED", distributionSeed)
 	t.Setenv("BASE_URL", serveOpts.BaseURL)
+	t.Setenv("SDP_UI_BASE_URL", serveTenantOpts.SDPUIBaseURL)
 	t.Setenv("RECAPTCHA_SITE_KEY", serveOpts.ReCAPTCHASiteKey)
 	t.Setenv("RECAPTCHA_SITE_SECRET_KEY", serveOpts.ReCAPTCHASiteSecretKey)
 	t.Setenv("CORS_ALLOWED_ORIGINS", "*")

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -148,7 +148,7 @@ func Test_serve(t *testing.T) {
 		EC256PrivateKey:                 "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgIqI1MzMZIw2pQDLx\nJn0+FcNT/hNjwtn2TW43710JKZqhRANCAARHzyHsCJDJUPKxFPEq8EHoJqI7+RJy\n8bKKYClQT/XaAWE1NF/ftITX0JIKWUrGy2dUU6kstYHtC7k4nRa9zPeG\n-----END PRIVATE KEY-----",
 		CorsAllowedOrigins:              []string{"*"},
 		SEP24JWTSecret:                  "jwt_secret_1234567890",
-		BaseURL:                         "https://sdp.com",
+		BaseURL:                         "https://sdp-backend.stellar.org",
 		ResetTokenExpirationHours:       24,
 		NetworkPassphrase:               network.TestNetworkPassphrase,
 		Sep10SigningPublicKey:           "GAX46JJZ3NPUM2EUBTTGFM6ITDF7IGAFNBSVWDONPYZJREHFPP2I5U7S",

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -215,8 +215,8 @@ func Test_serve(t *testing.T) {
 		TenantAccountNativeAssetBootstrapAmount: tenant.MinTenantDistributionAccountAmount,
 		AdminAccount:                            "admin-account",
 		AdminApiKey:                             "admin-api-key",
-		BaseURL:                                 "https://sdp.com",
-		SDPUIBaseURL:                            "http://sdp-ui.com",
+		BaseURL:                                 "https://sdp-backend.stellar.org",
+		SDPUIBaseURL:                            "https://sdp-ui.stellar.org",
 	}
 
 	eventBrokerOptions := cmdUtils.EventBrokerOptions{

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -215,6 +215,7 @@ func Test_serve(t *testing.T) {
 		TenantAccountNativeAssetBootstrapAmount: tenant.MinTenantDistributionAccountAmount,
 		AdminAccount:                            "admin-account",
 		AdminApiKey:                             "admin-api-key",
+		BaseURL:                                 "https://sdp.com",
 	}
 
 	eventBrokerOptions := cmdUtils.EventBrokerOptions{

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/sirupsen/logrus"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 )
 
@@ -13,6 +14,7 @@ type GlobalOptionsType struct {
 	GitCommit         string
 	DatabaseURL       string
 	BaseURL           string
+	SDPUIBaseURL      string
 	NetworkPassphrase string
 }
 

--- a/internal/utils/url.go
+++ b/internal/utils/url.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stellar/go/keypair"
 )
 
+const urlSeparator = "://"
+
 func SignURL(stellarSecretKey string, rawURL string) (string, error) {
 	// Validate stellar private key
 	kp, err := keypair.ParseFull(stellarSecretKey)
@@ -88,4 +90,14 @@ func GetURLWithScheme(rawURL string) (string, error) {
 	}
 
 	return rawURL, nil
+}
+
+func GenerateTenantURL(baseURL string, tenantID string) (string, error) {
+	protocol, urlName, validURL := strings.Cut(baseURL, urlSeparator)
+	if !validURL || protocol == "" || urlName == "" {
+		return "", fmt.Errorf("invalid base URL: %s", baseURL)
+	}
+
+	tntURL := protocol + urlSeparator + tenantID + "." + urlName
+	return tntURL, nil
 }

--- a/internal/utils/url_test.go
+++ b/internal/utils/url_test.go
@@ -195,6 +195,13 @@ func Test_GenerateTenantURL(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:        "returns the correct tenant URL - varying protocol",
+			baseURL:     "https://bluecorp.org.local",
+			tenantID:    tenantID,
+			expectedURL: fmt.Sprintf("https://%s.bluecorp.org.local", tenantID),
+			expectedErr: nil,
+		},
+		{
 			name:        "returns the correct tenant URL when it has port",
 			baseURL:     "http://bluecorp.org.local:3000",
 			tenantID:    tenantID,
@@ -209,18 +216,24 @@ func Test_GenerateTenantURL(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:        "returns error when tenant ID is empty",
+			baseURL:     "http://bluecorp.org.local/sdp",
+			expectedURL: "",
+			expectedErr: fmt.Errorf("tenantID is empty"),
+		},
+		{
 			name:        "returns error when invalid base URL - no protocol and URL separator",
 			baseURL:     "bluecorp.org.local:3000",
 			tenantID:    tenantID,
 			expectedURL: "",
-			expectedErr: fmt.Errorf("invalid base URL: bluecorp.org.local:3000"),
+			expectedErr: fmt.Errorf("base URL must have at least two domain parts bluecorp.org.local:3000"),
 		},
 		{
 			name:        "returns error when invalid base URL - no protocol",
 			baseURL:     "://bluecorp.org.local:3000",
 			tenantID:    tenantID,
 			expectedURL: "",
-			expectedErr: fmt.Errorf("invalid base URL: ://bluecorp.org.local:3000"),
+			expectedErr: fmt.Errorf("invalid base URL ://bluecorp.org.local:3000: parse \"://bluecorp.org.local:3000\": missing protocol scheme"),
 		},
 	}
 

--- a/internal/utils/url_test.go
+++ b/internal/utils/url_test.go
@@ -180,3 +180,59 @@ func Test_GetURLWithScheme(t *testing.T) {
 		})
 	}
 }
+
+func Test_GenerateTenantURL(t *testing.T) {
+	tenantID := "abc"
+	testCases := []struct {
+		name, baseURL, tenantID, expectedURL string
+		expectedErr                          error
+	}{
+		{
+			name:        "returns the correct tenant URL",
+			baseURL:     "http://bluecorp.org.local",
+			tenantID:    tenantID,
+			expectedURL: fmt.Sprintf("http://%s.bluecorp.org.local", tenantID),
+			expectedErr: nil,
+		},
+		{
+			name:        "returns the correct tenant URL when it has port",
+			baseURL:     "http://bluecorp.org.local:3000",
+			tenantID:    tenantID,
+			expectedURL: fmt.Sprintf("http://%s.bluecorp.org.local:3000", tenantID),
+			expectedErr: nil,
+		},
+		{
+			name:        "returns the correct tenant URL when it has a path",
+			baseURL:     "http://bluecorp.org.local/sdp",
+			tenantID:    tenantID,
+			expectedURL: fmt.Sprintf("http://%s.bluecorp.org.local/sdp", tenantID),
+			expectedErr: nil,
+		},
+		{
+			name:        "returns error when invalid base URL - no protocol and URL separator",
+			baseURL:     "bluecorp.org.local:3000",
+			tenantID:    tenantID,
+			expectedURL: "",
+			expectedErr: fmt.Errorf("invalid base URL: bluecorp.org.local:3000"),
+		},
+		{
+			name:        "returns error when invalid base URL - no protocol",
+			baseURL:     "://bluecorp.org.local:3000",
+			tenantID:    tenantID,
+			expectedURL: "",
+			expectedErr: fmt.Errorf("invalid base URL: ://bluecorp.org.local:3000"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotURL, err := GenerateTenantURL(tc.baseURL, tc.tenantID)
+			if tc.expectedErr != nil {
+				assert.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectedURL, gotURL)
+		})
+	}
+}

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -3,13 +3,14 @@ package httphandler
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/support/http/httpdecode"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
-	"net/http"
-	"strconv"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stellar/go/clients/horizonclient"
@@ -98,7 +99,9 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	tntBaseURL := "https://" + tnt.Name + "." + h.BaseURL
+	const urlSeparator = "://"
+	protocol, urlName, _ := strings.Cut(h.BaseURL, urlSeparator)
+	tntBaseURL := protocol + urlSeparator + tnt.Name + "." + urlName
 	tntSDPUIBaseURL := tntBaseURL
 	if reqBody.BaseURL != nil {
 		tntBaseURL = *reqBody.BaseURL

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -89,7 +89,6 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 		reqBody.OwnerLastName, reqBody.OwnerEmail, reqBody.OrganizationName,
 		string(h.NetworkType),
 	)
-
 	if err != nil {
 		if errors.Is(err, tenant.ErrDuplicatedTenantName) {
 			httperror.BadRequest("Tenant name already exists", err, nil).Render(rw)

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -24,7 +24,7 @@ import (
 )
 
 type TenantsHandler struct {
-	Manager                     *tenant.Manager
+	Manager                     tenant.ManagerInterface
 	Models                      *data.Models
 	HorizonClient               horizonclient.ClientInterface
 	DistributionAccountResolver signing.DistributionAccountResolver

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -99,15 +99,18 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	var generatedURL string
-	var tntBaseURL string
-	if reqBody.BaseURL != nil {
-		tntBaseURL = *reqBody.BaseURL
-	} else {
+	if reqBody.BaseURL == nil || reqBody.SDPUIBaseURL == nil {
 		generatedURL, err = utils.GenerateTenantURL(h.BaseURL, tnt.Name)
 		if err != nil {
 			httperror.InternalError(ctx, "Could not generate URL", err, nil).Render(rw)
 			return
 		}
+	}
+
+	var tntBaseURL string
+	if reqBody.BaseURL != nil {
+		tntBaseURL = *reqBody.BaseURL
+	} else {
 		tntBaseURL = generatedURL
 	}
 
@@ -116,13 +119,6 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 		tntSDPUIBaseURL = *reqBody.SDPUIBaseURL
 	} else {
 		tntSDPUIBaseURL = generatedURL
-		if generatedURL == "" {
-			tntSDPUIBaseURL, err = utils.GenerateTenantURL(h.BaseURL, tnt.Name)
-			if err != nil {
-				httperror.InternalError(ctx, "Could not generate URL", err, nil).Render(rw)
-				return
-			}
-		}
 	}
 
 	tnt, err = h.Manager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -89,6 +89,7 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 		reqBody.OwnerLastName, reqBody.OwnerEmail, reqBody.OrganizationName,
 		string(h.NetworkType),
 	)
+
 	if err != nil {
 		if errors.Is(err, tenant.ErrDuplicatedTenantName) {
 			httperror.BadRequest("Tenant name already exists", err, nil).Render(rw)
@@ -106,8 +107,6 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 	if reqBody.SDPUIBaseURL != nil {
 		tntSDPUIBaseURL = *reqBody.SDPUIBaseURL
 	}
-	fmt.Println("tntBaseURL", tntBaseURL)
-	fmt.Println("tntSDPUIBaseURL", tntSDPUIBaseURL)
 
 	tnt, err = h.Manager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
 		ID:           tnt.ID,

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -513,7 +513,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 	t.Run("returns badRequest for duplicate tenant name", func(t *testing.T) {
 		createMocks()
 
-		reqBody := `git gi
+		reqBody := `
 			{
 				"name": "my-aid-org",
 				"owner_email": "owner@email.org",

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -279,8 +279,8 @@ func Test_TenantHandler_Post(t *testing.T) {
 		Manager:             m,
 		ProvisioningManager: p,
 		NetworkType:         utils.TestnetNetworkType,
-		BaseURL:             "https://backend.sdp.org",
-		SDPUIBaseURL:        "https://frontend.sdp.org",
+		BaseURL:             "https://sdp-backend.stellar.org",
+		SDPUIBaseURL:        "https://sdp-ui.stellar.org",
 	}
 
 	createMocks := func() {
@@ -391,8 +391,8 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org",
-				"base_url": "https://backend.sdp.org",
-				"sdp_ui_base_url": "https://aid-org.sdp.org",
+				"base_url": "https://sdp-backend.stellar.org",
+				"sdp_ui_base_url": "https://sdp-ui.stellar.org",
 				"is_default": false
 			}
 		`, orgName)
@@ -406,8 +406,8 @@ func Test_TenantHandler_Post(t *testing.T) {
 			{
 				"id": %q,
 				"name": %q,
-				"base_url": "https://backend.sdp.org",
-				"sdp_ui_base_url": "https://aid-org.sdp.org",
+				"base_url": "https://sdp-backend.stellar.org",
+				"sdp_ui_base_url": "https://sdp-ui.stellar.org",
 				"status": "TENANT_PROVISIONED",
 				"is_default": false,
 				"created_at": %q,
@@ -444,8 +444,8 @@ func Test_TenantHandler_Post(t *testing.T) {
 		tnt, err := m.GetTenantByName(ctx, orgName)
 		require.NoError(t, err)
 
-		generatedURL := fmt.Sprintf("https://%s.backend.sdp.org", orgName)
-		generatedUIURL := fmt.Sprintf("https://%s.frontend.sdp.org", orgName)
+		generatedURL := fmt.Sprintf("https://%s.sdp-backend.stellar.org", orgName)
+		generatedUIURL := fmt.Sprintf("https://%s.sdp-ui.stellar.org", orgName)
 		expectedRespBody := fmt.Sprintf(`
 			{
 				"id": %q,
@@ -489,7 +489,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 		tnt, err := m.GetTenantByName(ctx, orgName)
 		require.NoError(t, err)
 
-		generatedUIURL := fmt.Sprintf("https://%s.frontend.sdp.org", orgName)
+		generatedUIURL := fmt.Sprintf("https://%s.sdp-ui.stellar.org", orgName)
 		expectedRespBody := fmt.Sprintf(`
 			{
 				"id": %q,
@@ -533,7 +533,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 		tnt, err := m.GetTenantByName(ctx, orgName)
 		require.NoError(t, err)
 
-		generatedURL := fmt.Sprintf("https://%s.backend.sdp.org", orgName)
+		generatedURL := fmt.Sprintf("https://%s.sdp-backend.stellar.org", orgName)
 		expectedRespBody := fmt.Sprintf(`
 			{
 				"id": %q,

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -363,6 +363,31 @@ func Test_TenantHandler_Post(t *testing.T) {
 		BaseURL:             "backend.sdp.org",
 	}
 
+	createMocks := func() {
+		messengerClientMock.
+			On("SendMessage", mock.AnythingOfType("message.Message")).
+			Run(func(args mock.Arguments) {
+				msg, ok := args.Get(0).(message.Message)
+				require.True(t, ok)
+
+				assert.Equal(t, "Welcome to Stellar Disbursement Platform", msg.Title)
+				assert.Equal(t, "owner@email.org", msg.ToEmail)
+				assert.Empty(t, msg.ToPhoneNumber)
+			}).
+			Return(nil).
+			Once()
+
+		distAccSigClient.
+			On("BatchInsert", ctx, 1).
+			Return([]string{distAcc}, nil).
+			Once()
+
+		distAccResolver.
+			On("HostDistributionAccount").
+			Return(distAcc, nil).
+			Once()
+	}
+
 	assertMigrations := func(orgName string) {
 		// Validating infrastructure
 		expectedSchema := fmt.Sprintf("sdp_%s", orgName)
@@ -428,28 +453,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 	})
 
 	t.Run("provisions a new tenant successfully", func(t *testing.T) {
-		messengerClientMock.
-			On("SendMessage", mock.AnythingOfType("message.Message")).
-			Run(func(args mock.Arguments) {
-				msg, ok := args.Get(0).(message.Message)
-				require.True(t, ok)
-
-				assert.Equal(t, "Welcome to Stellar Disbursement Platform", msg.Title)
-				assert.Equal(t, "owner@email.org", msg.ToEmail)
-				assert.Empty(t, msg.ToPhoneNumber)
-			}).
-			Return(nil).
-			Once()
-
-		distAccSigClient.
-			On("BatchInsert", ctx, 1).
-			Return([]string{distAcc}, nil).
-			Once()
-
-		distAccResolver.
-			On("HostDistributionAccount").
-			Return(distAcc, nil).
-			Once()
+		createMocks()
 
 		orgName := "aid-org-one"
 		reqBody := fmt.Sprintf(`
@@ -500,28 +504,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 	})
 
 	t.Run("provisions a new tenant successfully - dynamically generates base URL for tenant", func(t *testing.T) {
-		messengerClientMock.
-			On("SendMessage", mock.AnythingOfType("message.Message")).
-			Run(func(args mock.Arguments) {
-				msg, ok := args.Get(0).(message.Message)
-				require.True(t, ok)
-
-				assert.Equal(t, "Welcome to Stellar Disbursement Platform", msg.Title)
-				assert.Equal(t, "owner@email.org", msg.ToEmail)
-				assert.Empty(t, msg.ToPhoneNumber)
-			}).
-			Return(nil).
-			Once()
-
-		distAccSigClient.
-			On("BatchInsert", ctx, 1).
-			Return([]string{distAcc}, nil).
-			Once()
-
-		distAccResolver.
-			On("HostDistributionAccount").
-			Return(distAcc, nil).
-			Once()
+		createMocks()
 
 		orgName := "aid-org-two"
 		reqBody := fmt.Sprintf(`
@@ -571,28 +554,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 	})
 
 	t.Run("returns badRequest for duplicate tenant name", func(t *testing.T) {
-		messengerClientMock.
-			On("SendMessage", mock.AnythingOfType("message.Message")).
-			Run(func(args mock.Arguments) {
-				msg, ok := args.Get(0).(message.Message)
-				require.True(t, ok)
-
-				assert.Equal(t, "Welcome to Stellar Disbursement Platform", msg.Title)
-				assert.Equal(t, "owner@email.org", msg.ToEmail)
-				assert.Empty(t, msg.ToPhoneNumber)
-			}).
-			Return(nil).
-			Once()
-
-		distAccSigClient.
-			On("BatchInsert", ctx, 1).
-			Return([]string{distAcc}, nil).
-			Once()
-
-		distAccResolver.
-			On("HostDistributionAccount").
-			Return(distAcc, nil).
-			Once()
+		createMocks()
 
 		reqBody := `
 			{

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -360,7 +360,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 		Manager:             m,
 		ProvisioningManager: p,
 		NetworkType:         utils.TestnetNetworkType,
-		BaseURL:             "backend.sdp.org",
+		BaseURL:             "https://backend.sdp.org",
 	}
 
 	createMocks := func() {
@@ -533,7 +533,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 		tnt, err := m.GetTenantByName(ctx, orgName)
 		require.NoError(t, err)
 
-		baseURL := fmt.Sprintf("https://%s.%s", tnt.Name, handler.BaseURL)
+		baseURL := fmt.Sprintf("https://%s.backend.sdp.org", orgName)
 		expectedRespBody := fmt.Sprintf(`
 			{
 				"id": %q,

--- a/stellar-multitenant/internal/provisioning/manager.go
+++ b/stellar-multitenant/internal/provisioning/manager.go
@@ -102,10 +102,6 @@ func (m *Manager) handleProvisioningError(ctx context.Context, err error, t *ten
 	}
 
 	if isErrorInArray(err, deleteDistributionKeyErrors()) {
-		fmt.Println("--------------------")
-		fmt.Println(err)
-		fmt.Println("--------------------")
-
 		deleteDistributionAccFromVaultErr := m.deleteDistributionAccountKey(ctx, t)
 		// We should not let any failures from key deletion block us from completing the tenant cleanup process
 		if deleteDistributionAccFromVaultErr != nil {

--- a/stellar-multitenant/internal/provisioning/manager.go
+++ b/stellar-multitenant/internal/provisioning/manager.go
@@ -62,14 +62,13 @@ func rollbackTenantCreationAndSchemaErrors() []error {
 
 func (m *Manager) ProvisionNewTenant(
 	ctx context.Context, name, userFirstName, userLastName, userEmail,
-	organizationName, uiBaseURL, networkType string,
+	organizationName, networkType string,
 ) (*tenant.Tenant, error) {
 	pt := &ProvisionTenant{
 		name:          name,
 		userFirstName: userFirstName,
 		userLastName:  userLastName,
 		userEmail:     userEmail,
-		uiBaseURL:     uiBaseURL,
 		orgName:       organizationName,
 		networkType:   networkType,
 	}
@@ -103,6 +102,10 @@ func (m *Manager) handleProvisioningError(ctx context.Context, err error, t *ten
 	}
 
 	if isErrorInArray(err, deleteDistributionKeyErrors()) {
+		fmt.Println("--------------------")
+		fmt.Println(err)
+		fmt.Println("--------------------")
+
 		deleteDistributionAccFromVaultErr := m.deleteDistributionAccountKey(ctx, t)
 		// We should not let any failures from key deletion block us from completing the tenant cleanup process
 		if deleteDistributionAccFromVaultErr != nil {
@@ -165,7 +168,6 @@ func (m *Manager) provisionTenant(ctx context.Context, pt *ProvisionTenant) (*te
 		&tenant.TenantUpdate{
 			ID:                  t.ID,
 			Status:              &tenantStatus,
-			SDPUIBaseURL:        &pt.uiBaseURL,
 			DistributionAccount: t.DistributionAccount,
 		})
 	if err != nil {

--- a/stellar-multitenant/internal/provisioning/manager_test.go
+++ b/stellar-multitenant/internal/provisioning/manager_test.go
@@ -364,7 +364,6 @@ func Test_Manager_RollbackOnErrors(t *testing.T) {
 	firstName := "First"
 	lastName := "Last"
 	email := "first.last@email.com"
-	uiBaseURL := "http://localhost:3000"
 	networkType := utils.TestnetNetworkType
 
 	tenantDSN, err := router.GetDSNForTenant(dbt.DSN, tenantName)
@@ -416,7 +415,6 @@ func Test_Manager_RollbackOnErrors(t *testing.T) {
 				tntManagerMock.On("UpdateTenantConfig", ctx, &tenant.TenantUpdate{
 					ID:                  tnt.ID,
 					DistributionAccount: &distAcc,
-					SDPUIBaseURL:        &uiBaseURL,
 					Status:              &tStatus,
 				}).Return(&tnt, errors.New("foobar")).Once()
 

--- a/stellar-multitenant/internal/provisioning/manager_test.go
+++ b/stellar-multitenant/internal/provisioning/manager_test.go
@@ -184,12 +184,10 @@ func Test_Manager_ProvisionNewTenant(t *testing.T) {
 			WithNativeAssetBootstrapAmount(tenant.MinTenantDistributionAccountAmount),
 		)
 
-		//uiBaseURL := "http://localhost:3000"
 		tnt, err := p.ProvisionNewTenant(ctx, tenantName, user.FirstName, user.LastName, user.Email, user.OrgName, string(networkType))
 		require.NoError(t, err)
 
 		assert.Equal(t, tenantName, tnt.Name)
-		//assert.Equal(t, uiBaseURL, *tnt.SDPUIBaseURL)
 		if sigClientType == signing.DistributionAccountEnvSignatureClientType {
 			assert.Equal(t, distAcc.Address(), *tnt.DistributionAccount)
 		} else {

--- a/stellar-multitenant/internal/provisioning/manager_test.go
+++ b/stellar-multitenant/internal/provisioning/manager_test.go
@@ -184,12 +184,12 @@ func Test_Manager_ProvisionNewTenant(t *testing.T) {
 			WithNativeAssetBootstrapAmount(tenant.MinTenantDistributionAccountAmount),
 		)
 
-		uiBaseURL := "http://localhost:3000"
-		tnt, err := p.ProvisionNewTenant(ctx, tenantName, user.FirstName, user.LastName, user.Email, user.OrgName, uiBaseURL, string(networkType))
+		//uiBaseURL := "http://localhost:3000"
+		tnt, err := p.ProvisionNewTenant(ctx, tenantName, user.FirstName, user.LastName, user.Email, user.OrgName, string(networkType))
 		require.NoError(t, err)
 
 		assert.Equal(t, tenantName, tnt.Name)
-		assert.Equal(t, uiBaseURL, *tnt.SDPUIBaseURL)
+		//assert.Equal(t, uiBaseURL, *tnt.SDPUIBaseURL)
 		if sigClientType == signing.DistributionAccountEnvSignatureClientType {
 			assert.Equal(t, distAcc.Address(), *tnt.DistributionAccount)
 		} else {
@@ -433,7 +433,7 @@ func Test_Manager_RollbackOnErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockTntManagerFn(&tenantManagerMock)
 
-			_, err := tenantManager.ProvisionNewTenant(ctx, tenantName, firstName, lastName, email, orgName, uiBaseURL, string(networkType))
+			_, err := tenantManager.ProvisionNewTenant(ctx, tenantName, firstName, lastName, email, orgName, string(networkType))
 			if tc.expectedErr != nil {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedErr.Error())

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -13,13 +13,13 @@ import (
 var validTenantName *regexp.Regexp = regexp.MustCompile(`^[a-z-]+$`)
 
 type TenantRequest struct {
-	Name             string `json:"name"`
-	OwnerEmail       string `json:"owner_email"`
-	OwnerFirstName   string `json:"owner_first_name"`
-	OwnerLastName    string `json:"owner_last_name"`
-	OrganizationName string `json:"organization_name"`
-	BaseURL          string `json:"base_url"`
-	SDPUIBaseURL     string `json:"sdp_ui_base_url"`
+	Name             string  `json:"name"`
+	OwnerEmail       string  `json:"owner_email"`
+	OwnerFirstName   string  `json:"owner_first_name"`
+	OwnerLastName    string  `json:"owner_last_name"`
+	OrganizationName string  `json:"organization_name"`
+	BaseURL          *string `json:"base_url"`
+	SDPUIBaseURL     *string `json:"sdp_ui_base_url"`
 }
 
 type UpdateTenantRequest struct {
@@ -61,12 +61,16 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 	tv.Check(reqBody.OrganizationName != "", "organization_name", "organization_name is required")
 
 	var err error
-	if _, err = url.ParseRequestURI(reqBody.BaseURL); err != nil {
-		tv.Check(false, "base_url", "invalid base URL value")
+	if reqBody.BaseURL != nil {
+		if _, err = url.ParseRequestURI(*reqBody.BaseURL); err != nil {
+			tv.Check(false, "base_url", "invalid base URL value")
+		}
 	}
 
-	if _, err = url.ParseRequestURI(reqBody.SDPUIBaseURL); err != nil {
-		tv.Check(false, "sdp_ui_base_url", "invalid SDP UI base URL value")
+	if reqBody.SDPUIBaseURL != nil {
+		if _, err = url.ParseRequestURI(*reqBody.SDPUIBaseURL); err != nil {
+			tv.Check(false, "sdp_ui_base_url", "invalid SDP UI base URL value")
+		}
 	}
 
 	if tv.HasErrors() {

--- a/stellar-multitenant/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/internal/validators/tenant_validator_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
+	sdpUIBaseURL := "http://localhost:3000"
+	baseURL := "http://localhost:8000"
+	invalidURL := "%invalid%"
+
 	t.Run("returns error when request body is empty", func(t *testing.T) {
 		tv := NewTenantValidator()
 		tv.ValidateCreateTenantRequest(nil)
@@ -52,8 +56,8 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			OwnerFirstName:   "Owner",
 			OwnerLastName:    "Owner",
 			OrganizationName: "Aid Org",
-			SDPUIBaseURL:     "http://localhost:3000",
-			BaseURL:          "http://localhost:8000",
+			SDPUIBaseURL:     &sdpUIBaseURL,
+			BaseURL:          &baseURL,
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -71,8 +75,8 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			OwnerFirstName:   "",
 			OwnerLastName:    "",
 			OrganizationName: "",
-			BaseURL:          "http://localhost:8000",
-			SDPUIBaseURL:     "http://localhost:3000",
+			BaseURL:          &sdpUIBaseURL,
+			SDPUIBaseURL:     &baseURL,
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -102,8 +106,8 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			OwnerFirstName:   "Owner",
 			OwnerLastName:    "Owner",
 			OrganizationName: "Aid Org",
-			SDPUIBaseURL:     "%invalid%",
-			BaseURL:          "%invalid%",
+			SDPUIBaseURL:     &invalidURL,
+			BaseURL:          &invalidURL,
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -112,6 +116,21 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			"base_url":        "invalid base URL value",
 			"sdp_ui_base_url": "invalid SDP UI base URL value",
 		}, tv.Errors)
+	})
+
+	t.Run("validates request successfully without URLs", func(t *testing.T) {
+		tv := NewTenantValidator()
+		reqBody := &TenantRequest{
+			Name:             "aid-org",
+			OwnerEmail:       "owner@email.org",
+			OwnerFirstName:   "Owner",
+			OwnerLastName:    "Owner",
+			OrganizationName: "Aid Org",
+		}
+
+		tv.ValidateCreateTenantRequest(reqBody)
+		assert.False(t, tv.HasErrors())
+		assert.Equal(t, map[string]interface{}{}, tv.Errors)
 	})
 }
 

--- a/stellar-multitenant/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/internal/validators/tenant_validator_test.go
@@ -30,8 +30,6 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			"owner_first_name":  "owner_first_name is required",
 			"owner_last_name":   "owner_last_name is required",
 			"organization_name": "organization_name is required",
-			"base_url":          "invalid base URL value",
-			"sdp_ui_base_url":   "invalid SDP UI base URL value",
 		}, tv.Errors)
 
 		reqBody.Name = "aid-org"
@@ -43,8 +41,6 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			"owner_first_name":  "owner_first_name is required",
 			"owner_last_name":   "owner_last_name is required",
 			"organization_name": "organization_name is required",
-			"base_url":          "invalid base URL value",
-			"sdp_ui_base_url":   "invalid SDP UI base URL value",
 		}, tv.Errors)
 	})
 

--- a/stellar-multitenant/pkg/serve/serve.go
+++ b/stellar-multitenant/pkg/serve/serve.go
@@ -50,6 +50,7 @@ type ServeOptions struct {
 	AdminApiKey                             string
 	SingleTenantMode                        bool
 	BaseURL                                 string
+	SDPUIBaseURL                            string
 }
 
 // SetupDependencies uses the serve options to setup the dependencies for the server.
@@ -138,6 +139,7 @@ func handleHTTP(opts *ServeOptions) *chi.Mux {
 				HorizonClient:               opts.SubmitterEngine.HorizonClient,
 				DistributionAccountResolver: opts.SubmitterEngine.DistributionAccountResolver,
 				BaseURL:                     opts.BaseURL,
+				SDPUIBaseURL:                opts.SDPUIBaseURL,
 			}
 			r.Get("/", tenantsHandler.GetAll)
 			r.Post("/", tenantsHandler.Post)

--- a/stellar-multitenant/pkg/serve/serve.go
+++ b/stellar-multitenant/pkg/serve/serve.go
@@ -49,6 +49,7 @@ type ServeOptions struct {
 	AdminAccount                            string
 	AdminApiKey                             string
 	SingleTenantMode                        bool
+	BaseURL                                 string
 }
 
 // SetupDependencies uses the serve options to setup the dependencies for the server.
@@ -136,6 +137,7 @@ func handleHTTP(opts *ServeOptions) *chi.Mux {
 				Models:                      opts.Models,
 				HorizonClient:               opts.SubmitterEngine.HorizonClient,
 				DistributionAccountResolver: opts.SubmitterEngine.DistributionAccountResolver,
+				BaseURL:                     opts.BaseURL,
 			}
 			r.Get("/", tenantsHandler.GetAll)
 			r.Post("/", tenantsHandler.Post)

--- a/stellar-multitenant/pkg/tenant/tenant.go
+++ b/stellar-multitenant/pkg/tenant/tenant.go
@@ -68,7 +68,6 @@ func (tu *TenantUpdate) Validate() error {
 	if tu.DistributionAccount != nil && !strkey.IsValidEd25519PublicKey(*tu.DistributionAccount) {
 		return fmt.Errorf("invalid distribution account: %q", *tu.DistributionAccount)
 	}
-
 	return nil
 }
 

--- a/stellar-multitenant/pkg/tenant/tenant.go
+++ b/stellar-multitenant/pkg/tenant/tenant.go
@@ -102,6 +102,5 @@ func ValidateNativeAssetBootstrapAmount(amount int) error {
 
 		return fmt.Errorf("amount of native asset to send must be between %d and %d", MinTenantDistributionAccountAmount, MaxTenantDistributionAccountAmount)
 	}
-
 	return nil
 }


### PR DESCRIPTION
### What
- Make `base_url` and `sdp_ui_base_url` optional fields in the `POST /tenants` request body. Skip validation on fields if left blank
- If left blank in the request, handler when dynamically generate the url's based on the name in the request and the base url attached to the server.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
