### PR TITLE
remove "serve" from entrypoint.  its passed by helm

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -23,5 +23,5 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 # Ensure the binary has executable permissions
 RUN chmod +x /app/github.com/stellar/stellar-disbursement-platform/stellar-disbursement-platform
 EXPOSE 8001 2345
-ENTRYPOINT ["/go/bin/dlv", "exec", "--continue", "--accept-multiclient", "--headless", "--listen=:2345", "--api-version=2", "--log", "./stellar-disbursement-platform", "serve"]
+ENTRYPOINT ["/go/bin/dlv", "exec", "--continue", "--accept-multiclient", "--headless", "--listen=:2345", "--api-version=2", "--log", "./stellar-disbursement-platform"]
 


### PR DESCRIPTION
### What

This PR removes the argument from the Dockerfile.development entrypoint.  The reason is that helm provides the arg as the same docker container is used for both sdp and tss.

### Why

by hardcoding it, tss will fail, as it will startup as sdp instead of tss.

### Known limitations

no known limitations.

### Checklist

#### PR Structure

* [x ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ x] This PR title and description are clear enough for anyone to review it.
* [x ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview sexcrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ x] This is not a breaking change. its a fixing change rather :)
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x ] Does the deployment work after merging?  Yes tested in PR Previews which uses Helm. TSS and SDP started up correctly


PR previews testing 🟢 
```
❯ kubectl logs backend-pr314-tss
API server listening at: [::]:2345
2024-06-05T23:32:08Z warning layer=rpc Listening for remote connections (connections are not authenticated nor encrypted)
2024-06-05T23:32:08Z info layer=debugger launching process with args: [./stellar-disbursement-platform tss]
2024-06-05T23:32:11Z debug layer=debugger Adding target 12 "/app/github.com/stellar/stellar-disbursement-platform/stellar-disbursement-platform tss"
2024-06-05T23:32:11Z debug layer=debugger continuing
2024-06-05T23:32:11Z debug layer=debugger ContinueOnce
time="2024-06-05T23:32:11.472Z" level=debug msg="Setting log level to: \"info\"" pid=12
time="2024-06-05T23:32:11.472Z" level=info msg="Version: 2.0.0-rc1" pid=12
time="2024-06-05T23:32:11.472Z" level=info msg="GitCommit: " pid=12
time="2024-06-05T23:32:11.472Z" level=info msg="⚙️ Setting up TSS DBConnectionPool (withMetrics=true)" pid=12
time="2024-06-05T23:32:11.483Z" level=info msg="⚙️ Setting up Admin DBConnectionPool (withMetrics=true)" pid=12
time="2024-06-05T23:32:11.493Z" level=info msg="⚙️ Setting up Distribution Account Resolver" pid=12
time="2024-06-05T23:32:11.494Z" level=info msg="⚙️ Setting up Horizon Client" pid=12
time="2024-06-05T23:32:11.494Z" level=info msg="⚙️ Setting up Ledger Number Tracker" pid=12
time="2024-06-05T23:32:11.494Z" level=info msg="⚙️ Setting up Signature Service with distribution signer type: DISTRIBUTION_ACCOUNT_ENV" pid=12
time="2024-06-05T23:32:11.495Z" level=info msg="⚙️ Setting up Tx Submitter Engine" pid=12
time="2024-06-05T23:32:11.495Z" level=warning msg="Using \"DRY_RUN\" crash tracker" pid=12
time="2024-06-05T23:32:11.495Z" level=warning msg="Event Broker Type is NONE. Using Noop producer for logging events" pid=12
time="2024-06-05T23:32:11.496Z" level=info msg="Starting TSS_PROMETHEUS Metrics Server" pid=12
time="2024-06-05T23:32:11.496Z" level=info msg="Listening on :9002" pid=12
time="2024-06-05T23:32:11.497Z" level=info msg="Found '1' channel accounts in the database..." pid=12
time="2024-06-05T23:32:11.497Z" level=info msg="Starting Transaction Submission Service..." pid=12
```