### PR TITLE
[SDP-1224] (Replay #304) Improve how we handle erros on kafka event producers

### DIFF
--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -491,7 +491,7 @@ func (p *PaymentModel) GetReadyByDisbursementID(ctx context.Context, sqlExec db.
 }
 
 func (p *PaymentModel) GetReadyByID(ctx context.Context, sqlExec db.SQLExecuter, paymentIDs ...string) ([]*Payment, error) {
-	query := fmt.Sprintf(getReadyPaymentsBaseQuery, "AND p.id = ANY($4)")
+	query := fmt.Sprintf(getReadyPaymentsBaseQuery, "AND p.id = ANY($4) ORDER BY p.updated_at ASC")
 
 	var payments []*Payment
 	args := append(getReadyPaymentsBaseArgs, pq.Array(paymentIDs))

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -1,0 +1,132 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stellar/go/support/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ProduceEvents(t *testing.T) {
+	ctx := context.Background()
+
+	msg1 := &Message{
+		Topic:    "test_topic_1",
+		Key:      "test_key_1",
+		TenantID: "test_tenant_id_1",
+		Type:     "test_type_1",
+		Data:     "some-data_1",
+	}
+	msg2 := &Message{
+		Topic:    "test_topic_2",
+		Key:      "test_key_2",
+		TenantID: "test_tenant_id_2",
+		Type:     "test_type_2",
+		Data:     "some-data_2",
+	}
+
+	testCases := []struct {
+		name            string
+		getProducer     func(t *testing.T) Producer
+		messages        []*Message
+		assertLog       func(t *testing.T, logEntries []logrus.Entry)
+		wantErrContains string
+	}{
+		{
+			name:        "when the producer is nil, logs an error",
+			getProducer: func(t *testing.T) Producer { return nil },
+			messages:    []*Message{msg1},
+			assertLog: func(t *testing.T, logEntries []logrus.Entry) {
+				assert.Len(t, logEntries, 1)
+				expectedLogText := fmt.Sprintf("event producer is nil, could not publish messages %+v", []Message{*msg1})
+				assert.Equal(t, expectedLogText, logEntries[0].Message)
+				assert.Equal(t, logrus.ErrorLevel, logEntries[0].Level)
+			},
+		},
+		{
+			name:        "when all messages are nil, log warnings and does not produce any event",
+			getProducer: func(t *testing.T) Producer { return NewMockProducer(t) },
+			messages:    []*Message{nil, nil},
+			assertLog: func(t *testing.T, logEntries []logrus.Entry) {
+				assert.Len(t, logEntries, 3)
+				assert.Equal(t, "message at index 0 is nil, not producing event", logEntries[0].Message)
+				assert.Equal(t, logrus.WarnLevel, logEntries[0].Level)
+				assert.Equal(t, "message at index 1 is nil, not producing event", logEntries[1].Message)
+				assert.Equal(t, logrus.WarnLevel, logEntries[1].Level)
+				assert.Equal(t, "not producing events, since there are zero not-nil messages to produce", logEntries[2].Message)
+				assert.Equal(t, logrus.WarnLevel, logEntries[2].Level)
+			},
+		},
+		{
+			name:        "when there's no messages, logs a warning and does not produce any event",
+			getProducer: func(t *testing.T) Producer { return NewMockProducer(t) },
+			messages:    nil,
+			assertLog: func(t *testing.T, logEntries []logrus.Entry) {
+				assert.Len(t, logEntries, 1)
+				assert.Equal(t, "not producing events, since there are zero not-nil messages to produce", logEntries[0].Message)
+				assert.Equal(t, logrus.WarnLevel, logEntries[0].Level)
+			},
+		},
+		{
+			name: "returns an error when WriteMessage fails",
+			getProducer: func(t *testing.T) Producer {
+				mProducer := NewMockProducer(t)
+				mProducer.
+					On("WriteMessages", ctx, []Message{*msg1}).
+					Return(errors.New("some issue ocurred")).
+					Once()
+				return mProducer
+			},
+			messages:        []*Message{msg1},
+			wantErrContains: fmt.Sprintf("writing messages %+v on event producer: %v", []*Message{msg1}, errors.New("some issue ocurred")),
+		},
+		{
+			name: "🎉 successfully writes one message",
+			getProducer: func(t *testing.T) Producer {
+				mProducer := NewMockProducer(t)
+				mProducer.
+					On("WriteMessages", ctx, []Message{*msg1}).
+					Return(nil).
+					Once()
+				return mProducer
+			},
+			messages: []*Message{msg1},
+		},
+		{
+			name: "🎉 successfully writes only not-nil messages",
+			getProducer: func(t *testing.T) Producer {
+				mProducer := NewMockProducer(t)
+				mProducer.
+					On("WriteMessages", ctx, []Message{*msg1, *msg2}).
+					Return(nil).
+					Once()
+				return mProducer
+			},
+			messages: []*Message{msg1, nil, msg2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			getEntries := log.DefaultLogger.StartTest(log.DebugLevel)
+
+			producer := tc.getProducer(t)
+			err := ProduceEvents(ctx, producer, tc.messages...)
+			if tc.wantErrContains != "" {
+				require.ErrorContains(t, err, tc.wantErrContains)
+			} else {
+				require.NoError(t, err)
+			}
+
+			logEntries := getEntries()
+			if tc.assertLog != nil {
+				tc.assertLog(t, logEntries)
+			}
+		})
+	}
+}

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -311,11 +311,8 @@ func Test_DisbursementHandler_GetDisbursements_Errors(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := &DisbursementHandler{
-		Models: models,
-		DisbursementManagementService: &services.DisbursementManagementService{
-			Models:           models,
-			DBConnectionPool: dbConnectionPool,
-		},
+		Models:                        models,
+		DisbursementManagementService: &services.DisbursementManagementService{Models: models},
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(handler.GetDisbursements))
@@ -424,9 +421,8 @@ func Test_DisbursementHandler_GetDisbursements_Success(t *testing.T) {
 		Models:      models,
 		AuthManager: authManagerMock,
 		DisbursementManagementService: &services.DisbursementManagementService{
-			Models:           models,
-			DBConnectionPool: dbConnectionPool,
-			AuthManager:      authManagerMock,
+			Models:      models,
+			AuthManager: authManagerMock,
 		},
 	}
 
@@ -998,9 +994,8 @@ func Test_DisbursementHandler_GetDisbursement(t *testing.T) {
 		Models:      models,
 		AuthManager: authManagerMock,
 		DisbursementManagementService: &services.DisbursementManagementService{
-			Models:           models,
-			DBConnectionPool: dbConnectionPool,
-			AuthManager:      authManagerMock,
+			Models:      models,
+			AuthManager: authManagerMock,
 		},
 	}
 
@@ -1091,11 +1086,8 @@ func Test_DisbursementHandler_GetDisbursementReceivers(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := &DisbursementHandler{
-		Models: models,
-		DisbursementManagementService: &services.DisbursementManagementService{
-			Models:           models,
-			DBConnectionPool: dbConnectionPool,
-		},
+		Models:                        models,
+		DisbursementManagementService: &services.DisbursementManagementService{Models: models},
 	}
 
 	r := chi.NewRouter()
@@ -1289,11 +1281,10 @@ func Test_DisbursementHandler_PatchDisbursementStatus(t *testing.T) {
 		AuthManager:                 authManagerMock,
 		DistributionAccountResolver: distAccResolver,
 		DisbursementManagementService: &services.DisbursementManagementService{
-			Models:           models,
-			DBConnectionPool: dbConnectionPool,
-			AuthManager:      authManagerMock,
-			HorizonClient:    hMock,
-			EventProducer:    &mockEventProducer,
+			Models:        models,
+			AuthManager:   authManagerMock,
+			HorizonClient: hMock,
+			EventProducer: &mockEventProducer,
 		},
 	}
 

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -311,8 +311,11 @@ func Test_DisbursementHandler_GetDisbursements_Errors(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := &DisbursementHandler{
-		Models:                        models,
-		DisbursementManagementService: services.NewDisbursementManagementService(models, dbConnectionPool, nil, nil, nil),
+		Models: models,
+		DisbursementManagementService: &services.DisbursementManagementService{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+		},
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(handler.GetDisbursements))
@@ -418,9 +421,13 @@ func Test_DisbursementHandler_GetDisbursements_Success(t *testing.T) {
 
 	authManagerMock := &auth.AuthManagerMock{}
 	handler := &DisbursementHandler{
-		Models:                        models,
-		AuthManager:                   authManagerMock,
-		DisbursementManagementService: services.NewDisbursementManagementService(models, dbConnectionPool, authManagerMock, nil, nil),
+		Models:      models,
+		AuthManager: authManagerMock,
+		DisbursementManagementService: &services.DisbursementManagementService{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+		},
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(handler.GetDisbursements))
@@ -988,9 +995,13 @@ func Test_DisbursementHandler_GetDisbursement(t *testing.T) {
 		Return(allUsers, nil)
 
 	handler := &DisbursementHandler{
-		Models:                        models,
-		AuthManager:                   authManagerMock,
-		DisbursementManagementService: services.NewDisbursementManagementService(models, dbConnectionPool, authManagerMock, nil, nil),
+		Models:      models,
+		AuthManager: authManagerMock,
+		DisbursementManagementService: &services.DisbursementManagementService{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+		},
 	}
 
 	r := chi.NewRouter()
@@ -1080,8 +1091,11 @@ func Test_DisbursementHandler_GetDisbursementReceivers(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := &DisbursementHandler{
-		Models:                        models,
-		DisbursementManagementService: services.NewDisbursementManagementService(models, dbConnectionPool, nil, nil, nil),
+		Models: models,
+		DisbursementManagementService: &services.DisbursementManagementService{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+		},
 	}
 
 	r := chi.NewRouter()
@@ -1271,10 +1285,16 @@ func Test_DisbursementHandler_PatchDisbursementStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := &DisbursementHandler{
-		Models:                        models,
-		AuthManager:                   authManagerMock,
-		DistributionAccountResolver:   distAccResolver,
-		DisbursementManagementService: services.NewDisbursementManagementService(models, dbConnectionPool, authManagerMock, hMock, &mockEventProducer),
+		Models:                      models,
+		AuthManager:                 authManagerMock,
+		DistributionAccountResolver: distAccResolver,
+		DisbursementManagementService: &services.DisbursementManagementService{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+			HorizonClient:    hMock,
+			EventProducer:    &mockEventProducer,
+		},
 	}
 
 	r := chi.NewRouter()

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -147,7 +147,7 @@ func (p PaymentsHandler) RetryPayments(rw http.ResponseWriter, req *http.Request
 			if len(payments) > 0 {
 				msg, err := p.buildPaymentsReadyEventMessage(ctx, payments)
 				if err != nil {
-					return nil, fmt.Errorf("building payments ready event message: %w", err)
+					return nil, fmt.Errorf("building event message for payment retry: %w", err)
 				}
 
 				postCommitFn = func() error {

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -1075,7 +1075,9 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 			Return(errors.New("unexpected error")).
 			Once()
 		crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
-		crashTrackerMock.On("LogAndReportErrors", mock.Anything, mock.Anything, mock.Anything).Once()
+		crashTrackerMock.
+			On("LogAndReportErrors", mock.Anything, mock.Anything, "writing retry payment message on the event producer").
+			Once()
 		handler := PaymentsHandler{
 			Models:             models,
 			DBConnectionPool:   dbConnectionPool,

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
@@ -27,6 +28,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -611,16 +613,6 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 
-	authManagerMock := &auth.AuthManagerMock{}
-	eventProducerMock := events.MockProducer{}
-
-	handler := PaymentsHandler{
-		Models:           models,
-		DBConnectionPool: dbConnectionPool,
-		AuthManager:      authManagerMock,
-		EventProducer:    &eventProducerMock,
-	}
-
 	tnt := tenant.Tenant{ID: "tenant-id"}
 
 	ctx := context.Background()
@@ -650,6 +642,12 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 	})
 
 	t.Run("returns Unauthorized when no token in the context", func(t *testing.T) {
+		// Prepare the handler
+		handler := PaymentsHandler{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+		}
+
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", strings.NewReader("{}"))
 		require.NoError(t, err)
 
@@ -672,10 +670,17 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", strings.NewReader("{}"))
 		require.NoError(t, err)
 
+		// Prepare the handler and its mocks
+		authManagerMock := auth.NewAuthManagerMock(t)
 		authManagerMock.
 			On("GetUser", ctx, "mytoken").
 			Return(nil, errors.New("unexpected error")).
 			Once()
+		handler := PaymentsHandler{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+		}
 
 		rw := httptest.NewRecorder()
 		http.HandlerFunc(handler.RetryPayments).ServeHTTP(rw, req)
@@ -697,12 +702,17 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", payload)
 		require.NoError(t, err)
 
+		// Prepare the handler and its mocks
+		authManagerMock := auth.NewAuthManagerMock(t)
 		authManagerMock.
 			On("GetUser", ctx, "mytoken").
-			Return(&auth.User{
-				Email: "email@test.com",
-			}, nil).
+			Return(&auth.User{Email: "email@test.com"}, nil).
 			Once()
+		handler := PaymentsHandler{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+		}
 
 		rw := httptest.NewRecorder()
 		http.HandlerFunc(handler.RetryPayments).ServeHTTP(rw, req)
@@ -724,12 +734,17 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", payload)
 		require.NoError(t, err)
 
+		// Prepare the handler and its mocks
+		authManagerMock := auth.NewAuthManagerMock(t)
 		authManagerMock.
 			On("GetUser", ctx, "mytoken").
-			Return(&auth.User{
-				Email: "email@test.com",
-			}, nil).
+			Return(&auth.User{Email: "email@test.com"}, nil).
 			Once()
+		handler := PaymentsHandler{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+		}
 
 		rw := httptest.NewRecorder()
 		http.HandlerFunc(handler.RetryPayments).ServeHTTP(rw, req)
@@ -791,23 +806,23 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
-				"payment_ids": [
-					%q,
-					%q,
-					%q,
-					%q
-				]
+				"payment_ids": [%q, %q, %q, %q]
 			}
 		`, payment1.ID, payment2.ID, payment3.ID, payment4.ID))
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", payload)
 		require.NoError(t, err)
 
+		// Prepare the handler and its mocks
+		authManagerMock := auth.NewAuthManagerMock(t)
 		authManagerMock.
 			On("GetUser", ctx, "mytoken").
-			Return(&auth.User{
-				Email: "email@test.com",
-			}, nil).
+			Return(&auth.User{Email: "email@test.com"}, nil).
 			Once()
+		handler := PaymentsHandler{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+		}
 
 		rw := httptest.NewRecorder()
 		http.HandlerFunc(handler.RetryPayments).ServeHTTP(rw, req)
@@ -881,22 +896,19 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
-				"payment_ids": [
-					%q,
-					%q
-				]
+				"payment_ids": [%q, %q]
 			}
 		`, payment1.ID, payment2.ID))
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", payload)
 		require.NoError(t, err)
 
+		// Prepare the handler and its mocks
+		authManagerMock := auth.NewAuthManagerMock(t)
 		authManagerMock.
 			On("GetUser", ctx, "mytoken").
-			Return(&auth.User{
-				Email: "email@test.com",
-			}, nil).
+			Return(&auth.User{Email: "email@test.com"}, nil).
 			Once()
-
+		eventProducerMock := events.NewMockProducer(t)
 		eventProducerMock.
 			On("WriteMessages", ctx, []events.Message{
 				{
@@ -907,18 +919,20 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 					Data: schemas.EventPaymentsReadyToPayData{
 						TenantID: tnt.ID,
 						Payments: []schemas.PaymentReadyToPay{
-							{
-								ID: payment1.ID,
-							},
-							{
-								ID: payment2.ID,
-							},
+							{ID: payment1.ID},
+							{ID: payment2.ID},
 						},
 					},
 				},
 			}).
 			Return(nil).
 			Once()
+		handler := PaymentsHandler{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+			EventProducer:    eventProducerMock,
+		}
 
 		rw := httptest.NewRecorder()
 		http.HandlerFunc(handler.RetryPayments).ServeHTTP(rw, req)
@@ -982,21 +996,23 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
-				"payment_ids": [
-					%q,
-					%q
-				]
+				"payment_ids": [%q, %q]
 			}
 		`, payment1.ID, payment2.ID))
 		req, err := http.NewRequestWithContext(ctxWithoutTenant, http.MethodPatch, "/retry", payload)
 		require.NoError(t, err)
 
+		// Prepare the handler and its mocks
+		authManagerMock := auth.NewAuthManagerMock(t)
 		authManagerMock.
 			On("GetUser", ctxWithoutTenant, "mytoken").
-			Return(&auth.User{
-				Email: "email@test.com",
-			}, nil).
+			Return(&auth.User{Email: "email@test.com"}, nil).
 			Once()
+		handler := PaymentsHandler{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+		}
 
 		rw := httptest.NewRecorder()
 		http.HandlerFunc(handler.RetryPayments).ServeHTTP(rw, req)
@@ -1011,7 +1027,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 		assert.JSONEq(t, `{"error": "An internal error occurred while processing this request."}`, string(respBody))
 	})
 
-	t.Run("returns error when EventProducer fails writing a message", func(t *testing.T) {
+	t.Run("logs to crashTracker when EventProducer fails to write a message", func(t *testing.T) {
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
 
 		payment1 := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -1028,21 +1044,19 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
-				"payment_ids": [
-					%q
-				]
+				"payment_ids": [%q]
 			}
 		`, payment1.ID))
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", payload)
 		require.NoError(t, err)
 
+		// Prepare the handler and its mocks
+		authManagerMock := auth.NewAuthManagerMock(t)
 		authManagerMock.
 			On("GetUser", ctx, "mytoken").
-			Return(&auth.User{
-				Email: "email@test.com",
-			}, nil).
+			Return(&auth.User{Email: "email@test.com"}, nil).
 			Once()
-
+		eventProducerMock := events.NewMockProducer(t)
 		eventProducerMock.
 			On("WriteMessages", ctx, []events.Message{
 				{
@@ -1053,15 +1067,22 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 					Data: schemas.EventPaymentsReadyToPayData{
 						TenantID: tnt.ID,
 						Payments: []schemas.PaymentReadyToPay{
-							{
-								ID: payment1.ID,
-							},
+							{ID: payment1.ID},
 						},
 					},
 				},
 			}).
 			Return(errors.New("unexpected error")).
 			Once()
+		crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
+		crashTrackerMock.On("LogAndReportErrors", mock.Anything, mock.Anything, mock.Anything).Once()
+		handler := PaymentsHandler{
+			Models:             models,
+			DBConnectionPool:   dbConnectionPool,
+			AuthManager:        authManagerMock,
+			EventProducer:      eventProducerMock,
+			CrashTrackerClient: crashTrackerMock,
+		}
 
 		rw := httptest.NewRecorder()
 		http.HandlerFunc(handler.RetryPayments).ServeHTTP(rw, req)
@@ -1072,8 +1093,8 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.JSONEq(t, `{"error":"An internal error occurred while processing this request."}`, string(respBody))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.JSONEq(t, `{"message":"Payments retried successfully"}`, string(respBody))
 	})
 
 	t.Run("logs when couldn't write message because EventProducer is nil", func(t *testing.T) {
@@ -1103,23 +1124,25 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
-				"payment_ids": [
-					%q,
-					%q
-				]
+				"payment_ids": [%q, %q]
 			}
 		`, payment1.ID, payment2.ID))
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", payload)
 		require.NoError(t, err)
 
+		// Prepare the handler and its mocks
+		authManagerMock := auth.NewAuthManagerMock(t)
 		authManagerMock.
 			On("GetUser", ctx, "mytoken").
-			Return(&auth.User{
-				Email: "email@test.com",
-			}, nil).
+			Return(&auth.User{Email: "email@test.com"}, nil).
 			Once()
+		handler := PaymentsHandler{
+			Models:           models,
+			DBConnectionPool: dbConnectionPool,
+			AuthManager:      authManagerMock,
+		}
 
-		getEntries := log.DefaultLogger.StartTest(log.ErrorLevel)
+		getEntries := log.DefaultLogger.StartTest(log.DebugLevel)
 
 		handler.EventProducer = nil
 		rw := httptest.NewRecorder()
@@ -1142,23 +1165,16 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 			Data: schemas.EventPaymentsReadyToPayData{
 				TenantID: tnt.ID,
 				Payments: []schemas.PaymentReadyToPay{
-					{
-						ID: payment1.ID,
-					},
-					{
-						ID: payment2.ID,
-					},
+					{ID: payment1.ID},
+					{ID: payment2.ID},
 				},
 			},
 		}
 
 		entries := getEntries()
 		require.Len(t, entries, 1)
-		assert.Contains(t, fmt.Sprintf("event producer is nil, could not publish message %s", msg), entries[0].Message)
+		assert.Contains(t, fmt.Sprintf("event producer is nil, could not publish messages %+v", []events.Message{msg}), entries[0].Message)
 	})
-
-	authManagerMock.AssertExpectations(t)
-	eventProducerMock.AssertExpectations(t)
 }
 
 func Test_PaymentsHandler_getPaymentsWithCount(t *testing.T) {

--- a/internal/serve/httphandler/receiver_wallets_handler_test.go
+++ b/internal/serve/httphandler/receiver_wallets_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
@@ -32,22 +33,14 @@ func Test_RetryInvitation(t *testing.T) {
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
-	eventProducerMock := events.MockProducer{}
 	tnt := tenant.Tenant{ID: "tenant-id"}
-
-	handler := &ReceiverWalletsHandler{
-		Models:        models,
-		EventProducer: &eventProducerMock,
-	}
-
-	ctx := context.Background()
-
-	r := chi.NewRouter()
-	r.Patch("/receivers/wallets/{receiver_wallet_id}", handler.RetryInvitation)
-
-	ctx = tenant.SaveTenantInContext(ctx, &tnt)
+	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
 
 	t.Run("returns error when receiver wallet does not exist", func(t *testing.T) {
+		handler := ReceiverWalletsHandler{Models: models}
+		r := chi.NewRouter()
+		r.Patch("/receivers/wallets/{receiver_wallet_id}", handler.RetryInvitation)
+
 		route := "/receivers/wallets/invalid_id"
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, route, nil)
 		require.NoError(t, err)
@@ -61,6 +54,10 @@ func Test_RetryInvitation(t *testing.T) {
 	})
 
 	t.Run("returns error when tenant is not in the context", func(t *testing.T) {
+		handler := ReceiverWalletsHandler{Models: models}
+		r := chi.NewRouter()
+		r.Patch("/receivers/wallets/{receiver_wallet_id}", handler.RetryInvitation)
+
 		receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
 		wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "wallet", "https://www.wallet.com", "www.wallet.com", "wallet://")
 		rw := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
@@ -78,6 +75,14 @@ func Test_RetryInvitation(t *testing.T) {
 	})
 
 	t.Run("successfuly retry invitation", func(t *testing.T) {
+		eventProducerMock := events.NewMockProducer(t)
+		handler := ReceiverWalletsHandler{
+			Models:        models,
+			EventProducer: eventProducerMock,
+		}
+		r := chi.NewRouter()
+		r.Patch("/receivers/wallets/{receiver_wallet_id}", handler.RetryInvitation)
+
 		receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
 		wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "wallet", "https://www.wallet.com", "www.wallet.com", "wallet://")
 		rw := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
@@ -120,6 +125,17 @@ func Test_RetryInvitation(t *testing.T) {
 	})
 
 	t.Run("returns error when fails writing message on message broker", func(t *testing.T) {
+		crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
+		defer crashTrackerMock.AssertExpectations(t)
+		eventProducerMock := events.NewMockProducer(t)
+		handler := ReceiverWalletsHandler{
+			Models:             models,
+			EventProducer:      eventProducerMock,
+			CrashTrackerClient: crashTrackerMock,
+		}
+		r := chi.NewRouter()
+		r.Patch("/receivers/wallets/{receiver_wallet_id}", handler.RetryInvitation)
+
 		receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
 		wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "wallet", "https://www.wallet.com", "www.wallet.com", "wallet://")
 		rw := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
@@ -141,6 +157,11 @@ func Test_RetryInvitation(t *testing.T) {
 			Return(errors.New("unexpected error")).
 			Once()
 
+		crashTrackerMock.
+			On("LogAndReportErrors", mock.Anything, mock.AnythingOfType("*fmt.wrapError"), "writing retry invitation message on the event producer").
+			Return().
+			Once()
+
 		route := fmt.Sprintf("/receivers/wallets/%s", rw.ID)
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, route, nil)
 		require.NoError(t, err)
@@ -149,19 +170,25 @@ func Test_RetryInvitation(t *testing.T) {
 		r.ServeHTTP(rr, req)
 
 		resp := rr.Result()
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.JSONEq(t, `{"error":"An internal error occurred while processing this request."}`, rr.Body.String())
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		wantJson := fmt.Sprintf(`{
+			"id": %q,
+			"receiver_id": %q,
+			"wallet_id": %q,
+			"created_at": %q,
+			"invitation_sent_at": null
+		}`, rw.ID, receiver.ID, wallet.ID, rw.CreatedAt.Format(time.RFC3339Nano))
+		assert.JSONEq(t, wantJson, rr.Body.String())
 	})
 
 	t.Run("logs when couldn't write message because EventProducer is nil", func(t *testing.T) {
+		handler := ReceiverWalletsHandler{Models: models}
+		r := chi.NewRouter()
+		r.Patch("/receivers/wallets/{receiver_wallet_id}", handler.RetryInvitation)
+
 		receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
 		wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "wallet", "https://www.wallet.com", "www.wallet.com", "wallet://")
 		rw := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
-
-		handler := &ReceiverWalletsHandler{
-			Models:        models,
-			EventProducer: nil,
-		}
 
 		router := chi.NewRouter()
 		router.Patch("/receivers/wallets/{receiver_wallet_id}", handler.RetryInvitation)
@@ -200,6 +227,6 @@ func Test_RetryInvitation(t *testing.T) {
 
 		entries := getEntries()
 		require.Len(t, entries, 1)
-		assert.Equal(t, fmt.Sprintf("event producer is nil, could not publish message %s", msg), entries[0].Message)
+		assert.Equal(t, fmt.Sprintf("event producer is nil, could not publish messages %+v", []events.Message{msg}), entries[0].Message)
 	})
 }

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -300,7 +300,6 @@ func (v VerifyReceiverRegistrationHandler) VerifyReceiverRegistration(w http.Res
 				}
 
 				return nil
-				// return events.ProduceEvents(ctx, v.EventProducer, msg)
 			}
 
 			// STEP 6: PATCH transaction on the AnchorPlatform and update the receiver wallet with the anchor platform tx ID

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -288,7 +288,7 @@ func (v VerifyReceiverRegistrationHandler) VerifyReceiverRegistration(w http.Res
 				return nil, fmt.Errorf("processing OTP for receiver with phone number %s: %w", truncatedPhoneNumber, err)
 			}
 
-			// STEP 5: produce event to send receiver's ready payments to TSS
+			// STEP 5: build event message to trigger a transaction in the TSS
 			msg, err := v.buildPaymentsReadyToPayEventMessage(ctx, dbTx, &receiverWallet)
 			if err != nil {
 				return nil, fmt.Errorf("preparing payments ready-to-pay event message: %w", err)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -251,12 +251,13 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				AuthManager:                 authManager,
 				MonitorService:              o.MonitorService,
 				DistributionAccountResolver: o.SubmitterEngine.DistributionAccountResolver,
-				DisbursementManagementService: services.NewDisbursementManagementService(
-					o.Models,
-					o.MtnDBConnectionPool,
-					authManager,
-					o.SubmitterEngine.HorizonClient,
-					o.EventProducer),
+				DisbursementManagementService: &services.DisbursementManagementService{
+					Models:           o.Models,
+					DBConnectionPool: o.MtnDBConnectionPool,
+					AuthManager:      authManager,
+					HorizonClient:    o.SubmitterEngine.HorizonClient,
+					EventProducer:    o.EventProducer,
+				},
 			}
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Post("/", handler.PostDisbursement)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -252,10 +252,11 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				MonitorService:              o.MonitorService,
 				DistributionAccountResolver: o.SubmitterEngine.DistributionAccountResolver,
 				DisbursementManagementService: &services.DisbursementManagementService{
-					Models:        o.Models,
-					AuthManager:   authManager,
-					HorizonClient: o.SubmitterEngine.HorizonClient,
-					EventProducer: o.EventProducer,
+					Models:             o.Models,
+					AuthManager:        authManager,
+					HorizonClient:      o.SubmitterEngine.HorizonClient,
+					EventProducer:      o.EventProducer,
+					CrashTrackerClient: o.CrashTrackerClient,
 				},
 			}
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -252,11 +252,10 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				MonitorService:              o.MonitorService,
 				DistributionAccountResolver: o.SubmitterEngine.DistributionAccountResolver,
 				DisbursementManagementService: &services.DisbursementManagementService{
-					Models:           o.Models,
-					DBConnectionPool: o.MtnDBConnectionPool,
-					AuthManager:      authManager,
-					HorizonClient:    o.SubmitterEngine.HorizonClient,
-					EventProducer:    o.EventProducer,
+					Models:        o.Models,
+					AuthManager:   authManager,
+					HorizonClient: o.SubmitterEngine.HorizonClient,
+					EventProducer: o.EventProducer,
 				},
 			}
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -281,7 +281,13 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		})
 
 		r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).Route("/payments", func(r chi.Router) {
-			paymentsHandler := httphandler.PaymentsHandler{Models: o.Models, DBConnectionPool: o.MtnDBConnectionPool, AuthManager: o.authManager, EventProducer: o.EventProducer}
+			paymentsHandler := httphandler.PaymentsHandler{
+				Models:             o.Models,
+				DBConnectionPool:   o.MtnDBConnectionPool,
+				AuthManager:        o.authManager,
+				EventProducer:      o.EventProducer,
+				CrashTrackerClient: o.CrashTrackerClient,
+			}
 			r.Get("/", paymentsHandler.GetPayments)
 			r.Get("/{id}", paymentsHandler.GetPayment)
 			r.Patch("/retry", paymentsHandler.RetryPayments)
@@ -443,6 +449,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				ReCAPTCHAValidator:       reCAPTCHAValidator,
 				NetworkPassphrase:        o.NetworkPassphrase,
 				EventProducer:            o.EventProducer,
+				CrashTrackerClient:       o.CrashTrackerClient,
 			}.VerifyReceiverRegistration)
 		})
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -303,7 +303,11 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/{id}", updateReceiverHandler.UpdateReceiver)
 
-			receiverWalletHandler := httphandler.ReceiverWalletsHandler{Models: o.Models, EventProducer: o.EventProducer}
+			receiverWalletHandler := httphandler.ReceiverWalletsHandler{
+				Models:             o.Models,
+				CrashTrackerClient: o.CrashTrackerClient,
+				EventProducer:      o.EventProducer,
+			}
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/wallets/{receiver_wallet_id}", receiverWalletHandler.RetryInvitation)
 		})

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -22,11 +22,11 @@ import (
 
 // DisbursementManagementService is a service for managing disbursements.
 type DisbursementManagementService struct {
-	models           *data.Models
-	dbConnectionPool db.DBConnectionPool
-	eventProducer    events.Producer
-	authManager      auth.AuthManager
-	horizonClient    horizonclient.ClientInterface
+	Models           *data.Models
+	DBConnectionPool db.DBConnectionPool
+	EventProducer    events.Producer
+	AuthManager      auth.AuthManager
+	HorizonClient    horizonclient.ClientInterface
 }
 
 type UserReference struct {
@@ -73,23 +73,6 @@ func (e InsufficientBalanceError) Error() string {
 	)
 }
 
-// NewDisbursementManagementService is a factory function for creating a new DisbursementManagementService.
-func NewDisbursementManagementService(
-	models *data.Models,
-	dbConnectionPool db.DBConnectionPool,
-	authManager auth.AuthManager,
-	horizonClient horizonclient.ClientInterface,
-	eventProducer events.Producer,
-) *DisbursementManagementService {
-	return &DisbursementManagementService{
-		models:           models,
-		dbConnectionPool: dbConnectionPool,
-		authManager:      authManager,
-		eventProducer:    eventProducer,
-		horizonClient:    horizonClient,
-	}
-}
-
 func (s *DisbursementManagementService) AppendUserMetadata(ctx context.Context, disbursements []*data.Disbursement) ([]*DisbursementWithUserMetadata, error) {
 	users := map[string]*auth.User{}
 	for _, d := range disbursements {
@@ -107,7 +90,7 @@ func (s *DisbursementManagementService) AppendUserMetadata(ctx context.Context, 
 		}
 	}
 
-	usersList, err := s.authManager.GetUsersByID(ctx, maps.Keys(users))
+	usersList, err := s.AuthManager.GetUsersByID(ctx, maps.Keys(users))
 	if err != nil {
 		return nil, fmt.Errorf("error getting user for IDs: %w", err)
 	}
@@ -145,17 +128,17 @@ func (s *DisbursementManagementService) AppendUserMetadata(ctx context.Context, 
 
 func (s *DisbursementManagementService) GetDisbursementsWithCount(ctx context.Context, queryParams *data.QueryParams) (*utils.ResultWithTotal, error) {
 	return db.RunInTransactionWithResult(ctx,
-		s.dbConnectionPool,
+		s.DBConnectionPool,
 		&sql.TxOptions{Isolation: sql.LevelReadCommitted, ReadOnly: true},
 		func(dbTx db.DBTransaction) (*utils.ResultWithTotal, error) {
-			totalDisbursements, err := s.models.Disbursements.Count(ctx, dbTx, queryParams)
+			totalDisbursements, err := s.Models.Disbursements.Count(ctx, dbTx, queryParams)
 			if err != nil {
 				return nil, fmt.Errorf("error counting disbursements: %w", err)
 			}
 
 			var disbursements []*data.Disbursement
 			if totalDisbursements != 0 {
-				disbursements, err = s.models.Disbursements.GetAll(ctx, dbTx, queryParams)
+				disbursements, err = s.Models.Disbursements.GetAll(ctx, dbTx, queryParams)
 				if err != nil {
 					return nil, fmt.Errorf("error retrieving disbursements: %w", err)
 				}
@@ -174,10 +157,10 @@ func (s *DisbursementManagementService) GetDisbursementsWithCount(ctx context.Co
 
 func (s *DisbursementManagementService) GetDisbursementReceiversWithCount(ctx context.Context, disbursementID string, queryParams *data.QueryParams) (*utils.ResultWithTotal, error) {
 	return db.RunInTransactionWithResult(ctx,
-		s.dbConnectionPool,
+		s.DBConnectionPool,
 		&sql.TxOptions{Isolation: sql.LevelReadCommitted, ReadOnly: true},
 		func(dbTx db.DBTransaction) (*utils.ResultWithTotal, error) {
-			_, err := s.models.Disbursements.Get(ctx, dbTx, disbursementID)
+			_, err := s.Models.Disbursements.Get(ctx, dbTx, disbursementID)
 			if err != nil {
 				if errors.Is(err, data.ErrRecordNotFound) {
 					return nil, ErrDisbursementNotFound
@@ -186,14 +169,14 @@ func (s *DisbursementManagementService) GetDisbursementReceiversWithCount(ctx co
 				}
 			}
 
-			totalReceivers, err := s.models.DisbursementReceivers.Count(ctx, dbTx, disbursementID)
+			totalReceivers, err := s.Models.DisbursementReceivers.Count(ctx, dbTx, disbursementID)
 			if err != nil {
 				return nil, fmt.Errorf("error counting disbursement receivers for disbursement with id %s: %w", disbursementID, err)
 			}
 
 			receivers := []*data.DisbursementReceiver{}
 			if totalReceivers != 0 {
-				receivers, err = s.models.DisbursementReceivers.GetAll(ctx, dbTx, queryParams, disbursementID)
+				receivers, err = s.Models.DisbursementReceivers.GetAll(ctx, dbTx, queryParams, disbursementID)
 				if err != nil {
 					return nil, fmt.Errorf("error retrieving disbursement receivers for disbursement with id %s: %w", disbursementID, err)
 				}
@@ -206,9 +189,9 @@ func (s *DisbursementManagementService) GetDisbursementReceiversWithCount(ctx co
 // StartDisbursement starts a disbursement and all its payments and receivers wallets.
 func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, disbursementID string, user *auth.User, distributionPubKey string) error {
 	opts := db.TransactionOptions{
-		DBConnectionPool: s.dbConnectionPool,
+		DBConnectionPool: s.DBConnectionPool,
 		AtomicFunctionWithPostCommit: func(dbTx db.DBTransaction) (postCommitFn db.PostCommitFunction, err error) {
-			disbursement, err := s.models.Disbursements.GetWithStatistics(ctx, disbursementID)
+			disbursement, err := s.Models.Disbursements.GetWithStatistics(ctx, disbursementID)
 			if err != nil {
 				if errors.Is(err, data.ErrRecordNotFound) {
 					return nil, ErrDisbursementNotFound
@@ -228,7 +211,7 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 			}
 
 			// 3. Check if approval Workflow is enabled for this organization
-			organization, err := s.models.Organizations.Get(ctx)
+			organization, err := s.Models.Organizations.Get(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("error getting organization: %w", err)
 			}
@@ -243,7 +226,7 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 			}
 
 			// 4. Check if there is enough balance from the distribution wallet for this disbursement along with any pending disbursements
-			rootAccount, err := s.horizonClient.AccountDetail(
+			rootAccount, err := s.HorizonClient.AccountDetail(
 				horizonclient.AccountRequest{AccountID: distributionPubKey})
 			if err != nil {
 				err = tssUtils.NewHorizonErrorWrapper(err)
@@ -271,7 +254,7 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 			}
 
 			var totalPendingAmount float64 = 0.0
-			incompletePayments, err := s.models.Payment.GetAll(ctx, &data.QueryParams{
+			incompletePayments, err := s.Models.Payment.GetAll(ctx, &data.QueryParams{
 				Filters: map[data.FilterKey]interface{}{
 					data.FilterKeyStatus: data.PaymentInProgressStatuses(),
 				},
@@ -311,19 +294,19 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 			}
 
 			// 5. Update all correct payment status to `ready`
-			err = s.models.Payment.UpdateStatusByDisbursementID(ctx, dbTx, disbursementID, data.ReadyPaymentStatus)
+			err = s.Models.Payment.UpdateStatusByDisbursementID(ctx, dbTx, disbursementID, data.ReadyPaymentStatus)
 			if err != nil {
 				return nil, fmt.Errorf("error updating payment status to ready for disbursement with id %s: %w", disbursementID, err)
 			}
 
 			// 6. Update all receiver_wallets from `draft` to `ready`
-			err = s.models.ReceiverWallet.UpdateStatusByDisbursementID(ctx, dbTx, disbursementID, data.DraftReceiversWalletStatus, data.ReadyReceiversWalletStatus)
+			err = s.Models.ReceiverWallet.UpdateStatusByDisbursementID(ctx, dbTx, disbursementID, data.DraftReceiversWalletStatus, data.ReadyReceiversWalletStatus)
 			if err != nil {
 				return nil, fmt.Errorf("error updating receiver wallet status to ready for disbursement with id %s: %w", disbursementID, err)
 			}
 
 			// 7. Update disbursement status to `started`
-			err = s.models.Disbursements.UpdateStatus(ctx, dbTx, user.ID, disbursementID, data.StartedDisbursementStatus)
+			err = s.Models.Disbursements.UpdateStatus(ctx, dbTx, user.ID, disbursementID, data.StartedDisbursementStatus)
 			if err != nil {
 				return nil, fmt.Errorf("error updating disbursement status to started for disbursement with id %s: %w", disbursementID, err)
 			}
@@ -331,7 +314,7 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 			// 8. Produce events to send invitation message to the receivers
 			msgs := make([]events.Message, 0)
 
-			receiverWallets, err := s.models.ReceiverWallet.GetAllPendingRegistrationByDisbursementID(ctx, dbTx, disbursementID)
+			receiverWallets, err := s.Models.ReceiverWallet.GetAllPendingRegistrationByDisbursementID(ctx, dbTx, disbursementID)
 			if err != nil {
 				return nil, fmt.Errorf("getting pending registration receiver wallets: %w", err)
 			}
@@ -353,7 +336,7 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 			}
 
 			// 9. Produce events to send payments to the TSS
-			payments, err := s.models.Payment.GetReadyByDisbursementID(ctx, dbTx, disbursementID)
+			payments, err := s.Models.Payment.GetReadyByDisbursementID(ctx, dbTx, disbursementID)
 			if err != nil {
 				return nil, fmt.Errorf("getting ready payments for disbursement with id %s: %w", disbursementID, err)
 			}
@@ -391,12 +374,12 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 }
 
 func (s *DisbursementManagementService) produceEvents(ctx context.Context, msgs ...events.Message) error {
-	if s.eventProducer == nil {
+	if s.EventProducer == nil {
 		log.Ctx(ctx).Errorf("event producer is nil, could not publish messages %+v", msgs)
 		return nil
 	}
 
-	if err := s.eventProducer.WriteMessages(ctx, msgs...); err != nil {
+	if err := s.EventProducer.WriteMessages(ctx, msgs...); err != nil {
 		return fmt.Errorf("publishing messages %+v on event producer: %w", msgs, err)
 	}
 
@@ -405,8 +388,8 @@ func (s *DisbursementManagementService) produceEvents(ctx context.Context, msgs 
 
 // PauseDisbursement pauses a disbursement and all its payments.
 func (s *DisbursementManagementService) PauseDisbursement(ctx context.Context, disbursementID string, user *auth.User) error {
-	return db.RunInTransaction(ctx, s.dbConnectionPool, nil, func(dbTx db.DBTransaction) error {
-		disbursement, err := s.models.Disbursements.Get(ctx, dbTx, disbursementID)
+	return db.RunInTransaction(ctx, s.DBConnectionPool, nil, func(dbTx db.DBTransaction) error {
+		disbursement, err := s.Models.Disbursements.Get(ctx, dbTx, disbursementID)
 		if err != nil {
 			if errors.Is(err, data.ErrRecordNotFound) {
 				return ErrDisbursementNotFound
@@ -422,13 +405,13 @@ func (s *DisbursementManagementService) PauseDisbursement(ctx context.Context, d
 		}
 
 		// 2. Update all correct payment status to `paused`
-		err = s.models.Payment.UpdateStatusByDisbursementID(ctx, dbTx, disbursementID, data.PausedPaymentStatus)
+		err = s.Models.Payment.UpdateStatusByDisbursementID(ctx, dbTx, disbursementID, data.PausedPaymentStatus)
 		if err != nil {
 			return fmt.Errorf("error updating payment status to paused for disbursement with id %s: %w", disbursementID, err)
 		}
 
 		// 3. Update disbursement status to `paused`
-		err = s.models.Disbursements.UpdateStatus(ctx, dbTx, user.ID, disbursementID, data.PausedDisbursementStatus)
+		err = s.Models.Disbursements.UpdateStatus(ctx, dbTx, user.ID, disbursementID, data.PausedDisbursementStatus)
 		if err != nil {
 			return fmt.Errorf("error updating disbursement status to started for disbursement with id %s: %w", disbursementID, err)
 		}

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -73,9 +73,8 @@ func Test_DisbursementManagementService_GetDisbursementsWithCount(t *testing.T) 
 		Return(users, nil)
 
 	service := &DisbursementManagementService{
-		Models:           models,
-		DBConnectionPool: models.DBConnectionPool,
-		AuthManager:      authManagerMock,
+		Models:      models,
+		AuthManager: authManagerMock,
 	}
 
 	ctx := context.Background()
@@ -143,10 +142,7 @@ func Test_DisbursementManagementService_GetDisbursementReceiversWithCount(t *tes
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 
-	service := DisbursementManagementService{
-		Models:           models,
-		DBConnectionPool: dbConnectionPool,
-	}
+	service := DisbursementManagementService{Models: models}
 	disbursement := data.CreateDisbursementFixture(t, context.Background(), dbConnectionPool, models.Disbursements, &data.Disbursement{})
 
 	ctx := context.Background()
@@ -197,16 +193,12 @@ func Test_DisbursementManagementService_GetDisbursementReceiversWithCount(t *tes
 func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
-
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
-
-	mockEventProducer := events.MockProducer{}
-	defer mockEventProducer.AssertExpectations(t)
 
 	ctx := context.Background()
 
@@ -217,14 +209,14 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 	ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
 
 	asset := data.GetAssetFixture(t, ctx, dbConnectionPool, data.FixtureAssetUSDC)
-	hMock := &horizonclient.MockClient{}
 	distributionPubKey := "ABC"
 
+	mockEventProducer := events.NewMockProducer(t)
+	hMock := &horizonclient.MockClient{}
 	service := &DisbursementManagementService{
-		Models:           models,
-		DBConnectionPool: models.DBConnectionPool,
-		HorizonClient:    hMock,
-		EventProducer:    &mockEventProducer,
+		Models:        models,
+		HorizonClient: hMock,
+		EventProducer: mockEventProducer,
 	}
 
 	// create fixtures
@@ -648,9 +640,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 				TenantID: tnt.ID,
 				Type:     events.BatchReceiverWalletSMSInvitationType,
 				Data: []schemas.EventReceiverWalletSMSInvitationData{
-					{
-						ReceiverWalletID: rwReady.ID, // Receiver that can receive SMS
-					},
+					{ReceiverWalletID: rwReady.ID}, // Receiver that can receive SMS
 				},
 			},
 			{
@@ -661,9 +651,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 				Data: schemas.EventPaymentsReadyToPayData{
 					TenantID: tnt.ID,
 					Payments: []schemas.PaymentReadyToPay{
-						{
-							ID: payment.ID,
-						},
+						{ID: payment.ID},
 					},
 				},
 			},
@@ -907,10 +895,9 @@ func Test_DisbursementManagementService_PauseDisbursement(t *testing.T) {
 	distributionPubKey := "ABC"
 
 	service := &DisbursementManagementService{
-		Models:           models,
-		DBConnectionPool: models.DBConnectionPool,
-		HorizonClient:    hMock,
-		EventProducer:    &mockEventProducer,
+		Models:        models,
+		HorizonClient: hMock,
+		EventProducer: &mockEventProducer,
 	}
 
 	// create fixtures

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -200,30 +200,17 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 
-	ctx := context.Background()
-
 	tnt := tenant.Tenant{ID: "tenant-id"}
-	ctx = tenant.SaveTenantInContext(ctx, &tnt)
-
+	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
 	token := "token"
 	ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
 
+	// Create fixtures: asset, wallet, country
 	asset := data.GetAssetFixture(t, ctx, dbConnectionPool, data.FixtureAssetUSDC)
-	distributionPubKey := "ABC"
-
-	mockEventProducer := events.NewMockProducer(t)
-	hMock := &horizonclient.MockClient{}
-	service := &DisbursementManagementService{
-		Models:        models,
-		HorizonClient: hMock,
-		EventProducer: mockEventProducer,
-	}
-
-	// create fixtures
 	wallet := data.CreateDefaultWalletFixture(t, ctx, dbConnectionPool)
 	country := data.GetCountryFixture(t, ctx, dbConnectionPool, data.FixtureCountryUKR)
 
-	// create disbursements
+	// Create fixtures: disbursements
 	draftDisbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
 		Name:    "draft disbursement",
 		Status:  data.DraftDisbursementStatus,
@@ -231,7 +218,6 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		Wallet:  wallet,
 		Country: country,
 	})
-
 	readyDisbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
 		Name:    "ready disbursement",
 		Status:  data.ReadyDisbursementStatus,
@@ -240,7 +226,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		Country: country,
 	})
 
-	// create disbursement receivers
+	// Create fixtures: receivers, receiver wallets, payments
 	receiver1 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
 	receiver2 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
 	receiver3 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
@@ -284,9 +270,9 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 
 	payments := []*data.Payment{payment1, payment2, payment3, payment4}
 
-	mockDisbursementBalance := hMock.On(
-		"AccountDetail", horizonclient.AccountRequest{AccountID: distributionPubKey},
-	).Return(horizon.Account{
+	distributionPubKey := "GAAHIL6ZW4QFNLCKALZ3YOIWPP4TXQ7B7J5IU7RLNVGQAV6GFDZHLDTA"
+	hAccRequest := horizonclient.AccountRequest{AccountID: distributionPubKey}
+	hAccResponse := horizon.Account{
 		Balances: []horizon.Balance{
 			{
 				Balance: "10000000",
@@ -296,46 +282,51 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}
 
-	t.Run("disbursement doesn't exist", func(t *testing.T) {
-		id := "5e1f1c7f5b6c9c0001c1b1b1"
+	t.Run("returns an error if the disbursement doesn't exist", func(t *testing.T) {
+		service := DisbursementManagementService{Models: models}
 
-		err = service.StartDisbursement(context.Background(), id, nil, distributionPubKey)
+		err = service.StartDisbursement(context.Background(), "not-found-id", nil, distributionPubKey)
 		require.ErrorIs(t, err, ErrDisbursementNotFound)
 	})
 
-	t.Run("disbursement wallet is disabled", func(t *testing.T) {
+	t.Run("returns an error if the disbursement's wallet is disabled", func(t *testing.T) {
+		service := DisbursementManagementService{Models: models}
+
 		data.EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, false, wallet.ID)
 		defer data.EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, true, wallet.ID)
 		err = service.StartDisbursement(context.Background(), draftDisbursement.ID, nil, distributionPubKey)
 		require.ErrorIs(t, err, ErrDisbursementWalletDisabled)
 	})
 
-	t.Run("disbursement not ready to start", func(t *testing.T) {
+	t.Run("returns an error if the disbursement status is not READY", func(t *testing.T) {
+		service := DisbursementManagementService{Models: models}
+
 		err = service.StartDisbursement(context.Background(), draftDisbursement.ID, nil, distributionPubKey)
 		require.ErrorIs(t, err, ErrDisbursementNotReadyToStart)
 	})
 
-	t.Run("disbursement can't be started by its creator", func(t *testing.T) {
+	t.Run("(APPROVAL FLOW ENABLED) returns an error if the disbursement is started by its creator", func(t *testing.T) {
+		service := DisbursementManagementService{Models: models}
+
 		userID := "9ae68f09-cad9-4311-9758-4ff59d2e9e6d"
-		statusHistory := []data.DisbursementStatusHistoryEntry{
-			{
-				Status: data.DraftDisbursementStatus,
-				UserID: userID,
-			},
-			{
-				Status: data.ReadyDisbursementStatus,
-				UserID: userID,
-			},
-		}
 		disbursement := data.CreateDisbursementFixture(t, context.Background(), dbConnectionPool, models.Disbursements, &data.Disbursement{
-			Name:          "disbursement #1",
-			Status:        data.ReadyDisbursementStatus,
-			Asset:         asset,
-			Wallet:        wallet,
-			Country:       country,
-			StatusHistory: statusHistory,
+			Name:    "disbursement #1",
+			Status:  data.ReadyDisbursementStatus,
+			Asset:   asset,
+			Wallet:  wallet,
+			Country: country,
+			StatusHistory: []data.DisbursementStatusHistoryEntry{
+				{
+					Status: data.DraftDisbursementStatus,
+					UserID: userID,
+				},
+				{
+					Status: data.ReadyDisbursementStatus,
+					UserID: userID,
+				},
+			},
 		})
 
 		user := &auth.User{
@@ -357,7 +348,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("disbursement started with approval workflow", func(t *testing.T) {
+	t.Run("🎉 (APPROVAL FLOW ENABLED) successfully starts a disbursement using the approval workflow", func(t *testing.T) {
 		userID := "9ae68f09-cad9-4311-9758-4ff59d2e9e6d"
 		statusHistory := []data.DisbursementStatusHistoryEntry{
 			{
@@ -369,8 +360,6 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 				UserID: userID,
 			},
 		}
-
-		mockDisbursementBalance.Once()
 
 		disbursement := data.CreateDisbursementFixture(t, context.Background(), dbConnectionPool, models.Disbursements, &data.Disbursement{
 			Name:          "disbursement #2",
@@ -398,6 +387,11 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		err = models.Organizations.Update(ctx, &data.OrganizationUpdate{IsApprovalRequired: &isApprovalRequired})
 		require.NoError(t, err)
 
+		// Create Mocks
+		hMock := &horizonclient.MockClient{}
+		defer hMock.AssertExpectations(t)
+		hMock.On("AccountDetail", hAccRequest).Return(hAccResponse, nil).Once()
+		mockEventProducer := events.NewMockProducer(t)
 		mockEventProducer.
 			On("WriteMessages", ctx, mock.AnythingOfType("[]events.Message")).
 			Run(func(args mock.Arguments) {
@@ -420,6 +414,13 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			Return(nil).
 			Once()
 
+		// Create service
+		service := &DisbursementManagementService{
+			Models:        models,
+			HorizonClient: hMock,
+			EventProducer: mockEventProducer,
+		}
+
 		err = service.StartDisbursement(ctx, disbursement.ID, user, distributionPubKey)
 		require.NoError(t, err)
 
@@ -434,7 +435,12 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("disbursement started", func(t *testing.T) {
+	t.Run("🎉 successfully starts a disbursement", func(t *testing.T) {
+		// Create Mocks
+		hMock := &horizonclient.MockClient{}
+		defer hMock.AssertExpectations(t)
+		hMock.On("AccountDetail", hAccRequest).Return(hAccResponse, nil).Once()
+		mockEventProducer := events.NewMockProducer(t)
 		mockEventProducer.
 			On("WriteMessages", ctx, mock.AnythingOfType("[]events.Message")).
 			Run(func(args mock.Arguments) {
@@ -463,9 +469,7 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 					Data: schemas.EventPaymentsReadyToPayData{
 						TenantID: tnt.ID,
 						Payments: []schemas.PaymentReadyToPay{
-							{
-								ID: payment4.ID,
-							},
+							{ID: payment4.ID},
 						},
 					},
 				}, paymentsReadyToPayMsg)
@@ -473,13 +477,14 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			Return(nil).
 			Once()
 
-		user := &auth.User{
-			ID:    "user-id",
-			Email: "email@email.com",
+		// Create service
+		service := &DisbursementManagementService{
+			Models:        models,
+			HorizonClient: hMock,
+			EventProducer: mockEventProducer,
 		}
 
-		mockDisbursementBalance.Once()
-
+		user := &auth.User{ID: "user-id", Email: "email@email.com"}
 		err = service.StartDisbursement(ctx, readyDisbursement.ID, user, distributionPubKey)
 		require.NoError(t, err)
 
@@ -513,22 +518,8 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		}
 	})
 
-	t.Run("disbursement cannot be started because insufficient balance on distribution account", func(t *testing.T) {
+	t.Run("returns an error if the distribution account has insuficcient balance", func(t *testing.T) {
 		usdt := data.CreateAssetFixture(t, ctx, dbConnectionPool, "USDT", "GBVHJTRLQRMIHRYTXZQOPVYCVVH7IRJN3DOFT7VC6U75CBWWBVDTWURG")
-
-		hMock.On(
-			"AccountDetail", horizonclient.AccountRequest{AccountID: distributionPubKey},
-		).Return(horizon.Account{
-			Balances: []horizon.Balance{
-				{
-					Balance: "11111",
-					Asset: base.Asset{
-						Code:   usdt.Code,
-						Issuer: usdt.Issuer,
-					},
-				},
-			},
-		}, nil).Once()
 
 		disbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
 			Name:    "disbursement - balance insufficient",
@@ -580,6 +571,28 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 
+		// Create Mocks
+		hMock := &horizonclient.MockClient{}
+		defer hMock.AssertExpectations(t)
+		hMock.On("AccountDetail", hAccRequest).Return(horizon.Account{
+			Balances: []horizon.Balance{
+				{
+					Balance: "11111",
+					Asset: base.Asset{
+						Code:   usdt.Code,
+						Issuer: usdt.Issuer,
+					},
+				},
+			},
+		}, nil).Once()
+
+		// Create service
+		service := &DisbursementManagementService{
+			Models:        models,
+			HorizonClient: hMock,
+		}
+
+		err = service.StartDisbursement(ctx, disbursementInsufficientBalance.ID, nil, distributionPubKey)
 		expectedErr := InsufficientBalanceError{
 			DisbursementAsset:   *usdt,
 			DistributionAddress: distributionPubKey,
@@ -588,11 +601,10 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			DisbursementAmount:  22222.0,
 			TotalPendingAmount:  1100.0,
 		}
-		err = service.StartDisbursement(ctx, disbursementInsufficientBalance.ID, nil, distributionPubKey)
 		require.EqualError(t, err, fmt.Sprintf("running atomic function in RunInTransactionWithPostCommit: %v", expectedErr))
 
 		// PendingTotal includes payments associated with 'readyDisbursement' that were moved from the draft to ready status
-		expectedErrStr := fmt.Sprintf("the disbursement %s failed due to an account balance (11111.00) that was insufficient to fulfill new amount (22222.00) along with the pending amount (1100.00). To complete this action, your distribution account (ABC) needs to be recharged with at least 12211.00 USDT", disbursementInsufficientBalance.ID)
+		expectedErrStr := fmt.Sprintf("the disbursement %s failed due to an account balance (11111.00) that was insufficient to fulfill new amount (22222.00) along with the pending amount (1100.00). To complete this action, your distribution account (GAAHIL6ZW4QFNLCKALZ3YOIWPP4TXQ7B7J5IU7RLNVGQAV6GFDZHLDTA) needs to be recharged with at least 12211.00 USDT", disbursementInsufficientBalance.ID)
 		assert.Contains(t, buf.String(), expectedErrStr)
 	})
 
@@ -656,12 +668,23 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 				},
 			},
 		}
-		mockDisbursementBalance.Once()
 
+		// Create Mocks
+		hMock := &horizonclient.MockClient{}
+		defer hMock.AssertExpectations(t)
+		hMock.On("AccountDetail", hAccRequest).Return(hAccResponse, nil).Once()
+		mockEventProducer := events.NewMockProducer(t)
 		mockEventProducer.
 			On("WriteMessages", ctx, expectedMessages).
 			Return(errors.New("unexpected error")).
 			Once()
+
+		// Create service
+		service := &DisbursementManagementService{
+			Models:        models,
+			HorizonClient: hMock,
+			EventProducer: mockEventProducer,
+		}
 
 		user := &auth.User{
 			ID:    "user-id",
@@ -669,14 +692,12 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		}
 
 		err = service.StartDisbursement(ctx, disbursement.ID, user, distributionPubKey)
-		assert.EqualError(
-			t,
-			err,
+		assert.EqualError(t, err,
 			fmt.Sprintf("executing postCommit function: publishing messages %+v on event producer: unexpected error", expectedMessages),
 		)
 	})
 
-	t.Run("doesn't produce message when there's no payment ready to pay", func(t *testing.T) {
+	t.Run("doesn't produce message when there are no payments ready to pay", func(t *testing.T) {
 		userID := "9ae68f09-cad9-4311-9758-4ff59d2e9e6d"
 		statusHistory := []data.DisbursementStatusHistoryEntry{
 			{
@@ -705,6 +726,11 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			Status:         data.ReadyPaymentStatus,
 		})
 
+		// Create Mocks
+		hMock := &horizonclient.MockClient{}
+		defer hMock.AssertExpectations(t)
+		hMock.On("AccountDetail", hAccRequest).Return(hAccResponse, nil).Once()
+		mockEventProducer := events.NewMockProducer(t)
 		mockEventProducer.
 			On("WriteMessages", ctx, []events.Message{
 				{
@@ -713,28 +739,29 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 					TenantID: tnt.ID,
 					Type:     events.BatchReceiverWalletSMSInvitationType,
 					Data: []schemas.EventReceiverWalletSMSInvitationData{
-						{
-							ReceiverWalletID: rwReady.ID, // Receiver that can receive SMS
-						},
+						{ReceiverWalletID: rwReady.ID}, // Receiver that can receive SMS
 					},
 				},
 			}).
 			Return(nil).
 			Once()
 
-		getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
-
-		user := &auth.User{
-			ID:    "user-id",
-			Email: "email@email.com",
+		// Create service
+		service := &DisbursementManagementService{
+			Models:        models,
+			HorizonClient: hMock,
+			EventProducer: mockEventProducer,
 		}
 
-		mockDisbursementBalance.Once()
+		getEntries := log.DefaultLogger.StartTest(log.InfoLevel)
+
+		user := &auth.User{ID: "user-id", Email: "email@email.com"}
+
 		err = service.StartDisbursement(ctx, disbursement.ID, user, distributionPubKey)
 		require.NoError(t, err)
 
 		entries := getEntries()
-		require.Len(t, entries, 4)
+		require.Len(t, entries, 5)
 		assert.Contains(t, fmt.Sprintf("no payments ready to pay for disbursement ID %s", disbursement.ID), entries[3].Message)
 	})
 
@@ -769,12 +796,19 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			Status:         data.ReadyPaymentStatus,
 		})
 
-		user := &auth.User{
-			ID:    "user-id",
-			Email: "email@email.com",
+		user := &auth.User{ID: "user-id", Email: "email@email.com"}
+
+		// Create Mocks
+		hMock := &horizonclient.MockClient{}
+		defer hMock.AssertExpectations(t)
+		hMock.On("AccountDetail", hAccRequest).Return(hAccResponse, nil).Once()
+
+		// Create service
+		service := &DisbursementManagementService{
+			Models:        models,
+			HorizonClient: hMock,
 		}
 
-		mockDisbursementBalance.Once()
 		err = service.StartDisbursement(ctxWithoutTenant, disbursement.ID, user, distributionPubKey)
 		assert.EqualError(t, err, "running atomic function in RunInTransactionWithPostCommit: creating new message: getting tenant from context: tenant not found in context")
 	})
@@ -818,12 +852,20 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 
 		getEntries := log.DefaultLogger.StartTest(log.ErrorLevel)
 
-		user := &auth.User{
-			ID:    "user-id",
-			Email: "email@email.com",
+		user := &auth.User{ID: "user-id", Email: "email@email.com"}
+
+		// Create Mocks
+		hMock := &horizonclient.MockClient{}
+		defer hMock.AssertExpectations(t)
+		hMock.On("AccountDetail", hAccRequest).Return(hAccResponse, nil).Once()
+
+		// Create service
+		service := &DisbursementManagementService{
+			Models:        models,
+			HorizonClient: hMock,
+			EventProducer: nil, // <----- EventProducer is nil
 		}
-		service.EventProducer = nil
-		mockDisbursementBalance.Once()
+
 		err = service.StartDisbursement(ctx, disbursement.ID, user, distributionPubKey)
 		require.NoError(t, err)
 
@@ -859,7 +901,6 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		require.Len(t, entries, 1)
 		assert.Contains(t, fmt.Sprintf("event producer is nil, could not publish messages %+v", msgs), entries[0].Message)
 	})
-	hMock.AssertExpectations(t)
 }
 
 func Test_DisbursementManagementService_PauseDisbursement(t *testing.T) {

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -142,7 +142,7 @@ func (tw *TransactionWorker) Run(ctx context.Context, txJob *TxJob) {
 	ctx = tw.updateContextLogger(ctx, txJob)
 	err := tw.runJob(ctx, txJob)
 	if err != nil {
-		log.Ctx(ctx).Errorf("Handle unexpected error: %v", err)
+		tw.crashTrackerClient.LogAndReportErrors(ctx, err, "unexpected TSS error")
 	}
 }
 
@@ -153,9 +153,7 @@ func (tw *TransactionWorker) runJob(ctx context.Context, txJob *TxJob) error {
 		return fmt.Errorf("validating job: %w", err)
 	}
 
-	if txJob == nil {
-		return fmt.Errorf("received nil transaction job")
-	} else if txJob.Transaction.StellarTransactionHash.Valid {
+	if txJob.Transaction.StellarTransactionHash.Valid {
 		return tw.reconcileSubmittedTransaction(ctx, txJob)
 	} else {
 		return tw.processTransactionSubmission(ctx, txJob)
@@ -211,6 +209,16 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 
 			if hErrWrapper.ShouldMarkAsError() {
 				metricsMetadata.PaymentEventType = sdpMonitor.PaymentFailedLabel
+
+				// Building the payment completed event before updating the transaction status. This way, if the message
+				// fails to be built, the transaction will be marked for reprocessing -> reconciliation and the event
+				// will be re-tried.
+				var msg *events.Message
+				msg, err = tw.buildPaymentCompletedEvent(events.PaymentCompletedErrorType, &txJob.Transaction, data.FailedPaymentStatus, hErrWrapper.Error())
+				if err != nil {
+					return fmt.Errorf("producing payment completed event Status %s - Job %v: %w", txJob.Transaction.Status, txJob, err)
+				}
+
 				var updatedTx *store.Transaction
 				updatedTx, err = tw.txModel.UpdateStatusToError(ctx, txJob.Transaction, hErrWrapper.Error())
 				if err != nil {
@@ -219,7 +227,7 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 				txJob.Transaction = *updatedTx
 
 				// Publishing a new event on the event producer
-				err = tw.producePaymentCompletedEvent(ctx, events.PaymentCompletedErrorType, &txJob.Transaction, data.FailedPaymentStatus)
+				err = events.ProduceEvents(ctx, tw.eventProducer, msg)
 				if err != nil {
 					return fmt.Errorf("producing payment completed event Status %s - Job %v: %w", txJob.Transaction.Status, txJob, err)
 				}
@@ -271,6 +279,13 @@ func (tw *TransactionWorker) handleSuccessfulTransaction(ctx context.Context, tx
 		return fmt.Errorf("transaction was not successful for some reason")
 	}
 
+	// Building the payment completed event before updating the transaction status. This way, if the message fails to be
+	// built, the transaction will be marked for reprocessing -> reconciliation and the event will be re-tried.
+	msg, err := tw.buildPaymentCompletedEvent(events.PaymentCompletedSuccessType, &txJob.Transaction, data.SuccessPaymentStatus, "")
+	if err != nil {
+		return fmt.Errorf("building payment completed event Status %s - Job %v: %w", txJob.Transaction.Status, txJob, err)
+	}
+
 	updatedTx, err := tw.txModel.UpdateStatusToSuccess(ctx, txJob.Transaction)
 	if err != nil {
 		return utils.NewTransactionStatusUpdateError("SUCCESS", txJob.Transaction.ID, false, err)
@@ -278,7 +293,7 @@ func (tw *TransactionWorker) handleSuccessfulTransaction(ctx context.Context, tx
 	txJob.Transaction = *updatedTx
 
 	// Publishing a new event on the event producer
-	err = tw.producePaymentCompletedEvent(ctx, events.PaymentCompletedSuccessType, &txJob.Transaction, data.SuccessPaymentStatus)
+	err = events.ProduceEvents(ctx, tw.eventProducer, msg)
 	if err != nil {
 		return fmt.Errorf("producing payment completed event Status %s - Job %v: %w", txJob.Transaction.Status, txJob, err)
 	}
@@ -361,12 +376,12 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 	return nil
 }
 
-func (tw *TransactionWorker) producePaymentCompletedEvent(ctx context.Context, eventType string, tx *store.Transaction, paymentStatus data.PaymentStatus) error {
+func (tw *TransactionWorker) buildPaymentCompletedEvent(eventType string, tx *store.Transaction, paymentStatus data.PaymentStatus, statusMsg string) (*events.Message, error) {
 	if paymentStatus != data.SuccessPaymentStatus && paymentStatus != data.FailedPaymentStatus {
-		return fmt.Errorf("invalid payment status to produce payment completed event")
+		return nil, fmt.Errorf("invalid payment status to produce payment completed event")
 	}
 
-	msg := events.Message{
+	msg := &events.Message{
 		Topic:    events.PaymentCompletedTopic,
 		Key:      tx.ExternalID,
 		TenantID: tx.TenantID,
@@ -375,22 +390,18 @@ func (tw *TransactionWorker) producePaymentCompletedEvent(ctx context.Context, e
 			TransactionID:        tx.ID,
 			PaymentID:            tx.ExternalID,
 			PaymentStatus:        string(paymentStatus),
-			PaymentStatusMessage: tx.StatusMessage.String,
+			PaymentStatusMessage: statusMsg,
 			PaymentCompletedAt:   time.Now(),
 			StellarTransactionID: tx.StellarTransactionHash.String,
 		},
 	}
 
-	if tw.eventProducer != nil {
-		err := tw.eventProducer.WriteMessages(ctx, msg)
-		if err != nil {
-			return fmt.Errorf("writing message %s on event producer: %w", msg, err)
-		}
-	} else {
-		log.Ctx(ctx).Errorf("event producer is nil, could not publish message %s", msg)
+	err := msg.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("validating message: %w", err)
 	}
 
-	return nil
+	return msg, nil
 }
 
 func (tw *TransactionWorker) processTransactionSubmission(ctx context.Context, txJob *TxJob) error {
@@ -425,6 +436,10 @@ func (tw *TransactionWorker) processTransactionSubmission(ctx context.Context, t
 
 // validateJob will check if the job is valid for processing or reconciliation.
 func (tw *TransactionWorker) validateJob(txJob *TxJob) error {
+	if txJob == nil {
+		return fmt.Errorf("transaction job cannot be nil")
+	}
+
 	allowedStatuses := []store.TransactionStatus{store.TransactionStatusPending, store.TransactionStatusProcessing}
 	if !slices.Contains(allowedStatuses, txJob.Transaction.Status) {
 		return fmt.Errorf("invalid transaction status: %v", txJob.Transaction.Status)

--- a/stellar-auth/pkg/auth/mocks.go
+++ b/stellar-auth/pkg/auth/mocks.go
@@ -327,3 +327,19 @@ func (am *AuthManagerMock) AuthenticateMFA(ctx context.Context, deviceID, code s
 }
 
 var _ AuthManager = (*AuthManagerMock)(nil)
+
+type testInterface interface {
+	mock.TestingT
+	Cleanup(func())
+}
+
+// AuthManagerMock creates a new instance of AuthManagerMock. It also registers a testing interface on the mock and a
+// cleanup function to assert the mocks expectations.
+func NewAuthManagerMock(t testInterface) *AuthManagerMock {
+	mock := &AuthManagerMock{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}


### PR DESCRIPTION
### What

Replay #304, by @marcelosalloum 

Handle errors in message publishing in a consistent way:
- **Retry SMS invitation**: it now makes the change to the DB regardless of the event publishing succeeding. This way, the system is consistent and can rely on the scheduled jobs.
- **TSS->SDP**: when failing to publish an event, it's now triggering a crash report, so the sysadmin gets notified.
- **SEP-24 registration completed**, **New disbursement**, **Retry Payment**: all of these were returning a 500 and were changed to return a 2xx instead, and creating a crash report.

Additional changes:
- Removed `services.NewDisbursementManagementService` because it was going nothing except for increasing complexity
- Removed a redundant parameter from the DisbursementManagementService.
- Created `ProduceEvents` as a shared method to publish events and handle the common issues related to that. This improved consistency and removed code repetition
- Separated the logic of building messages from publishing messages, this way the tests would fail for a misconstructing message logic, and also it enables us to use the new method `events.ProduceEvents`
- Refactored a few tests so they use one mock instance per subtest.
- Slightly refactored some existing tests to cover the new behaviors.

### Why

Address https://stellarorg.atlassian.net/browse/SDP-1224

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
