### PR TITLE
[Fix][SDP-1274] Deactivate distribution acc when Circle API  returns 401

### DIFF
--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -246,7 +246,7 @@ func (m *Manager) DeactivateTenantDistributionAccount(ctx context.Context, tenan
 			distribution_account_status = 'PENDING_USER_ACTIVATION'
 		WHERE id = $1
 		AND distribution_account_type = 'DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT'
-		AND status = 'TENANT_ACTIVATED'
+		AND status != 'TENANT_DEACTIVATED'
 	`
 
 	if _, err := m.db.ExecContext(ctx, q, tenantID); err != nil {

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -246,7 +246,6 @@ func (m *Manager) DeactivateTenantDistributionAccount(ctx context.Context, tenan
 			distribution_account_status = 'PENDING_USER_ACTIVATION'
 		WHERE id = $1
 		AND distribution_account_type = 'DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT'
-		AND status != 'TENANT_DEACTIVATED'
 	`
 
 	if _, err := m.db.ExecContext(ctx, q, tenantID); err != nil {

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -616,24 +616,6 @@ func TestManager_DeactivateTenantDistributionAccount(t *testing.T) {
 		assert.NotEqual(t, schema.AccountStatusPendingUserActivation, dbTnt.DistributionAccountStatus)
 	})
 
-	t.Run("does not deactivate distribution account if tenant is deactivated", func(t *testing.T) {
-		tnt, err = m.UpdateTenantConfig(
-			ctx, &TenantUpdate{
-				ID:                        tnt.ID,
-				DistributionAccountType:   schema.DistributionAccountCircleDBVault,
-				Status:                    pointerTo(DeactivatedTenantStatus),
-				DistributionAccountStatus: schema.AccountStatusActive,
-			})
-		require.NoError(t, err)
-
-		err = m.DeactivateTenantDistributionAccount(ctx, tnt.ID)
-		require.NoError(t, err)
-
-		dbTnt, dbErr := m.GetTenant(ctx, &QueryParams{Filters: map[FilterKey]interface{}{FilterKeyID: tnt.ID}})
-		require.NoError(t, dbErr)
-		assert.NotEqual(t, schema.AccountStatusPendingUserActivation, dbTnt.DistributionAccountStatus)
-	})
-
 	t.Run("operation is idempotent if distribution account is already deactivated", func(t *testing.T) {
 		tnt, err = m.UpdateTenantConfig(
 			ctx, &TenantUpdate{
@@ -647,36 +629,6 @@ func TestManager_DeactivateTenantDistributionAccount(t *testing.T) {
 		require.NoError(t, err)
 
 		dbTnt, dbErr := m.GetTenant(ctx, &QueryParams{Filters: map[FilterKey]interface{}{FilterKeyID: tnt.ID}})
-		require.NoError(t, dbErr)
-		assert.Equal(t, schema.AccountStatusPendingUserActivation, dbTnt.DistributionAccountStatus)
-	})
-
-	t.Run("successfully deactivates tenant distribution account if tenant is not deactivated", func(t *testing.T) {
-		_, err = m.UpdateTenantConfig(
-			ctx, &TenantUpdate{
-				ID:                      tnt.ID,
-				DistributionAccountType: schema.DistributionAccountCircleDBVault,
-				Status:                  pointerTo(ActivatedTenantStatus),
-			})
-		require.NoError(t, err)
-		err = m.DeactivateTenantDistributionAccount(ctx, tnt.ID)
-		require.NoError(t, err)
-
-		dbTnt, dbErr := m.GetTenant(ctx, &QueryParams{Filters: map[FilterKey]interface{}{FilterKeyID: tnt.ID}})
-		require.NoError(t, dbErr)
-		assert.Equal(t, schema.AccountStatusPendingUserActivation, dbTnt.DistributionAccountStatus)
-
-		_, err = m.UpdateTenantConfig(
-			ctx, &TenantUpdate{
-				ID:                        tnt.ID,
-				Status:                    pointerTo(ProvisionedTenantStatus),
-				DistributionAccountStatus: schema.AccountStatusActive,
-			})
-		require.NoError(t, err)
-		err = m.DeactivateTenantDistributionAccount(ctx, tnt.ID)
-		require.NoError(t, err)
-
-		dbTnt, dbErr = m.GetTenant(ctx, &QueryParams{Filters: map[FilterKey]interface{}{FilterKeyID: tnt.ID}})
 		require.NoError(t, dbErr)
 		assert.Equal(t, schema.AccountStatusPendingUserActivation, dbTnt.DistributionAccountStatus)
 	})

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -619,9 +619,10 @@ func TestManager_DeactivateTenantDistributionAccount(t *testing.T) {
 	t.Run("does not deactivate distribution account if tenant is deactivated", func(t *testing.T) {
 		tnt, err = m.UpdateTenantConfig(
 			ctx, &TenantUpdate{
-				ID:                      tnt.ID,
-				DistributionAccountType: schema.DistributionAccountCircleDBVault,
-				Status:                  pointerTo(DeactivatedTenantStatus),
+				ID:                        tnt.ID,
+				DistributionAccountType:   schema.DistributionAccountCircleDBVault,
+				Status:                    pointerTo(DeactivatedTenantStatus),
+				DistributionAccountStatus: schema.AccountStatusActive,
 			})
 		require.NoError(t, err)
 

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -617,7 +617,7 @@ func TestManager_DeactivateTenantDistributionAccount(t *testing.T) {
 	})
 
 	t.Run("operation is idempotent if distribution account is already deactivated", func(t *testing.T) {
-		tnt, err = m.UpdateTenantConfig(
+		_, err = m.UpdateTenantConfig(
 			ctx, &TenantUpdate{
 				ID:                        tnt.ID,
 				DistributionAccountType:   schema.DistributionAccountCircleDBVault,
@@ -625,6 +625,22 @@ func TestManager_DeactivateTenantDistributionAccount(t *testing.T) {
 			})
 		require.NoError(t, err)
 
+		err = m.DeactivateTenantDistributionAccount(ctx, tnt.ID)
+		require.NoError(t, err)
+
+		dbTnt, dbErr := m.GetTenant(ctx, &QueryParams{Filters: map[FilterKey]interface{}{FilterKeyID: tnt.ID}})
+		require.NoError(t, dbErr)
+		assert.Equal(t, schema.AccountStatusPendingUserActivation, dbTnt.DistributionAccountStatus)
+	})
+
+	t.Run("successfully deactivates tenant distribution account", func(t *testing.T) {
+		_, err = m.UpdateTenantConfig(
+			ctx, &TenantUpdate{
+				ID:                        tnt.ID,
+				DistributionAccountType:   schema.DistributionAccountCircleDBVault,
+				DistributionAccountStatus: schema.AccountStatusActive,
+			})
+		require.NoError(t, err)
 		err = m.DeactivateTenantDistributionAccount(ctx, tnt.ID)
 		require.NoError(t, err)
 


### PR DESCRIPTION
### What
When the Circle API actually responds with a 401, the error handler doesn't actually modify the distribution account status on the tenant because the condition for the tenant status is incorrect (we don't actually set the status to `TENANT_ACTIVATED` via the FE) so no tenant is selected. This fix changes the query so that it will attempt to select the tenant ~~as long as the tenant itself is not deactivated~~ regardless of tenant status.

### Why
bug fix for release

#### encountering 401
configured w/ a RW key
<img width="641" alt="Screenshot 2024-07-24 at 3 21 32 AM" src="https://github.com/user-attachments/assets/39ada88b-5840-4d3e-9f88-fc01d7cbcdb6">

tenant distribution account is set to active in the db
```
605ca84b-9b5b-4416-996f-4b92a5ef37d4	bluecorp	http://bluecorp.stellar.local:8000	http://bluecorp.stellar.local:3000	TENANT_PROVISIONED	2024-07-23 17:40:26.169097+00	2024-07-23 18:20:12.398806+00		FALSE		DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT	ACTIVE
```

after deleting the same RW key in the Circle dashboard

<img width="617" alt="Screenshot 2024-07-24 at 3 24 04 AM" src="https://github.com/user-attachments/assets/bed34928-a294-44a0-9dbf-20201fae3fcb">

tenant distribution account status is reset

```
605ca84b-9b5b-4416-996f-4b92a5ef37d4	bluecorp	http://bluecorp.stellar.local:8000	http://bluecorp.stellar.local:3000	TENANT_PROVISIONED	2024-07-23 17:40:26.169097+00	2024-07-23 18:23:54.171656+00		FALSE		DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT	PENDING_USER_ACTIVATION
```

#### encountering 403
configured w/ a read-only key
<img width="641" alt="Screenshot 2024-07-24 at 4 02 14 AM" src="https://github.com/user-attachments/assets/420eb8fb-80ae-480c-ab8b-9889c47670bc">

tenant distribution account is set to active in the db
```
605ca84b-9b5b-4416-996f-4b92a5ef37d4	bluecorp	http://bluecorp.stellar.local:8000	http://bluecorp.stellar.local:3000	TENANT_PROVISIONED	2024-07-23 17:40:26.169097+00	2024-07-23 19:02:07.563351+00		FALSE		DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT	ACTIVE
```

attempted disbursement
<img width="1142" alt="Screenshot 2024-07-24 at 4 07 35 AM" src="https://github.com/user-attachments/assets/068e525b-0ed5-4c38-83b4-3b258b82a3dc">

tenant distribution account status is reset
```
605ca84b-9b5b-4416-996f-4b92a5ef37d4	bluecorp	http://bluecorp.stellar.local:8000	http://bluecorp.stellar.local:3000	TENANT_PROVISIONED	2024-07-23 17:40:26.169097+00	2024-07-23 19:07:09.94067+00		FALSE		DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT	PENDING_USER_ACTIVATION
```

### Known limitations

[TODO or N/A]
### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
