### PR TITLE
[SDP-1276] Add retry for circle 429 requests

### DIFF
--- a/internal/circle/client.go
+++ b/internal/circle/client.go
@@ -183,12 +183,13 @@ func (client *Client) GetWalletByID(ctx context.Context, id string) (*Wallet, er
 }
 
 type RetryableError struct {
-	err        string
+	err        error
 	retryAfter time.Duration
 }
 
-func (err RetryableError) Error() string {
-	return err.err
+func (re RetryableError) Error() string {
+	retryableErr := fmt.Errorf("retryable error: %w", re.err)
+	return retryableErr.Error()
 }
 
 // request makes an HTTP request to the Circle API.
@@ -219,7 +220,7 @@ func (client *Client) request(ctx context.Context, u string, method string, isAu
 				retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
 				log.Ctx(ctx).Warnf("CircleClient - Request to %s is rate limited, retry after: %s", u, retryAfter)
 				return RetryableError{
-					err:        fmt.Sprintf("rate limited, retry after: %s", retryAfter),
+					err:        fmt.Errorf("rate limited, retry after: %s", retryAfter),
 					retryAfter: retryAfter,
 				}
 			}

--- a/internal/circle/client.go
+++ b/internal/circle/client.go
@@ -4,11 +4,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"slices"
+	"strconv"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
@@ -113,7 +118,7 @@ func (client *Client) PostTransfer(ctx context.Context, transferReq TransferRequ
 		return nil, err
 	}
 
-	resp, err := client.request(ctx, u, http.MethodPost, true, bytes.NewBuffer(transferData))
+	resp, err := client.request(ctx, u, http.MethodPost, true, transferData)
 	if err != nil {
 		return nil, fmt.Errorf("making request: %w", err)
 	}
@@ -177,22 +182,85 @@ func (client *Client) GetWalletByID(ctx context.Context, id string) (*Wallet, er
 	return parseWalletResponse(resp)
 }
 
+type RetryableError struct {
+	err        string
+	retryAfter time.Duration
+}
+
+func (err RetryableError) Error() string {
+	return err.err
+}
+
 // request makes an HTTP request to the Circle API.
-func (client *Client) request(ctx context.Context, u string, method string, isAuthed bool, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, method, u, body)
+func (client *Client) request(ctx context.Context, u string, method string, isAuthed bool, bodyBytes []byte) (*http.Response, error) {
+	var resp *http.Response
+	err := retry.Do(
+		func() error {
+			bodyReader := bytes.NewReader(bodyBytes)
+			req, err := http.NewRequestWithContext(ctx, method, u, bodyReader)
+			if err != nil {
+				return fmt.Errorf("creating request: %w", err)
+			}
+
+			if isAuthed {
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.APIKey))
+			}
+
+			if bodyReader != nil {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			resp, err = client.httpClient.Do(req)
+			if err != nil {
+				return fmt.Errorf("submitting request to %s: %w", u, err)
+			}
+
+			if resp.StatusCode == http.StatusTooManyRequests {
+				retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+				log.Ctx(ctx).Warnf("CircleClient - Request to %s is rate limited, retry after: %s", u, retryAfter)
+				return RetryableError{
+					err:        fmt.Sprintf("rate limited, retry after: %s", retryAfter),
+					retryAfter: retryAfter,
+				}
+			}
+			return nil
+		},
+		retry.DelayType(func(n uint, err error, config *retry.Config) time.Duration {
+			// if err is RetryableError, return retryAfter
+			var retryableErr RetryableError
+			ok := errors.As(err, &retryableErr)
+			if ok {
+				return retryableErr.retryAfter
+			}
+			// default is back-off delay
+			return retry.BackOffDelay(n, err, config)
+		}),
+		retry.Attempts(4),
+		retry.MaxDelay(time.Second*600),
+		retry.RetryIf(func(err error) bool {
+			return errors.As(err, &RetryableError{})
+		}),
+		retry.OnRetry(func(n uint, err error) {
+			log.Ctx(ctx).Warnf("CircleClient - Request to %s is rate limited, Retry number %d due to: %s", u, n, err)
+		}),
+		retry.LastErrorOnly(true),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, err
 	}
 
-	if isAuthed {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.APIKey))
-	}
+	return resp, nil
+}
 
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+func parseRetryAfter(retryAfter string) time.Duration {
+	if retryAfter == "" {
+		return 0
 	}
-
-	return client.httpClient.Do(req)
+	seconds, err := strconv.Atoi(retryAfter)
+	if err != nil {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func (client *Client) handleError(ctx context.Context, resp *http.Response) error {


### PR DESCRIPTION
### What
Adding basic retry for Circle 429 retries

Circle requests in Sandbox environment usually fail after 6 requests. With this change we can finish processing all the payments in a disbursement. 

<img width="1029" alt="Screenshot 2024-07-23 at 7 25 58 PM" src="https://github.com/user-attachments/assets/475c6eb8-bb50-44e5-a095-f32ba1591b54">


### Known limitations
* 🚨 Current implementation holds the database session until a retry is completed. In the case of Sandbox, that means the session is held for 5 minutes before the payment status is committed to the database. 

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
