### PR TITLE
[SDP-1167] When provisioning a tenant, indicate the signer type

### DIFF
--- a/cmd/integration_tests.go
+++ b/cmd/integration_tests.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/log"
+
 	cmdUtils "github.com/stellar/stellar-disbursement-platform-backend/cmd/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/integrationtests"
 )

--- a/dev/main.sh
+++ b/dev/main.sh
@@ -122,7 +122,8 @@ for tenant in "${tenants[@]}"; do
                         "sdp_ui_base_url": "'"$sdpUIBaseURL"'",
                         "owner_email": "'"$ownerEmail"'",
                         "owner_first_name": "jane",
-                        "owner_last_name": "doe"
+                        "owner_last_name": "doe",
+                        "distribution_account_type": "DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT"
                 }')
 
         http_code=$(echo "$response" | tail -n1)

--- a/internal/integrationtests/admin_api.go
+++ b/internal/integrationtests/admin_api.go
@@ -9,10 +9,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 

--- a/internal/integrationtests/admin_api.go
+++ b/internal/integrationtests/admin_api.go
@@ -26,14 +26,14 @@ type AdminApiIntegrationTestsInterface interface {
 }
 
 type CreateTenantRequest struct {
-	Name                string `json:"name"`
-	OwnerEmail          string `json:"owner_email"`
-	OwnerFirstName      string `json:"owner_first_name"`
-	OwnerLastName       string `json:"owner_last_name"`
-	OrganizationName    string `json:"organization_name"`
-	BaseURL             string `json:"base_url"`
-	SDPUIBaseURL        string `json:"sdp_ui_base_url"`
-	DistributionAccount string `json:"distribution_account"`
+	Name                    string `json:"name"`
+	OwnerEmail              string `json:"owner_email"`
+	OwnerFirstName          string `json:"owner_first_name"`
+	OwnerLastName           string `json:"owner_last_name"`
+	OrganizationName        string `json:"organization_name"`
+	DistributionAccountType string `json:"distribution_account_type"`
+	BaseURL                 string `json:"base_url"`
+	SDPUIBaseURL            string `json:"sdp_ui_base_url"`
 }
 
 func (aa AdminApiIntegrationTests) CreateTenant(ctx context.Context, body CreateTenantRequest) (*tenant.Tenant, error) {

--- a/internal/integrationtests/admin_api.go
+++ b/internal/integrationtests/admin_api.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"net/http"
 	"net/url"
 
@@ -26,14 +27,14 @@ type AdminApiIntegrationTestsInterface interface {
 }
 
 type CreateTenantRequest struct {
-	Name                    string `json:"name"`
-	OwnerEmail              string `json:"owner_email"`
-	OwnerFirstName          string `json:"owner_first_name"`
-	OwnerLastName           string `json:"owner_last_name"`
-	OrganizationName        string `json:"organization_name"`
-	DistributionAccountType string `json:"distribution_account_type"`
-	BaseURL                 string `json:"base_url"`
-	SDPUIBaseURL            string `json:"sdp_ui_base_url"`
+	Name                    string             `json:"name"`
+	OwnerEmail              string             `json:"owner_email"`
+	OwnerFirstName          string             `json:"owner_first_name"`
+	OwnerLastName           string             `json:"owner_last_name"`
+	OrganizationName        string             `json:"organization_name"`
+	DistributionAccountType schema.AccountType `json:"distribution_account_type"`
+	BaseURL                 string             `json:"base_url"`
+	SDPUIBaseURL            string             `json:"sdp_ui_base_url"`
 }
 
 func (aa AdminApiIntegrationTests) CreateTenant(ctx context.Context, body CreateTenantRequest) (*tenant.Tenant, error) {

--- a/internal/integrationtests/admin_api.go
+++ b/internal/integrationtests/admin_api.go
@@ -6,9 +6,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"net/http"
 	"net/url"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"

--- a/internal/integrationtests/integration_tests.go
+++ b/internal/integrationtests/integration_tests.go
@@ -314,7 +314,7 @@ func (it *IntegrationTestsService) CreateTestData(ctx context.Context, opts Inte
 		OwnerFirstName:          "John",
 		OwnerLastName:           "Doe",
 		OrganizationName:        "Integration Tests Organization",
-		DistributionAccountType: string(schema.DistributionAccountStellarEnv),
+		DistributionAccountType: schema.DistributionAccountStellarEnv,
 		BaseURL:                 "http://localhost:8000",
 		SDPUIBaseURL:            "http://localhost:3000",
 	})

--- a/internal/integrationtests/integration_tests.go
+++ b/internal/integrationtests/integration_tests.go
@@ -5,17 +5,18 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/support/log"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httphandler"
 	tss "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/store"
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 const (
@@ -308,13 +309,14 @@ func (it *IntegrationTestsService) StartIntegrationTests(ctx context.Context, op
 func (it *IntegrationTestsService) CreateTestData(ctx context.Context, opts IntegrationTestsOpts) error {
 	// 1. Create new tenant and add owner user
 	t, err := it.adminAPI.CreateTenant(ctx, CreateTenantRequest{
-		Name:             opts.TenantName,
-		OwnerEmail:       opts.UserEmail,
-		OwnerFirstName:   "John",
-		OwnerLastName:    "Doe",
-		OrganizationName: "Integration Tests Organization",
-		BaseURL:          "http://localhost:8000",
-		SDPUIBaseURL:     "http://localhost:3000",
+		Name:                    opts.TenantName,
+		OwnerEmail:              opts.UserEmail,
+		OwnerFirstName:          "John",
+		OwnerLastName:           "Doe",
+		OrganizationName:        "Integration Tests Organization",
+		DistributionAccountType: string(schema.DistributionAccountStellarEnv),
+		BaseURL:                 "http://localhost:8000",
+		SDPUIBaseURL:            "http://localhost:3000",
 	})
 	if err != nil {
 		return fmt.Errorf("creating tenant: %w", err)

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -106,8 +106,6 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// TODO: in SDP-1167, send the accountType will be sent in the request body
-	accountType := schema.DistributionAccountStellarEnv
 	tnt, err := h.ProvisioningManager.ProvisionNewTenant(ctx, provisioning.ProvisionTenant{
 		Name:                    reqBody.Name,
 		UserFirstName:           reqBody.OwnerFirstName,
@@ -117,7 +115,7 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 		NetworkType:             string(h.NetworkType),
 		UiBaseURL:               tntSDPUIBaseURL,
 		BaseURL:                 tntBaseURL,
-		DistributionAccountType: accountType,
+		DistributionAccountType: schema.AccountType(reqBody.DistributionAccountType),
 	})
 	if err != nil {
 		if errors.Is(err, tenant.ErrDuplicatedTenantName) {

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -333,6 +333,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
+		fmt.Println(respBody)
 		assert.Equal(t, expectedStatus, resp.StatusCode)
 		return respBody
 	}
@@ -404,7 +405,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org",
-				"distribution_account_type": %q",
+				"distribution_account_type": %q,
 				"base_url": "https://sdp-backend.stellar.org",
 				"sdp_ui_base_url": "https://sdp-ui.stellar.org",
 				"is_default": false
@@ -450,7 +451,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org 2",
-				"distribution_account_type": %q",
+				"distribution_account_type": %q,
 				"is_default": false
 			}
 		`, orgName, accountType)
@@ -496,7 +497,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org 3",
-				"distribution_account_type": %q",
+				"distribution_account_type": %q,
 				"base_url": %q,
 				"is_default": false
 			}
@@ -542,7 +543,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org 4",
-				"distribution_account_type": %q",
+				"distribution_account_type": %q,
 				"sdp_ui_base_url": %q,
 				"is_default": false
 			}
@@ -587,7 +588,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org",
-				"distribution_account_type": %q",
+				"distribution_account_type": %q,
 				"base_url": "https://backend.sdp.org",
 				"sdp_ui_base_url": "https://aid-org.sdp.org"
 			}
@@ -614,7 +615,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"organization_name": "My Aid Org",
 				"base_url": "https://sdp-backend.stellar.org",
 				"sdp_ui_base_url": "https://sdp-ui.stellar.org",
-				"distribution_account_type": %q",
+				"distribution_account_type": %q,
 				"is_default": false
 			}
 		`, orgName, accountType)

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -333,7 +333,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		fmt.Println(respBody)
 		assert.Equal(t, expectedStatus, resp.StatusCode)
 		return respBody
 	}

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -385,7 +385,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 					"owner_first_name": "owner_first_name is required",
 					"owner_last_name": "owner_last_name is required",
 					"organization_name": "organization_name is required",
-					"distribution_account_type": "distribution_account_type is required"
+					"distribution_account_type": "distribution_account_type is required. valid values are: DISTRIBUTION_ACCOUNT.STELLAR.ENV, DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT, DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT"
 				}
 			}
 		`

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -384,7 +384,8 @@ func Test_TenantHandler_Post(t *testing.T) {
 					"owner_email": "invalid email",
 					"owner_first_name": "owner_first_name is required",
 					"owner_last_name": "owner_last_name is required",
-					"organization_name": "organization_name is required"
+					"organization_name": "organization_name is required",
+					"distribution_account_type": "distribution_account_type is required"
 				}
 			}
 		`
@@ -392,7 +393,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 	})
 
 	t.Run("provisions a new tenant successfully", func(t *testing.T) {
-		// TODO: in SDP-1167, send the accountType in the request body
 		accountType := schema.DistributionAccountStellarEnv
 		createMocks(t, accountType, nil)
 
@@ -404,11 +404,12 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org",
+				"distribution_account_type": %q",
 				"base_url": "https://sdp-backend.stellar.org",
 				"sdp_ui_base_url": "https://sdp-ui.stellar.org",
 				"is_default": false
 			}
-		`, orgName)
+		`, orgName, accountType)
 
 		respBody := makeRequest(t, reqBody, http.StatusCreated)
 
