### PR TITLE
[SDP-1213] Retry Payment Not Working

### DIFF
--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -901,7 +901,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 			On("WriteMessages", ctx, []events.Message{
 				{
 					Topic:    events.PaymentReadyToPayTopic,
-					Key:      "",
+					Key:      tnt.ID,
 					TenantID: tnt.ID,
 					Type:     events.PaymentReadyToPayRetryFailedPayment,
 					Data: schemas.EventPaymentsReadyToPayData{
@@ -1047,7 +1047,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 			On("WriteMessages", ctx, []events.Message{
 				{
 					Topic:    events.PaymentReadyToPayTopic,
-					Key:      "",
+					Key:      tnt.ID,
 					TenantID: tnt.ID,
 					Type:     events.PaymentReadyToPayRetryFailedPayment,
 					Data: schemas.EventPaymentsReadyToPayData{
@@ -1136,7 +1136,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 
 		msg := events.Message{
 			Topic:    events.PaymentReadyToPayTopic,
-			Key:      "",
+			Key:      tnt.ID,
 			TenantID: tnt.ID,
 			Type:     events.PaymentReadyToPayRetryFailedPayment,
 			Data: schemas.EventPaymentsReadyToPayData{


### PR DESCRIPTION
### What
Retry Payments were not working because of the absence of a `Key` when submitting a Kafka event. 

In the following test, I retried a failed payment a couple of times (receiver didn't have a trust line to USDC), then added the trust line and retried a 3rd time. Payment eventually succeeded. 

<img width="947" alt="Screenshot 2024-05-23 at 3 41 44 PM" src="https://github.com/stellar/stellar-disbursement-platform-backend/assets/4129193/ed8b65cc-7c1a-4299-8082-cbdfe0fc9716">

### Why
https://stellarorg.atlassian.net/browse/SDP-1213 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
