### PR TITLE
[SDP-1219] Retry messages on failed handlers only

### DIFF
--- a/dev/main.sh
+++ b/dev/main.sh
@@ -19,7 +19,7 @@ echo "====> ✅Step 1: finish preparation"
 # Run docker compose
 echo $DIVIDER
 echo "====> 👀Step 2: start calling docker compose up"
-docker-compose down && docker-compose -p sdp-multi-tenant up -d
+docker-compose down && docker-compose -p sdp-multi-tenant up -d --build
 echo "====> ✅Step 2: finish calling docker-compose up"
 
 # Initialize tenants

--- a/dev/main.sh
+++ b/dev/main.sh
@@ -19,7 +19,7 @@ echo "====> ✅Step 1: finish preparation"
 # Run docker compose
 echo $DIVIDER
 echo "====> 👀Step 2: start calling docker compose up"
-docker-compose down && docker-compose -p sdp-multi-tenant up -d --build
+docker-compose down && docker-compose -p sdp-multi-tenant up -d
 echo "====> ✅Step 2: finish calling docker-compose up"
 
 # Initialize tenants

--- a/internal/events/backoff_manager.go
+++ b/internal/events/backoff_manager.go
@@ -23,9 +23,11 @@ func NewBackoffManager(backoffChan chan<- struct{}, maxBackoff int) *ConsumerBac
 	}
 }
 
-func (bm *ConsumerBackoffManager) TriggerBackoffWithMessage(msg *Message, backoffErr error) {
+func (bm *ConsumerBackoffManager) TriggerBackoffWithMessage(msg *Message, hErr *HandlerError) {
 	if msg != nil {
-		msg.RecordError(backoffErr.Error())
+		if hErr != nil {
+			msg.RecordError(hErr)
+		}
 		bm.message = msg
 	}
 	bm.TriggerBackoff()

--- a/internal/events/backoff_manager.go
+++ b/internal/events/backoff_manager.go
@@ -23,11 +23,8 @@ func NewBackoffManager(backoffChan chan<- struct{}, maxBackoff int) *ConsumerBac
 	}
 }
 