@@ -438,7 +439,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 	})
 
 	t.Run("provisions a new tenant successfully - dynamically generates base URL and SDP UI base URL for tenant", func(t *testing.T) {
-		// TODO: in SDP-1167, send the accountType in the request body
 		accountType := schema.DistributionAccountStellarEnv
 		createMocks(t, accountType, nil)
 
@@ -450,9 +450,10 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org 2",
+				"distribution_account_type": %q",
 				"is_default": false
 			}
-		`, orgName)
+		`, orgName, accountType)
 
 		respBody := makeRequest(t, reqBody, http.StatusCreated)
 
@@ -484,7 +485,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 	})
 
 	t.Run("provisions a new tenant successfully - dynamically generates only SDP UI base URL", func(t *testing.T) {
-		// TODO: in SDP-1167, send the accountType in the request body
 		accountType := schema.DistributionAccountStellarEnv
 		createMocks(t, accountType, nil)
 
@@ -496,10 +496,11 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org 3",
+				"distribution_account_type": %q",
 				"base_url": %q,
 				"is_default": false
 			}
-		`, orgName, handler.BaseURL)
+		`, orgName, accountType, handler.BaseURL)
 
 		respBody := makeRequest(t, reqBody, http.StatusCreated)
 
@@ -530,7 +531,6 @@ func Test_TenantHandler_Post(t *testing.T) {
 	})
 
 	t.Run("provisions a new tenant successfully - dynamically generates only backend base URL", func(t *testing.T) {
-		// TODO: in SDP-1167, send the accountType in the request body
 		accountType := schema.DistributionAccountStellarEnv
 		createMocks(t, accountType, nil)
 
@@ -542,10 +542,11 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org 4",
+				"distribution_account_type": %q",
 				"sdp_ui_base_url": %q,
 				"is_default": false
 			}
-		`, orgName, handler.SDPUIBaseURL)
+		`, orgName, accountType, handler.SDPUIBaseURL)
 
 		respBody := makeRequest(t, reqBody, http.StatusCreated)
 
