### PR TITLE
DRAFT: main.sh updates for debugging locally without any manual steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-# To build:
-#    make docker-build
-# To push:
-#    make docker-push
-
+# Stage 1: Build the Go application
 FROM golang:1.22.1-bullseye AS build
 ARG GIT_COMMIT
 
@@ -12,12 +8,25 @@ RUN go mod download
 ADD . ./
 RUN go build -o /bin/stellar-disbursement-platform -ldflags "-X main.GitCommit=$GIT_COMMIT" .
 
+# Stage 2: Setup the development environment with Delve for debugging
+FROM golang:1.22.1-bullseye AS development
 
-FROM ubuntu:22.04
+WORKDIR /app/github.com/stellar/stellar-disbursement-platform
+# Copy the built executable and all source files for debugging
+COPY --from=build /src/stellar-disbursement-platform /app/github.com/stellar/stellar-disbursement-platform
+# Build a debug version of the binary
+RUN go build -gcflags="all=-N -l" -o stellar-disbursement-platform .
+# Install Delve
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+# Ensure the binary has executable permissions
+RUN chmod +x /app/github.com/stellar/stellar-disbursement-platform/stellar-disbursement-platform
+EXPOSE 8001 2345
+ENTRYPOINT ["/go/bin/dlv", "debug", "./stellar-disbursement-platform", "serve", "--headless", "--listen=:2345", "--api-version=2", "--log"]
 
+# Stage 3: Create a production image using Ubuntu
+FROM ubuntu:22.04 AS production
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-# ADD migrations/ /app/migrations/
-COPY --from=build /bin/stellar-disbursement-platform /app/
+COPY --from=build /bin/stellar-disbursement-platform /app/stellar-disbursement-platform
 EXPOSE 8001
 WORKDIR /app
 ENTRYPOINT ["./stellar-disbursement-platform"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,13 @@ ARG GIT_COMMIT
 WORKDIR /src/stellar-disbursement-platform
 ADD go.mod go.sum ./
 RUN go mod download
-ADD . ./
+COPY . ./
 RUN go build -o /bin/stellar-disbursement-platform -ldflags "-X main.GitCommit=$GIT_COMMIT" .
 
 # Stage 2: Setup the development environment with Delve for debugging
 FROM golang:1.22.1-bullseye AS development
 
+# set workdir according to repo structure so remote debug source code is in sync
 WORKDIR /app/github.com/stellar/stellar-disbursement-platform
 # Copy the built executable and all source files for debugging
 COPY --from=build /src/stellar-disbursement-platform /app/github.com/stellar/stellar-disbursement-platform
@@ -21,7 +22,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 # Ensure the binary has executable permissions
 RUN chmod +x /app/github.com/stellar/stellar-disbursement-platform/stellar-disbursement-platform
 EXPOSE 8001 2345
-ENTRYPOINT ["/go/bin/dlv", "debug", "./stellar-disbursement-platform", "serve", "--headless", "--listen=:2345", "--api-version=2", "--log"]
+ENTRYPOINT ["/go/bin/dlv", "exec", "--continue", "--accept-multiclient", "--headless", "--listen=:2345", "--api-version=2", "--log", "./stellar-disbursement-platform", "serve"]
 
 # Stage 3: Create a production image using Ubuntu
 FROM ubuntu:22.04 AS production
@@ -29,4 +30,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/stellar-disbursement-platform /app/stellar-disbursement-platform
 EXPOSE 8001
 WORKDIR /app
-ENTRYPOINT ["./stellar-disbursement-platform"]
+ENTRYPOINT ["./stellar-disbursement-platform", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM golang:1.22.1-bullseye AS development
 
 # set workdir according to repo structure so remote debug source code is in sync
 WORKDIR /app/github.com/stellar/stellar-disbursement-platform
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 # Copy the built executable and all source files for debugging
 COPY --from=build /src/stellar-disbursement-platform /app/github.com/stellar/stellar-disbursement-platform
 # Build a debug version of the binary

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -11,18 +11,18 @@ services:
       - "5432:5432"
     volumes:
       - postgres-db:/data/postgres
-
   sdp-api:
     container_name: sdp-api-mtn
-    image: stellar/sdp-v2:latest
-    target: development
+    image: stellar/sdp-v2:debug
     build:
       context: ../
       dockerfile: Dockerfile
+      target: development
     ports:
       - "8000:8000"
       - "8002:8002"
       - "8003:8003"
+      - "2345:2345"
     environment:
       BASE_URL: http://localhost:8000
       DATABASE_URL: postgres://postgres@db:5432/sdp_mtn?sslmode=disable
@@ -82,18 +82,7 @@ services:
       SEP24_JWT_SECRET: jwt_secret_1234567890
       RECAPTCHA_SITE_SECRET_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
       ANCHOR_PLATFORM_OUTGOING_JWT_SECRET: mySdpToAnchorPlatformSecret
-    entrypoint: ""
-    command:
-      - sh
-      - -c
-      - |
-        sleep 5
-        ./stellar-disbursement-platform db admin migrate up
-        ./stellar-disbursement-platform db tss migrate up
-        ./stellar-disbursement-platform db auth migrate up --all
-        ./stellar-disbursement-platform db sdp migrate up --all
-        ./stellar-disbursement-platform db setup-for-network --all
-        ./stellar-disbursement-platform serve
+    entrypoint: "./dev/scripts/debug_entrypoint.sh"
 
   db-anchor-platform:
     container_name: anchor-platform-postgres-db-mtn

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -15,6 +15,7 @@ services:
   sdp-api:
     container_name: sdp-api-mtn
     image: stellar/sdp-v2:latest
+    target: development
     build:
       context: ../
       dockerfile: Dockerfile
@@ -49,15 +50,15 @@ services:
       INSTANCE_NAME: "SDP Testnet on Docker"
       TENANT_XLM_BOOTSTRAP_AMOUNT: 5
       DISTRIBUTION_SIGNER_TYPE: ${DISTRIBUTION_SIGNER_TYPE:-DISTRIBUTION_ACCOUNT_ENV}
-      SINGLE_TENANT_MODE: "false"
+      SINGLE_TENANT_MODE: "true"
 
       # scheduler options
-      ENABLE_SCHEDULER: "false" # disabled - we're using kafka for this.
+      ENABLE_SCHEDULER: "true" # disabled - we're using kafka for this.
       # SCHEDULER_RECEIVER_INVITATION_JOB_SECONDS: "10"
       # SCHEDULER_PAYMENT_JOB_SECONDS: "10"
 
       # Broker options
-      EVENT_BROKER_TYPE: "KAFKA"
+      EVENT_BROKER_TYPE: "NONE"
       BROKER_URLS: "kafka:9092"
       CONSUMER_GROUP_ID: "group-id"
       KAFKA_SECURITY_PROTOCOL: "PLAINTEXT"

--- a/dev/launch.json
+++ b/dev/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "DEBUG SDP-API",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "/app/github.com/stellar/stellar-disbursement-platform",
+            "localRoot": "/Users/reecemarkowsky/dev/sdp-debugging-pr/stellar-disbursement-platform-backend", 
+            "port": 2345,
+            "host": "127.0.0.1"
+        }
+    ]
+}

