### PR TITLE
[SDP-1229] Add database and Kafka to Healthcheck `GET /health` 

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -582,8 +582,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 			}
 
 			// Kafka (background)
-			serveOpts.EventBrokerType = eventBrokerOptions.EventBrokerType
-			if serveOpts.EventBrokerType == events.KafkaEventBrokerType {
+			if eventBrokerOptions.EventBrokerType == events.KafkaEventBrokerType {
 				kafkaProducer, kafkaErr := events.NewKafkaProducer(cmdUtils.KafkaConfig(eventBrokerOptions))
 				if kafkaErr != nil {
 					log.Ctx(ctx).Fatalf("error creating Kafka Producer: %v", kafkaErr)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -582,12 +582,13 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 			}
 
 			// Kafka (background)
-			if eventBrokerOptions.EventBrokerType == events.KafkaEventBrokerType {
+			serveOpts.EventBrokerType = eventBrokerOptions.EventBrokerType
+			if serveOpts.EventBrokerType == events.KafkaEventBrokerType {
 				kafkaProducer, kafkaErr := events.NewKafkaProducer(cmdUtils.KafkaConfig(eventBrokerOptions))
 				if kafkaErr != nil {
 					log.Ctx(ctx).Fatalf("error creating Kafka Producer: %v", kafkaErr)
 				}
-				defer kafkaProducer.Close()
+				defer kafkaProducer.Close(ctx)
 				serveOpts.EventProducer = kafkaProducer
 
 				kafkaErr = serverService.SetupConsumers(ctx, SetupConsumersOptions{

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -163,7 +163,6 @@ func Test_serve(t *testing.T) {
 		EnableScheduler:                 false,
 		SubmitterEngine:                 submitterEngine,
 		MaxInvitationSMSResendAttempts:  3,
-		EventBrokerType:                 events.KafkaEventBrokerType,
 	}
 	serveOpts.AnchorPlatformAPIService, err = anchorplatform.NewAnchorPlatformAPIService(httpclient.DefaultClient(), serveOpts.AnchorPlatformBasePlatformURL, serveOpts.AnchorPlatformOutgoingJWTSecret)
 	require.NoError(t, err)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -163,6 +163,7 @@ func Test_serve(t *testing.T) {
 		EnableScheduler:                 false,
 		SubmitterEngine:                 submitterEngine,
 		MaxInvitationSMSResendAttempts:  3,
+		EventBrokerType:                 events.KafkaEventBrokerType,
 	}
 	serveOpts.AnchorPlatformAPIService, err = anchorplatform.NewAnchorPlatformAPIService(httpclient.DefaultClient(), serveOpts.AnchorPlatformBasePlatformURL, serveOpts.AnchorPlatformOutgoingJWTSecret)
 	require.NoError(t, err)

--- a/cmd/transaction_submitter.go
+++ b/cmd/transaction_submitter.go
@@ -204,7 +204,7 @@ func (c *TxSubmitterCommand) Command(submitterService TxSubmitterServiceInterfac
 				if err != nil {
 					log.Ctx(ctx).Fatalf("error creating Kafka Producer: %v", err)
 				}
-				defer kafkaProducer.Close()
+				defer kafkaProducer.Close(ctx)
 				tssOpts.EventProducer = kafkaProducer
 			} else {
 				log.Ctx(ctx).Warn("Event Broker Type is NONE. Using Noop producer for logging events")

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -10,7 +10,8 @@ import (
 // Producer is an interface that defines the methods that a producer should implement.
 type Producer interface {
 	WriteMessages(ctx context.Context, messages ...Message) error
-	Close() error
+	Ping(ctx context.Context) error
+	Close(ctx context.Context)
 }
 
 // Consumer is an interface that defines the methods that a consumer should implement.
@@ -29,7 +30,11 @@ func (p NoopProducer) WriteMessages(ctx context.Context, messages ...Message) er
 	return nil
 }
 
-func (p NoopProducer) Close() error {
+func (p NoopProducer) Close(ctx context.Context) {
+	log.Ctx(ctx).Info("NoopProducer: Closing NoopProducer")
+}
+
+func (p NoopProducer) Ping(ctx context.Context) error {
 	return nil
 }
 

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -12,6 +12,7 @@ type Producer interface {
 	WriteMessages(ctx context.Context, messages ...Message) error
 	Ping(ctx context.Context) error
 	Close(ctx context.Context)
+	BrokerType() EventBrokerType
 }
 
 // Consumer is an interface that defines the methods that a consumer should implement.
@@ -20,6 +21,7 @@ type Consumer interface {
 	Topic() string
 	Handlers() []EventHandler
 	Close() error
+	BrokerType() EventBrokerType
 }
 
 // NoopProducer is a producer used to log messages instead of sending them to a real producer.
@@ -36,6 +38,10 @@ func (p NoopProducer) Close(ctx context.Context) {
 
 func (p NoopProducer) Ping(ctx context.Context) error {
 	return nil
+}
+
+func (p NoopProducer) BrokerType() EventBrokerType {
+	return NoneEventBrokerType
 }
 
 var _ Producer = NoopProducer{}

--- a/internal/events/mocks.go
+++ b/internal/events/mocks.go
@@ -54,8 +54,12 @@ func (c *MockProducer) WriteMessages(ctx context.Context, messages ...Message) e
 	return args.Error(0)
 }
 
-func (c *MockProducer) Close() error {
-	args := c.Called()
+func (c *MockProducer) Close(ctx context.Context) {
+	c.Called(ctx)
+}
+
+func (c *MockProducer) Ping(ctx context.Context) error {
+	args := c.Called(ctx)
 	return args.Error(0)
 }
 

--- a/internal/events/mocks.go
+++ b/internal/events/mocks.go
@@ -42,6 +42,10 @@ func (c *MockConsumer) Handlers() []EventHandler {
 	return args.Get(0).([]EventHandler)
 }
 
+func (c *MockConsumer) BrokerType() EventBrokerType {
+	return c.Called().Get(0).(EventBrokerType)
+}
+
 // MockProducer is a mock implementation of Producer
 type MockProducer struct {
 	mock.Mock
@@ -61,6 +65,10 @@ func (c *MockProducer) Close(ctx context.Context) {
 func (c *MockProducer) Ping(ctx context.Context) error {
 	args := c.Called(ctx)
 	return args.Error(0)
+}
+
+func (c *MockProducer) BrokerType() EventBrokerType {
+	return c.Called().Get(0).(EventBrokerType)
 }
 
 type testInterface interface {

--- a/internal/serve/httphandler/health_handler.go
+++ b/internal/serve/httphandler/health_handler.go
@@ -39,7 +39,6 @@ type HealthHandler struct {
 	ReleaseID        string
 	DBConnectionPool db.DBConnectionPool
 	Producer         events.Producer
-	EventBrokerType  events.EventBrokerType
 }
 
 // ServeHTTP implements the http.Handler interface.
@@ -56,7 +55,7 @@ func (h HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"database": dbStatus,
 	}
 
-	if h.EventBrokerType == events.KafkaEventBrokerType {
+	if h.Producer.BrokerType() == events.KafkaEventBrokerType {
 		eventBrokerStatus := StatusPass
 		if err := h.Producer.Ping(context); err != nil {
 			eventBrokerStatus = StatusFail

--- a/internal/serve/httphandler/health_handler.go
+++ b/internal/serve/httphandler/health_handler.go
@@ -3,6 +3,9 @@ package httphandler
 import (
 	"net/http"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
+
 	"github.com/stellar/go/support/render/httpjson"
 )
 
@@ -22,28 +25,60 @@ const (
 //
 // https://datatracker.ietf.org/doc/html/draft-inadarei-api-health-check-06#name-api-health-response
 type HealthResponse struct {
-	Status    Status `json:"status"`
-	Version   string `json:"version,omitempty"`
-	ServiceID string `json:"service_id,omitempty"`
-	ReleaseID string `json:"release_id,omitempty"`
+	Status    Status            `json:"status"`
+	Version   string            `json:"version,omitempty"`
+	ServiceID string            `json:"service_id,omitempty"`
+	ReleaseID string            `json:"release_id,omitempty"`
+	Services  map[string]Status `json:"services,omitempty"`
 }
 
 // HealthHandler implements a simple handler that returns the health response.
 type HealthHandler struct {
-	Version   string
-	ServiceID string
-	ReleaseID string
+	Version          string
+	ServiceID        string
+	ReleaseID        string
+	DBConnectionPool db.DBConnectionPool
+	Producer         events.Producer
+	EventBrokerType  events.EventBrokerType
 }
 
 // ServeHTTP implements the http.Handler interface.
 func (h HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	context := r.Context()
+
+	dbStatus, responseStatus := StatusPass, StatusPass
+	if err := h.DBConnectionPool.Ping(context); err != nil {
+		dbStatus = StatusFail
+		responseStatus = StatusFail
+	}
+
+	services := map[string]Status{
+		"database": dbStatus,
+	}
+
+	if h.EventBrokerType == events.KafkaEventBrokerType {
+		eventBrokerStatus := StatusPass
+		if err := h.Producer.Ping(context); err != nil {
+			eventBrokerStatus = StatusFail
+			responseStatus = StatusFail
+		}
+		services["kafka"] = eventBrokerStatus
+	}
+
 	response := HealthResponse{
-		Status:    StatusPass,
+		Status:    responseStatus,
 		Version:   h.Version,
 		ServiceID: h.ServiceID,
 		ReleaseID: h.ReleaseID,
+		Services:  services,
 	}
 
-	// TODO: after we have a DB connection, we should check if the DB is healthy
+	// If any of the services are unhealthy, return a 503 Service Unavailable status.
+	// This signals to the orchestrator that the service is not healthy.
+	if response.Status == StatusFail {
+		httpjson.RenderStatus(w, http.StatusServiceUnavailable, response, httpjson.JSON)
+		return
+	}
+
 	httpjson.RenderStatus(w, http.StatusOK, response, httpjson.JSON)
 }

--- a/internal/serve/httphandler/health_handler.go
+++ b/internal/serve/httphandler/health_handler.go
@@ -55,7 +55,7 @@ func (h HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"database": dbStatus,
 	}
 
-	if h.Producer.BrokerType() == events.KafkaEventBrokerType {
+	if h.Producer != nil && h.Producer.BrokerType() == events.KafkaEventBrokerType {
 		eventBrokerStatus := StatusPass
 		if err := h.Producer.Ping(context); err != nil {
 			eventBrokerStatus = StatusFail

--- a/internal/serve/httphandler/health_handler_test.go
+++ b/internal/serve/httphandler/health_handler_test.go
@@ -1,9 +1,15 @@
 package httphandler
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
@@ -12,27 +18,95 @@ import (
 
 // test HealthHandler:
 func TestHealthHandler(t *testing.T) {
-	// setup
+	// create database connection pool
+	dbt := dbtest.OpenWithoutMigrations(t)
+	defer dbt.Close()
+
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	producerMock := events.NewMockProducer(t)
+
 	r := chi.NewRouter()
 	r.Get("/health", HealthHandler{
-		Version:   "x.y.z",
-		ServiceID: "my-api",
-		ReleaseID: "1234567890abcdef",
+		Version:          "x.y.z",
+		ServiceID:        "my-api",
+		ReleaseID:        "1234567890abcdef",
+		DBConnectionPool: dbConnectionPool,
+		Producer:         producerMock,
+		EventBrokerType:  events.KafkaEventBrokerType,
 	}.ServeHTTP)
 
-	// test
-	req, err := http.NewRequest("GET", "/health", nil)
-	require.NoError(t, err)
-	rr := httptest.NewRecorder()
-	r.ServeHTTP(rr, req)
+	t.Run("✅SDP healthy", func(t *testing.T) {
+		producerMock.
+			On("Ping", mock.Anything).
+			Return(nil).
+			Once()
 
-	// assert response
-	assert.Equal(t, http.StatusOK, rr.Code)
-	wantJson := `{
-		"status": "pass",
-		"version": "x.y.z",
-		"service_id": "my-api",
-		"release_id": "1234567890abcdef"
-	}`
-	assert.JSONEq(t, wantJson, rr.Body.String())
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.JSONEq(t, `{
+			"status": "pass",
+			"version": "x.y.z",
+			"service_id": "my-api",
+			"release_id": "1234567890abcdef",
+			"services": {
+				"database": "pass",
+				"kafka": "pass"
+			}
+		}`, w.Body.String())
+	})
+
+	t.Run("❌SDP unhealthy", func(t *testing.T) {
+		producerMock.
+			On("Ping", mock.Anything).
+			Return(errors.New("error")).
+			Once()
+
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+		assert.JSONEq(t, `{
+			"status": "fail",
+			"version": "x.y.z",
+			"service_id": "my-api",
+			"release_id": "1234567890abcdef",
+			"services": {
+				"database": "pass",	
+				"kafka": "fail"
+			}
+		}`, w.Body.String())
+	})
+
+	t.Run("No healthcheck for Kafka event broker", func(t *testing.T) {
+		r.Get("/health", HealthHandler{
+			Version:          "x.y.z",
+			ServiceID:        "my-api",
+			ReleaseID:        "1234567890abcdef",
+			DBConnectionPool: dbConnectionPool,
+			Producer:         producerMock,
+			EventBrokerType:  events.NoneEventBrokerType,
+		}.ServeHTTP)
+
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.JSONEq(t, `{
+			"status": "pass",
+			"version": "x.y.z",
+			"service_id": "my-api",
+			"release_id": "1234567890abcdef",
+			"services": {
+				"database": "pass"
+			}
+		}`, w.Body.String())
+	})
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -85,6 +85,7 @@ type ServeOptions struct {
 	EnableScheduler                 bool
 	tenantManager                   tenant.ManagerInterface
 	EventProducer                   events.Producer
+	EventBrokerType                 events.EventBrokerType
 	MaxInvitationSMSResendAttempts  int
 	SingleTenantMode                bool
 }
@@ -419,9 +420,12 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	// SEP-24 and miscellaneous endpoints that are tenant-unaware
 	mux.Group(func(r chi.Router) {
 		r.Get("/health", httphandler.HealthHandler{
-			ReleaseID: o.GitCommit,
-			ServiceID: ServiceID,
-			Version:   o.Version,
+			ReleaseID:        o.GitCommit,
+			ServiceID:        ServiceID,
+			Version:          o.Version,
+			DBConnectionPool: o.AdminDBConnectionPool,
+			Producer:         o.EventProducer,
+			EventBrokerType:  o.EventBrokerType,
 		}.ServeHTTP)
 
 		// START SEP-24 endpoints

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -85,7 +85,6 @@ type ServeOptions struct {
 	EnableScheduler                 bool
 	tenantManager                   tenant.ManagerInterface
 	EventProducer                   events.Producer
-	EventBrokerType                 events.EventBrokerType
 	MaxInvitationSMSResendAttempts  int
 	SingleTenantMode                bool
 }
@@ -425,7 +424,6 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			Version:          o.Version,
 			DBConnectionPool: o.AdminDBConnectionPool,
 			Producer:         o.EventProducer,
-			EventBrokerType:  o.EventBrokerType,
 		}.ServeHTTP)
 
 		// START SEP-24 endpoints

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -217,6 +217,10 @@ func Test_handleHTTP_Health(t *testing.T) {
 		On("Ping", mock.Anything).
 		Return(nil).
 		Once()
+	producerMock.
+		On("BrokerType").
+		Return(events.KafkaEventBrokerType).
+		Once()
 
 	handlerMux := handleHTTP(ServeOptions{
 		EC256PrivateKey:       privateKeyStr,
@@ -229,7 +233,6 @@ func Test_handleHTTP_Health(t *testing.T) {
 		Version:               "x.y.z",
 		tenantManager:         tenant.NewManager(tenant.WithDatabase(dbConnectionPool)),
 		EventProducer:         producerMock,
-		EventBrokerType:       events.KafkaEventBrokerType,
 		AdminDBConnectionPool: dbConnectionPool,
 	})
 
@@ -329,6 +332,10 @@ func getServeOptionsForTests(t *testing.T, dbConnectionPool db.DBConnectionPool)
 		On("Ping", mock.Anything).
 		Return(nil).
 		Maybe()
+	producerMock.
+		On("BrokerType").
+		Return(events.KafkaEventBrokerType).
+		Maybe()
 
 	serveOptions := ServeOptions{
 		CrashTrackerClient:              crashTrackerClient,
@@ -349,7 +356,6 @@ func getServeOptionsForTests(t *testing.T, dbConnectionPool db.DBConnectionPool)
 		NetworkPassphrase:               network.TestNetworkPassphrase,
 		SubmitterEngine:                 submitterEngine,
 		EventProducer:                   producerMock,
-		EventBrokerType:                 events.KafkaEventBrokerType,
 	}
 	err = serveOptions.SetupDependencies()
 	require.NoError(t, err)

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/network"
@@ -205,18 +207,30 @@ func Test_handleHTTP_Health(t *testing.T) {
 		Route:  "/health",
 		Method: "GET",
 	}
-	mMonitorService.On("MonitorHttpRequestDuration", mock.AnythingOfType("time.Duration"), mLabels).Return(nil).Once()
+	mMonitorService.
+		On("MonitorHttpRequestDuration", mock.AnythingOfType("time.Duration"), mLabels).
+		Return(nil).
+		Once()
+
+	producerMock := events.NewMockProducer(t)
+	producerMock.
+		On("Ping", mock.Anything).
+		Return(nil).
+		Once()
 
 	handlerMux := handleHTTP(ServeOptions{
-		EC256PrivateKey: privateKeyStr,
-		EC256PublicKey:  publicKeyStr,
-		Environment:     "test",
-		GitCommit:       "1234567890abcdef",
-		Models:          models,
-		MonitorService:  mMonitorService,
-		SEP24JWTSecret:  "jwt_secret_1234567890",
-		Version:         "x.y.z",
-		tenantManager:   tenant.NewManager(tenant.WithDatabase(dbConnectionPool)),
+		EC256PrivateKey:       privateKeyStr,
+		EC256PublicKey:        publicKeyStr,
+		Environment:           "test",
+		GitCommit:             "1234567890abcdef",
+		Models:                models,
+		MonitorService:        mMonitorService,
+		SEP24JWTSecret:        "jwt_secret_1234567890",
+		Version:               "x.y.z",
+		tenantManager:         tenant.NewManager(tenant.WithDatabase(dbConnectionPool)),
+		EventProducer:         producerMock,
+		EventBrokerType:       events.KafkaEventBrokerType,
+		AdminDBConnectionPool: dbConnectionPool,
 	})
 
 	req := httptest.NewRequest("GET", "/health", nil)
@@ -232,7 +246,11 @@ func Test_handleHTTP_Health(t *testing.T) {
 		"status": "pass",
 		"version": "x.y.z",
 		"service_id": "serve",
-		"release_id": "1234567890abcdef"
+		"release_id": "1234567890abcdef",
+		"services": {
+			"database": "pass",
+			"kafka": "pass"
+		}
 	}`
 	assert.JSONEq(t, wantBody, string(body))
 }
@@ -306,6 +324,12 @@ func getServeOptionsForTests(t *testing.T, dbConnectionPool db.DBConnectionPool)
 		Return(schema.NewDefaultStellarDistributionAccount(distAccPublicKey), nil).
 		Maybe()
 
+	producerMock := events.NewMockProducer(t)
+	producerMock.
+		On("Ping", mock.Anything).
+		Return(nil).
+		Maybe()
+
 	serveOptions := ServeOptions{
 		CrashTrackerClient:              crashTrackerClient,
 		MtnDBConnectionPool:             dbConnectionPool,
@@ -324,6 +348,8 @@ func getServeOptionsForTests(t *testing.T, dbConnectionPool db.DBConnectionPool)
 		Version:                         "x.y.z",
 		NetworkPassphrase:               network.TestNetworkPassphrase,
 		SubmitterEngine:                 submitterEngine,
+		EventProducer:                   producerMock,
+		EventBrokerType:                 events.KafkaEventBrokerType,
 	}
 	err = serveOptions.SetupDependencies()
 	require.NoError(t, err)


### PR DESCRIPTION
### What
* Adding Database and Kafka to healthcheck 
* Return 5xx when any of these two is failing. 

### Why
* Have a more accurate healthcheck 
* Not process requests when service is not fully operational to avoid inconsistent state. 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