@@ -576,21 +577,21 @@ func Test_TenantHandler_Post(t *testing.T) {
 	})
 
 	t.Run("returns badRequest for duplicate tenant name", func(t *testing.T) {
-		// TODO: in SDP-1167, send the accountType in the request body
 		accountType := schema.DistributionAccountStellarEnv
 		createMocks(t, accountType, nil)
 
-		reqBody := `
+		reqBody := fmt.Sprintf(`
 			{
 				"name": "my-aid-org",
 				"owner_email": "owner@email.org",
 				"owner_first_name": "Owner",
 				"owner_last_name": "Owner",
 				"organization_name": "My Aid Org",
+				"distribution_account_type": %q",
 				"base_url": "https://backend.sdp.org",
 				"sdp_ui_base_url": "https://aid-org.sdp.org"
 			}
-		`
+		`, accountType)
 
 		// make first request to create tenant
 		_ = makeRequest(t, reqBody, http.StatusCreated)
@@ -613,9 +614,10 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"organization_name": "My Aid Org",
 				"base_url": "https://sdp-backend.stellar.org",
 				"sdp_ui_base_url": "https://sdp-ui.stellar.org",
+				"distribution_account_type": %q",
 				"is_default": false
 			}
-		`, orgName)
+		`, orgName, accountType)
 
 		respBody := makeRequest(t, reqBody, http.StatusCreated)
 

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -67,7 +67,8 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 		switch schema.AccountType(reqBody.DistributionAccountType) {
 		case schema.DistributionAccountStellarEnv, schema.DistributionAccountStellarDBVault, schema.DistributionAccountCircleDBVault:
 		default:
-			tv.Check(false, "distribution_account_type", "invalid distribution account type")
+			tv.Check(false,
+				"distribution_account_type", "invalid distribution account type. valid values are: DISTRIBUTION_ACCOUNT.STELLAR.ENV, DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT, DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT")
 		}
 	}
 

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -62,7 +62,7 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 	tv.Check(reqBody.OwnerLastName != "", "owner_last_name", "owner_last_name is required")
 	tv.Check(reqBody.OrganizationName != "", "organization_name", "organization_name is required")
 
