### PR TITLE
[SDP-1243] `GET /balances` return 500 when circle account is not activated

### DIFF
--- a/internal/serve/httphandler/balances_handler.go
+++ b/internal/serve/httphandler/balances_handler.go
@@ -51,6 +51,12 @@ func (h BalancesHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if distAccount.Status == schema.AccountStatusPendingUserActivation {
+		errResponseMsg := fmt.Sprintf("This organization is not configured to use %v", schema.CirclePlatform)
+		httperror.BadRequest(errResponseMsg, nil, nil).Render(w)
+		return
+	}
+
 	apiKey, err := h.CircleClientConfigModel.GetDecryptedAPIKey(ctx, h.EncryptionPassphrase)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot retrieve Circle API key", err, nil).Render(w)

--- a/internal/serve/httphandler/balances_handler_test.go
+++ b/internal/serve/httphandler/balances_handler_test.go
@@ -103,6 +103,20 @@ func Test_BalancesHandler_Get(t *testing.T) {
 			}`,
 		},
 		{
+			name: "returns a 400 if account status is PENDING_USER_ACTIVATION",
+			prepareMocks: func(t *testing.T, mCircleClient *circleMocks.MockClient, mDistributionAccountResolver *sigMocks.MockDistributionAccountResolver, mCircleClientConfigModel *circleMocks.MockClientConfigModel) {
+				mDistributionAccountResolver.
+					On("DistributionAccountFromContext", mock.Anything).
+					Return(schema.TransactionAccount{
+						Type:   schema.DistributionAccountCircleDBVault,
+						Status: schema.AccountStatusPendingUserActivation,
+					}, nil).
+					Once()
+			},
+			expectedStatus:   http.StatusBadRequest,
+			expectedResponse: `{"error": "This organization is not configured to use CIRCLE"}`,
+		},
+		{
 			name: "returns a 500 if circle.GetWalletByID fails with an unexpected error",
 			prepareMocks: func(t *testing.T, mCircleClient *circleMocks.MockClient, mDistributionAccountResolver *sigMocks.MockDistributionAccountResolver, mCircleClientConfigModel *circleMocks.MockClientConfigModel) {
 				mDistributionAccountResolver.


### PR DESCRIPTION
### What

#### Steps to reproduce

1. Provision a new tenant with distribution_account_type = DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT 
e.g.
```
{
    "name": "circle-alpha",
    "owner_email": "marwen@stellar.org",
    "owner_first_name": "Marwen",
    "owner_last_name": "Owner",
    "organization_name": "Circle Alpha Testing",
    "sdp_ui_base_url": "https://circle-alpha.mtn-sdp-frontend-dev.stellar.org",
    "base_url": "https://circle-alpha.mtn-sdp-backend-dev.stellar.org",
    "distribution_account_type": "DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT"
}
```
2. Call `GET /balances` endpoint before configuring Circle. 

#### Expected Behaviour
1. Returns 400 error because circle account is not configured. 

#### Actual Behaviour
1. Returns 500 error because of nil pointer 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