--- a/dev/main.sh
+++ b/dev/main.sh
@@ -2,6 +2,7 @@
 # This script is used to locally start the integration between SDP and AnchorPlatform for the SEP-24 deposit flow, needed for registering users.
 set -eu
 
+export DIVIDER="----------------------------------------"
 # Check if curl is installed
 if ! command -v curl &> /dev/null
 then
@@ -9,18 +10,85 @@ then
     exit 1
 fi
 
-export DIVIDER="----------------------------------------"
+
 
 # prepare
-echo "====> 👀Step 1: start preparation"
-docker ps -aq | xargs docker stop | xargs docker rm
-echo "====> ✅Step 1: finish preparation"
+
+echo $DIVIDER
+echo "====> 👀 Step 2: start calling docker-compose up"
+docker-compose -p sdp-multi-tenant down
+echo "====> ✅ Step 2: finish calling docker-compose up"
+
+# Check if "--delete_pv" is passed as a parameter
+if [[ " $@ " =~ " --delete_pv " ]]; then
+    echo "You have opted to delete persistent volumes sdp-multi-tenant_kafka-data sdp-multi-tenant_postgres-ap-db sdp-multi-tenant_postgres-db. Are you sure? (yes/no)"
+    read -r confirmation
+    if [ "$confirmation" == "yes" ]; then
+        echo "Deleting persistent volumes..."
+        docker volume rm sdp-multi-tenant_kafka-data sdp-multi-tenant_postgres-ap-db sdp-multi-tenant_postgres-db
+    else
+        echo "Persistent volumes will not be deleted."
+    fi
+fi
+
+# Check if .env already exists
+if [ ! -f ".env" ]; then
+    GO_EXECUTABLE="go run ./scripts/create_and_fund.go"
+    echo ".env file does not exist. creating."
+
+    # Function to run Go script and extract keys
+    function generate_keys() {
+        # Run the Go script with the necessary arguments
+        if [ "$1" == "nop" ]; then
+            output=$($GO_EXECUTABLE -fundxlm=true)
+        else
+            output=$($GO_EXECUTABLE -fundxlm=true -fundusdc=true -xlm_amount="20")
+        fi
+        echo "$output"
+    }
+
+    # Generate keys for SEP-10 without funding
+    echo "Generating SEP-10 signing keys..."
+    sep10_output=$(generate_keys "nop")
+    sep10_public=$(echo "$sep10_output" | grep 'Public Key:' | awk '{print $3}')
+    sep10_private=$(echo "$sep10_output" | grep 'Secret Key:' | awk '{print $3}')
+
+    # Generate keys for distribution with funding
+    echo "Generating distribution keys with funding..."
+    distribution_output=$(generate_keys "with_funding")
+    distribution_public=$(echo "$distribution_output" | grep 'Public Key:' | awk '{print $3}')
+    distribution_private=$(echo "$distribution_output" | grep 'Secret Key:' | awk '{print $3}')
+
+    # Create .env file with the extracted values
+    cat << EOF > .env
+    # Generate a new keypair for SEP-10 signing
+    SEP10_SIGNING_PUBLIC_KEY=$sep10_public
+    SEP10_SIGNING_PRIVATE_KEY=$sep10_private
+
+    # Generate a new keypair for the distribution account
+    DISTRIBUTION_PUBLIC_KEY=$distribution_public
+    DISTRIBUTION_SEED=$distribution_private
+
+    # CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE
+    CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE=$distribution_private
+
+    # Distribution signer
+    DISTRIBUTION_SIGNER_TYPE=DISTRIBUTION_ACCOUNT_ENV
+    DISTRIBUTION_ACCOUNT_ENCRYPTION_PASSPHRASE=$distribution_private
+EOF
+
+    echo ".env file created successfully."
+fi
+
+
+docker-compose -p sdp-multi-tenant up -d --build
 
 # Run docker compose
 echo $DIVIDER
 echo "====> 👀Step 2: start calling docker compose up"
 docker-compose down && docker-compose -p sdp-multi-tenant up -d --build
 echo "====> ✅Step 2: finish calling docker-compose up"