-	tv.Check(reqBody.DistributionAccountType != "", "distribution_account_type", "distribution_account_type is required")
+	tv.Check(reqBody.DistributionAccountType != "", "distribution_account_type", "distribution_account_type is required. valid values are: DISTRIBUTION_ACCOUNT.STELLAR.ENV, DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT, DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT")
 	if reqBody.DistributionAccountType != "" {
 		switch schema.AccountType(reqBody.DistributionAccountType) {
 		case schema.DistributionAccountStellarEnv, schema.DistributionAccountStellarDBVault, schema.DistributionAccountCircleDBVault:

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -84,8 +84,6 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 		}
 	}
 
-	fmt.Println(tv.Errors)
-
 	if tv.HasErrors() {
 		return nil
 	}

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -7,19 +7,21 @@ import (
 	"strings"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 var validTenantName *regexp.Regexp = regexp.MustCompile(`^[a-z-]+$`)
 
 type TenantRequest struct {
-	Name             string  `json:"name"`
-	OwnerEmail       string  `json:"owner_email"`
-	OwnerFirstName   string  `json:"owner_first_name"`
-	OwnerLastName    string  `json:"owner_last_name"`
-	OrganizationName string  `json:"organization_name"`
-	BaseURL          *string `json:"base_url"`
-	SDPUIBaseURL     *string `json:"sdp_ui_base_url"`
+	Name                    string  `json:"name"`
+	OwnerEmail              string  `json:"owner_email"`
+	OwnerFirstName          string  `json:"owner_first_name"`
+	OwnerLastName           string  `json:"owner_last_name"`
+	OrganizationName        string  `json:"organization_name"`
+	DistributionAccountType string  `json:"distribution_account_type"`
+	BaseURL                 *string `json:"base_url"`
+	SDPUIBaseURL            *string `json:"sdp_ui_base_url"`
 }
 
 type UpdateTenantRequest struct {
@@ -59,6 +61,15 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 	tv.Check(reqBody.OwnerFirstName != "", "owner_first_name", "owner_first_name is required")
 	tv.Check(reqBody.OwnerLastName != "", "owner_last_name", "owner_last_name is required")
 	tv.Check(reqBody.OrganizationName != "", "organization_name", "organization_name is required")
+
+	tv.Check(reqBody.DistributionAccountType != "", "distribution_account_type", "distribution_account_type is required")
+	if reqBody.DistributionAccountType != "" {
+		switch schema.AccountType(reqBody.DistributionAccountType) {
+		case schema.DistributionAccountStellarEnv, schema.DistributionAccountStellarDBVault, schema.DistributionAccountCircleDBVault:
+		default:
+			tv.Check(false, "distribution_account_type", "invalid distribution account type")
+		}
+	}
 
 	var err error
 	if reqBody.BaseURL != nil {

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -84,6 +84,8 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 		}
 	}
 
+	fmt.Println(tv.Errors)
+
 	if tv.HasErrors() {
 		return nil
 	}

--- a/stellar-multitenant/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/internal/validators/tenant_validator_test.go
@@ -32,7 +32,7 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			"owner_first_name":          "owner_first_name is required",
 			"owner_last_name":           "owner_last_name is required",
 			"organization_name":         "organization_name is required",
-			"distribution_account_type": "distribution_account_type is required. DISTRIBUTION_ACCOUNT.STELLAR.ENV, DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT, DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT",
+			"distribution_account_type": "distribution_account_type is required. valid values are: DISTRIBUTION_ACCOUNT.STELLAR.ENV, DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT, DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT",
 		}, tv.Errors)
 
 		reqBody.Name = "aid-org"
