### PR TITLE
Fix: Add missing tenantID when updating the tenant from `PATCH /organization/circle-config`

### DIFF
--- a/internal/serve/httphandler/circle_config_handler.go
+++ b/internal/serve/httphandler/circle_config_handler.go
@@ -45,6 +45,12 @@ func (r PatchCircleConfigRequest) validate() error {
 func (h CircleConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	tnt, err := tenant.GetTenantFromContext(ctx)
+	if err != nil {
+		httperror.InternalError(ctx, "Cannot retrieve the tenant from the context", err, nil).Render(w)
+		return
+	}
+
 	distAccount, err := h.DistributionAccountResolver.DistributionAccountFromContext(ctx)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot retrieve distribution account", err, nil).Render(w)
@@ -106,6 +112,7 @@ func (h CircleConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 
 	// Update tenant status to active
 	_, err = h.TenantManager.UpdateTenantConfig(ctx, &tenant.TenantUpdate{
+		ID:                        tnt.ID,
 		DistributionAccountStatus: schema.AccountStatusActive,
 	})
 	if err != nil {

--- a/internal/serve/httphandler/mfa_handler.go
+++ b/internal/serve/httphandler/mfa_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stellar/go/support/http/httpdecode"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
+
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"

--- a/internal/testutils/http.go
+++ b/internal/testutils/http.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,10 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Request(t *testing.T, r *chi.Mux, url, httpMethod string, body io.Reader) *httptest.ResponseRecorder {
+func Request(t *testing.T, ctx context.Context, r *chi.Mux, url, httpMethod string, body io.Reader) *httptest.ResponseRecorder {
 	t.Helper()
 
-	req, err := http.NewRequest(httpMethod, url, body)
+	req, err := http.NewRequestWithContext(ctx, httpMethod, url, body)
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
### What

Add missing tenantID when updating the tenant from `PATCH /organization/circle-config`

### Why

It should have been added in #332 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
