### PR TITLE
[SDP-1179] Make `sendPaymentsReadyToPay` atomic by synchronizing the database transactions

### DIFF
--- a/internal/services/payment_to_submitter_service.go
+++ b/internal/services/payment_to_submitter_service.go
@@ -45,18 +45,15 @@ func (s PaymentToSubmitterService) SendPaymentsReadyToPay(ctx context.Context, p
 		paymentIDs = append(paymentIDs, paymentReadyToPay.ID)
 	}
 
-	err := db.RunInTransaction(ctx, s.sdpModels.DBConnectionPool, nil, func(sdpDBTx db.DBTransaction) error {
-		return db.RunInTransaction(ctx, s.tssModel.DBConnectionPool, nil, func(tssDBTx db.DBTransaction) error {
-			log.Ctx(ctx).Infof("Registering %d payments into the TSS, paymentIDs=%v", len(paymentIDs), paymentIDs)
-			payments, err := s.sdpModels.Payment.GetReadyByID(ctx, sdpDBTx, paymentIDs...)
-			if err != nil {
-				return fmt.Errorf("getting payments ready to be sent: %w", err)
-			}
-			if len(payments) != len(paymentIDs) {
-				log.Ctx(ctx).Errorf("[PaymentToSubmitterService] The number of incoming payments to be processed (%d) is different from the number ready to be processed found in the database (%d)", len(paymentIDs), len(payments))
-			}
-			return s.sendPaymentsReadyToPay(ctx, sdpDBTx, tssDBTx, paymentsReadyToPay.TenantID, payments)
-		})
+	err := s.sendPaymentsReadyToPay(ctx, paymentsReadyToPay.TenantID, func(sdpDBTx db.DBTransaction) ([]*data.Payment, error) {
+		log.Ctx(ctx).Infof("Registering %d payments into the TSS, paymentIDs=%v", len(paymentIDs), paymentIDs)
+
+		payments, innerErr := s.sdpModels.Payment.GetReadyByID(ctx, sdpDBTx, paymentIDs...)
+		if len(payments) != len(paymentIDs) {
+			log.Ctx(ctx).Errorf("[PaymentToSubmitterService] The number of incoming payments to be processed (%d) is different from the number ready to be processed found in the database (%d)", len(paymentIDs), len(payments))
+		}
+
+		return payments, innerErr
 	})
 	if err != nil {
 		return fmt.Errorf("sending payments: %w", err)
@@ -72,15 +69,8 @@ func (s PaymentToSubmitterService) SendBatchPayments(ctx context.Context, batchS
 		return fmt.Errorf("getting tenant from context: %w", tenantErr)
 	}
 
-	err := db.RunInTransaction(ctx, s.sdpModels.DBConnectionPool, nil, func(sdpDBTx db.DBTransaction) error {
-		return db.RunInTransaction(ctx, s.tssModel.DBConnectionPool, nil, func(tssDBTx db.DBTransaction) error {
-			// Get payments that are ready to be sent. This will lock the rows.
-			payments, err := s.sdpModels.Payment.GetBatchForUpdate(ctx, sdpDBTx, batchSize)
-			if err != nil {
-				return fmt.Errorf("getting payments ready to be sent: %w", err)
-			}
-			return s.sendPaymentsReadyToPay(ctx, sdpDBTx, tssDBTx, t.ID, payments)
-		})
+	err := s.sendPaymentsReadyToPay(ctx, t.ID, func(sdpDBTx db.DBTransaction) ([]*data.Payment, error) {
+		return s.sdpModels.Payment.GetBatchForUpdate(ctx, sdpDBTx, batchSize)
 	})
 	if err != nil {
 		return fmt.Errorf("sending payments: %w", err)
@@ -99,78 +89,92 @@ func (s PaymentToSubmitterService) SendBatchPayments(ctx context.Context, batchS
 //	c. Disbursement is in `STARTED` status.
 func (s PaymentToSubmitterService) sendPaymentsReadyToPay(
 	ctx context.Context,
-	sdpDBTx db.DBTransaction,
-	tssDBTx db.DBTransaction,
 	tenantID string,
-	payments []*data.Payment,
+	getPaymentsFn func(sdpDBTx db.DBTransaction) ([]*data.Payment, error),
 ) error {
-	var transactions []txSubStore.Transaction
-	var failedPayments []*data.Payment
-	var pendingPayments []*data.Payment
+	outerErr := db.RunInTransaction(ctx, s.sdpModels.DBConnectionPool, nil, func(sdpDBTx db.DBTransaction) error {
+		return db.RunInTransaction(ctx, s.tssModel.DBConnectionPool, nil, func(tssDBTx db.DBTransaction) error {
+			payments, err := getPaymentsFn(sdpDBTx)
+			if err != nil {
+				return fmt.Errorf("getting payments ready to be sent: %w", err)
+			}
 
-	for _, payment := range payments {
-		// 1. For each payment, validate it is ready to be sent
-		if err := validatePaymentReadyForSending(payment); err != nil {
-			// if payment is not ready for sending, we will mark it as failed later.
-			failedPayments = append(failedPayments, payment)
-			log.Ctx(ctx).Errorf("Payment %s is not ready for sending. Error:%s", payment.ID, err.Error())
-			continue
-		}
+			var transactions []txSubStore.Transaction
+			var failedPayments []*data.Payment
+			var pendingPayments []*data.Payment
 
-		// TODO: change TSS to use string amount [SDP-483]
-		amount, err := strconv.ParseFloat(payment.Amount, 64)
-		if err != nil {
-			return fmt.Errorf("parsing payment amount %s for payment ID %s: %w", payment.Amount, payment.ID, err)
-		}
-		transaction := txSubStore.Transaction{
-			ExternalID:  payment.ID,
-			AssetCode:   payment.Asset.Code,
-			AssetIssuer: payment.Asset.Issuer,
-			Amount:      amount,
-			Destination: payment.ReceiverWallet.StellarAddress,
-			TenantID:    tenantID,
-		}
-		transactions = append(transactions, transaction)
-		pendingPayments = append(pendingPayments, payment)
-	}
+			for _, payment := range payments {
+				// 1. For each payment, validate it is ready to be sent
+				err = validatePaymentReadyForSending(payment)
+				if err != nil {
+					// if payment is not ready for sending, we will mark it as failed later.
+					failedPayments = append(failedPayments, payment)
+					log.Ctx(ctx).Errorf("Payment %s is not ready for sending. Error:%s", payment.ID, err.Error())
+					continue
+				}
 
-	// 3. Persist data in Transactions table
-	insertedTransactions, err := s.tssModel.BulkInsert(ctx, tssDBTx, transactions)
-	if err != nil {
-		return fmt.Errorf("inserting transactions: %w", err)
-	}
-	if len(insertedTransactions) > 0 {
-		insertedTxIDs := make([]string, 0, len(insertedTransactions))
-		for _, insertedTransaction := range insertedTransactions {
-			insertedTxIDs = append(insertedTxIDs, insertedTransaction.ID)
-		}
-		log.Ctx(ctx).Infof("Submitted %d transaction(s) to TSS: %v", len(insertedTransactions), insertedTxIDs)
-	}
+				// TODO: change TSS to use string amount [SDP-483]
+				var amount float64
+				amount, err = strconv.ParseFloat(payment.Amount, 64)
+				if err != nil {
+					return fmt.Errorf("parsing payment amount %s for payment ID %s: %w", payment.Amount, payment.ID, err)
+				}
+				transaction := txSubStore.Transaction{
+					ExternalID:  payment.ID,
+					AssetCode:   payment.Asset.Code,
+					AssetIssuer: payment.Asset.Issuer,
+					Amount:      amount,
+					Destination: payment.ReceiverWallet.StellarAddress,
+					TenantID:    tenantID,
+				}
+				transactions = append(transactions, transaction)
+				pendingPayments = append(pendingPayments, payment)
+			}
 
-	// 4. Update payment statuses to `Pending`
-	if len(pendingPayments) > 0 {
-		numUpdated, err := s.sdpModels.Payment.UpdateStatuses(ctx, sdpDBTx, pendingPayments, data.PendingPaymentStatus)
-		if err != nil {
-			return fmt.Errorf("updating payment statuses to Pending: %w", err)
-		}
-		updatedPaymentIDs := make([]string, 0, len(pendingPayments))
-		for _, pendingPayment := range pendingPayments {
-			updatedPaymentIDs = append(updatedPaymentIDs, pendingPayment.ID)
-		}
-		log.Ctx(ctx).Infof("Updated %d payments to Pending: %v", numUpdated, updatedPaymentIDs)
-	}
+			// 3. Persist data in Transactions table
+			insertedTransactions, err := s.tssModel.BulkInsert(ctx, tssDBTx, transactions)
+			if err != nil {
+				return fmt.Errorf("inserting transactions: %w", err)
+			}
+			if len(insertedTransactions) > 0 {
+				insertedTxIDs := make([]string, 0, len(insertedTransactions))
+				for _, insertedTransaction := range insertedTransactions {
+					insertedTxIDs = append(insertedTxIDs, insertedTransaction.ID)
+				}
+				log.Ctx(ctx).Infof("Submitted %d transaction(s) to TSS: %v", len(insertedTransactions), insertedTxIDs)
+			}
 
-	// 5. Update failed payments statuses to `Failed`
-	if len(failedPayments) != 0 {
-		numUpdated, err := s.sdpModels.Payment.UpdateStatuses(ctx, sdpDBTx, failedPayments, data.FailedPaymentStatus)
-		if err != nil {
-			return fmt.Errorf("updating payment statuses to Failed: %w", err)
-		}
-		failedPaymentIDs := make([]string, 0, len(failedPayments))
-		for _, failedPayment := range failedPayments {
-			failedPaymentIDs = append(failedPaymentIDs, failedPayment.ID)
-		}
-		log.Ctx(ctx).Warnf("Updated %d payments to Failed: %v", numUpdated, failedPaymentIDs)
+			// 4. Update payment statuses to `Pending`
+			if len(pendingPayments) > 0 {
+				numUpdated, err := s.sdpModels.Payment.UpdateStatuses(ctx, sdpDBTx, pendingPayments, data.PendingPaymentStatus)
+				if err != nil {
+					return fmt.Errorf("updating payment statuses to Pending: %w", err)
+				}
+				updatedPaymentIDs := make([]string, 0, len(pendingPayments))
+				for _, pendingPayment := range pendingPayments {
+					updatedPaymentIDs = append(updatedPaymentIDs, pendingPayment.ID)
+				}
+				log.Ctx(ctx).Infof("Updated %d payments to Pending: %v", numUpdated, updatedPaymentIDs)
+			}
+
+			// 5. Update failed payments statuses to `Failed`
+			if len(failedPayments) != 0 {
+				numUpdated, err := s.sdpModels.Payment.UpdateStatuses(ctx, sdpDBTx, failedPayments, data.FailedPaymentStatus)
+				if err != nil {
+					return fmt.Errorf("updating payment statuses to Failed: %w", err)
+				}
+				failedPaymentIDs := make([]string, 0, len(failedPayments))
+				for _, failedPayment := range failedPayments {
+					failedPaymentIDs = append(failedPaymentIDs, failedPayment.ID)
+				}
+				log.Ctx(ctx).Warnf("Updated %d payments to Failed: %v", numUpdated, failedPaymentIDs)
+			}
+
+			return nil
+		})
+	})
+	if outerErr != nil {
+		return fmt.Errorf("sending payments inside syncronized database transactions: %w", outerErr)
 	}
 
 	return nil

--- a/internal/transactionsubmission/store/mocks/transaction_store.go
+++ b/internal/transactionsubmission/store/mocks/transaction_store.go
@@ -94,7 +94,7 @@ func (_m *MockTransactionStore) GetAllByPaymentIDs(ctx context.Context, paymentI
 	return r0, r1
 }
 
-// GetTransactionBatchForUpdate provides a mock function with given fields: ctx, dbTx, batchSize
+// GetTransactionBatchForUpdate provides a mock function with given fields: ctx, dbTx, batchSize, tenantID
 func (_m *MockTransactionStore) GetTransactionBatchForUpdate(ctx context.Context, dbTx db.DBTransaction, batchSize int, tenantID string) ([]*store.Transaction, error) {
 	ret := _m.Called(ctx, dbTx, batchSize, tenantID)
 


### PR DESCRIPTION
### What

Make `sendPaymentsReadyToPay` atomic by synchronizing the database transactions

### Why

the atomicity was not done correctly.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