+
 
 # Initialize tenants
 echo $DIVIDER
@@ -58,7 +126,7 @@ for tenant in "${tenants[@]}"; do
         echo "🐈Provisioning missing tenant: $tenant"
         baseURL="http://$tenant.stellar.local:8000"
         sdpUIBaseURL="http://$tenant.stellar.local:3000"
-        ownerEmail="owner@$tenant.org"
+        ownerEmail="init_owner@$tenant.org"
 
         curl -X POST $AdminTenantURL \
         -H "Content-Type: application/json" \
@@ -66,18 +134,30 @@ for tenant in "${tenants[@]}"; do
         -d '{
                 "name": "'"$tenant"'",
                 "organization_name": "'"$tenant"'",
+                "email_sender_type": "DRY_RUN",
+                "sms_sender_type": "DRY_RUN",
                 "base_url": "'"$baseURL"'",
                 "sdp_ui_base_url": "'"$sdpUIBaseURL"'",
                 "owner_email": "'"$ownerEmail"'",
                 "owner_first_name": "jane",
-                "owner_last_name": "doe"
+                "owner_last_name": "doe",
+                "password": "Password123!"
         }'
-
         echo "✅Tenant $tenant created successfully."
-        echo "🔗You can now reset the password for the owner $ownerEmail on $sdpUIBaseURL/forgot-password"
+        echo "🔗Note: You can reset the password for the owner $ownerEmail on $sdpUIBaseURL/forgot-password"
     fi
 done
 
 echo "====> ✅Step 3: finished initialization of tenants"
 echo $DIVIDER
+# Initialize test_users
+echo "====> Step 4: initialize test users..."
+docker-compose -p sdp-multi-tenant exec sdp-api ./dev/scripts/add_test_users.sh
+echo $DIVIDER
+
 echo "🎉🎉🎉🎉 SUCCESS! 🎉🎉🎉🎉"
+echo "Login URLs for each tenant:"
+for tenant in "${tenants[@]}"; do
+    echo "🔗Tenant $tenant: http://$tenant.stellar.local:3000"
+    echo "username: owner@$tenant.org  password: Password123!"
+done

--- a/dev/main.sh
+++ b/dev/main.sh
@@ -10,28 +10,29 @@ then
     exit 1
 fi
 
-
-
 # prepare
-
 echo $DIVIDER
-echo "====> 👀 Step 2: start calling docker-compose up"
-docker-compose -p sdp-multi-tenant down
-echo "====> ✅ Step 2: finish calling docker-compose up"
+echo "====> 👀 start calling docker-compose -p sdp-multi-tenant down"
+#docker-compose -p sdp-multi-tenant down
+docker-compose down
+echo "====> ✅ finish calling docker-compose down"
 
 # Check if "--delete_pv" is passed as a parameter
 if [[ " $@ " =~ " --delete_pv " ]]; then
-    echo "You have opted to delete persistent volumes sdp-multi-tenant_kafka-data sdp-multi-tenant_postgres-ap-db sdp-multi-tenant_postgres-db. Are you sure? (yes/no)"
-    read -r confirmation
-    if [ "$confirmation" == "yes" ]; then
-        echo "Deleting persistent volumes..."
-        docker volume rm sdp-multi-tenant_kafka-data sdp-multi-tenant_postgres-ap-db sdp-multi-tenant_postgres-db
-    else
-        echo "Persistent volumes will not be deleted."
-    fi
+    echo "====> 👀 deleting persistent volumes sdp-multi-tenant_kafka-data sdp-multi-tenant_postgres-ap-db sdp-multi-tenant_postgres-db"
+    #echo "You have opted to delete persistent volumes sdp-multi-tenant_kafka-data sdp-multi-tenant_postgres-ap-db sdp-multi-tenant_postgres-db. Are you sure? (yes/no)"
+    #read -r confirmation
+    #if [ "$confirmation" == "yes" ]; then
+    #    echo "Deleting persistent volumes..."
+    docker volume rm sdp-multi-tenant_kafka-data sdp-multi-tenant_postgres-ap-db sdp-multi-tenant_postgres-db
+    #else
+    #    echo "Persistent volumes will not be deleted."
+    #fi
+    echo "====> ✅ finish deleting persistent volumes"
 fi
 
 # Check if .env already exists
+echo "====> 👀 creating accounts and .env environment file if it does not exist"
 if [ ! -f ".env" ]; then
     GO_EXECUTABLE="go run ./scripts/create_and_fund.go"
     echo ".env file does not exist. creating."
@@ -79,15 +80,16 @@ EOF
 
     echo ".env file created successfully."
 fi
+echo "====> ✅ finished .env setup"
 
-
+echo $DIVIDER
+echo "====> 👀calling docker compose up"
+export GIT_COMMIT="debug"
 docker-compose -p sdp-multi-tenant up -d --build
 
 # Run docker compose
 echo $DIVIDER