@@ -44,7 +44,7 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			"owner_first_name":          "owner_first_name is required",
 			"owner_last_name":           "owner_last_name is required",
 			"organization_name":         "organization_name is required",
-			"distribution_account_type": "distribution_account_type is required",
+			"distribution_account_type": "distribution_account_type is required. valid values are: DISTRIBUTION_ACCOUNT.STELLAR.ENV, DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT, DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT",
 		}, tv.Errors)
 	})
 
@@ -119,8 +119,8 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			"distribution_account_type": "invalid distribution account type. valid values are: DISTRIBUTION_ACCOUNT.STELLAR.ENV, DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT, DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT",
 		}, tv.Errors)
 
-		for _, accountType := range []string{string(schema.DistributionAccountStellarEnv), string(schema.DistributionAccountStellarDBVault), string(schema.DistributionAccountCircleDBVault)} {
-			reqBody.DistributionAccountType = accountType
+		for _, accountType := range []schema.AccountType{schema.DistributionAccountStellarEnv, schema.DistributionAccountStellarDBVault, schema.DistributionAccountCircleDBVault} {
+			reqBody.DistributionAccountType = string(accountType)
 			tv.Errors = map[string]interface{}{}
 			tv.ValidateCreateTenantRequest(reqBody)
 			assert.False(t, tv.HasErrors())

--- a/stellar-multitenant/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/internal/validators/tenant_validator_test.go
@@ -129,7 +129,7 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("validates the URLs successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:                    "aid org",
+			Name:                    "aid-org",
 			OwnerEmail:              "owner@email.org",
 			OwnerFirstName:          "Owner",
 			OwnerLastName:           "Owner",

--- a/stellar-multitenant/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/internal/validators/tenant_validator_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 )
 
 func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
@@ -25,11 +27,12 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"name":              "invalid tenant name. It should only contains lower case letters and dash (-)",
-			"owner_email":       "invalid email",
-			"owner_first_name":  "owner_first_name is required",
-			"owner_last_name":   "owner_last_name is required",
-			"organization_name": "organization_name is required",
+			"name":                      "invalid tenant name. It should only contains lower case letters and dash (-)",
+			"owner_email":               "invalid email",
+			"owner_first_name":          "owner_first_name is required",
+			"owner_last_name":           "owner_last_name is required",
+			"organization_name":         "organization_name is required",
+			"distribution_account_type": "distribution_account_type is required",
 		}, tv.Errors)
 
 		reqBody.Name = "aid-org"
@@ -37,23 +40,25 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"owner_email":       "invalid email",
-			"owner_first_name":  "owner_first_name is required",
-			"owner_last_name":   "owner_last_name is required",
-			"organization_name": "organization_name is required",
+			"owner_email":               "invalid email",
+			"owner_first_name":          "owner_first_name is required",
+			"owner_last_name":           "owner_last_name is required",
+			"organization_name":         "organization_name is required",
+			"distribution_account_type": "distribution_account_type is required",
 		}, tv.Errors)
 	})
 
 	t.Run("returns error when name is invalid", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:             "aid org",
-			OwnerEmail:       "owner@email.org",
-			OwnerFirstName:   "Owner",
-			OwnerLastName:    "Owner",
-			OrganizationName: "Aid Org",
-			SDPUIBaseURL:     &sdpUIBaseURL,
-			BaseURL:          &baseURL,
+			Name:                    "aid org",
+			OwnerEmail:              "owner@email.org",
+			OwnerFirstName:          "Owner",
+			OwnerLastName:           "Owner",
+			OrganizationName:        "Aid Org",
+			DistributionAccountType: string(schema.DistributionAccountStellarEnv),
+			SDPUIBaseURL:            &sdpUIBaseURL,
+			BaseURL:                 &baseURL,
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -66,13 +71,14 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("returns error when owner info is invalid", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:             "aid-org",
-			OwnerEmail:       "invalid",
-			OwnerFirstName:   "",
-			OwnerLastName:    "",
-			OrganizationName: "",
-			BaseURL:          &sdpUIBaseURL,
-			SDPUIBaseURL:     &baseURL,
+			Name:                    "aid-org",
+			OwnerEmail:              "invalid",
+			OwnerFirstName:          "",
+			OwnerLastName:           "",
+			OrganizationName:        "",
+			DistributionAccountType: string(schema.DistributionAccountStellarEnv),
+			BaseURL:                 &sdpUIBaseURL,
+			SDPUIBaseURL:            &baseURL,
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -94,16 +100,43 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		assert.Equal(t, map[string]interface{}{}, tv.Errors)
 	})
 