-func (bm *ConsumerBackoffManager) TriggerBackoffWithMessage(msg *Message, hErr *HandlerError) {
+func (bm *ConsumerBackoffManager) TriggerBackoffWithMessage(msg *Message) {
 	if msg != nil {
-		if hErr != nil {
-			msg.RecordError(hErr)
-		}
 		bm.message = msg
 	}
 	bm.TriggerBackoff()

--- a/internal/events/event_consumer.go
+++ b/internal/events/event_consumer.go
@@ -136,7 +136,9 @@ func (ec *EventConsumer) handleMessage(ctx context.Context, msg *Message) bool {
 		if ShouldHandleMessage(ctx, handler, msg) {
 			handleErr := handler.Handle(ctx, msg)
 			if handleErr != nil {
-				ec.crashTracker.LogAndReportErrors(ctx, handleErr, fmt.Sprintf("handling message for topic %s", ec.consumer.Topic()))
+				ec.crashTracker.LogAndReportErrors(ctx, handleErr, fmt.Sprintf("handling message for topic %s with handler %s",
+					ec.consumer.Topic(),
+					handler.Name()))
 				msg.RecordError(handler.Name(), handleErr)
 				allHandlersSuccessful = false
 			} else {

--- a/internal/events/event_consumer.go
+++ b/internal/events/event_consumer.go
@@ -30,7 +30,7 @@ func NewEventConsumer(consumer Consumer, producer Producer, crashTracker crashtr
 }
 
 func (ec *EventConsumer) Consume(ctx context.Context) {
-	log.Ctx(ctx).Infof("starting consuming messages for topic %s...", ec.consumer.Topic())
+	log.Ctx(ctx).Infof("Starting consuming messages for topic %s...", ec.consumer.Topic())
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
@@ -53,7 +53,11 @@ func (ec *EventConsumer) Consume(ctx context.Context) {
 
 		case <-backoffChan:
 			backoff := backoffManager.GetBackoffDuration()
-			log.Ctx(ctx).Warnf("Waiting %s before retrying reading new messages", backoff)
+			if backoffManager.GetMessage() != nil {
+				log.Ctx(ctx).Warnf("Waiting %s before retrying handling message with key %s", backoff, backoffManager.GetMessage().Key)
+			} else {
+				log.Ctx(ctx).Warnf("Waiting %s before retrying reading new messages", backoff)
+			}
 			time.Sleep(backoff)
 
 		default:
@@ -76,18 +80,20 @@ func (ec *EventConsumer) Consume(ctx context.Context) {
 			// 3. If no message in backoff manager, read message from Kafka.
 			if msg == nil {
 				var readErr error
+				log.Ctx(ctx).Infof("Reading message from topic %s...", ec.consumer.Topic())
 				msg, readErr = ec.consumer.ReadMessage(ctx)
 				if readErr != nil {
 					ec.crashTracker.LogAndReportErrors(ctx, readErr, fmt.Sprintf("consuming messages for topic %s", ec.consumer.Topic()))
 					backoffManager.TriggerBackoff()
 					continue
 				}
+			} else {
+				log.Ctx(ctx).Warnf("Retrying handling message with key %s", msg.Key)
 			}
 
 			// 4. Run the message through the handler chain.
-			if handleErr := ec.handleMessage(ctx, msg); handleErr != nil {
-				backoffManager.TriggerBackoffWithMessage(msg, handleErr)
-				ec.crashTracker.LogAndReportErrors(ctx, handleErr.Err, fmt.Sprintf("handling message for topic %s", ec.consumer.Topic()))
+			if handledOk := ec.handleMessage(ctx, msg); !handledOk {
+				backoffManager.TriggerBackoffWithMessage(msg)
 				continue
 			}
 
@@ -124,15 +130,34 @@ func (ec *EventConsumer) sendMessageToDLQ(ctx context.Context, msg Message) erro
 }
 
 // handleMessage handles the message by the handler chain of the consumer.
-func (ec *EventConsumer) handleMessage(ctx context.Context, msg *Message) *HandlerError {
+func (ec *EventConsumer) handleMessage(ctx context.Context, msg *Message) bool {
+	allHandlersSuccessful := true
 	for _, handler := range ec.consumer.Handlers() {
-		if handler.CanHandleMessage(ctx, msg) {
+		if ShouldHandleMessage(ctx, handler, msg) {
 			handleErr := handler.Handle(ctx, msg)
 			if handleErr != nil {
-				hError := NewHandlerErrorWrapper(handleErr, handler.Name())
-				return &hError
+				ec.crashTracker.LogAndReportErrors(ctx, handleErr, fmt.Sprintf("handling message for topic %s", ec.consumer.Topic()))
+				msg.RecordError(handler.Name(), handleErr)
+				allHandlersSuccessful = false
+			} else {
+				msg.RecordSuccess(handler.Name())
 			}
 		}
 	}
-	return nil
+	return allHandlersSuccessful
+}
+
+// ShouldHandleMessage returns true if the message should be handled by the handler passed by parameter.
+// A message should be handled by a handler if the handler can handle the message and the handler has not been executed before.
+func ShouldHandleMessage(ctx context.Context, handler EventHandler, msg *Message) bool {
+	if handler.CanHandleMessage(ctx, msg) {
+		for _, execution := range msg.SuccessfulExecutions {
+			if execution.HandlerName == handler.Name() {
+				log.Ctx(ctx).Infof("Handler %s has already been executed for message with key %s. Skipping...", handler.Name(), msg.Key)
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }

--- a/internal/events/event_consumer_test.go
+++ b/internal/events/event_consumer_test.go
@@ -17,7 +17,7 @@ func Test_EventConsumer_Consume(t *testing.T) {
 	// setup mocks
 	consumerMock := &MockConsumer{}
 	crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
-	producerMock := &MockProducer{}
+	producerMock := NewMockProducer(t)
 
 	msg := &Message{Key: "key-1", Topic: "test.test_topic"}
 	unexpectedErr := errors.New("unexpected error")
@@ -56,8 +56,8 @@ func Test_EventConsumer_Consume_SendDLQ(t *testing.T) {
 	// setup mocks
 	consumerMock := &MockConsumer{}
 	crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
-	producerMock := &MockProducer{}
-	failedEventHandlerMock := &MockEventHandler{}
+	producerMock := NewMockProducer(t)
+	failedEventHandlerMock := NewMockEventHandler(t)
 
 	handlingErr := errors.New("handling message for topic test.test_topic")
 	msg := &Message{Key: "key-1", Topic: "test.test_topic"}
@@ -95,17 +95,15 @@ func Test_EventConsumer_Consume_SendDLQ(t *testing.T) {
 
 	consumerMock.AssertExpectations(t)
 	crashTrackerMock.AssertExpectations(t)
-	producerMock.AssertExpectations(t)
-	failedEventHandlerMock.AssertExpectations(t)
 }
 
 func Test_EventConsumer_Consume_HandleFailedOnly(t *testing.T) {
 	// setup mocks
 	consumerMock := &MockConsumer{}
 	crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
-	producerMock := &MockProducer{}
-	failedEventHandlerMock := &MockEventHandler{}
-	successfulEventHandlerMock := &MockEventHandler{}
+	producerMock := NewMockProducer(t)
+	failedEventHandlerMock := NewMockEventHandler(t)
+	successfulEventHandlerMock := NewMockEventHandler(t)
 
 	handlingErr := errors.New("handling message for topic test.test_topic")
 	msg := &Message{Key: "key-1", Topic: "test.test_topic"}
@@ -205,17 +203,14 @@ func Test_EventConsumer_Consume_HandleFailedOnly(t *testing.T) {
 
 	consumerMock.AssertExpectations(t)
 	crashTrackerMock.AssertExpectations(t)
-	producerMock.AssertExpectations(t)
-	successfulEventHandlerMock.AssertExpectations(t)
-	failedEventHandlerMock.AssertExpectations(t)
 }
 
 func Test_EventConsumer_Consume_FinalizeConsumer(t *testing.T) {
 	// setup mocks
 	consumerMock := &MockConsumer{}
 	crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
-	producerMock := &MockProducer{}
-	failedEventHandlerMock := &MockEventHandler{}
+	producerMock := NewMockProducer(t)
+	failedEventHandlerMock := NewMockEventHandler(t)
 
 	handlingErr := errors.New("handling message for topic test.test_topic")
 	msg := &Message{Key: "key-1", Topic: "test.test_topic"}
@@ -263,6 +258,4 @@ func Test_EventConsumer_Consume_FinalizeConsumer(t *testing.T) {
 
 	consumerMock.AssertExpectations(t)
 	crashTrackerMock.AssertExpectations(t)
-	producerMock.AssertExpectations(t)
-	failedEventHandlerMock.AssertExpectations(t)
 }

--- a/internal/events/event_consumer_test.go
+++ b/internal/events/event_consumer_test.go
@@ -28,25 +28,15 @@ func Test_EventConsumer_Consume(t *testing.T) {
 	defer cancel()
 
 	crashTrackerMock.
-		On("LogAndReportErrors", ctx, unexpectedErr, "consuming messages for topic test.test_topic").
-		Return()
+		On("LogAndReportErrors", ctx, unexpectedErr, "consuming messages for topic test.test_topic").Return()
 
 	consumerMock.
-		On("Topic").
-		Return("test.test_topic").
-		On("ReadMessage", ctx).
-		Return(nil, unexpectedErr).
-		Twice().
-		On("ReadMessage", ctx).
-		Return(msg, nil).
-		Once().
-		On("ReadMessage", ctx).
-		Return(nil, unexpectedErr).
-		Once().
-		On("ReadMessage", ctx).
-		Return(msg, nil).
-		On("Handlers").
-		Return([]EventHandler{})
+		On("Topic").Return("test.test_topic").
+		On("ReadMessage", ctx).Return(nil, unexpectedErr).Twice().
+		On("ReadMessage", ctx).Return(msg, nil).Once().
+		On("ReadMessage", ctx).Return(nil, unexpectedErr).Once().
+		On("ReadMessage", ctx).Return(msg, nil).
+		On("Handlers").Return([]EventHandler{})
 
 	getEntries := log.DefaultLogger.StartTest(log.WarnLevel)
 
@@ -67,6 +57,7 @@ func Test_EventConsumer_Consume_SendDLQ(t *testing.T) {
 	consumerMock := &MockConsumer{}
 	crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
 	producerMock := &MockProducer{}
+	failedEventHandlerMock := &MockEventHandler{}
 
 	handlingErr := errors.New("handling message for topic test.test_topic")
 	msg := &Message{Key: "key-1", Topic: "test.test_topic"}
@@ -78,33 +69,145 @@ func Test_EventConsumer_Consume_SendDLQ(t *testing.T) {
 	defer cancel()
 
 	crashTrackerMock.
-		On("LogAndReportErrors", mock.Anything, mock.Anything, handlingErr.Error()).
-		Return()
+		On("LogAndReportErrors", mock.Anything, mock.Anything, handlingErr.Error()).Return()
 
 	consumerMock.
-		On("Topic").
-		Return("test.test_topic").
-		On("ReadMessage", ctx).
-		Return(msg, nil).
-		On("Handlers").
-		Return([]EventHandler{&FailEventHandler{}})
+		On("Topic").Return("test.test_topic").
+		On("ReadMessage", ctx).Return(msg, nil).
+		On("Handlers").Return([]EventHandler{failedEventHandlerMock})
+
+	failedEventHandlerMock.
+		On("Handle", ctx, msg).Return(handlingErr).
+		On("CanHandleMessage", ctx, msg).Return(true).
+		On("Name").Return("FailedEventHandler")
 
 	producerMock.
-		On("WriteMessages", ctx, mock.Anything).
-		Return(nil)
+		On("WriteMessages", ctx, mock.Anything).Return(nil)
 
 	getEntries := log.DefaultLogger.StartTest(log.WarnLevel)
 
 	ec.Consume(ctx)
 
 	entries := getEntries()
-	assert.Equal(t, "Waiting 2s before retrying reading new messages", entries[0].Message)
+	assert.Equal(t, "Waiting 2s before retrying handling message with key key-1", entries[0].Message)
 	assert.Equal(t, "Max backoff reached for topic test.test_topic.", entries[1].Message)
 	assert.Equal(t, "Sending message with key key-1 to DLQ for topic test.test_topic", entries[2].Message) // backoffManager.ResetBackoff() was called
 
 	consumerMock.AssertExpectations(t)
 	crashTrackerMock.AssertExpectations(t)
 	producerMock.AssertExpectations(t)
+	failedEventHandlerMock.AssertExpectations(t)
+}
+
+func Test_EventConsumer_Consume_HandleFailedOnly(t *testing.T) {
+	// setup mocks
+	consumerMock := &MockConsumer{}
+	crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
+	producerMock := &MockProducer{}
+	failedEventHandlerMock := &MockEventHandler{}
+	successfulEventHandlerMock := &MockEventHandler{}
+
+	handlingErr := errors.New("handling message for topic test.test_topic")
+	msg := &Message{Key: "key-1", Topic: "test.test_topic"}
+
+	ec := NewEventConsumer(consumerMock, producerMock, crashTrackerMock)
+
+	// Kill the consumer after 3 seconds.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*3))
+	defer cancel()
+
+	crashTrackerMock.
+		On("LogAndReportErrors", mock.Anything, mock.Anything, handlingErr.Error()).
+		Return()
+
+	// In the 3 seconds runtime, we're expecting call `ReadMessage` once.
+	consumerMock.
+		On("ReadMessage", ctx).Return(msg, nil).Once().
+		On("Topic").Return("test.test_topic").
+		On("Handlers").Return([]EventHandler{failedEventHandlerMock, successfulEventHandlerMock})
+
+	// In the 3 seconds runtime, we're expecting to call `Handle` twice for `FailedEventHandler`.
+	// 1 call triggered by the original message and one backoff.
+	failedEventHandlerMock.
+		On("Handle", ctx, msg).Return(handlingErr).Twice().
+		On("CanHandleMessage", ctx, msg).Return(true).
+		On("Name").Return("FailedEventHandler")
+
+	// In the 3 seconds runtime, we're expecting to call `Handle` once for `SuccessfulEventHandler`.
+	//  This is triggered by the original message. The backoff shouldn't trigger this handler.
+	successfulEventHandlerMock.
+		On("Handle", ctx, msg).Return(nil).Once().
+		On("CanHandleMessage", ctx, msg).Return(true).
+		On("Name").Return("SuccessfulEventHandler")
+
+	// We expect the message to be re-broadcasted to the same topic when consumer gets interrupted by context deadline.
+	producerMock.
+		On("WriteMessages", ctx, mock.MatchedBy(func(m []Message) bool {
+			if len(m) != 1 {
+				return false
+			}
+			message := m[0]
+			// Verify that there is only 1 successful message
+			if len(message.SuccessfulExecutions) != 1 {
+				return false
+			}
+
+			// Verify that one error is recorded correctly. in 3 seconds there should be one backoff.
+			if len(message.Errors) != 1 && message.Errors[0].ErrorMessage != handlingErr.Error() {
+				return false
+			}
+
+			// Verify that re-broadcasted message is the same as the one that failed
+			return message.Key == msg.Key && message.Topic == msg.Topic
+		})).
+		Return(nil)
+
+	getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
+
+	ec.Consume(ctx)
+
+	entries := getEntries()
+	assert.Equal(t, "Starting consuming messages for topic test.test_topic...", entries[0].Message)
+	assert.Equal(t, log.InfoLevel, entries[0].Level)
+
+	assert.Equal(t, "Reading message from topic test.test_topic...", entries[1].Message)
+	assert.Equal(t, log.InfoLevel, entries[1].Level)
+
+	// logged by mock handler
+	assert.Equal(t, "Handling message with key key-1 by handler FailedEventHandler", entries[2].Message)
+	assert.Equal(t, log.InfoLevel, entries[2].Level)
+
+	// logged by mock handler
+	assert.Equal(t, "Handling message with key key-1 by handler SuccessfulEventHandler", entries[3].Message)
+	assert.Equal(t, log.InfoLevel, entries[3].Level)
+
+	assert.Equal(t, "Waiting 2s before retrying handling message with key key-1", entries[4].Message)
+	assert.Equal(t, log.WarnLevel, entries[4].Level)
+
+	assert.Equal(t, "Retrying handling message with key key-1", entries[5].Message)
+	assert.Equal(t, log.WarnLevel, entries[5].Level)
+	assert.Equal(t, entries[4].Time.Truncate(time.Second).Add(time.Second*2), entries[5].Time.Truncate(time.Second))
+
+	assert.Equal(t, "Handling message with key key-1 by handler FailedEventHandler", entries[6].Message)
+	assert.Equal(t, log.InfoLevel, entries[6].Level)
+
+	assert.Equal(t, "Handler SuccessfulEventHandler has already been executed for message with key key-1. Skipping...", entries[7].Message)
+	assert.Equal(t, log.InfoLevel, entries[7].Level)
+
+	assert.Equal(t, "Waiting 4s before retrying handling message with key key-1", entries[8].Message)
+	assert.Equal(t, log.WarnLevel, entries[8].Level)
+
+	assert.Equal(t, "Stopping consuming messages for topic test.test_topic due to context cancellation...", entries[9].Message)
+	assert.Equal(t, log.InfoLevel, entries[9].Level)
+
+	assert.Equal(t, "Replaying message with key key-1 to topic test.test_topic", entries[10].Message)
+	assert.Equal(t, log.WarnLevel, entries[10].Level)
+
+	consumerMock.AssertExpectations(t)
+	crashTrackerMock.AssertExpectations(t)
+	producerMock.AssertExpectations(t)
+	successfulEventHandlerMock.AssertExpectations(t)
+	failedEventHandlerMock.AssertExpectations(t)
 }
 
 func Test_EventConsumer_Consume_FinalizeConsumer(t *testing.T) {
@@ -112,6 +215,7 @@ func Test_EventConsumer_Consume_FinalizeConsumer(t *testing.T) {
 	consumerMock := &MockConsumer{}
 	crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
 	producerMock := &MockProducer{}
+	failedEventHandlerMock := &MockEventHandler{}
 
 	handlingErr := errors.New("handling message for topic test.test_topic")
 	msg := &Message{Key: "key-1", Topic: "test.test_topic"}
@@ -126,12 +230,14 @@ func Test_EventConsumer_Consume_FinalizeConsumer(t *testing.T) {
 		Return()
 
 	consumerMock.
-		On("Topic").
-		Return("test.test_topic").
-		On("ReadMessage", ctx).
-		Return(msg, nil).
-		On("Handlers").
-		Return([]EventHandler{&FailEventHandler{}})
+		On("Topic").Return("test.test_topic").
+		On("ReadMessage", ctx).Return(msg, nil).
+		On("Handlers").Return([]EventHandler{failedEventHandlerMock})
+
+	failedEventHandlerMock.
+		On("Handle", ctx, msg).Return(handlingErr).
+		On("CanHandleMessage", ctx, msg).Return(true).
+		On("Name").Return("FailedEventHandler")
 
 	producerMock.
 		On("WriteMessages", mock.Anything, mock.MatchedBy(func(m []Message) bool {
@@ -152,25 +258,11 @@ func Test_EventConsumer_Consume_FinalizeConsumer(t *testing.T) {
 	ec.Consume(ctx)
 
 	entries := getEntries()
-	assert.Equal(t, "Waiting 2s before retrying reading new messages", entries[0].Message)
+	assert.Equal(t, "Waiting 2s before retrying handling message with key key-1", entries[0].Message)
 	assert.Equal(t, "Replaying message with key key-1 to topic test.test_topic", entries[1].Message)
 
 	consumerMock.AssertExpectations(t)
 	crashTrackerMock.AssertExpectations(t)
 	producerMock.AssertExpectations(t)
-}
-
-// Always fail event handler
-type FailEventHandler struct{}
-
-func (h *FailEventHandler) Handle(ctx context.Context, msg *Message) error {
-	return errors.New("handler failed")
-}
-
-func (h *FailEventHandler) CanHandleMessage(ctx context.Context, msg *Message) bool {
-	return true
-}
-
-func (h *FailEventHandler) Name() string {
-	return "FailEventHandler"
+	failedEventHandlerMock.AssertExpectations(t)
 }

--- a/internal/events/eventhandlers/patch_anchor_platform_transaction_completion_event_handler.go
+++ b/internal/events/eventhandlers/patch_anchor_platform_transaction_completion_event_handler.go
@@ -49,7 +49,7 @@ func NewPatchAnchorPlatformTransactionCompletionEventHandler(options PatchAnchor
 }
 
 func (h *PatchAnchorPlatformTransactionCompletionEventHandler) Name() string {
-	return "PatchAnchorPlatformTransactionCompletionEventHandler"
+	return utils.GetTypeName(h)
 }
 
 func (h *PatchAnchorPlatformTransactionCompletionEventHandler) CanHandleMessage(ctx context.Context, message *events.Message) bool {

--- a/internal/events/eventhandlers/payment_from_submitter_event_handler.go
+++ b/internal/events/eventhandlers/payment_from_submitter_event_handler.go
@@ -44,7 +44,7 @@ func NewPaymentFromSubmitterEventHandler(options PaymentFromSubmitterEventHandle
 }
 
 func (h *PaymentFromSubmitterEventHandler) Name() string {
-	return "PaymentFromSubmitterEventHandler"
+	return utils.GetTypeName(h)
 }
 
 func (h *PaymentFromSubmitterEventHandler) CanHandleMessage(ctx context.Context, message *events.Message) bool {

--- a/internal/events/eventhandlers/payment_to_submitter_event_handler.go
+++ b/internal/events/eventhandlers/payment_to_submitter_event_handler.go
@@ -45,7 +45,7 @@ func NewPaymentToSubmitterEventHandler(options PaymentToSubmitterEventHandlerOpt
 }
 
 func (h *PaymentToSubmitterEventHandler) Name() string {
-	return "PaymentToSubmitterEventHandler"
+	return utils.GetTypeName(h)
 }
 
 func (h *PaymentToSubmitterEventHandler) CanHandleMessage(ctx context.Context, message *events.Message) bool {

--- a/internal/events/eventhandlers/send_receiver_wallets_sms_invitation_event_handler.go
+++ b/internal/events/eventhandlers/send_receiver_wallets_sms_invitation_event_handler.go
@@ -62,7 +62,7 @@ func NewSendReceiverWalletsSMSInvitationEventHandler(options SendReceiverWallets
 }
 
 func (h *SendReceiverWalletsSMSInvitationEventHandler) Name() string {
-	return "SendReceiverWalletsSMSInvitationEventHandler"
+	return utils.GetTypeName(h)
 }
 
 func (h *SendReceiverWalletsSMSInvitationEventHandler) CanHandleMessage(ctx context.Context, message *events.Message) bool {

--- a/internal/events/message.go
+++ b/internal/events/message.go
@@ -10,13 +10,13 @@ import (
 )
 
 type Message struct {
-	Topic                string            `json:"topic"`
-	Key                  string            `json:"key"`
-	TenantID             string            `json:"tenant_id"`
-	Type                 string            `json:"type"`
-	Data                 any               `json:"data"`
-	Errors               []*HandlerError   `json:"errors,omitempty"`
-	SuccessfulExecutions []*HandlerSuccess `json:"successful_executions,omitempty"`
+	Topic                string           `json:"topic"`
+	Key                  string           `json:"key"`
+	TenantID             string           `json:"tenant_id"`
+	Type                 string           `json:"type"`
+	Data                 any              `json:"data"`
+	Errors               []HandlerError   `json:"errors,omitempty"`
+	SuccessfulExecutions []HandlerSuccess `json:"successful_executions,omitempty"`
 }
 
 type HandlerError struct {
@@ -55,7 +55,7 @@ func NewMessage(ctx context.Context, topic, key, messageType string, data any) (
 	}, nil
 }
 
-func NewHandlerErrorWrapper(hError error, handlerName string) HandlerError {
+func NewHandlerError(hError error, handlerName string) HandlerError {
 	return HandlerError{
 		FailedAt:     time.Now(),
 		ErrorMessage: hError.Error(),
@@ -92,6 +92,14 @@ func (m Message) Validate() error {
 	return nil
 }
 
-func (m *Message) RecordError(hError *HandlerError) {
+func (m *Message) RecordError(handlerName string, handleErr error) {
+	hError := NewHandlerError(handleErr, handlerName)
 	m.Errors = append(m.Errors, hError)
+}
+
+func (m *Message) RecordSuccess(handlerName string) {
+	m.SuccessfulExecutions = append(m.SuccessfulExecutions, HandlerSuccess{
+		ExecutedAt:  time.Now(),
+		HandlerName: handlerName,
+	})
 }

--- a/internal/events/message.go
+++ b/internal/events/message.go
@@ -10,17 +10,32 @@ import (
 )
 
 type Message struct {
-	Topic    string  `json:"topic"`
-	Key      string  `json:"key"`
-	TenantID string  `json:"tenant_id"`
-	Type     string  `json:"type"`
-	Data     any     `json:"data"`
-	Errors   []Error `json:"errors,omitempty"`
+	Topic                string            `json:"topic"`
+	Key                  string            `json:"key"`
+	TenantID             string            `json:"tenant_id"`
+	Type                 string            `json:"type"`
+	Data                 any               `json:"data"`
+	Errors               []*HandlerError   `json:"errors,omitempty"`
+	SuccessfulExecutions []*HandlerSuccess `json:"successful_executions,omitempty"`
 }
 
-type Error struct {
-	FailedAt     time.Time `json:"failed_at"`
-	ErrorMessage string    `json:"error_message"`
+type HandlerError struct {
+	// FailedAt timestamp for the time of failure.
+	FailedAt time.Time `json:"failed_at"`
+	// ErrorMessage detailed error message. Used for displaying.
+	ErrorMessage string `json:"error_message"`
+	// HandlerName name of the handler where the error occurred.
+	HandlerName string `json:"handler_name"`
+	// Err full handler error.
+	Err error `json:"-"`
+}
+
+// HandlerSuccess represents a successful handling of a message
+type HandlerSuccess struct {
+	// ExecutedAt timestamp for the time of successful handling
+	ExecutedAt time.Time `json:"executed_at"`
+	// HandlerName name of the handler that succeeded
+	HandlerName string `json:"handler_name"`
 }
 
 // NewMessage returns a new message with values passed by parameters. It also parses the `TenantID` from the context and inject it into the message.
@@ -38,6 +53,15 @@ func NewMessage(ctx context.Context, topic, key, messageType string, data any) (
 		Type:     messageType,
 		Data:     data,
 	}, nil
+}
+
+func NewHandlerErrorWrapper(hError error, handlerName string) HandlerError {
+	return HandlerError{
+		FailedAt:     time.Now(),
+		ErrorMessage: hError.Error(),
+		HandlerName:  handlerName,
+		Err:          hError,
+	}
 }
 
 func (m Message) String() string {
@@ -68,10 +92,6 @@ func (m Message) Validate() error {
 	return nil
 }
 
-func (m *Message) RecordError(errMsg string) {
-	newError := Error{
-		FailedAt:     time.Now(),
-		ErrorMessage: errMsg,
-	}
-	m.Errors = append(m.Errors, newError)
+func (m *Message) RecordError(hError *HandlerError) {
+	m.Errors = append(m.Errors, hError)
 }

--- a/internal/events/message_test.go
+++ b/internal/events/message_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,14 +52,16 @@ func Test_Message_RecordError(t *testing.T) {
 
 	t.Run("record error", func(t *testing.T) {
 		m := Message{}
-		m.RecordError("test-error")
+		m.RecordError("test-handler", errors.New("test-error"))
 		assert.Len(t, m.Errors, 1)
 		assert.Equal(t, "test-error", m.Errors[0].ErrorMessage)
+		assert.Equal(t, "test-handler", m.Errors[0].HandlerName)
 		assert.NotZero(t, m.Errors[0].FailedAt)
 
-		m.RecordError("test-error-2")
+		m.RecordError("test-handler-2", errors.New("test-error-2"))
 		assert.Len(t, m.Errors, 2)
 		assert.Equal(t, "test-error-2", m.Errors[1].ErrorMessage)
 		assert.NotZero(t, m.Errors[1].FailedAt)
+		assert.Equal(t, "test-handler-2", m.Errors[1].HandlerName)
 	})
 }

--- a/internal/events/mocks.go
+++ b/internal/events/mocks.go
@@ -80,6 +80,15 @@ type MockEventHandler struct {
 	mock.Mock
 }
 
+func NewMockEventHandler(t testInterface) *MockEventHandler {
+	mock := MockEventHandler{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return &mock
+}
+
 func (h *MockEventHandler) Handle(ctx context.Context, msg *Message) error {
 	log.Ctx(ctx).Infof("Handling message with key %s by handler %s", msg.Key, h.Name())
 	args := h.Called(ctx, msg)

--- a/internal/events/mocks.go
+++ b/internal/events/mocks.go
@@ -3,9 +3,12 @@ package events
 import (
 	"context"
 
+	"github.com/stellar/go/support/log"
+
 	"github.com/stretchr/testify/mock"
 )
 
+// MockConsumer is a mock implementation of Consumer
 type MockConsumer struct {
 	mock.Mock
 }
@@ -39,6 +42,7 @@ func (c *MockConsumer) Handlers() []EventHandler {
 	return args.Get(0).([]EventHandler)
 }
 
+// MockProducer is a mock implementation of Producer
 type MockProducer struct {
 	mock.Mock
 }
@@ -69,4 +73,25 @@ func NewMockProducer(t testInterface) *MockProducer {
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
 	return mock
+}
+
+// MockEventHandler is a mock implementation of EventHandler
+type MockEventHandler struct {
+	mock.Mock
+}
+
+func (h *MockEventHandler) Handle(ctx context.Context, msg *Message) error {
+	log.Ctx(ctx).Infof("Handling message with key %s by handler %s", msg.Key, h.Name())
+	args := h.Called(ctx, msg)
+	return args.Error(0)
+}
+
+func (h *MockEventHandler) CanHandleMessage(ctx context.Context, msg *Message) bool {
+	args := h.Called(ctx, msg)
+	return args.Bool(0)
+}
+
+func (h *MockEventHandler) Name() string {
+	args := h.Called()
+	return args.String(0)
 }


### PR DESCRIPTION
### 🐞 Bug Description
#### 🏛️ Background
* When a message is consumed by Kafka, it is ran through the handler chain (list of handlers compatible with that message) 
* If a message fails on a consumer, it gets retried (re-runs through the handler chain) 

#### 🧨 Issue
* When the message re-runs through the handler chain, it runs through all handlers (those on which it succeeded and those on which it failed) 

### 🩹 Fix
* Introduce a `SuccessfulExecutions` in the message to keep track of the history of successful executions 
* Introduce `ShouldHandleMessage` to determine the logic of when a message would be executed by a handler 
    * Messages that already succeeded wouldn't be executed

**Logs after fix**
```
time="2024-05-31T11:05:03.174+01:00" level=info msg="starting consuming messages for topic test.test_topic..." pid=31444
time="2024-05-31T11:05:03.174+01:00" level=info msg="Reading message from topic test.test_topic..." pid=31444
time="2024-05-31T11:05:03.174+01:00" level=info msg="Handling message with key key-1 by handler FailedEventHandler" pid=31444
time="2024-05-31T11:05:03.175+01:00" level=info msg="Handling message with key key-1 by handler SuccessfulEventHandler" pid=31444
time="2024-05-31T11:05:03.175+01:00" level=warning msg="Waiting 2s before retrying handling message with key key-1" pid=31444
time="2024-05-31T11:05:05.176+01:00" level=warning msg="Retrying handling message with key key-1" pid=31444
time="2024-05-31T11:05:05.176+01:00" level=info msg="Handling message with key key-1 by handler FailedEventHandler" pid=31444
time="2024-05-31T11:05:05.176+01:00" level=info msg="Handler SuccessfulEventHandler has already been executed for message with key key-1. Skipping..." pid=31444
time="2024-05-31T11:05:05.176+01:00" level=warning msg="Waiting 4s before retrying handling message with key key-1" pid=31444
time="2024-05-31T11:05:09.178+01:00" level=info msg="Stopping consuming messages for topic test.test_topic due to context cancellation..." pid=31444
time="2024-05-31T11:05:09.178+01:00" level=warning msg="Replaying message with key key-1 to topic test.test_topic" pid=31444
```

### 💄 Cosmetic changes 
* Use `utils.GetTypeName(..)` to fetch the name of the handler, instead of hard-coded string. 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