-echo "====> 👀Step 2: start calling docker compose up"
-docker-compose down && docker-compose -p sdp-multi-tenant up -d --build
-echo "====> ✅Step 2: finish calling docker-compose up"
+echo "====> ✅finish calling docker-compose up"
 
 
 # Initialize tenants
@@ -141,7 +143,6 @@ for tenant in "${tenants[@]}"; do
                 "owner_email": "'"$ownerEmail"'",
                 "owner_first_name": "jane",
                 "owner_last_name": "doe",
-                "password": "Password123!"
         }'
         echo "✅Tenant $tenant created successfully."
         echo "🔗Note: You can reset the password for the owner $ownerEmail on $sdpUIBaseURL/forgot-password"

--- a/dev/scripts/add_test_users.sh
+++ b/dev/scripts/add_test_users.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+echo "running $0 from directory $(pwd)"
+
+# Credentials for Basic Auth
+USERNAME="SDP-admin"
+PASSWORD="api_key_1234567890"
+
+# Retrieve tenant details using curl with Basic Auth from an API endpoint
+TENANTS_JSON=$(curl -u $USERNAME:$PASSWORD -s http://localhost:8003/tenants/)
+
+if [ -z "$TENANTS_JSON" ]; then
+  echo "No tenant details could be retrieved. Exiting."
+  exit 1
+fi
+
+# Function to add a user for  tenant
+add_user_for_tenant() {
+  echo
+  local tenant_id=$1
+  local tenant_name=$2
+  local email="owner_${tenant_name}@example.com"
+  local username="Owner${tenant_name}"
+  local password="SecureOwner${tenant_name}123"
+
+  echo "Adding owner user to tenant: $tenant_name (ID: $tenant_id)"
+  echo "Password123!" |  ./stellar-disbursement-platform auth add-user "owner@${tenant_name}.org" "john" "doe" --password  --owner --roles "owner" --tenant-id "${tenant_id}"
+
+} 
+
+# Loop through each tenant and add an owner user
+echo "$TENANTS_JSON" | jq -c '.[]' | while read -r tenant; do
+  tenant_id=$(echo "$tenant" | jq -r '.id')
+  tenant_name=$(echo "$tenant" | jq -r '.name' | tr -d '[:space:]') # Remove spaces from tenant name for usernames and emails
+
+  add_user_for_tenant "$tenant_id" "$tenant_name"
+done
+
+echo "Owner users added successfully to all tenants."
+
+

--- a/dev/scripts/create_and_fund.go
+++ b/dev/scripts/create_and_fund.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "log"
+    "os"
+
+    "github.com/stellar/go/keypair"
+    "github.com/stellar/go/clients/horizonclient"
+    "github.com/stellar/go/network"
+    "github.com/stellar/go/txnbuild"  
+)
+
+func main() {
+    var secretKey string
+    var fundXLM bool
+    var fundUSDC bool
+    var xlmAmount string
+    var pair *keypair.Full
+    var err error
+
+    flag.StringVar(&secretKey, "secret", "", "The secret key of an existing Stellar account")
+    flag.BoolVar(&fundXLM, "fundxlm", false, "Set to true to fund the account with XLM using Friendbot")
+    flag.BoolVar(&fundUSDC, "fundusdc", false, "Set to true to fund the account with USDC and establish a trustline")
+    flag.StringVar(&xlmAmount, "xlm_amount", "10", "The amount of USDC to fund the account with (default is 10).")
+
+    
+    flag.Usage = func() {
+        fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+        fmt.Fprintf(flag.CommandLine.Output(), "  This program creates and manages funding for Stellar accounts.\n")
+        fmt.Fprintf(flag.CommandLine.Output(), "  It can generate a new keypair or use an existing secret key to manage account operations.\n\n")
+        flag.PrintDefaults()
+        fmt.Fprintf(flag.CommandLine.Output(), "\nExamples:\n")
+        fmt.Fprintf(flag.CommandLine.Output(), "  %s -secret=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -fundxlm=true\n", os.Args[0])
+        fmt.Fprintf(flag.CommandLine.Output(), "  %s -secret=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -fundusdc=true\n", os.Args[0])
+    }
+
+    flag.Parse()
+    
+    if secretKey == "" {
+            // Do not redeclare pair, just assign
+            pair, err = keypair.Random()
+            if err != nil {
+                log.Fatalf("Failed to generate a new keypair: %v", err)
+            }
+        } else {
+            // Do not redeclare pair, just assign
+            pair, err = keypair.ParseFull(secretKey)
+            if err != nil {
+                log.Fatalf("Failed to parse secret key: %v", err)
+            }
+        }
+    
+        // Ensure that pair is not nil before using it
+        if pair != nil {
+            fmt.Printf("Public Key: %s\n", pair.Address())
+            fmt.Printf("Secret Key: %s\n", pair.Seed())
+        } else {
+            log.Fatal("Key pair was not initialized.")
+        }
+
+    client := horizonclient.DefaultTestNetClient
+
+    // Fund with XLM using Friendbot if --fundxlm is specified
+    if fundXLM {
+        _, err := client.Fund(pair.Address())
+        if err != nil {
+            log.Fatalf("Failed to fund with Friendbot: %v", err)
+        }
+        fmt.Println("Funded with XLM using Friendbot.")
+    }
+
+    if fundUSDC {
+        err := establishTrustlineAndBuyUSDC(client, pair, xlmAmount)
+        if err != nil {
+            log.Fatal(err)
+        }
+    }
+}
+
+func establishTrustlineAndBuyUSDC(client *horizonclient.Client, pair *keypair.Full, xlmAmount string) error {
+    sourceAccount, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: pair.Address()})
+    if err != nil {
+        return fmt.Errorf("failed to get account details: %v", err)
+    }
+
+    usdcAsset := txnbuild.CreditAsset{Code: "USDC", Issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"}
+    changeTrustAsset, err := usdcAsset.ToChangeTrustAsset()
+        if err != nil {
+            log.Fatalf("Failed to convert to ChangeTrustAsset: %v", err)
+        }
+    
+    trustLine := txnbuild.ChangeTrust{
+        Line: changeTrustAsset,
+    }
+
+      // Create a path payment strict send operation
+    pathPaymentOp := txnbuild.PathPaymentStrictSend{
+        SendAsset:   txnbuild.NativeAsset{},
+        SendAmount:  xlmAmount,
+        Destination: pair.Address(),
+        DestAsset:   usdcAsset,
+        DestMin:     "0.1", // Very low minimum to ensure the trade goes through
+    }
+
+    // Build the transaction with both operations
+    tx, err := txnbuild.NewTransaction(
+        txnbuild.TransactionParams{
+            SourceAccount:        &sourceAccount,
+            IncrementSequenceNum: true,
+            Operations:           []txnbuild.Operation{&trustLine, &pathPaymentOp},
+            BaseFee:              txnbuild.MinBaseFee,
+            Preconditions:           txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(300)},
+        },
+    )
+    if err != nil {
+        return fmt.Errorf("failed to build the transaction: %v", err)
+    }
+
+    // Sign the transaction with the network passphrase and the secret key
+    tx, err = tx.Sign(network.TestNetworkPassphrase, pair)
+    if err != nil {
+        return fmt.Errorf("failed to sign the transaction: %v", err)
+    }
+
+    // Submit the transaction to the Stellar network
+    resp, err := client.SubmitTransaction(tx)
+    if err != nil {
+        return fmt.Errorf("failed to submit the transaction: %v", err)
+    }
+
+    fmt.Printf("Transaction successful: %s\n", resp.Hash)
+    return nil
+}
+