+	t.Run("returns error when distribution account type is invalid", func(t *testing.T) {
+		tv := NewTenantValidator()
+		reqBody := &TenantRequest{
+			Name:                    "aid-org",
+			OwnerEmail:              "owner@email.org",
+			OwnerFirstName:          "Owner",
+			OwnerLastName:           "Owner",
+			OrganizationName:        "Aid Org",
+			DistributionAccountType: "foobar",
+			SDPUIBaseURL:            &sdpUIBaseURL,
+			BaseURL:                 &baseURL,
+		}
+
+		tv.ValidateCreateTenantRequest(reqBody)
+		assert.True(t, tv.HasErrors())
+		assert.Equal(t, map[string]interface{}{
+			"distribution_account_type": "invalid distribution account type",
+		}, tv.Errors)
+
+		reqBody.DistributionAccountType = string(schema.DistributionAccountStellarEnv)
+		tv.Errors = map[string]interface{}{}
+		tv.ValidateCreateTenantRequest(reqBody)
+		assert.False(t, tv.HasErrors())
+		assert.Equal(t, map[string]interface{}{}, tv.Errors)
+	})
+
 	t.Run("validates the URLs successfully", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:             "aid-org",
-			OwnerEmail:       "owner@email.org",
-			OwnerFirstName:   "Owner",
-			OwnerLastName:    "Owner",
-			OrganizationName: "Aid Org",
-			SDPUIBaseURL:     &invalidURL,
-			BaseURL:          &invalidURL,
+			Name:                    "aid org",
+			OwnerEmail:              "owner@email.org",
+			OwnerFirstName:          "Owner",
+			OwnerLastName:           "Owner",
+			OrganizationName:        "Aid Org",
+			DistributionAccountType: string(schema.DistributionAccountStellarEnv),
+			SDPUIBaseURL:            &invalidURL,
+			BaseURL:                 &invalidURL,
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
@@ -117,11 +150,12 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 	t.Run("validates request successfully without URLs", func(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
-			Name:             "aid-org",
-			OwnerEmail:       "owner@email.org",
-			OwnerFirstName:   "Owner",
-			OwnerLastName:    "Owner",
-			OrganizationName: "Aid Org",
+			Name:                    "aid-org",
+			OwnerEmail:              "owner@email.org",
+			OwnerFirstName:          "Owner",
+			OwnerLastName:           "Owner",
+			OrganizationName:        "Aid Org",
+			DistributionAccountType: string(schema.DistributionAccountStellarEnv),
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)

--- a/stellar-multitenant/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/internal/validators/tenant_validator_test.go
@@ -32,7 +32,7 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 			"owner_first_name":          "owner_first_name is required",
 			"owner_last_name":           "owner_last_name is required",
 			"organization_name":         "organization_name is required",
-			"distribution_account_type": "distribution_account_type is required",
+			"distribution_account_type": "distribution_account_type is required. DISTRIBUTION_ACCOUNT.STELLAR.ENV, DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT, DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT",
 		}, tv.Errors)
 
 		reqBody.Name = "aid-org"
@@ -116,14 +116,16 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"distribution_account_type": "invalid distribution account type",
+			"distribution_account_type": "invalid distribution account type. valid values are: DISTRIBUTION_ACCOUNT.STELLAR.ENV, DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT, DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT",
 		}, tv.Errors)
 
-		reqBody.DistributionAccountType = string(schema.DistributionAccountStellarEnv)
-		tv.Errors = map[string]interface{}{}
-		tv.ValidateCreateTenantRequest(reqBody)
-		assert.False(t, tv.HasErrors())
-		assert.Equal(t, map[string]interface{}{}, tv.Errors)
+		for _, accountType := range []string{string(schema.DistributionAccountStellarEnv), string(schema.DistributionAccountStellarDBVault), string(schema.DistributionAccountCircleDBVault)} {
+			reqBody.DistributionAccountType = accountType
+			tv.Errors = map[string]interface{}{}
+			tv.ValidateCreateTenantRequest(reqBody)
+			assert.False(t, tv.HasErrors())
+			assert.Equal(t, map[string]interface{}{}, tv.Errors)
+		}
 	})
 
 	t.Run("validates the URLs successfully", func(t *testing.T) {


### PR DESCRIPTION
### What
Allow request `POST /tenants` to specify the signer type when provisioning a tenant's distribution account

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
