### PR TITLE
Update `PATCH /organization/circle-config` to ping Circle and to update the tenant data

### DIFF
--- a/internal/serve/httphandler/circle_config_handler.go
+++ b/internal/serve/httphandler/circle_config_handler.go
@@ -68,6 +68,12 @@ func (h CircleConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	validationErr := h.validateConfigWithCircle(ctx, patchRequest)
+	if validationErr != nil {
+		validationErr.Render(w)
+		return
+	}
+
 	var clientConfigUpdate circle.ClientConfigUpdate
 	if patchRequest.APIKey != nil {
 		kp, kpErr := keypair.ParseFull(h.EncryptionPassphrase)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -388,6 +388,9 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole)).
 				Patch("/circle-config", httphandler.CircleConfigHandler{
+					NetworkType:                 o.NetworkType,
+					CircleFactory:               circle.NewClient,
+					TenantManager:               o.tenantManager,
 					Encrypter:                   &utils.DefaultPrivateKeyEncrypter{},
 					EncryptionPassphrase:        o.DistAccEncryptionPassphrase,
 					CircleClientConfigModel:     circle.NewClientConfigModel(o.MtnDBConnectionPool),

--- a/internal/utils/mocks.go
+++ b/internal/utils/mocks.go
@@ -18,3 +18,17 @@ func (pke *PrivateKeyEncrypterMock) Decrypt(message, passphrase string) (string,
 
 // Making sure that PrivateKeyEncrypterMock implements PrivateKeyEncrypter
 var _ PrivateKeyEncrypter = (*PrivateKeyEncrypterMock)(nil)
+
+type testInterface interface {
+	mock.TestingT
+	Cleanup(func())
+}
+
+func NewPrivateKeyEncrypterMock(t testInterface) *PrivateKeyEncrypterMock {
+	mock := &PrivateKeyEncrypterMock{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}

--- a/stellar-multitenant/pkg/tenant/mocks.go
+++ b/stellar-multitenant/pkg/tenant/mocks.go
@@ -3,8 +3,9 @@ package tenant
 import (
 	"context"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
 )
 
 type TenantManagerMock struct {
@@ -126,3 +127,17 @@ func (m *TenantManagerMock) UpdateTenantConfig(ctx context.Context, tu *TenantUp
 }
 
 var _ ManagerInterface = (*TenantManagerMock)(nil)
+
+type testInterface interface {
+	mock.TestingT
+	Cleanup(func())
+}
+
+func NewTenantManagerMock(t testInterface) *TenantManagerMock {
+	mock := &TenantManagerMock{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}


### PR DESCRIPTION
### What

Update `PATCH /organization/circle-config` to:
1. Ping Circle to ensure the CIrcle API Key is correct
2. Get the Wallet from Circle, to ensure the walletID is correct.
3. Update the tenant's `DIstributionAccountStatus` to ACTIVE, once everything works out correctly.

### Why

To wrap up the tenant setup and to ensure the Circle data is correct.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