--- a/dev/scripts/create_and_fund.go.back
+++ b/dev/scripts/create_and_fund.go.back
@@ -1,0 +1,108 @@
+# create stellar wallet wallet, fund xlm, add/fund usdc with trustline @reecemarkowsky
+package main
+
+import (
+    "flag"
+    "fmt"
+    "log"
+
+    "github.com/stellar/go/keypair"
+    "github.com/stellar/go/clients/horizonclient"
+    "github.com/stellar/go/network"
+    "github.com/stellar/go/txnbuild"
+    "github.com/stellar/go/xdr"
+)
+
+var pair *keypair.Full
+var err error
+
+if secretKey == "" {
+        // Do not redeclare pair, just assign
+        pair, err = keypair.Random()
+        if err != nil {
+            log.Fatalf("Failed to generate a new keypair: %v", err)
+        }
+    } else {
+        // Do not redeclare pair, just assign
+        pair, err = keypair.ParseFull(secretKey)
+        if err != nil {
+            log.Fatalf("Failed to parse secret key: %v", err)
+        }
+    }
+
+    // Ensure that pair is not nil before using it
+    if pair != nil {
+        fmt.Printf("Public Key: %s\n", pair.Address())
+        fmt.Printf("Secret Key: %s\n", pair.Seed())
+    } else {
+        log.Fatal("Key pair was not initialized.")
+    }
+
+    client := horizonclient.DefaultTestNetClient
+
+    // Fund with XLM using Friendbot if --fundxlm is specified
+    if fundXLM {
+        _, err = client.Fund(pair.Address())
+        if err != nil {
+            log.Fatalf("Failed to fund with Friendbot: %v", err)
+        }
+    }
+
+    accRequest := horizonclient.AccountRequest{AccountID: pair.Address()}
+    sourceAccount, err := client.AccountDetail(accRequest)
+    if err != nil {
+        log.Fatalf("Failed to get account details: %v", err)
+    }
+
+    // Fund with USDC using a DEX buy offer if --fundusdc is specified
+    if fundUSDC {
+        // Define the USDC asset and convert it to a ChangeTrustAsset
+        usdcAsset := txnbuild.CreditAsset{Code: "USDC", Issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"}
+        changeTrustAsset, err := usdcAsset.ToChangeTrustAsset()
+        if err != nil {
+            log.Fatalf("Failed to convert to ChangeTrustAsset: %v", err)
+        }
+
+        trustLine := txnbuild.ChangeTrust{
+            Line: changeTrustAsset,
+        }
+
+        price := xdr.Price{N: 1, D: 2} // This creates a price of 0.5 (1/2)
+
+        buyOffer := txnbuild.ManageBuyOffer{
+            Selling: &txnbuild.NativeAsset{}, // Selling XLM
+            Buying:  &usdcAsset,             // Buying USDC
+            Amount:  "10",                   // Amount of USDC you want to buy
+            Price:   price,                  // Price of 1 USDC in terms of XLM
+            OfferID: 0,                      // Set to 0 to create a new offer
+        }
+
+        // Add this buy offer to your transaction
+        tx, err := txnbuild.NewTransaction(
+            txnbuild.TransactionParams{
+                SourceAccount:        &sourceAccount,
+                IncrementSequenceNum: true,
+                Operations:           []txnbuild.Operation{&trustLine, &buyOffer},
+                BaseFee:              txnbuild.MinBaseFee,
+                Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(300)},
+            },
+        )
+
+        if err != nil {
+            log.Fatalf("Failed to build the transaction: %v", err)
+        }
+
+        tx, err = tx.Sign(network.TestNetworkPassphrase, pair)
+        if err != nil {
+            log.Fatalf("Failed to sign the transaction: %v", err)
+        }
+
+        resp, err := client.SubmitTransaction(tx)
+        if err != nil {
+            log.Fatalf("Failed to submit the buy offer transaction: %v", err)
+        }
+        fmt.Printf("Buy offer transaction successful: %s\n", resp.Hash)
+    }
+
+    // Additional transaction logic can be added below as needed
+}

