### PR TITLE
[SDP-1208] Make tenant provisioning atomic, even to failures in fundTenantDistributionAccount

### DIFF
--- a/stellar-multitenant/internal/provisioning/manager.go
+++ b/stellar-multitenant/internal/provisioning/manager.go
@@ -209,10 +209,10 @@ func (m *Manager) provisionDistributionAccount(ctx context.Context, t *tenant.Te
 	}
 
 	// Assigning the account key to the tenant so that it can be referenced if it needs to be deleted in the vault if any subsequent errors are encountered
-	t.DistributionAccountAddress = &distributionAccPubKeys[0]
 	if len(distributionAccPubKeys) != 1 {
 		return fmt.Errorf("%w: expected single distribution account public key, got %d", ErrUpdateTenantFailed, len(distributionAccPubKeys))
 	}
+	t.DistributionAccountAddress = &distributionAccPubKeys[0]
 	log.Ctx(ctx).Infof("distribution account %s created for tenant %s", *t.DistributionAccountAddress, t.Name)
 	return nil
 }

--- a/stellar-multitenant/internal/provisioning/manager.go
+++ b/stellar-multitenant/internal/provisioning/manager.go
@@ -136,7 +136,7 @@ func (m *Manager) handleProvisioningError(ctx context.Context, err error, t *ten
 	return provisioningErr
 }
 
-func (m *Manager) provisionTenant(ctx context.Context, pt *ProvisionTenant) (*tenant.Tenant, error) {
+func (m *Manager) provisionTenant(ctx context.Context, pt *ProvisionTenant) (t *tenant.Tenant, err error) {
 	t, addTntErr := m.tenantManager.AddTenant(ctx, pt.name)
 	if addTntErr != nil {
 		return t, fmt.Errorf("%w: adding tenant %s: %w", ErrTenantCreationFailed, pt.name, addTntErr)
@@ -161,7 +161,7 @@ func (m *Manager) provisionTenant(ctx context.Context, pt *ProvisionTenant) (*te
 	distSignerType := signing.SignatureClientType(distSignerTypeStr)
 	distAccType, err := distSignerType.DistributionAccountType()
 	if err != nil {
-		return nil, fmt.Errorf("parsing getting distribution account type: %w", err)
+		return t, fmt.Errorf("parsing getting distribution account type: %w", err)
 	}
 
 	tenantStatus := tenant.ProvisionedTenantStatus

--- a/stellar-multitenant/internal/provisioning/manager.go
+++ b/stellar-multitenant/internal/provisioning/manager.go
@@ -165,7 +165,7 @@ func (m *Manager) provisionTenant(ctx context.Context, pt *ProvisionTenant) (*te
 	}
 
 	tenantStatus := tenant.ProvisionedTenantStatus
-	t, err = m.tenantManager.UpdateTenantConfig(
+	updatedTenant, err := m.tenantManager.UpdateTenantConfig(
 		ctx,
 		&tenant.TenantUpdate{
 			ID:                         t.ID,
@@ -178,7 +178,7 @@ func (m *Manager) provisionTenant(ctx context.Context, pt *ProvisionTenant) (*te
 		return t, fmt.Errorf("%w: updating tenant %s status to %s: %w", ErrUpdateTenantFailed, pt.name, tenant.ProvisionedTenantStatus, err)
 	}
 
-	return t, nil
+	return updatedTenant, nil
 }
 
 func (m *Manager) fundTenantDistributionAccount(ctx context.Context, distributionAccount string) error {

--- a/stellar-multitenant/internal/provisioning/manager_test.go
+++ b/stellar-multitenant/internal/provisioning/manager_test.go
@@ -526,7 +526,7 @@ func Test_Manager_RollbackOnErrors(t *testing.T) {
 						DistributionAccountStatus:  schema.DistributionAccountStatusActive,
 						Status:                     &tStatus,
 					}).
-					Return(&updatedTnt, errors.New("foobar")).
+					Return(nil, errors.New("foobar")).
 					Once()
 
 				// ROLLBACK: [tenant_creation, schema_creation, distribution_account_creation]


### PR DESCRIPTION
### What

Make tenant provisioning atomic, even to failures in fundTenantDistributionAccount.

### Why

Address https://stellarorg.atlassian.net/browse/SDP-1208.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
