### PR TITLE
Chore: fix error handling when `distSignerType.DistributionAccountType()` returns an error

### DIFF
--- a/stellar-multitenant/internal/provisioning/manager.go
+++ b/stellar-multitenant/internal/provisioning/manager.go
@@ -53,11 +53,11 @@ func deleteDistributionKeyErrors() []error {
 }
 
 func rollbackTenantDataSetupErrors() []error {
-	return []error{ErrUpdateTenantFailed, ErrProvisionTenantDistributionAccountFailed, ErrTenantDataSetupFailed}
+	return append(deleteDistributionKeyErrors(), ErrProvisionTenantDistributionAccountFailed, ErrTenantDataSetupFailed)
 }
 
 func rollbackTenantCreationAndSchemaErrors() []error {
-	return []error{ErrUpdateTenantFailed, ErrProvisionTenantDistributionAccountFailed, ErrTenantDataSetupFailed, ErrTenantSchemaFailed}
+	return append(rollbackTenantDataSetupErrors(), ErrTenantSchemaFailed)
 }
 
 func (m *Manager) ProvisionNewTenant(
@@ -142,7 +142,7 @@ func (m *Manager) provisionTenant(ctx context.Context, pt *ProvisionTenant) (*te
 	distSignerType := signing.SignatureClientType(m.SubmitterEngine.DistAccountSigner.Type())
 	distAccType, err := distSignerType.DistributionAccountType()
 	if err != nil {
-		return t, fmt.Errorf("parsing getting distribution account type: %w", err)
+		return t, fmt.Errorf("%w: parsing getting distribution account type: %w", ErrUpdateTenantFailed, err)
 	}
 
 	tenantStatus := tenant.ProvisionedTenantStatus


### PR DESCRIPTION
### What

Chore: fix error handling when `distSignerType.DistributionAccountType()` returns an error.

### Why

Otherwise `handleProvisioningError()` will not deal with the error properly.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