--- a/dev/scripts/debug_entrypoint.sh
+++ b/dev/scripts/debug_entrypoint.sh
@@ -11,4 +11,4 @@ echo "Running DB migrations and setup..."
 
 # Starting the main process using original entrypoint
 echo "starting dlv stellar-disbursement-platform"
-/go/bin/dlv exec ./stellar-disbursement-platform -- serve --continue --accept-multiclient --headless --listen=:2345 --api-version=2 --log
+/go/bin/dlv exec ./stellar-disbursement-platform serve --continue --accept-multiclient --headless --listen=:2345 --api-version=2 --log

--- a/dev/scripts/debug_entrypoint.sh
+++ b/dev/scripts/debug_entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Running migrations
+echo "Running DB migrations and setup..."
+./stellar-disbursement-platform db admin migrate up
+./stellar-disbursement-platform db tss migrate up
+./stellar-disbursement-platform db auth migrate up --all
+./stellar-disbursement-platform db sdp migrate up --all
+./stellar-disbursement-platform db setup-for-network --all
+
+# Starting the main process using original entrypoint
+echo "starting dlv stellar-disbursement-platform"
+/go/bin/dlv exec ./stellar-disbursement-platform serve --headless --listen=:2345 --api-version=2 --log

--- a/dev/scripts/debug_entrypoint.sh
+++ b/dev/scripts/debug_entrypoint.sh
@@ -11,4 +11,4 @@ echo "Running DB migrations and setup..."
 
 # Starting the main process using original entrypoint
 echo "starting dlv stellar-disbursement-platform"
-/go/bin/dlv exec ./stellar-disbursement-platform serve --headless --listen=:2345 --api-version=2 --log
+/go/bin/dlv exec ./stellar-disbursement-platform -- serve --continue --accept-multiclient --headless --listen=:2345 --api-version=2 --log

--- a/dev/scripts/exclude_from_coverage.sh
+++ b/dev/scripts/exclude_from_coverage.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+exclude_terms() {
+    local terms="$1"
+    local infile="$2"
+    local tmpfile="${infile}.tmp"
+
+    while IFS= read -r term || [ -n "$term" ]; do
+        local exp=".*${term}.*"
+        grep -v "$exp" "$infile" > "$tmpfile"
+        mv "$tmpfile" "$infile"
+    done << EOF
+$terms
+EOF
+}
+
+# Usage
+exclude_terms "mock" "c.out"
+exclude_terms "tss_payments_loadtest.go" "c.out"
+exclude_terms "fixtures.go" "c.out"

