### PR TITLE
[SDP-1232] During disbursement start, use Circle to fetch the available balance when the tenant uses Circle

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -584,14 +584,6 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 				log.Ctx(ctx).Fatalf("error parsing network type: %v", err)
 			}
 
-			distributionAccountServiceOptions := services.DistributionAccountServiceOptions{HorizonClient: submitterEngine.HorizonClient}
-			distributionAccountService, err := di.NewDistributionAccountService(ctx, distributionAccountServiceOptions)
-			if err != nil {
-				log.Ctx(ctx).Fatalf("error creating distribution account service: %v", err)
-			}
-			serveOpts.DistributionAccountService = distributionAccountService
-			adminServeOpts.DistributionAccountService = distributionAccountService
-
 			// Inject Circle Service dependencies
 			circleService, err := di.NewCircleService(ctx, circle.ServiceOptions{
 				ClientFactory:        circle.NewClient,
@@ -603,6 +595,19 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 				log.Ctx(ctx).Fatalf("error creating Circle service: %v", err)
 			}
 			serveOpts.CircleService = circleService
+
+			// Setup Distribution Account Service
+			distributionAccountServiceOptions := services.DistributionAccountServiceOptions{
+				NetworkType:   serveOpts.NetworkType,
+				HorizonClient: submitterEngine.HorizonClient,
+				CircleService: circleService,
+			}
+			distributionAccountService, err := di.NewDistributionAccountService(ctx, distributionAccountServiceOptions)
+			if err != nil {
+				log.Ctx(ctx).Fatalf("error creating distribution account service: %v", err)
+			}
+			serveOpts.DistributionAccountService = distributionAccountService
+			adminServeOpts.DistributionAccountService = distributionAccountService
 
 			// Validate the Event Broker Type and Scheduler Jobs
 			if eventBrokerOptions.EventBrokerType == events.NoneEventBrokerType && !serveOpts.EnableScheduler {

--- a/internal/circle/balance.go
+++ b/internal/circle/balance.go
@@ -19,6 +19,7 @@ type Balance struct {
 	Currency string `json:"currency"`
 }
 
+// AllowedAssetsMap is a map of Circle currency codes to Stellar assets, for each network type.
 var AllowedAssetsMap = map[string]map[utils.NetworkType]data.Asset{
 	"USD": {
 		utils.PubnetNetworkType:  assets.USDCAssetPubnet,
@@ -30,11 +31,14 @@ var AllowedAssetsMap = map[string]map[utils.NetworkType]data.Asset{
 	},
 }
 
-// ParseStellarAsset returns the Stellar asset for the given Circle currency code, or an error if the currency is not supported in the SDP.
+// ParseStellarAsset returns the Stellar asset for the given Circle currency code, or an error if the currency is not
+// supported in the SDP.
 func ParseStellarAsset(circleCurrency string, networkType utils.NetworkType) (data.Asset, error) {
 	return ParseStellarAssetFromAllowlist(circleCurrency, networkType, AllowedAssetsMap)
 }
 
+// ParseStellarAssetFromAllowlist returns the Stellar asset for the given Circle currency code, or an error if the
+// currency is not supported in the SDP. This function allows for the use of a custom asset allowlist.
 func ParseStellarAssetFromAllowlist(circleCurrency string, networkType utils.NetworkType, allowedAssetsMap map[string]map[utils.NetworkType]data.Asset) (data.Asset, error) {
 	assetByNetworkType, ok := allowedAssetsMap[circleCurrency]
 	if !ok {

--- a/internal/circle/balance.go
+++ b/internal/circle/balance.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
+var (
+	ErrUnsupportedCurrency           = errors.New("unsupported Circle currency code")
+	ErrUnsupportedCurrencyForNetwork = errors.New("unsupported Circle currency code for this network type")
+)
+
 // Balance represents the amount and currency of a balance or transfer.
 type Balance struct {
 	Amount   string `json:"amount"`
@@ -24,11 +29,6 @@ var AllowedAssetsMap = map[string]map[utils.NetworkType]data.Asset{
 		utils.TestnetNetworkType: assets.EURCAssetTestnet,
 	},
 }
-
-var (
-	ErrUnsupportedCurrency           = errors.New("unsupported Circle currency code")
-	ErrUnsupportedCurrencyForNetwork = errors.New("unsupported Circle currency code for this network type")
-)
 
 // ParseStellarAsset returns the Stellar asset for the given Circle currency code, or an error if the currency is not supported in the SDP.
 func ParseStellarAsset(circleCurrency string, networkType utils.NetworkType) (data.Asset, error) {

--- a/internal/circle/balance.go
+++ b/internal/circle/balance.go
@@ -1,0 +1,7 @@
+package circle
+
+// Balance represents the amount and currency of a balance or transfer.
+type Balance struct {
+	Amount   string `json:"amount"`
+	Currency string `json:"currency"`
+}

--- a/internal/circle/balance.go
+++ b/internal/circle/balance.go
@@ -1,7 +1,50 @@
 package circle
 
+import (
+	"errors"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+)
+
 // Balance represents the amount and currency of a balance or transfer.
 type Balance struct {
 	Amount   string `json:"amount"`
 	Currency string `json:"currency"`
+}
+
+var AllowedAssetsMap = map[string]map[utils.NetworkType]data.Asset{
+	"USD": {
+		utils.PubnetNetworkType:  assets.USDCAssetPubnet,
+		utils.TestnetNetworkType: assets.USDCAssetTestnet,
+	},
+	"EUR": {
+		utils.PubnetNetworkType:  assets.EURCAssetPubnet,
+		utils.TestnetNetworkType: assets.EURCAssetTestnet,
+	},
+}
+
+var (
+	ErrUnsupportedCurrency           = errors.New("unsupported Circle currency code")
+	ErrUnsupportedCurrencyForNetwork = errors.New("unsupported Circle currency code for this network type")
+)
+
+// ParseStellarAsset returns the Stellar asset for the given Circle currency code, or an error if the currency is not supported in the SDP.
+func ParseStellarAsset(circleCurrency string, networkType utils.NetworkType) (data.Asset, error) {
+	return ParseStellarAssetFromAllowlist(circleCurrency, networkType, AllowedAssetsMap)
+}
+
+func ParseStellarAssetFromAllowlist(circleCurrency string, networkType utils.NetworkType, allowedAssetsMap map[string]map[utils.NetworkType]data.Asset) (data.Asset, error) {
+	assetByNetworkType, ok := allowedAssetsMap[circleCurrency]
+	if !ok {
+		return data.Asset{}, ErrUnsupportedCurrency
+	}
+
+	asset, ok := assetByNetworkType[networkType]
+	if !ok {
+		return data.Asset{}, ErrUnsupportedCurrencyForNetwork
+	}
+
+	return asset, nil
 }

--- a/internal/circle/balance_test.go
+++ b/internal/circle/balance_test.go
@@ -1,0 +1,100 @@
+package circle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+)
+
+func Test_ParseStellarAsset(t *testing.T) {
+	testCases := []struct {
+		name             string
+		circleCurrency   string
+		networkType      utils.NetworkType
+		allowedAssetsMap map[string]map[utils.NetworkType]data.Asset
+		expectedAsset    data.Asset
+		expectedError    error
+	}{
+		{
+			name:             "[Pubnet] USDC",
+			circleCurrency:   "USD",
+			networkType:      utils.PubnetNetworkType,
+			allowedAssetsMap: AllowedAssetsMap,
+			expectedAsset:    assets.USDCAssetPubnet,
+			expectedError:    nil,
+		},
+		{
+			name:             "[Testnet] USDC",
+			circleCurrency:   "USD",
+			networkType:      utils.TestnetNetworkType,
+			allowedAssetsMap: AllowedAssetsMap,
+			expectedAsset:    assets.USDCAssetTestnet,
+			expectedError:    nil,
+		},
+		{
+			name:             "[Pubnet] EUR",
+			circleCurrency:   "EUR",
+			networkType:      utils.PubnetNetworkType,
+			allowedAssetsMap: AllowedAssetsMap,
+			expectedAsset:    assets.EURCAssetPubnet,
+			expectedError:    nil,
+		},
+		{
+			name:             "[Testnet] EUR",
+			circleCurrency:   "EUR",
+			networkType:      utils.TestnetNetworkType,
+			allowedAssetsMap: AllowedAssetsMap,
+			expectedAsset:    assets.EURCAssetTestnet,
+			expectedError:    nil,
+		},
+		{
+			name:             "Unsupported currency",
+			circleCurrency:   "JPY",
+			networkType:      utils.PubnetNetworkType,
+			allowedAssetsMap: AllowedAssetsMap,
+			expectedAsset:    data.Asset{},
+			expectedError:    ErrUnsupportedCurrency,
+		},
+		{
+			name:           "Unsupported currency for network type",
+			circleCurrency: "JPY",
+			networkType:    utils.PubnetNetworkType,
+			allowedAssetsMap: map[string]map[utils.NetworkType]data.Asset{
+				"JPY": {},
+			},
+			expectedAsset: data.Asset{},
+			expectedError: ErrUnsupportedCurrencyForNetwork,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !assert.ObjectsAreEqual(tc.allowedAssetsMap, AllowedAssetsMap) {
+				t.Skip("skipping ParseStellarAsset since we want to test things with a custom map")
+			}
+			asset, err := ParseStellarAsset(tc.circleCurrency, tc.networkType)
+
+			if tc.expectedError == nil {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedAsset, asset)
+			} else {
+				assert.Equal(t, tc.expectedError, err)
+			}
+		})
+
+		t.Run("FromAllowlist/"+tc.name, func(t *testing.T) {
+			asset, err := ParseStellarAssetFromAllowlist(tc.circleCurrency, tc.networkType, tc.allowedAssetsMap)
+
+			if tc.expectedError == nil {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedAsset, asset)
+			} else {
+				assert.Equal(t, tc.expectedError, err)
+			}
+		})
+	}
+}

--- a/internal/circle/balance_test.go
+++ b/internal/circle/balance_test.go
@@ -74,7 +74,7 @@ func Test_ParseStellarAsset(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if !assert.ObjectsAreEqual(tc.allowedAssetsMap, AllowedAssetsMap) {
-				t.Skip("skipping ParseStellarAsset since we want to test things with a custom map")
+				return
 			}
 			asset, err := ParseStellarAsset(tc.circleCurrency, tc.networkType)
 

--- a/internal/circle/client_test.go
+++ b/internal/circle/client_test.go
@@ -79,7 +79,7 @@ func Test_Client_PostTransfer(t *testing.T) {
 	validTransferReq := TransferRequest{
 		Source:      TransferAccount{Type: TransferAccountTypeWallet, ID: "source-id"},
 		Destination: TransferAccount{Type: TransferAccountTypeBlockchain, Chain: "XLM", Address: "GBG2DFASN2E5ZZSOYH7SJ7HWBKR4M5LYQ5Q5ZVBWS3RI46GDSYTEA6YF", AddressTag: "txmemo2"},
-		Amount:      Money{Amount: "100.00", Currency: "USD"},
+		Amount:      Balance{Amount: "100.00", Currency: "USD"},
 	}
 
 	t.Run("post transfer error", func(t *testing.T) {
@@ -280,7 +280,7 @@ func Test_Client_GetWalletByID(t *testing.T) {
 			EntityID:    "2f47c999-9022-4939-acea-dc3afa9ccbaf",
 			Type:        "end_user_wallet",
 			Description: "Treasury Wallet",
-			Balances: []Money{
+			Balances: []Balance{
 				{Amount: "4790.00", Currency: "USD"},
 			},
 		}

--- a/internal/circle/environments.go
+++ b/internal/circle/environments.go
@@ -19,4 +19,8 @@ var AllowedAssetsMap = map[string]map[utils.NetworkType]data.Asset{
 		utils.PubnetNetworkType:  assets.USDCAssetPubnet,
 		utils.TestnetNetworkType: assets.USDCAssetTestnet,
 	},
+	"EUR": {
+		utils.PubnetNetworkType:  assets.EURCAssetPubnet,
+		utils.TestnetNetworkType: assets.EURCAssetTestnet,
+	},
 }

--- a/internal/circle/environments.go
+++ b/internal/circle/environments.go
@@ -1,11 +1,5 @@
 package circle
 
-import (
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
-)
-
 // Environment holds the possible environments for the Circle API.
 type Environment string
 
@@ -13,14 +7,3 @@ const (
 	Production Environment = "https://api.circle.com"
 	Sandbox    Environment = "https://api-sandbox.circle.com"
 )
-
-var AllowedAssetsMap = map[string]map[utils.NetworkType]data.Asset{
-	"USD": {
-		utils.PubnetNetworkType:  assets.USDCAssetPubnet,
-		utils.TestnetNetworkType: assets.USDCAssetTestnet,
-	},
-	"EUR": {
-		utils.PubnetNetworkType:  assets.EURCAssetPubnet,
-		utils.TestnetNetworkType: assets.EURCAssetTestnet,
-	},
-}

--- a/internal/circle/service_test.go
+++ b/internal/circle/service_test.go
@@ -212,7 +212,7 @@ func Test_Service_allMethods(t *testing.T) {
 				Chain:   "XLM",
 				Address: pubKey,
 			},
-			Amount: Money{
+			Amount: Balance{
 				Amount:   "123.45",
 				Currency: "USD",
 			},

--- a/internal/circle/transfer.go
+++ b/internal/circle/transfer.go
@@ -13,7 +13,7 @@ type Transfer struct {
 	ID              string          `json:"id"`
 	Source          TransferAccount `json:"source"`
 	Destination     TransferAccount `json:"destination"`
-	Amount          Money           `json:"amount"`
+	Amount          Balance         `json:"amount"`
 	TransactionHash string          `json:"transactionHash,omitempty"`
 	Status          string          `json:"status"`
 	CreateDate      time.Time       `json:"createDate"`
@@ -38,12 +38,6 @@ type TransferAccount struct {
 	AddressTag string              `json:"addressTag,omitempty"`
 }
 
-// Money represents the amount transferred between source and destination.
-type Money struct {
-	Amount   string `json:"amount"`
-	Currency string `json:"currency"`
-}
-
 // TransferResponse represents the response from the Circle APIs.
 type TransferResponse struct {
 	Data Transfer `json:"data"`
@@ -53,7 +47,7 @@ type TransferResponse struct {
 type TransferRequest struct {
 	Source         TransferAccount `json:"source"`
 	Destination    TransferAccount `json:"destination"`
-	Amount         Money           `json:"amount"`
+	Amount         Balance         `json:"amount"`
 	IdempotencyKey string          `json:"idempotencyKey"`
 }
 

--- a/internal/circle/transfer_test.go
+++ b/internal/circle/transfer_test.go
@@ -67,7 +67,7 @@ func Test_TransferRequest_validate(t *testing.T) {
 			tr: TransferRequest{
 				Source:      TransferAccount{Type: TransferAccountTypeWallet, ID: "1014442536"},
 				Destination: TransferAccount{Type: TransferAccountTypeBlockchain, Chain: "XLM", Address: "GBG2DFASN2E5ZZSOYH7SJ7HWBKR4M5LYQ5Q5ZVBWS3RI46GDSYTEA6YF"},
-				Amount:      Money{Amount: "invalid", Currency: "USD"},
+				Amount:      Balance{Amount: "invalid", Currency: "USD"},
 			},
 			wantErr: errors.New("amount must be a valid number"),
 		},
@@ -76,7 +76,7 @@ func Test_TransferRequest_validate(t *testing.T) {
 			tr: TransferRequest{
 				Source:      TransferAccount{Type: TransferAccountTypeWallet, ID: "1014442536"},
 				Destination: TransferAccount{Type: TransferAccountTypeBlockchain, Chain: "XLM", Address: "GBG2DFASN2E5ZZSOYH7SJ7HWBKR4M5LYQ5Q5ZVBWS3RI46GDSYTEA6YF"},
-				Amount:      Money{Amount: "0.25", Currency: "USD"},
+				Amount:      Balance{Amount: "0.25", Currency: "USD"},
 			},
 			wantErr: nil,
 		},

--- a/internal/circle/wallet.go
+++ b/internal/circle/wallet.go
@@ -11,11 +11,11 @@ type WalletResponse struct {
 }
 
 type Wallet struct {
-	WalletID    string  `json:"walletId"`
-	EntityID    string  `json:"entityId"`
-	Type        string  `json:"type"`
-	Description string  `json:"description"`
-	Balances    []Money `json:"balances"`
+	WalletID    string    `json:"walletId"`
+	EntityID    string    `json:"entityId"`
+	Type        string    `json:"type"`
+	Description string    `json:"description"`
+	Balances    []Balance `json:"balances"`
 }
 
 // parseWalletResponse parses the response from the Circle API into a Wallet struct.

--- a/internal/dependencyinjection/distribution_account_service.go
+++ b/internal/dependencyinjection/distribution_account_service.go
@@ -23,7 +23,10 @@ func NewDistributionAccountService(ctx context.Context, opts services.Distributi
 	}
 
 	log.Ctx(ctx).Info("⚙️ Setting up Distribution Account Service")
-	newInstance := services.NewDistributionAccountService(opts)
+	newInstance, err := services.NewDistributionAccountService(opts)
+	if err != nil {
+		return nil, fmt.Errorf("initializing new distribution account service: %w", err)
+	}
 	SetInstance(instanceName, newInstance)
 
 	return newInstance, nil

--- a/internal/dependencyinjection/distribution_account_service_test.go
+++ b/internal/dependencyinjection/distribution_account_service_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
 func Test_dependencyinjection_NewDistributionAccountService(t *testing.T) {
@@ -16,6 +18,8 @@ func Test_dependencyinjection_NewDistributionAccountService(t *testing.T) {
 	mockHorizonClient := &horizonclient.MockClient{}
 	svcOpts := services.DistributionAccountServiceOptions{
 		HorizonClient: mockHorizonClient,
+		CircleService: &circle.Service{},
+		NetworkType:   utils.TestnetNetworkType,
 	}
 
 	t.Run("should create and return the same instance on the second call", func(t *testing.T) {

--- a/internal/serve/httphandler/balances_handler.go
+++ b/internal/serve/httphandler/balances_handler.go
@@ -73,15 +73,9 @@ func (h BalancesHandler) Get(w http.ResponseWriter, r *http.Request) {
 func (h BalancesHandler) filterBalances(ctx context.Context, circleWallet *circle.Wallet) []Balance {
 	balances := []Balance{}
 	for _, balance := range circleWallet.Balances {
-		networkAssetMap, ok := circle.AllowedAssetsMap[balance.Currency]
-		if !ok {
-			log.Ctx(ctx).Debugf("Ignoring balance for asset %s, as it's not supported by the SDP", balance.Currency)
-			continue
-		}
-
-		asset, ok := networkAssetMap[h.NetworkType]
-		if !ok {
-			log.Ctx(ctx).Debugf("Ignoring balance for asset %s, as it's not supported by the SDP in the %v network", balance.Currency, h.NetworkType)
+		asset, err := circle.ParseStellarAsset(balance.Currency, h.NetworkType)
+		if err != nil {
+			log.Ctx(ctx).Debugf("Ignoring balance for asset %s, as it's not supported by the SDP: %v", balance.Currency, err)
 			continue
 		}
 

--- a/internal/serve/httphandler/balances_handler.go
+++ b/internal/serve/httphandler/balances_handler.go
@@ -49,7 +49,7 @@ func (h BalancesHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if distAccount.Status == schema.AccountStatusPendingUserActivation {
+	if distAccount.Status != schema.AccountStatusActive {
 		errResponseMsg := fmt.Sprintf("This organization's distribution account is in %s state, please complete the %s activation process to access this endpoint.", distAccount.Status, distAccount.Type.Platform())
 		httperror.BadRequest(errResponseMsg, nil, nil).Render(w)
 		return

--- a/internal/serve/httphandler/balances_handler.go
+++ b/internal/serve/httphandler/balances_handler.go
@@ -50,7 +50,7 @@ func (h BalancesHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if distAccount.Status == schema.AccountStatusPendingUserActivation {
-		errResponseMsg := fmt.Sprintf("This organization is not configured to use %v", schema.CirclePlatform)
+		errResponseMsg := fmt.Sprintf("This organization's distribution account is in %s state, please complete the %s activation process to access this endpoint.", distAccount.Status, distAccount.Type.Platform())
 		httperror.BadRequest(errResponseMsg, nil, nil).Render(w)
 		return
 	}

--- a/internal/serve/httphandler/balances_handler_test.go
+++ b/internal/serve/httphandler/balances_handler_test.go
@@ -151,7 +151,7 @@ func Test_BalancesHandler_Get(t *testing.T) {
 						EntityID:    "2f47c999-9022-4939-acea-dc3afa9ccbaf",
 						Type:        "end_user_wallet",
 						Description: "Treasury Wallet",
-						Balances: []circle.Money{
+						Balances: []circle.Balance{
 							{Amount: "123.00", Currency: "USD"},
 						},
 					}, nil).
@@ -190,7 +190,7 @@ func Test_BalancesHandler_Get(t *testing.T) {
 						EntityID:    "2f47c999-9022-4939-acea-dc3afa9ccbaf",
 						Type:        "end_user_wallet",
 						Description: "Treasury Wallet",
-						Balances: []circle.Money{
+						Balances: []circle.Balance{
 							{Amount: "123.00", Currency: "USD"},
 						},
 					}, nil).
@@ -252,7 +252,7 @@ func Test_BalancesHandler_filterBalances(t *testing.T) {
 			name:        "[Pubnet] only supported assets are included",
 			networkType: utils.PubnetNetworkType,
 			circleWallet: &circle.Wallet{
-				Balances: []circle.Money{
+				Balances: []circle.Balance{
 					{Currency: "FOO", Amount: "100"},
 					{Currency: "USD", Amount: "200"},
 					{Currency: "BAR", Amount: "300"},
@@ -270,7 +270,7 @@ func Test_BalancesHandler_filterBalances(t *testing.T) {
 			name:        "[Testnet] only supported assets are included",
 			networkType: utils.TestnetNetworkType,
 			circleWallet: &circle.Wallet{
-				Balances: []circle.Money{
+				Balances: []circle.Balance{
 					{Currency: "FOO", Amount: "100"},
 					{Currency: "USD", Amount: "200"},
 					{Currency: "BAR", Amount: "300"},
@@ -288,7 +288,7 @@ func Test_BalancesHandler_filterBalances(t *testing.T) {
 			name:        "[Pubnet] none of the provided assets is supported",
 			networkType: utils.PubnetNetworkType,
 			circleWallet: &circle.Wallet{
-				Balances: []circle.Money{
+				Balances: []circle.Balance{
 					{Currency: "FOO", Amount: "100"},
 				},
 			},
@@ -298,7 +298,7 @@ func Test_BalancesHandler_filterBalances(t *testing.T) {
 			name:        "[Testnet] none of the provided assets is supported",
 			networkType: utils.TestnetNetworkType,
 			circleWallet: &circle.Wallet{
-				Balances: []circle.Money{
+				Balances: []circle.Balance{
 					{Currency: "FOO", Amount: "100"},
 				},
 			},

--- a/internal/serve/httphandler/balances_handler_test.go
+++ b/internal/serve/httphandler/balances_handler_test.go
@@ -256,6 +256,7 @@ func Test_BalancesHandler_filterBalances(t *testing.T) {
 					{Currency: "FOO", Amount: "100"},
 					{Currency: "USD", Amount: "200"},
 					{Currency: "BAR", Amount: "300"},
+					{Currency: "EUR", Amount: "400"},
 				},
 			},
 			expectedBalances: []Balance{
@@ -263,6 +264,11 @@ func Test_BalancesHandler_filterBalances(t *testing.T) {
 					Amount:      "200",
 					AssetCode:   assets.USDCAssetPubnet.Code,
 					AssetIssuer: assets.USDCAssetPubnet.Issuer,
+				},
+				{
+					Amount:      "400",
+					AssetCode:   assets.EURCAssetPubnet.Code,
+					AssetIssuer: assets.EURCAssetPubnet.Issuer,
 				},
 			},
 		},
@@ -274,6 +280,7 @@ func Test_BalancesHandler_filterBalances(t *testing.T) {
 					{Currency: "FOO", Amount: "100"},
 					{Currency: "USD", Amount: "200"},
 					{Currency: "BAR", Amount: "300"},
+					{Currency: "EUR", Amount: "400"},
 				},
 			},
 			expectedBalances: []Balance{
@@ -281,6 +288,11 @@ func Test_BalancesHandler_filterBalances(t *testing.T) {
 					Amount:      "200",
 					AssetCode:   assets.USDCAssetTestnet.Code,
 					AssetIssuer: assets.USDCAssetTestnet.Issuer,
+				},
+				{
+					Amount:      "400",
+					AssetCode:   assets.EURCAssetTestnet.Code,
+					AssetIssuer: assets.EURCAssetTestnet.Issuer,
 				},
 			},
 		},

--- a/internal/serve/httphandler/balances_handler_test.go
+++ b/internal/serve/httphandler/balances_handler_test.go
@@ -110,7 +110,7 @@ func Test_BalancesHandler_Get(t *testing.T) {
 					Once()
 			},
 			expectedStatus:   http.StatusBadRequest,
-			expectedResponse: `{"error": "This organization is not configured to use CIRCLE"}`,
+			expectedResponse: `{"error": "This organization's distribution account is in PENDING_USER_ACTIVATION state, please complete the CIRCLE activation process to access this endpoint."}`,
 		},
 		{
 			name:        "returns a 500 if circle.GetWalletByID fails with an unexpected error",

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -1447,7 +1447,7 @@ func Test_DisbursementHandler_PatchDisbursementStatus(t *testing.T) {
 			Return(distAcc, nil).
 			Once()
 
-		mockDistAccSvc.On("GetBalance", &distAcc, mock.AnythingOfType("data.Asset")).
+		mockDistAccSvc.On("GetBalance", mock.Anything, &distAcc, mock.AnythingOfType("data.Asset")).
 			Return(10000.0, nil).Once()
 
 		mockEventProducer.
@@ -1479,7 +1479,7 @@ func Test_DisbursementHandler_PatchDisbursementStatus(t *testing.T) {
 			Return(distAcc, nil).
 			Once()
 
-		mockDistAccSvc.On("GetBalance", &distAcc, mock.AnythingOfType("data.Asset")).
+		mockDistAccSvc.On("GetBalance", mock.Anything, &distAcc, mock.AnythingOfType("data.Asset")).
 			Return(10000.0, nil).Once()
 
 		mockEventProducer.

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -229,7 +229,7 @@ func (s *DisbursementManagementService) StartDisbursement(ctx context.Context, d
 			}
 
 			// 4. Check if there is enough balance from the distribution wallet for this disbursement along with any pending disbursements
-			availableBalance, err := s.DistributionAccountService.GetBalance(distributionAccount, *disbursement.Asset)
+			availableBalance, err := s.DistributionAccountService.GetBalance(ctx, distributionAccount, *disbursement.Asset)
 			if err != nil {
 				return nil, fmt.Errorf(
 					"getting balance for asset (%s,%s) on distribution account %s: %w",

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -17,11 +17,13 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
@@ -420,10 +422,12 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			Once()
 
 		// Setup dependent services
-		distAccSvcOpts := DistributionAccountServiceOptions{
+		distAccSvc, err := NewDistributionAccountService(DistributionAccountServiceOptions{
 			HorizonClient: hMock,
-		}
-		distAccSvc := NewDistributionAccountService(distAccSvcOpts)
+			CircleService: &circle.Service{},
+			NetworkType:   utils.TestnetNetworkType,
+		})
+		require.NoError(t, err)
 
 		// Create service
 		service := &DisbursementManagementService{
@@ -489,10 +493,12 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			Once()
 
 		// Setup dependent services
-		distAccSvcOpts := DistributionAccountServiceOptions{
+		distAccSvc, err := NewDistributionAccountService(DistributionAccountServiceOptions{
 			HorizonClient: hMock,
-		}
-		distAccSvc := NewDistributionAccountService(distAccSvcOpts)
+			CircleService: &circle.Service{},
+			NetworkType:   utils.TestnetNetworkType,
+		})
+		require.NoError(t, err)
 
 		// Create service
 		service := &DisbursementManagementService{
@@ -604,10 +610,12 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		}, nil).Once()
 
 		// Setup dependent services
-		distAccSvcOpts := DistributionAccountServiceOptions{
+		distAccSvc, err := NewDistributionAccountService(DistributionAccountServiceOptions{
 			HorizonClient: hMock,
-		}
-		distAccSvc := NewDistributionAccountService(distAccSvcOpts)
+			CircleService: &circle.Service{},
+			NetworkType:   utils.TestnetNetworkType,
+		})
+		require.NoError(t, err)
 
 		// Create service
 		service := &DisbursementManagementService{
@@ -713,10 +721,12 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			Once()
 
 		// Setup dependent services
-		distAccSvcOpts := DistributionAccountServiceOptions{
+		distAccSvc, err := NewDistributionAccountService(DistributionAccountServiceOptions{
 			HorizonClient: hMock,
-		}
-		distAccSvc := NewDistributionAccountService(distAccSvcOpts)
+			CircleService: &circle.Service{},
+			NetworkType:   utils.TestnetNetworkType,
+		})
+		require.NoError(t, err)
 
 		// Create service
 		service := &DisbursementManagementService{
@@ -785,10 +795,12 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 			Once()
 
 		// Setup dependent services
-		distAccSvcOpts := DistributionAccountServiceOptions{
+		distAccSvc, err := NewDistributionAccountService(DistributionAccountServiceOptions{
 			HorizonClient: hMock,
-		}
-		distAccSvc := NewDistributionAccountService(distAccSvcOpts)
+			CircleService: &circle.Service{},
+			NetworkType:   utils.TestnetNetworkType,
+		})
+		require.NoError(t, err)
 
 		// Create service
 		service := &DisbursementManagementService{
@@ -848,10 +860,12 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		hMock.On("AccountDetail", hAccRequest).Return(hAccResponse, nil).Once()
 
 		// Setup dependent services
-		distAccSvcOpts := DistributionAccountServiceOptions{
+		distAccSvc, err := NewDistributionAccountService(DistributionAccountServiceOptions{
 			HorizonClient: hMock,
-		}
-		distAccSvc := NewDistributionAccountService(distAccSvcOpts)
+			CircleService: &circle.Service{},
+			NetworkType:   utils.TestnetNetworkType,
+		})
+		require.NoError(t, err)
 
 		// Create service
 		service := &DisbursementManagementService{
@@ -910,10 +924,12 @@ func Test_DisbursementManagementService_StartDisbursement(t *testing.T) {
 		hMock.On("AccountDetail", hAccRequest).Return(hAccResponse, nil).Once()
 
 		// Setup dependent services
-		distAccSvcOpts := DistributionAccountServiceOptions{
+		distAccSvc, err := NewDistributionAccountService(DistributionAccountServiceOptions{
 			HorizonClient: hMock,
-		}
-		distAccSvc := NewDistributionAccountService(distAccSvcOpts)
+			CircleService: &circle.Service{},
+			NetworkType:   utils.TestnetNetworkType,
+		})
+		require.NoError(t, err)
 
 		// Create service
 		service := &DisbursementManagementService{
@@ -991,10 +1007,12 @@ func Test_DisbursementManagementService_PauseDisbursement(t *testing.T) {
 	hMock := &horizonclient.MockClient{}
 	distributionAccPubKey := "ABC"
 	distributionAcc := schema.NewDefaultStellarTransactionAccount(distributionAccPubKey)
-	distAccSvcOpts := DistributionAccountServiceOptions{
+	distAccSvc, err := NewDistributionAccountService(DistributionAccountServiceOptions{
 		HorizonClient: hMock,
-	}
-	distAccSvc := NewDistributionAccountService(distAccSvcOpts)
+		CircleService: &circle.Service{},
+		NetworkType:   utils.TestnetNetworkType,
+	})
+	require.NoError(t, err)
 
 	service := &DisbursementManagementService{
 		Models:                     models,

--- a/internal/services/distribution_account_service.go
+++ b/internal/services/distribution_account_service.go
@@ -53,7 +53,7 @@ func NewDistributionAccountService(opts DistributionAccountServiceOptions) (*Dis
 		return nil, fmt.Errorf("validating options: %w", err)
 	}
 
-	stellarDistributionAccSvc := &StellarNativeDistributionAccountService{
+	stellarDistributionAccSvc := &StellarDistributionAccountService{
 		horizonClient: opts.HorizonClient,
 	}
 
@@ -80,14 +80,13 @@ func (s *DistributionAccountService) GetBalances(ctx context.Context, account *s
 
 var _ DistributionAccountServiceInterface = (*DistributionAccountService)(nil)
 
-type StellarNativeDistributionAccountService struct {
+type StellarDistributionAccountService struct {
 	horizonClient horizonclient.ClientInterface
 }
 
-var _ DistributionAccountServiceInterface = (*StellarNativeDistributionAccountService)(nil)
+var _ DistributionAccountServiceInterface = (*StellarDistributionAccountService)(nil)
 
-// TODO: rename StellarNativeDistributionAccountService to StellarDistributionAccountService
-func (s *StellarNativeDistributionAccountService) GetBalances(_ context.Context, account *schema.TransactionAccount) (map[data.Asset]float64, error) {
+func (s *StellarDistributionAccountService) GetBalances(_ context.Context, account *schema.TransactionAccount) (map[data.Asset]float64, error) {
 	accountDetails, err := s.horizonClient.AccountDetail(horizonclient.AccountRequest{AccountID: account.Address})
 	if err != nil {
 		return nil, fmt.Errorf("getting details for account from Horizon: %w", err)
@@ -117,7 +116,7 @@ func (s *StellarNativeDistributionAccountService) GetBalances(_ context.Context,
 	return balances, nil
 }
 
-func (s *StellarNativeDistributionAccountService) GetBalance(ctx context.Context, account *schema.TransactionAccount, asset data.Asset) (float64, error) {
+func (s *StellarDistributionAccountService) GetBalance(ctx context.Context, account *schema.TransactionAccount, asset data.Asset) (float64, error) {
 	accBalances, err := s.GetBalances(ctx, account)
 	if err != nil {
 		return 0, fmt.Errorf("getting balances for distribution account: %w", err)

--- a/internal/services/distribution_account_service_test.go
+++ b/internal/services/distribution_account_service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
@@ -13,8 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 )
 
@@ -109,7 +112,8 @@ func Test_StellarNativeDistributionAccount_GetBalance(t *testing.T) {
 	distAcc := schema.NewStellarEnvTransactionAccount(accAddress)
 
 	nativeAsset := data.Asset{Code: assets.XLMAssetCode}
-	usdcAsset := data.Asset{Code: assets.USDCAssetCode, Issuer: assets.USDCAssetIssuerTestnet}
+	usdcAsset := assets.USDCAssetTestnet
+	eurcAsset := assets.EURCAssetTestnet
 
 	mockSetup := func(mHorizonClient *horizonclient.MockClient) {
 		mHorizonClient.On("AccountDetail", horizonclient.AccountRequest{
@@ -127,9 +131,6 @@ func Test_StellarNativeDistributionAccount_GetBalance(t *testing.T) {
 			},
 		}, nil).Once()
 	}
-
-	eurcIssuer := keypair.MustRandom().Address()
-	eurcAsset := data.Asset{Code: "EURC", Issuer: eurcIssuer}
 
 	testCases := []struct {
 		name            string
@@ -171,6 +172,216 @@ func Test_StellarNativeDistributionAccount_GetBalance(t *testing.T) {
 			}
 
 			mHorizonClient.AssertExpectations(t)
+		})
+	}
+}
+
+func Test_CircleDistributionAccountService_GetBalances(t *testing.T) {
+	ctx := context.Background()
+	circleDistAcc := schema.TransactionAccount{
+		CircleWalletID: "circle-wallet-id",
+		Type:           schema.DistributionAccountCircleDBVault,
+		Status:         schema.AccountStatusActive,
+	}
+
+	testCases := []struct {
+		name             string
+		networkType      utils.NetworkType
+		account          schema.TransactionAccount
+		prepareMocksFn   func(mCircleService *circle.MockService)
+		expectedBalances map[data.Asset]float64
+		expectedError    error
+	}{
+		{
+			name:          "🔴returns an error if the account is not a Circle type",
+			networkType:   utils.TestnetNetworkType,
+			account:       schema.NewDefaultHostAccount("gost-account-address"),
+			expectedError: errors.New("distribution account is not a Circle account"),
+		},
+		{
+			name:        "🔴returns an error if the circle account is not ACTIVE",
+			networkType: utils.TestnetNetworkType,
+			account: schema.TransactionAccount{
+				CircleWalletID: "circle-wallet-id",
+				Type:           schema.DistributionAccountCircleDBVault,
+				Status:         schema.AccountStatusPendingUserActivation,
+			},
+			expectedError: fmt.Errorf("This organization's distribution account is in %s state, please complete the %s activation process to access this endpoint.", schema.AccountStatusPendingUserActivation, schema.CirclePlatform),
+		},
+		{
+			name:        "🔴wrap error comming from GetWalletByID",
+			networkType: utils.TestnetNetworkType,
+			account:     circleDistAcc,
+			prepareMocksFn: func(mCircleService *circle.MockService) {
+				mCircleService.
+					On("GetWalletByID", ctx, circleDistAcc.CircleWalletID).
+					Return(nil, errors.New("foobar")).
+					Once()
+			},
+			expectedError: errors.New("getting wallet by ID: foobar"),
+		},
+		{
+			name:        "🟢[Testnet]successfully gets balances, ignoring the unsupported ones",
+			networkType: utils.TestnetNetworkType,
+			account:     circleDistAcc,
+			prepareMocksFn: func(mCircleService *circle.MockService) {
+				mCircleService.
+					On("GetWalletByID", ctx, circleDistAcc.CircleWalletID).
+					Return(&circle.Wallet{
+						WalletID: circleDistAcc.CircleWalletID,
+						Balances: []circle.Balance{
+							{Currency: "USD", Amount: "100.0"},
+							{Currency: "EUR", Amount: "200.0"},
+							{Currency: "UNSUPPORTED_ASSET", Amount: "300.0"},
+						},
+					}, nil).
+					Once()
+			},
+			expectedBalances: map[data.Asset]float64{
+				assets.USDCAssetTestnet: 100.0,
+				assets.EURCAssetTestnet: 200.0,
+			},
+		},
+		{
+			name:        "🟢[Pubnet]successfully gets balances, ignoring the unsupported ones",
+			networkType: utils.PubnetNetworkType,
+			account:     circleDistAcc,
+			prepareMocksFn: func(mCircleService *circle.MockService) {
+				mCircleService.
+					On("GetWalletByID", ctx, circleDistAcc.CircleWalletID).
+					Return(&circle.Wallet{
+						WalletID: circleDistAcc.CircleWalletID,
+						Balances: []circle.Balance{
+							{Currency: "USD", Amount: "100.0"},
+							{Currency: "EUR", Amount: "200.0"},
+							{Currency: "UNSUPPORTED_ASSET", Amount: "300.0"},
+						},
+					}, nil).
+					Once()
+			},
+			expectedBalances: map[data.Asset]float64{
+				assets.USDCAssetPubnet: 100.0,
+				assets.EURCAssetPubnet: 200.0,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := CircleDistributionAccountService{
+				NetworkType: tc.networkType,
+			}
+
+			if tc.prepareMocksFn != nil {
+				mCircleService := circle.NewMockService(t)
+				svc.CircleService = mCircleService
+				tc.prepareMocksFn(mCircleService)
+			}
+
+			balances, err := svc.GetBalances(ctx, &tc.account)
+			if tc.expectedError != nil {
+				require.ErrorContains(t, err, tc.expectedError.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedBalances, balances)
+			}
+		})
+	}
+}
+
+func Test_CircleDistributionAccountService_GetBalance(t *testing.T) {
+	ctx := context.Background()
+	circleDistAcc := schema.TransactionAccount{
+		CircleWalletID: "circle-wallet-id",
+		Type:           schema.DistributionAccountCircleDBVault,
+		Status:         schema.AccountStatusActive,
+	}
+	unsupportedAsset := data.Asset{Code: "FOO", Issuer: "GCANIBF4EHC5ZKKMSPX2WFGJ4ZO7BI4JFHZHBUQC5FH3JOOLKG7F5DL3"}
+	mockGetWalletByIDFn := func(mCircleService *circle.MockService) {
+		mCircleService.
+			On("GetWalletByID", ctx, circleDistAcc.CircleWalletID).
+			Return(&circle.Wallet{
+				WalletID: circleDistAcc.CircleWalletID,
+				Balances: []circle.Balance{
+					{Currency: "USD", Amount: "100.0"},
+					{Currency: "EUR", Amount: "200.0"},
+				},
+			}, nil).
+			Once()
+	}
+
+	testCases := []struct {
+		name            string
+		networkType     utils.NetworkType
+		account         schema.TransactionAccount
+		asset           data.Asset
+		prepareMocksFn  func(mCircleService *circle.MockService)
+		expectedBalance float64
+		expectedError   error
+	}{
+		{
+			name:          "🔴wrap error from GetBalances",
+			networkType:   utils.TestnetNetworkType,
+			account:       schema.NewDefaultHostAccount("gost-account-address"),
+			asset:         assets.USDCAssetTestnet,
+			expectedError: errors.New("distribution account is not a Circle account"),
+		},
+		{
+			name:           "🔴returns an error if the desired asset could not be found",
+			networkType:    utils.TestnetNetworkType,
+			account:        circleDistAcc,
+			asset:          unsupportedAsset,
+			prepareMocksFn: mockGetWalletByIDFn,
+			expectedError:  fmt.Errorf("balance for asset %v not found for distribution account", unsupportedAsset),
+		},
+		{
+			name:            "🟢[Testnet]successfully gets balance for supported asset USDC",
+			networkType:     utils.TestnetNetworkType,
+			account:         circleDistAcc,
+			asset:           assets.USDCAssetTestnet,
+			prepareMocksFn:  mockGetWalletByIDFn,
+			expectedBalance: 100.0,
+		},
+		{
+			name:            "🟢[Pubnet]successfully gets balance for supported asset EURC",
+			networkType:     utils.PubnetNetworkType,
+			account:         circleDistAcc,
+			asset:           assets.EURCAssetPubnet,
+			prepareMocksFn:  mockGetWalletByIDFn,
+			expectedBalance: 200.0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := CircleDistributionAccountService{
+				NetworkType: tc.networkType,
+			}
+
+			if tc.prepareMocksFn != nil {
+				mCircleService := circle.NewMockService(t)
+				svc.CircleService = mCircleService
+				tc.prepareMocksFn(mCircleService)
+			}
+
+			// Create some noise by injecting extra fields in the asset boject, to check if the service is (correctly) ignoring them.
+			now := time.Now()
+			assetWithExtraFields := data.Asset{
+				Code:      tc.asset.Code,
+				Issuer:    tc.asset.Issuer,
+				ID:        "asset-id",
+				CreatedAt: &now,
+				UpdatedAt: &now,
+				DeletedAt: &now,
+			}
+
+			balance, err := svc.GetBalance(ctx, &tc.account, assetWithExtraFields)
+			if tc.expectedError != nil {
+				require.ErrorContains(t, err, tc.expectedError.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedBalance, balance)
+			}
 		})
 	}
 }

--- a/internal/services/distribution_account_service_test.go
+++ b/internal/services/distribution_account_service_test.go
@@ -70,7 +70,7 @@ func Test_DistributionAccountServiceOptions_Validate(t *testing.T) {
 	}
 }
 
-func Test_StellarNativeDistributionAccount_GetBalances(t *testing.T) {
+func Test_StellarDistributionAccountService_GetBalances(t *testing.T) {
 	ctx := context.Background()
 	accAddress := keypair.MustRandom().Address()
 	distAcc := schema.NewStellarEnvTransactionAccount(accAddress)
@@ -137,7 +137,7 @@ func Test_StellarNativeDistributionAccount_GetBalances(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mHorizonClient := horizonclient.MockClient{}
-			svc := StellarNativeDistributionAccountService{
+			svc := StellarDistributionAccountService{
 				horizonClient: &mHorizonClient,
 			}
 
@@ -155,7 +155,7 @@ func Test_StellarNativeDistributionAccount_GetBalances(t *testing.T) {
 	}
 }
 
-func Test_StellarNativeDistributionAccount_GetBalance(t *testing.T) {
+func Test_StellarDistributionAccountService_GetBalance(t *testing.T) {
 	ctx := context.Background()
 	accAddress := keypair.MustRandom().Address()
 	distAcc := schema.NewStellarEnvTransactionAccount(accAddress)
@@ -207,7 +207,7 @@ func Test_StellarNativeDistributionAccount_GetBalance(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mHorizonClient := horizonclient.MockClient{}
-			svc := StellarNativeDistributionAccountService{
+			svc := StellarDistributionAccountService{
 				horizonClient: &mHorizonClient,
 			}
 
@@ -446,7 +446,7 @@ func Test_NewDistributionAccountService(t *testing.T) {
 	svc, err := NewDistributionAccountService(svcOpts)
 	require.NoError(t, err)
 
-	stellarDistributionAccSvc := &StellarNativeDistributionAccountService{
+	stellarDistributionAccSvc := &StellarDistributionAccountService{
 		horizonClient: mHorizonClient,
 	}
 	circleDistributionAccSvc := &CircleDistributionAccountService{

--- a/internal/services/distribution_account_service_test.go
+++ b/internal/services/distribution_account_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -18,6 +19,7 @@ import (
 )
 
 func Test_StellarNativeDistributionAccount_GetBalances(t *testing.T) {
+	ctx := context.Background()
 	accAddress := keypair.MustRandom().Address()
 	distAcc := schema.NewStellarEnvTransactionAccount(accAddress)
 
@@ -88,7 +90,7 @@ func Test_StellarNativeDistributionAccount_GetBalances(t *testing.T) {
 			}
 
 			tc.mockHorizonClientFn(&mHorizonClient)
-			balances, err := svc.GetBalances(&distAcc)
+			balances, err := svc.GetBalances(ctx, &distAcc)
 			if tc.expectedError != nil {
 				require.ErrorContains(t, err, tc.expectedError.Error())
 			} else {
@@ -102,6 +104,7 @@ func Test_StellarNativeDistributionAccount_GetBalances(t *testing.T) {
 }
 
 func Test_StellarNativeDistributionAccount_GetBalance(t *testing.T) {
+	ctx := context.Background()
 	accAddress := keypair.MustRandom().Address()
 	distAcc := schema.NewStellarEnvTransactionAccount(accAddress)
 
@@ -159,7 +162,7 @@ func Test_StellarNativeDistributionAccount_GetBalance(t *testing.T) {
 			}
 
 			mockSetup(&mHorizonClient)
-			balance, err := svc.GetBalance(&distAcc, tc.asset)
+			balance, err := svc.GetBalance(ctx, &distAcc, tc.asset)
 			if tc.expectedError != nil {
 				require.ErrorContains(t, err, tc.expectedError.Error())
 			} else {

--- a/internal/services/mocks/distribution_account_service.go
+++ b/internal/services/mocks/distribution_account_service.go
@@ -3,6 +3,8 @@
 package mocks
 
 import (
+	context "context"
+
 	data "github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	mock "github.com/stretchr/testify/mock"
 
@@ -14,9 +16,9 @@ type MockDistributionAccountService struct {
 	mock.Mock
 }
 
-// GetBalance provides a mock function with given fields: account, asset
-func (_m *MockDistributionAccountService) GetBalance(account *schema.TransactionAccount, asset data.Asset) (float64, error) {
-	ret := _m.Called(account, asset)
+// GetBalance provides a mock function with given fields: _a0, account, asset
+func (_m *MockDistributionAccountService) GetBalance(_a0 context.Context, account *schema.TransactionAccount, asset data.Asset) (float64, error) {
+	ret := _m.Called(_a0, account, asset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBalance")
@@ -24,17 +26,17 @@ func (_m *MockDistributionAccountService) GetBalance(account *schema.Transaction
 
 	var r0 float64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*schema.TransactionAccount, data.Asset) (float64, error)); ok {
-		return rf(account, asset)
+	if rf, ok := ret.Get(0).(func(context.Context, *schema.TransactionAccount, data.Asset) (float64, error)); ok {
+		return rf(_a0, account, asset)
 	}
-	if rf, ok := ret.Get(0).(func(*schema.TransactionAccount, data.Asset) float64); ok {
-		r0 = rf(account, asset)
+	if rf, ok := ret.Get(0).(func(context.Context, *schema.TransactionAccount, data.Asset) float64); ok {
+		r0 = rf(_a0, account, asset)
 	} else {
 		r0 = ret.Get(0).(float64)
 	}
 
-	if rf, ok := ret.Get(1).(func(*schema.TransactionAccount, data.Asset) error); ok {
-		r1 = rf(account, asset)
+	if rf, ok := ret.Get(1).(func(context.Context, *schema.TransactionAccount, data.Asset) error); ok {
+		r1 = rf(_a0, account, asset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -42,9 +44,9 @@ func (_m *MockDistributionAccountService) GetBalance(account *schema.Transaction
 	return r0, r1
 }
 
-// GetBalances provides a mock function with given fields: account
-func (_m *MockDistributionAccountService) GetBalances(account *schema.TransactionAccount) (map[data.Asset]float64, error) {
-	ret := _m.Called(account)
+// GetBalances provides a mock function with given fields: _a0, account
+func (_m *MockDistributionAccountService) GetBalances(_a0 context.Context, account *schema.TransactionAccount) (map[data.Asset]float64, error) {
+	ret := _m.Called(_a0, account)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBalances")
@@ -52,19 +54,19 @@ func (_m *MockDistributionAccountService) GetBalances(account *schema.Transactio
 
 	var r0 map[data.Asset]float64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*schema.TransactionAccount) (map[data.Asset]float64, error)); ok {
-		return rf(account)
+	if rf, ok := ret.Get(0).(func(context.Context, *schema.TransactionAccount) (map[data.Asset]float64, error)); ok {
+		return rf(_a0, account)
 	}
-	if rf, ok := ret.Get(0).(func(*schema.TransactionAccount) map[data.Asset]float64); ok {
-		r0 = rf(account)
+	if rf, ok := ret.Get(0).(func(context.Context, *schema.TransactionAccount) map[data.Asset]float64); ok {
+		r0 = rf(_a0, account)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[data.Asset]float64)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*schema.TransactionAccount) error); ok {
-		r1 = rf(account)
+	if rf, ok := ret.Get(1).(func(context.Context, *schema.TransactionAccount) error); ok {
+		r1 = rf(_a0, account)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -264,7 +264,7 @@ func (t TenantsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		distAccBalances, getBalErr := t.DistributionAccountService.GetBalances(&tntDistributionAcc)
+		distAccBalances, getBalErr := t.DistributionAccountService.GetBalances(ctx, &tntDistributionAcc)
 		if getBalErr != nil {
 			httperror.InternalError(ctx, "Cannot get tenant distribution account balances", getBalErr, nil).Render(w)
 			return

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -1165,7 +1165,7 @@ func Test_TenantHandler_Delete(t *testing.T) {
 					Once()
 				distAccResolver.On("HostDistributionAccount").Return(hostAccount).Once()
 				distAccResolver.On("DistributionAccount", mock.Anything, tntID).Return(tntDistributionAcc, nil).Once()
-				distAccSvc.On("GetBalances", &tntDistributionAcc).Return(nil, errors.New("foobar")).Once()
+				distAccSvc.On("GetBalances", mock.Anything, &tntDistributionAcc).Return(nil, errors.New("foobar")).Once()
 			},
 			expectedStatus: http.StatusInternalServerError,
 		},
@@ -1179,7 +1179,7 @@ func Test_TenantHandler_Delete(t *testing.T) {
 					Once()
 				distAccResolver.On("HostDistributionAccount").Return(hostAccount).Once()
 				distAccResolver.On("DistributionAccount", mock.Anything, tntID).Return(tntDistributionAcc, nil).Once()
-				distAccSvc.On("GetBalances", &tntDistributionAcc).
+				distAccSvc.On("GetBalances", mock.Anything, &tntDistributionAcc).
 					Return(map[data.Asset]float64{
 						{Code: assets.USDCAssetCode, Issuer: assets.USDCAssetIssuerTestnet}: 100.0,
 					}, nil).Once()
@@ -1196,7 +1196,7 @@ func Test_TenantHandler_Delete(t *testing.T) {
 					Once()
 				distAccResolver.On("HostDistributionAccount").Return(hostAccount).Once()
 				distAccResolver.On("DistributionAccount", mock.Anything, tntID).Return(tntDistributionAcc, nil).Once()
-				distAccSvc.On("GetBalances", &tntDistributionAcc).
+				distAccSvc.On("GetBalances", mock.Anything, &tntDistributionAcc).
 					Return(map[data.Asset]float64{
 						{Code: "XLM", Issuer: ""}: 120.0,
 					}, nil).Once()
@@ -1214,7 +1214,7 @@ func Test_TenantHandler_Delete(t *testing.T) {
 					Once()
 				distAccResolver.On("HostDistributionAccount").Return(hostAccount).Once()
 				distAccResolver.On("DistributionAccount", mock.Anything, tntID).Return(tntDistributionAcc, nil).Once()
-				distAccSvc.On("GetBalances", &tntDistributionAcc).
+				distAccSvc.On("GetBalances", mock.Anything, &tntDistributionAcc).
 					Return(map[data.Asset]float64{}, nil).Once()
 				tntManagerMock.On("SoftDeleteTenantByID", mock.Anything, tntID).
 					Return(nil, errors.New("foobar")).
@@ -1255,7 +1255,7 @@ func Test_TenantHandler_Delete(t *testing.T) {
 					Once()
 				distAccResolver.On("HostDistributionAccount").Return(hostAccount).Once()
 				distAccResolver.On("DistributionAccount", mock.Anything, tntID).Return(tntDistributionAcc, nil).Once()
-				distAccSvc.On("GetBalances", &tntDistributionAcc).
+				distAccSvc.On("GetBalances", mock.Anything, &tntDistributionAcc).
 					Return(map[data.Asset]float64{}, nil).Once()
 				tntManagerMock.On("SoftDeleteTenantByID", mock.Anything, tntID).
 					Return(&tenant.Tenant{


### PR DESCRIPTION
### What

During disbursement start, use Circle to fetch the available balance when the tenant uses Circle.

### Why

Address https://stellarorg.atlassian.net/browse/SDP-1232

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
