### PR TITLE
[SDP-1217] [SDP-1212] Provisioning script improvements

### DIFF
--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -26,7 +26,7 @@ services:
       BASE_URL: http://localhost:8000
       DATABASE_URL: postgres://postgres@db:5432/sdp_mtn?sslmode=disable
       ENVIRONMENT: localhost
-      LOG_LEVEL: TRACE
+      LOG_LEVEL: INFO
       PORT: "8000"
       METRICS_PORT: "8002"
       METRICS_TYPE: PROMETHEUS

--- a/internal/serve/httpclient/http_client.go
+++ b/internal/serve/httpclient/http_client.go
@@ -14,7 +14,7 @@ type HttpClientInterface interface {
 	PostForm(url string, data url.Values) (resp *http.Response, err error)
 }
 
-const TimeoutClientInSeconds = 30
+const TimeoutClientInSeconds = 40
 
 // DefaultClient returns a default HTTP client with a timeout.
 func DefaultClient() HttpClientInterface {

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -131,6 +131,7 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	log.Ctx(ctx).Infof("Tenant %s created successfully.", tnt.Name)
 	httpjson.RenderStatus(rw, http.StatusCreated, tnt, httpjson.JSON)
 }
 

--- a/stellar-multitenant/internal/provisioning/manager.go
+++ b/stellar-multitenant/internal/provisioning/manager.go
@@ -190,6 +190,7 @@ func (m *Manager) fundTenantDistributionAccount(ctx context.Context, distributio
 		}
 
 		// Bootstrap tenant distribution account with native asset
+		log.Ctx(ctx).Infof("Creating and funding tenant distribution account %s with native asset", distributionAccount)
 		err = tssSvc.CreateAndFundAccount(ctx, m.SubmitterEngine, m.nativeAssetBootstrapAmount, hostDistributionAccPubKey, distributionAccount)
 		if err != nil {
 			return fmt.Errorf("bootstrapping tenant distribution account with native asset: %w", err)

--- a/stellar-multitenant/pkg/serve/serve.go
+++ b/stellar-multitenant/pkg/serve/serve.go
@@ -91,7 +91,7 @@ func StartServe(opts ServeOptions, httpServer HTTPServerInterface) error {
 		TCPKeepAlive:        time.Minute * 3,
 		ShutdownGracePeriod: time.Second * 50,
 		ReadTimeout:         time.Second * 5,
-		WriteTimeout:        time.Second * 35,
+		WriteTimeout:        time.Second * 50,
 		IdleTimeout:         time.Minute * 2,
 		OnStarting: func() {
 			log.Info("Starting Tenant Server")

--- a/stellar-multitenant/pkg/serve/serve_test.go
+++ b/stellar-multitenant/pkg/serve/serve_test.go
@@ -72,7 +72,7 @@ func Test_Serve(t *testing.T) {
 		assert.Equal(t, time.Minute*3, conf.TCPKeepAlive)
 		assert.Equal(t, time.Second*50, conf.ShutdownGracePeriod)
 		assert.Equal(t, time.Second*5, conf.ReadTimeout)
-		assert.Equal(t, time.Second*35, conf.WriteTimeout)
+		assert.Equal(t, time.Second*50, conf.WriteTimeout)
 		assert.Equal(t, time.Minute*2, conf.IdleTimeout)
 		assert.Nil(t, conf.TLS)
 		assert.ObjectsAreEqualValues(handleHTTP(&opts), conf.Handler)


### PR DESCRIPTION
### What
* Add some logging 
* Change timeout values to show some obfuscated errors. The problem was that different components were timing out at the same time which caused random errors to show up. 

#### Before
```
--> Admin Server (35s) ---> HttpClient (30s) ----> Horizon (30s)*
```
#### Now 
```
--> Admin Server (50s) ---> HttpClient (40s) ----> Horizon (30s)*
```
[*] Horizon timeout is outside of our control

### Why
* SDP-1217 [Provisioning] Random failures when funding disbursement account
* SDP-1212 main.sh does not deal with response codes that are different from 2xx

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