--- a/dev/scripts/sep24_deposit.go
+++ b/dev/scripts/sep24_deposit.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/txnbuild"
+)
+
+const (
+	tomlPath = "/.well-known/stellar.toml"
+)
+
+type StellarTOML struct {
+	WEB_AUTH_ENDPOINT   string `toml:"WEB_AUTH_ENDPOINT"`
+	TRANSFER_SERVER_SEP string `toml:"TRANSFER_SERVER_SEP0024"`
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Println("Usage: go run script.go [domain] [secretKey]")
+		os.Exit(1)
+	}
+
+	domain := os.Args[1]
+	secretKey := os.Args[2]
+
+	// Fetch and parse the stellar.toml file
+	config, err := fetchStellarTOML(domain)
+	
+	if err != nil {
+		fmt.Println("Failed to fetch or parse stellar.toml:", err)
+		return
+	}
+	fmt.Println("Fetched stellar.toml successfully:", config)
+	print (config.WEB_AUTH_ENDPOINT)
+
+	kp, err := keypair.ParseFull(secretKey)
+	if err != nil {
+		fmt.Println("Failed to parse secret key:", err)
+		return
+	}
+	fmt.Println("Successfully parsed secret key, public key is:", kp.Address())
+	fmt.Println("AUTH SERVER:", config.WEB_AUTH_ENDPOINT)
+
+	token, err := performSEP10Auth(config.WEB_AUTH_ENDPOINT, kp)
+	if err != nil {
+		fmt.Println("SEP-10 Authentication failed:", err)
+		return
+	}
+	fmt.Println("SEP-10 Authentication successful, token obtained:", token)
+
+	err = performSEP24Deposit(config.TRANSFER_SERVER_SEP, token, kp.Address())
+	if err != nil {
+		fmt.Println("SEP-24 Deposit failed:", err)
+		return
+	}
+	fmt.Println("SEP-24 Deposit initiated successfully")
+}
+
+func fetchStellarTOML(domain string) (StellarTOML, error) {
+	var config StellarTOML
+	tomlURL := "http://" + domain + tomlPath
+	print (tomlURL)
+
+	// Create a client to skip certificate verification (for testing)
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Get(tomlURL)
+	if err != nil {
+		return config, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		return config, fmt.Errorf("failed to fetch stellar.toml: %s, response: %s", tomlURL, string(bodyBytes))
+	}
+
+	_, err = toml.DecodeReader(resp.Body, &config)
+	return config, err
+}
+
+func performSEP10Auth(authURL string, kp *keypair.Full) (string, error) {
+	fmt.Println("Fetching challenge transaction from:", authURL)
+
+        // request a transaction to sign
+	resp, err := http.Get(authURL + "?account=" + kp.Address())
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch challenge: status code %d, response: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var challenge struct {
+		Transaction string `json:"transaction"`
+		Network     string `json:"network"`
+	}
+
+	if err := json.Unmarshal(bodyBytes, &challenge); err != nil {
+		return "", err
+	}
+
+	// Parse the transaction from XDR
+	genericTx, err := txnbuild.TransactionFromXDR(challenge.Transaction)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse challenge transaction: %v", err)
+	}
+
+	// Check if it's a regular transaction and unwrap it
+	tx, ok := genericTx.Transaction()
+	if !ok {
+		return "", fmt.Errorf("parsed data is not a regular transaction")
+	}
+
+	// Sign the transaction
+	networkPassphrase := network.TestNetworkPassphrase // or network.PublicNetworkPassphrase for production
+	signedTx, err := tx.Sign(networkPassphrase, kp)
+	if err != nil {
+		return "", fmt.Errorf("unable to sign challenge transaction: %v", err)
+	}
+
+	// Convert the signed transaction to base64 XDR format to be ready for submission
+	signedTxXDR, err := signedTx.Base64()
+	if err != nil {
+		return "", fmt.Errorf("unable to convert signed transaction to base64 XDR: %v", err)
+	}
+
+	// Submit the signed transaction
+	reqBody, err := json.Marshal(map[string]string{"transaction": signedTxXDR})
+	if err != nil {
+		return "", err
+	}
+
+	verifyResp, err := http.Post(authURL, "application/json", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return "", err
+	}
+	defer verifyResp.Body.Close()
+
+	verifyBodyBytes, _ := ioutil.ReadAll(verifyResp.Body)
+	if verifyResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("verification failed: status code %d, response: %s", verifyResp.StatusCode, string(verifyBodyBytes))
+	}
+
+	var authResponse struct {
+		Token string `json:"token"`
+	}
+
+	if err := json.Unmarshal(verifyBodyBytes, &authResponse); err != nil {
+		return "", fmt.Errorf("error parsing verification response: %v", err)
+	}
+
+	return authResponse.Token, nil
+}
+
+func performSEP24Deposit(depositURL, token, account string) error {
+	params := map[string]string{
+		"account":                    account,
+		"asset_code":                 "USDC",
+		"lang":                       "en",
+		"claimable_balance_supported": "false",
+	}
+	jsonData, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", depositURL + "/transactions/deposit/interactive", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed deposit: %s", string(body))
+	}
+
+	fmt.Println("Deposit response status:", resp.Status)
+	fmt.Println("Deposit response body:", string(body))
+	return nil
+}

--- a/dev/scripts/stellar.toml
+++ b/dev/scripts/stellar.toml
@@ -1,0 +1,24 @@
+ACCOUNTS=["GDFSZFORVKOAGHJVLE7OJTM44KR2NYICFIYZ7HUES3ULUYQVD4PX5B6O", "GAH74OK3PJ76LJQ5DH5QMWUL3UJ5D2JCNLQ7LXHUQHXLEBXER2DWYOB4"]
+SIGNING_KEY="GAH74OK3PJ76LJQ5DH5QMWUL3UJ5D2JCNLQ7LXHUQHXLEBXER2DWYOB4"
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+HORIZON_URL="https://horizon-testnet.stellar.org"
+WEB_AUTH_ENDPOINT="http://localhost:8080/auth"
+TRANSFER_SERVER_SEP0024="http://localhost:8080/sep24"
+
+[DOCUMENTATION]
+ORG_NAME="redcorp"
+
+[[CURRENCIES]]
+code = "USDC"
+issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+is_asset_anchored = true
+anchor_asset_type = "fiat"
+status = "live"
+desc = "USDC"
+
+[[CURRENCIES]]
+code = "native"
+status = "live"
+is_asset_anchored = true
+anchor_asset_type = "crypto"
+desc = "XLM, the native token of the Stellar Network."

--- a/dev/scripts/stellar.toml.1
+++ b/dev/scripts/stellar.toml.1
@@ -1,0 +1,24 @@
+ACCOUNTS=["GDFSZFORVKOAGHJVLE7OJTM44KR2NYICFIYZ7HUES3ULUYQVD4PX5B6O", "GAH74OK3PJ76LJQ5DH5QMWUL3UJ5D2JCNLQ7LXHUQHXLEBXER2DWYOB4"]
+SIGNING_KEY="GAH74OK3PJ76LJQ5DH5QMWUL3UJ5D2JCNLQ7LXHUQHXLEBXER2DWYOB4"
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+HORIZON_URL="https://horizon-testnet.stellar.org"
+WEB_AUTH_ENDPOINT="http://localhost:8080/auth"
+TRANSFER_SERVER_SEP0024="http://localhost:8080/sep24"
+
+[DOCUMENTATION]
+ORG_NAME="redcorp"
+
+[[CURRENCIES]]
+code = "USDC"
+issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+is_asset_anchored = true
+anchor_asset_type = "fiat"
+status = "live"
+desc = "USDC"
+
+[[CURRENCIES]]
+code = "native"
+status = "live"
+is_asset_anchored = true
+anchor_asset_type = "crypto"
+desc = "XLM, the native token of the Stellar Network."

