### PR TITLE
[SDP-1226] KAFKA_SECURITY_PROTOCOL config should be optional

### DIFF
--- a/cmd/utils/custom_set_value.go
+++ b/cmd/utils/custom_set_value.go
@@ -288,6 +288,9 @@ func SetConfigOptionEventBrokerType(co *config.ConfigOption) error {
 
 func SetConfigOptionKafkaSecurityProtocol(co *config.ConfigOption) error {
 	protocol := viper.GetString(co.Name)
+	if protocol == "" {
+		return nil
+	}
 
 	protocolParsed, err := events.ParseKafkaSecurityProtocol(protocol)
 	if err != nil {

--- a/cmd/utils/shared_config_options.go
+++ b/cmd/utils/shared_config_options.go
@@ -172,7 +172,7 @@ func EventBrokerConfigOptions(opts *EventBrokerOptions) []*config.ConfigOption {
 			OptType:        types.String,
 			CustomSetValue: SetConfigOptionKafkaSecurityProtocol,
 			ConfigKey:      &opts.KafkaSecurityProtocol,
-			Required:       true,
+			Required:       false,
 		},
 		{
 			Name:      "kafka-sasl-username",


### PR DESCRIPTION
### What
* Change `KAFKA_SECURITY_PROTOCOL` to be optional

### Why
* `KAFKA_SECURITY_PROTOCOL` is only required when `EVENT_BROKER_TYPE=kafka`.
* We can make it optional and let the validator take care of validating kafka configurations. 

When `EVENT_BROKER_TYPE=KAFKA` and `KAFKA_SECURITY_PROTOCOL` is not passed, we get the following error on startup : 
```
FATA[2024-05-31T17:08:24.769+01:00] error creating Kafka Producer: invalid kafka config: security protocol cannot be empty  pid=39478
```

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