--- a/dev/scripts/stellar.toml.2
+++ b/dev/scripts/stellar.toml.2
@@ -1,0 +1,24 @@
+ACCOUNTS=["GDFSZFORVKOAGHJVLE7OJTM44KR2NYICFIYZ7HUES3ULUYQVD4PX5B6O", "GAH74OK3PJ76LJQ5DH5QMWUL3UJ5D2JCNLQ7LXHUQHXLEBXER2DWYOB4"]
+SIGNING_KEY="GAH74OK3PJ76LJQ5DH5QMWUL3UJ5D2JCNLQ7LXHUQHXLEBXER2DWYOB4"
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+HORIZON_URL="https://horizon-testnet.stellar.org"
+WEB_AUTH_ENDPOINT="http://localhost:8080/auth"
+TRANSFER_SERVER_SEP0024="http://localhost:8080/sep24"
+
+[DOCUMENTATION]
+ORG_NAME="redcorp"
+
+[[CURRENCIES]]
+code = "USDC"
+issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+is_asset_anchored = true
+anchor_asset_type = "fiat"
+status = "live"
+desc = "USDC"
+
+[[CURRENCIES]]
+code = "native"
+status = "live"
+is_asset_anchored = true
+anchor_asset_type = "crypto"
+desc = "XLM, the native token of the Stellar Network."

--- a/dev/scripts/test.sh
+++ b/dev/scripts/test.sh
@@ -1,0 +1,5 @@
+eval $(go run create_and_fund.go)
+
+# Now the environment variables are set in the shell
+echo $STELLAR_PUBLIC_KEY
+echo $STELLAR_SECRET_KEY

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -214,6 +214,13 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	mux.Use(chimiddleware.CleanPath)
 	mux.Use(chimiddleware.Compress(5))
 
+    // Health check endpoint
+    mux.Get("/health", httphandler.HealthHandler{
+        ReleaseID: o.GitCommit,
+        ServiceID: ServiceID,
+        Version:   o.Version,
+    }.ServeHTTP)
+
 	// Create a route along /static that will serve contents from the ./public_files folder.
 	staticFileServer(mux, publicfiles.PublicFiles)
 
@@ -406,11 +413,6 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 	// SEP-24 and miscellaneous endpoints that are tenant-unaware
 	mux.Group(func(r chi.Router) {
-		r.Get("/health", httphandler.HealthHandler{
-			ReleaseID: o.GitCommit,
-			ServiceID: ServiceID,
-			Version:   o.Version,
-		}.ServeHTTP)
 
 		// START SEP-24 endpoints
 		r.Get("/.well-known/stellar.toml", httphandler.StellarTomlHandler{


### PR DESCRIPTION
### What

made some update

I have made some updates to the main.sh local development flow, so than upon cloning branch you could send a disbursement right away with a funded distribution wallet and no manual steps other than logging in.
../main.sh
(runs)
----------------------------------------
🎉🎉🎉🎉 SUCCESS! 🎉🎉🎉🎉
Login URLs for each tenant:
🔗Tenant redcorp: http://redcorp.stellar.local:3000
username: owner@redcorp.org  password: Password123!
🔗Tenant bluecorp: http://bluecorp.stellar.local:3000
username: owner@bluecorp.org  password: Password123!
🔗Tenant pinkcorp: http://pinkcorp.stellar.local:3000
username: owner@pinkcorp.org  password: Password123!
<img width="1294" alt="image" src="https://github.com/stellar/stellar-disbursement-platform-backend/assets/98427531/08c235f7-a4d9-49a4-b5e0-895ba4f6218e">


They include
- launch in single-tenant mode for multi-tenancy TODO: make this configurable
- add a --delete_pv flag for main.sh to delete persisten volumes if you want to start from scratch
- add a script and check to see if .env exists. if it does, use it. if it does not run a script to create sep10 stellar account, create a distribution wallet. fund both with xlm, also create a path payment and fund the distribution wallet with some usdc
- update dockerfile to have both `production` and `development` stages.  update main.sh to use development stage which includes source-code, dlv, jq to launch sdp-mtn container debug build so you can connect from your IDE and debug remotely
- updated docker-compose-sdp-anchor to support the debug mode
- add sample launch.json to connect with vscode
- add entrypoint script to run for debugging which runs the data migrations then runs dlv exec for the stellar-disbursement-platform executable
- add a script to add users (run as docker exec from main.sh) so you do not need to go through the forgot password/password reset manually
- update main.sh to retrieve the id for redcorp and set as the default tenant
- add a postman collection for tenant api

### Why

so a developer can sync repo, run main.sh and is able to send disbursement right away without any manual steps.

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.


#### Release
currently draft pr.

* [ x] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?
tested once and will do some more testing today. DR