### PR TITLE
[SDP-1247] new API role for bypassing reCAPTCHA

### DIFF
--- a/internal/data/roles.go
+++ b/internal/data/roles.go
@@ -8,7 +8,7 @@ func (u UserRole) String() string {
 
 func (u UserRole) IsValid() bool {
 	switch u {
-	case OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole, APIOwnerUserRole:
+	case OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole, APIUserRole:
 		return true
 	}
 	return false
@@ -24,8 +24,10 @@ const (
 	DeveloperUserRole UserRole = "developer"
 	// BusinessUserRole has read-only permissions - except for user management that they can't read any data.
 	BusinessUserRole UserRole = "business"
-	// APIOwnerUserRole has permissions to access to the same suite of APIs as OwnerUserRole, without needing to perform verification through reCAPTCHA.
-	APIOwnerUserRole UserRole = "api_owner"
+
+	// APIUserRole removes the need for the user to be verified through reCAPTCHA.
+	// This role must be paired with one or more of the above permission-based roles to be valid.
+	APIUserRole UserRole = "api"
 )
 
 // GetAllRoles returns all roles available
@@ -35,7 +37,7 @@ func GetAllRoles() []UserRole {
 		FinancialControllerUserRole,
 		DeveloperUserRole,
 		BusinessUserRole,
-		APIOwnerUserRole,
+		APIUserRole,
 	}
 }
 

--- a/internal/data/roles.go
+++ b/internal/data/roles.go
@@ -30,6 +30,16 @@ const (
 	APIUserRole UserRole = "api"
 )
 
+// GetAllBusinessRoles returns all business roles that control endpoint permission
+func GetAllBusinessRoles() []UserRole {
+	return []UserRole{
+		OwnerUserRole,
+		FinancialControllerUserRole,
+		DeveloperUserRole,
+		BusinessUserRole,
+	}
+}
+
 // GetAllRoles returns all roles available
 func GetAllRoles() []UserRole {
 	return []UserRole{

--- a/internal/data/roles.go
+++ b/internal/data/roles.go
@@ -25,7 +25,7 @@ const (
 	// BusinessUserRole has read-only permissions - except for user management that they can't read any data.
 	BusinessUserRole UserRole = "business"
 
-	// APIUserRole removes the need for the user to be verified through reCAPTCHA.
+	// APIUserRole removes the need for the user to be verified through reCAPTCHA for endpoints that require it.
 	// This role must be paired with one or more of the above permission-based roles to be valid.
 	APIUserRole UserRole = "api"
 )

--- a/internal/data/roles.go
+++ b/internal/data/roles.go
@@ -1,5 +1,9 @@
 package data
 
+import (
+	"slices"
+)
+
 type UserRole string
 
 func (u UserRole) String() string {
@@ -7,11 +11,7 @@ func (u UserRole) String() string {
 }
 
 func (u UserRole) IsValid() bool {
-	switch u {
-	case OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole, APIUserRole:
-		return true
-	}
-	return false
+	return slices.Contains(GetAllRoles(), u)
 }
 
 // Roles description reference: https://stellarfoundation.slack.com/archives/C04C9MLM9UZ/p1681238994830149

--- a/internal/data/roles.go
+++ b/internal/data/roles.go
@@ -8,7 +8,7 @@ func (u UserRole) String() string {
 
 func (u UserRole) IsValid() bool {
 	switch u {
-	case OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole:
+	case OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole, APIOwnerUserRole:
 		return true
 	}
 	return false
@@ -24,6 +24,8 @@ const (
 	DeveloperUserRole UserRole = "developer"
 	// BusinessUserRole has read-only permissions - except for user management that they can't read any data.
 	BusinessUserRole UserRole = "business"
+	// APIOwnerUserRole has permissions to access to the same suite of APIs as OwnerUserRole, without needing to perform verification through reCAPTCHA.
+	APIOwnerUserRole UserRole = "api_owner"
 )
 
 // GetAllRoles returns all roles available
@@ -33,6 +35,7 @@ func GetAllRoles() []UserRole {
 		FinancialControllerUserRole,
 		DeveloperUserRole,
 		BusinessUserRole,
+		APIOwnerUserRole,
 	}
 }
 

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -71,9 +71,9 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	user, err := h.AuthManager.GetUserByEmail(ctx, forgotPasswordRequest.Email)
+	user, err := h.AuthManager.GetUserByEmail(ctx, strings.TrimSpace(forgotPasswordRequest.Email))
 	if err != nil {
-		// If user cannot be found, we will default to user requiring to validate reCAPTCHA.
+		// If user cannot be found, we will default to user requiring to validate reCAPTCHA
 		if errors.Is(err, auth.ErrUserNotFound) {
 			// If we don't find the user by email, we just return an ok response
 			// to prevent malicious client from searching accounts in the system

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -59,21 +59,6 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if !h.ReCAPTCHADisabled {
-		// validating reCAPTCHA Token
-		isValid, recaptchaErr := h.ReCAPTCHAValidator.IsTokenValid(ctx, forgotPasswordRequest.ReCAPTCHAToken)
-		if recaptchaErr != nil {
-			httperror.InternalError(ctx, "Cannot validate reCAPTCHA token", recaptchaErr, nil).Render(w)
-			return
-		}
-
-		if !isValid {
-			log.Ctx(ctx).Errorf("reCAPTCHA token is invalid for request with email %s", utils.TruncateString(forgotPasswordRequest.Email, 3))
-			httperror.BadRequest("reCAPTCHA token invalid", nil, nil).Render(w)
-			return
-		}
-	}
-
 	// validate request
 	v := validators.NewValidator()
 
@@ -94,6 +79,28 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			log.Ctx(ctx).Errorf("error in forgot password handler, user has a valid token")
 		} else {
 			httperror.InternalError(ctx, "", err, nil).Render(w)
+			return
+		}
+	}
+
+	roleCanBypassReCAPTCHA, err := validators.UserRoleCanBypassReCAPTCHA(ctx, h.AuthManager, resetToken)
+	if err != nil {
+		log.Ctx(ctx).Errorf("error checking if user role in token can bypass ReCAPTCHA: %s", err)
+		httperror.InternalError(ctx, "", err, nil).Render(w)
+		return
+	}
+
+	if !h.ReCAPTCHADisabled && !roleCanBypassReCAPTCHA {
+		// validating reCAPTCHA Token
+		isValid, recaptchaErr := h.ReCAPTCHAValidator.IsTokenValid(ctx, forgotPasswordRequest.ReCAPTCHAToken)
+		if recaptchaErr != nil {
+			httperror.InternalError(ctx, "Cannot validate reCAPTCHA token", recaptchaErr, nil).Render(w)
+			return
+		}
+
+		if !isValid {
+			log.Ctx(ctx).Errorf("reCAPTCHA token is invalid for request with email %s", utils.TruncateString(forgotPasswordRequest.Email, 3))
+			httperror.BadRequest("reCAPTCHA token invalid", nil, nil).Render(w)
 			return
 		}
 	}

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -79,7 +79,7 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-	canBypassReCAPTCHA := slices.Contains(user.Roles, data.APIOwnerUserRole.String())
+	canBypassReCAPTCHA := slices.Contains(user.Roles, data.APIUserRole.String())
 
 	if !h.ReCAPTCHADisabled && !canBypassReCAPTCHA {
 		// validating reCAPTCHA Token

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -61,13 +61,13 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		SDPUIBaseURL: &uiBaseURL,
 	}
 	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
-	email := "valid@email.com"
+	const email = "valid@email.com"
 	defaultUserRoles := []string{data.OwnerUserRole.String()}
 	user := &auth.User{
 		ID:    "userID",
 		Email: email,
 	}
-	reCAPTCHAToken := "validToken"
+	const reCAPTCHAToken = "validToken"
 	defaultReqBody := fmt.Sprintf(`
 				{ 
 					"email": "%s",
@@ -160,7 +160,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 			Once()
 		userByEmailSetup(user, defaultUserRoles)
 		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "validToken").
+			On("IsTokenValid", mock.Anything, reCAPTCHAToken).
 			Return(true, nil).
 			Once()
 

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -320,7 +320,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		authenticatorMock.
-			On("ForgotPassword", req.Context(), "valid@email.com").
+			On("ForgotPassword", req.Context(), email).
 			Return("", errors.New("unexpected error")).
 			Once()
 		authenticatorMock.

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -91,7 +91,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 				}`, targetUser.Email)
 
 			authenticatorMock.
-				On("ForgotPassword", mock.Anything, email).
+				On("ForgotPassword", mock.Anything, targetUser.Email).
 				Return("resetToken", nil).
 				Once()
 			authenticatorMock.
@@ -155,7 +155,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 			On("GetUserByEmail", mock.Anything, user.Email).
 			Return(user, nil).
 			Once().
-			On("ForgotPassword", mock.Anything, email).
+			On("ForgotPassword", mock.Anything, user.Email).
 			Return("resetToken", nil).
 			Once()
 		reCAPTCHAValidatorMock.

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -92,16 +92,21 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		// role can bypass reCAPTCHA
 		usersRoles[1] = []string{data.OwnerUserRole.String(), data.APIUserRole.String()}
 		for _, userRoles := range usersRoles {
+			targetUser := &auth.User{
+				ID:    "user-ID",
+				Email: email,
+				Roles: userRoles,
+			}
 			requestBody := fmt.Sprintf(`
 				{ 
 					"email": "%s"
-				}`, user.Email)
+				}`, targetUser.Email)
 
 			authenticatorMock.
 				On("ForgotPassword", mock.Anything, email).
 				Return("resetToken", nil).
 				Once()
-			UserByEmailSetup(authenticatorMock, roleManagerMock, user, userRoles)
+			UserByEmailSetup(authenticatorMock, roleManagerMock, targetUser, userRoles)
 			if !slices.Contains(userRoles, data.APIUserRole.String()) {
 				requestBody = defaultReqBody
 				reCAPTCHAValidatorMock.

--- a/internal/serve/httphandler/list_roles_handler_test.go
+++ b/internal/serve/httphandler/list_roles_handler_test.go
@@ -28,5 +28,5 @@ func Test_ListRoles(t *testing.T) {
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	assert.JSONEq(t, `{"roles": ["owner", "financial_controller",  "developer", "business"]}`, string(respBody))
+	assert.JSONEq(t, `{"roles": ["owner", "financial_controller",  "developer", "business", "api"]}`, string(respBody))
 }

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/stellar/go/support/http/httpdecode"
 	"github.com/stellar/go/support/log"
@@ -69,15 +70,12 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	user, err := h.AuthManager.GetUserByEmail(ctx, reqBody.Email)
+	user, err := h.AuthManager.GetUserByEmail(ctx, strings.TrimSpace(reqBody.Email))
 	if err != nil {
 		if errors.Is(err, auth.ErrUserNotFound) {
 			// If we don't find the user by email, we just return an ok response
 			// to prevent malicious client from searching accounts in the system
-			log.Ctx(ctx).Errorf("Email in request not found: %s", reqBody.Email)
-		} else {
-			httperror.InternalError(ctx, "Getting user by email", err, nil).Render(rw)
-			return
+			log.Ctx(ctx).Errorf("Email in request not found: %s", utils.TruncateString(reqBody.Email, 3))
 		}
 	}
 

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -79,7 +79,7 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	roleCanBypassReCAPTCHA, err := validators.UserRoleCanBypassReCAPTCHA(ctx, h.AuthManager, token)
+	roleCanBypassReCAPTCHA, err := validators.TokenUserRoleCanBypassReCAPTCHA(ctx, h.AuthManager, token)
 	if err != nil {
 		log.Ctx(ctx).Errorf("error checking if user role in token can bypass ReCAPTCHA: %s", err)
 		httperror.InternalError(ctx, "", err, nil).Render(rw)
@@ -88,9 +88,9 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	if !h.ReCAPTCHADisabled && !roleCanBypassReCAPTCHA {
 		// validating reCAPTCHA Token
-		isValid, err := h.ReCAPTCHAValidator.IsTokenValid(ctx, reqBody.ReCAPTCHAToken)
-		if err != nil {
-			httperror.Unauthorized("Cannot validate reCAPTCHA token", err, nil).Render(rw)
+		isValid, recaptchaErr := h.ReCAPTCHAValidator.IsTokenValid(ctx, reqBody.ReCAPTCHAToken)
+		if recaptchaErr != nil {
+			httperror.Unauthorized("Cannot validate reCAPTCHA token", recaptchaErr, nil).Render(rw)
 			return
 		}
 

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -72,6 +72,7 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	user, err := h.AuthManager.GetUserByEmail(ctx, strings.TrimSpace(reqBody.Email))
 	if err != nil {
+		// If user cannot be found, we will default to user requiring to validate reCAPTCHA
 		if errors.Is(err, auth.ErrUserNotFound) {
 			// If we don't find the user by email, we just return an ok response
 			// to prevent malicious client from searching accounts in the system

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -294,7 +294,7 @@ func Test_LoginHandler(t *testing.T) {
 			Return(user, nil).
 			Once()
 		reCAPTCHAValidator.
-			On("IsTokenValid", mock.Anything, "XyZ").
+			On("IsTokenValid", mock.Anything, defaultReCAPTCHAToken).
 			Return(false, nil).
 			Once()
 
@@ -330,7 +330,6 @@ func Test_LoginHandler(t *testing.T) {
 			{data.OwnerUserRole.String()},                            // API roles cannot bypass reCAPTCHA
 			{data.OwnerUserRole.String(), data.APIUserRole.String()}, // API roles can bypass reCAPTCHA
 		}
-		usersRoles[1] = []string{data.OwnerUserRole.String(), data.APIUserRole.String()}
 		for _, userRoles := range usersRoles {
 			targetUser := &auth.User{
 				ID:    "user-ID",

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -334,7 +334,12 @@ func Test_LoginHandler(t *testing.T) {
 		// user roles can bypass reCAPTCHA
 		usersRoles[1] = []string{data.OwnerUserRole.String(), data.APIUserRole.String()}
 		for _, userRoles := range usersRoles {
-			UserByEmailSetup(authenticatorMock, roleManagerMock, user, userRoles)
+			targetUser := &auth.User{
+				ID:    "user-ID",
+				Email: email,
+				Roles: userRoles,
+			}
+			UserByEmailSetup(authenticatorMock, roleManagerMock, targetUser, userRoles)
 			reqBody := `
 				{
 					"email": "testuser@email.com",
@@ -347,7 +352,7 @@ func Test_LoginHandler(t *testing.T) {
 					Once()
 				reqBody = defaultReqBody
 			}
-			authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, defaultUserToken)
+			authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, targetUser, password, defaultUserToken)
 
 			r.Post(url, handler.ServeHTTP)
 

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -28,7 +28,8 @@ func authenticateSetup(
 	authenticatorMock *auth.AuthenticatorMock,
 	roleManagerMock *auth.RoleManagerMock,
 	jwtManagerMock *auth.JWTManagerMock,
-	user *auth.User, password, userToken string) {
+	user *auth.User, password, userToken string,
+) {
 	authenticatorMock.
 		On("ValidateCredentials", mock.Anything, user.Email, password).
 		Return(user, nil).
@@ -44,7 +45,8 @@ func authenticateSetup(
 }
 
 func userRoleLookupSetup(roleManagerMock *auth.RoleManagerMock,
-	jwtManagerMock *auth.JWTManagerMock, user *auth.User, userCanBypassRole bool, userToken string) {
+	jwtManagerMock *auth.JWTManagerMock, user *auth.User, userCanBypassRole bool, userToken string,
+) {
 	jwtManagerMock.On("ValidateToken", mock.Anything, userToken).
 		Return(true, nil).Once()
 	jwtManagerMock.On("GetUserFromToken", mock.Anything, userToken).
@@ -260,15 +262,6 @@ func Test_LoginHandler(t *testing.T) {
 	}
 	password := "pass1234"
 	userToken := "token123"
-
-	/*roleLookupSetup := func(userCanBypassRole bool, userToken string) {
-		jwtManagerMock.On("ValidateToken", mock.Anything, userToken).
-			Return(true, nil).Once()
-		jwtManagerMock.On("GetUserFromToken", mock.Anything, userToken).
-			Return(user, nil).Once()
-		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
-			Return(userCanBypassRole, nil).Once()
-	}*/
 
 	t.Run("returns error when unable to validate recaptcha", func(t *testing.T) {
 		authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -93,13 +93,12 @@ func Test_LoginHandler(t *testing.T) {
 	const email = "testuser@email.com"
 	const password = "pass1234"
 	const defaultReCAPTCHAToken = "XyZ"
-	defaultUserRoles := []string{data.OwnerUserRole.String()}
 	defaultReqBody := fmt.Sprintf(
 		`{"email": "%s", "password": "%s", "recaptcha_token": "%s"}`, email, password, defaultReCAPTCHAToken)
 	user := &auth.User{
 		ID:    "user-ID",
 		Email: email,
-		Roles: defaultUserRoles,
+		Roles: []string{data.OwnerUserRole.String()},
 	}
 	const defaultUserToken = "token123"
 

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -51,7 +51,7 @@ func userRoleLookupSetup(roleManagerMock *auth.RoleManagerMock,
 		Return(true, nil).Once()
 	jwtManagerMock.On("GetUserFromToken", mock.Anything, userToken).
 		Return(user, nil).Once()
-	roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
+	roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIUserRole.String()}).
 		Return(userCanBypassRole, nil).Once()
 }
 
@@ -439,7 +439,6 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 
 	userToken := "token123"
 	password := "pass1234"
-	authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)
 	jwtManagerMock.
 		On("ValidateToken", mock.Anything, userToken).
 		Return(true, nil)
@@ -450,7 +449,8 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 	deviceID := "safari-xyz"
 
 	t.Run("error getting user from token", func(t *testing.T) {
-		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
+		authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)
+		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIUserRole.String()}).
 			Return(false, nil).Once()
 		authenticatorMock.
 			On("GetUser", mock.Anything, user.ID).
@@ -468,18 +468,19 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 	})
 
 	t.Run("error when deviceID header is empty", func(t *testing.T) {
+		authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)
 		roleManagerMock.
 			On("GetUserRoles", mock.Anything, user).
 			Return(user.Roles, nil).
 			Once()
-		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
+		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIUserRole.String()}).
 			Return(false, nil).Once()
 		authenticatorMock.
-			On("GetUser", mock.Anything, "userID").
+			On("GetUser", mock.Anything, user.ID).
 			Return(user, nil).
 			Once()
 
-		body := LoginRequest{Email: "testuser@mail.com", Password: "pass1234"}
+		body := LoginRequest{Email: user.Email, Password: password}
 		req := httptest.NewRequest(http.MethodPost, "/login", requestToJSON(t, &body))
 		rw := httptest.NewRecorder()
 
@@ -490,11 +491,12 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 	})
 
 	t.Run("error validating MFA device", func(t *testing.T) {
+		authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)
 		roleManagerMock.
 			On("GetUserRoles", mock.Anything, user).
 			Return(user.Roles, nil).
 			Once()
-		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
+		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIUserRole.String()}).
 			Return(false, nil).Once()
 		authenticatorMock.
 			On("GetUser", mock.Anything, "userID").
@@ -517,11 +519,12 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 	})
 
 	t.Run("when device is remembered, return token", func(t *testing.T) {
+		authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)
 		roleManagerMock.
 			On("GetUserRoles", mock.Anything, user).
 			Return(user.Roles, nil).
 			Once()
-		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
+		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIUserRole.String()}).
 			Return(false, nil).Once()
 		authenticatorMock.
 			On("GetUser", mock.Anything, "userID").
@@ -544,11 +547,12 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 	})
 
 	t.Run("error generating MFA code", func(t *testing.T) {
+		authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)
 		roleManagerMock.
 			On("GetUserRoles", mock.Anything, user).
 			Return(user.Roles, nil).
 			Once()
-		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
+		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIUserRole.String()}).
 			Return(false, nil).Once()
 		authenticatorMock.
 			On("GetUser", mock.Anything, "userID").
@@ -575,11 +579,12 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 	})
 
 	t.Run("error when code returned is empty", func(t *testing.T) {
+		authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)
 		roleManagerMock.
 			On("GetUserRoles", mock.Anything, user).
 			Return(user.Roles, nil).
 			Once()
-		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
+		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIUserRole.String()}).
 			Return(false, nil).Once()
 		authenticatorMock.
 			On("GetUser", mock.Anything, "userID").
@@ -606,11 +611,12 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 	})
 
 	t.Run("error sending MFA message", func(t *testing.T) {
+		authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)
 		roleManagerMock.
 			On("GetUserRoles", mock.Anything, user).
 			Return(user.Roles, nil).
 			Once()
-		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
+		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIUserRole.String()}).
 			Return(false, nil).Once()
 		authenticatorMock.
 			On("GetUser", mock.Anything, "userID").
@@ -641,11 +647,12 @@ func Test_LoginHandlerr_ServeHTTP_MFA(t *testing.T) {
 	})
 
 	t.Run("🎉  Successful login", func(t *testing.T) {
+		authenticateSetup(authenticatorMock, roleManagerMock, jwtManagerMock, user, password, userToken)
 		roleManagerMock.
 			On("GetUserRoles", mock.Anything, user).
 			Return(user.Roles, nil).
 			Once()
-		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIOwnerUserRole.String()}).
+		roleManagerMock.On("HasAnyRoles", mock.Anything, user, []string{data.APIUserRole.String()}).
 			Return(false, nil).Once()
 		authenticatorMock.
 			On("GetUser", mock.Anything, "userID").

--- a/internal/serve/httphandler/mfa_handler.go
+++ b/internal/serve/httphandler/mfa_handler.go
@@ -66,7 +66,7 @@ func (h MFAHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	roleCanBypassReCAPTCHA, err := validators.UserRoleCanBypassReCAPTCHA(ctx, h.AuthManager, token)
+	roleCanBypassReCAPTCHA, err := validators.TokenUserRoleCanBypassReCAPTCHA(ctx, h.AuthManager, token)
 	if err != nil {
 		log.Ctx(ctx).Errorf("error checking if user role in token can bypass ReCAPTCHA: %s", err)
 		httperror.InternalError(ctx, "", err, nil).Render(rw)

--- a/internal/serve/httphandler/mfa_handler.go
+++ b/internal/serve/httphandler/mfa_handler.go
@@ -49,7 +49,11 @@ func (h MFAHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log.Ctx(ctx).Info(deviceID, " ", reqBody.MFACode)
+	if reqBody.MFACode == "" {
+		extras := map[string]interface{}{"mfa_code": "MFA Code is required"}
+		httperror.BadRequest("Request invalid", nil, extras).Render(rw)
+		return
+	}
 
 	token, err := h.AuthManager.AuthenticateMFA(ctx, deviceID, reqBody.MFACode, reqBody.RememberMe)
 	if err != nil {
@@ -82,12 +86,6 @@ func (h MFAHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			httperror.BadRequest("reCAPTCHA token invalid", nil, nil).Render(rw)
 			return
 		}
-	}
-
-	if reqBody.MFACode == "" {
-		extras := map[string]interface{}{"mfa_code": "MFA Code is required"}
-		httperror.BadRequest("Request invalid", nil, extras).Render(rw)
-		return
 	}
 
 	userID, err := h.AuthManager.GetUserID(ctx, token)

--- a/internal/serve/httphandler/mfa_handler.go
+++ b/internal/serve/httphandler/mfa_handler.go
@@ -49,6 +49,8 @@ func (h MFAHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	log.Ctx(ctx).Info(deviceID, " ", reqBody.MFACode)
+
 	token, err := h.AuthManager.AuthenticateMFA(ctx, deviceID, reqBody.MFACode, reqBody.RememberMe)
 	if err != nil {
 		if errors.Is(err, auth.ErrMFACodeInvalid) {

--- a/internal/serve/httphandler/mfa_handler.go
+++ b/internal/serve/httphandler/mfa_handler.go
@@ -60,6 +60,7 @@ func (h MFAHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	user, err := h.AuthManager.GetUserByDeviceID(ctx, strings.TrimSpace(deviceID))
 	if err != nil {
+		// If device ID cannot be found, we will default to user requiring to validate reCAPTCHA
 		if errors.Is(err, auth.ErrMFADeviceIDNotFound) {
 			// If we don't find the user by device id, we just return an ok response
 			// to prevent malicious client from searching for the device in the system

--- a/internal/serve/httphandler/mfa_handler_test.go
+++ b/internal/serve/httphandler/mfa_handler_test.go
@@ -53,8 +53,48 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 		ReCAPTCHADisabled:  false,
 	}
 
-	deviceID := "safari-xyz"
+	userToken := "token123"
+	user := &auth.User{
+		ID:    "userID",
+		Email: "email@email.com",
+	}
 
+	deviceID := "safari-xyz"
+	mfaCode := "123456"
+	validateMFASetup := func(deviceID, mfaCode string, rememberMe bool) {
+		mfaManagerMock.
+			On("ValidateMFACode", mock.Anything, deviceID, mfaCode).
+			Return(user.ID, nil).
+			Once()
+
+		if rememberMe {
+			mfaManagerMock.
+				On("RememberDevice", mock.Anything, deviceID, mfaCode).
+				Return(nil).
+				Once()
+		}
+
+		authenticatorMock.
+			On("GetUser", mock.Anything, user.ID).
+			Return(user, nil).
+			Once()
+
+		roleManagerMock.
+			On("GetUserRoles", mock.Anything, user).
+			Return(user.Roles, nil).
+			Once()
+
+		jwtManagerMock.
+			On("GenerateToken", mock.Anything, user, mock.AnythingOfType("time.Time")).
+			Return(userToken, nil).
+			On("ValidateToken", mock.Anything, userToken).
+			Return(true, nil).
+			On("GetUserFromToken", mock.Anything, userToken).
+			Return(user, nil).
+			Once()
+	}
+
+	reCAPTCHAToken := "token"
 	t.Run("Test handler with invalid body", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, nil)
 		rw := httptest.NewRecorder()
@@ -64,46 +104,8 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, rw.Code)
 	})
 
-	t.Run("Test handler with unexpected reCAPTCHA error", func(t *testing.T) {
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "token").
-			Return(false, errors.New("unexpected error")).
-			Once()
-
-		body := MFARequest{MFACode: "123456", ReCAPTCHAToken: "token"}
-		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
-		rw := httptest.NewRecorder()
-
-		mfaHandler.ServeHTTP(rw, req)
-
-		require.Equal(t, http.StatusInternalServerError, rw.Code)
-		require.Contains(t, rw.Body.String(), "Cannot validate reCAPTCHA token")
-	})
-
-	t.Run("Test handler with invalid reCAPTCHA token", func(t *testing.T) {
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "token").
-			Return(false, nil).
-			Once()
-
-		body := MFARequest{MFACode: "123456", ReCAPTCHAToken: "token"}
-		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
-		rw := httptest.NewRecorder()
-
-		mfaHandler.ServeHTTP(rw, req)
-
-		require.Equal(t, http.StatusBadRequest, rw.Code)
-		require.Contains(t, rw.Body.String(), "reCAPTCHA token invalid")
-	})
-
 	t.Run("Test Device ID header is empty", func(t *testing.T) {
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "token").
-			Return(true, nil).
-			Once()
-
-		body := MFARequest{MFACode: "123456", ReCAPTCHAToken: "token"}
-
+		body := MFARequest{MFACode: mfaCode, ReCAPTCHAToken: reCAPTCHAToken}
 		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
 		rw := httptest.NewRecorder()
 
@@ -114,14 +116,10 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("Test MFA code is empty", func(t *testing.T) {
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "token").
-			Return(true, nil).
-			Once()
-
-		body := MFARequest{ReCAPTCHAToken: "token"}
+		body := MFARequest{ReCAPTCHAToken: reCAPTCHAToken}
 
 		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
+		req.Header.Set(DeviceIDHeader, deviceID)
 		rw := httptest.NewRecorder()
 
 		mfaHandler.ServeHTTP(rw, req)
@@ -131,17 +129,11 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("Test MFA code is invalid", func(t *testing.T) {
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "token").
-			Return(true, nil).
-			Once()
-
+		body := MFARequest{MFACode: mfaCode, ReCAPTCHAToken: reCAPTCHAToken}
 		mfaManagerMock.
 			On("ValidateMFACode", mock.Anything, deviceID, "123456").
 			Return("", auth.ErrMFACodeInvalid).
 			Once()
-
-		body := MFARequest{MFACode: "123456", ReCAPTCHAToken: "token"}
 
 		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
 		req.Header.Set(DeviceIDHeader, deviceID)
@@ -154,17 +146,11 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("Test MFA validation failed", func(t *testing.T) {
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "token").
-			Return(true, nil).
-			Once()
-
+		body := MFARequest{MFACode: mfaCode, ReCAPTCHAToken: reCAPTCHAToken}
 		mfaManagerMock.
 			On("ValidateMFACode", mock.Anything, deviceID, "123456").
 			Return("", errors.New("weird error happened")).
 			Once()
-
-		body := MFARequest{MFACode: "123456", ReCAPTCHAToken: "token"}
 
 		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
 		req.Header.Set(DeviceIDHeader, deviceID)
@@ -177,11 +163,7 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("Test MFA remember me failed", func(t *testing.T) {
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "token").
-			Return(true, nil).
-			Once()
-
+		body := MFARequest{MFACode: mfaCode, ReCAPTCHAToken: reCAPTCHAToken, RememberMe: true}
 		mfaManagerMock.
 			On("ValidateMFACode", mock.Anything, deviceID, "123456").
 			Return("userID", nil).
@@ -191,8 +173,6 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 			On("RememberDevice", mock.Anything, deviceID, "123456").
 			Return(errors.New("weird error happened")).
 			Once()
-
-		body := MFARequest{MFACode: "123456", ReCAPTCHAToken: "token", RememberMe: true}
 
 		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
 		req.Header.Set(DeviceIDHeader, deviceID)
@@ -205,11 +185,7 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("Test MFA get user failed", func(t *testing.T) {
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "token").
-			Return(true, nil).
-			Once()
-
+		body := MFARequest{MFACode: mfaCode, ReCAPTCHAToken: reCAPTCHAToken, RememberMe: true}
 		mfaManagerMock.
 			On("ValidateMFACode", mock.Anything, deviceID, "123456").
 			Return("userID", nil).
@@ -225,8 +201,6 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 			Return(nil, errors.New("weird error happened")).
 			Once()
 
-		body := MFARequest{MFACode: "123456", ReCAPTCHAToken: "token", RememberMe: true}
-
 		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
 		req.Header.Set(DeviceIDHeader, deviceID)
 		rw := httptest.NewRecorder()
@@ -237,51 +211,52 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 		require.Contains(t, rw.Body.String(), "Cannot authenticate user")
 	})
 
-	t.Run("Test MFA validation successful", func(t *testing.T) {
+	t.Run("Test handler with unexpected reCAPTCHA error", func(t *testing.T) {
+		body := MFARequest{MFACode: mfaCode, ReCAPTCHAToken: reCAPTCHAToken}
+		validateMFASetup(deviceID, body.MFACode, body.RememberMe)
+		userRoleLookupSetup(roleManagerMock, jwtManagerMock, user, false, userToken)
+		reCAPTCHAValidatorMock.
+			On("IsTokenValid", mock.Anything, reCAPTCHAToken).
+			Return(false, errors.New("unexpected error")).
+			Once()
+
+		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
+		req.Header.Set(DeviceIDHeader, deviceID)
+		rw := httptest.NewRecorder()
+
+		mfaHandler.ServeHTTP(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
+		require.Contains(t, rw.Body.String(), "Cannot validate reCAPTCHA token")
+	})
+
+	t.Run("Test handler with invalid reCAPTCHA token", func(t *testing.T) {
+		body := MFARequest{MFACode: mfaCode, ReCAPTCHAToken: reCAPTCHAToken}
+		validateMFASetup(deviceID, body.MFACode, body.RememberMe)
+		userRoleLookupSetup(roleManagerMock, jwtManagerMock, user, false, userToken)
+		reCAPTCHAValidatorMock.
+			On("IsTokenValid", mock.Anything, reCAPTCHAToken).
+			Return(false, nil).
+			Once()
+
+		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
+		req.Header.Set(DeviceIDHeader, deviceID)
+		rw := httptest.NewRecorder()
+
+		mfaHandler.ServeHTTP(rw, req)
+
+		require.Equal(t, http.StatusBadRequest, rw.Code)
+		require.Contains(t, rw.Body.String(), "reCAPTCHA token invalid")
+	})
+
+	t.Run("Test handler without reCAPTCHA token when user role can bypass check", func(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 		log.SetLevel(log.InfoLevel)
 
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "token").
-			Return(true, nil).
-			Once()
-
-		mfaManagerMock.
-			On("ValidateMFACode", mock.Anything, deviceID, "123456").
-			Return("userID", nil).
-			Once()
-
-		mfaManagerMock.
-			On("RememberDevice", mock.Anything, deviceID, "123456").
-			Return(nil).
-			Once()
-
-		user := &auth.User{
-			ID:    "user-id",
-			Email: "email@email.com",
-		}
-
-		authenticatorMock.
-			On("GetUser", mock.Anything, "userID").
-			Return(user, nil).
-			Once()
-
-		roleManagerMock.
-			On("GetUserRoles", mock.Anything, user).
-			Return([]string{"role1"}, nil).
-			Once()
-
-		jwtManagerMock.
-			On("GenerateToken", mock.Anything, user, mock.AnythingOfType("time.Time")).
-			Return("token123", nil).
-			On("ValidateToken", mock.Anything, "token123").
-			Return(true, nil).
-			On("GetUserFromToken", mock.Anything, "token123").
-			Return(user, nil).
-			Once()
-
-		body := MFARequest{MFACode: "123456", ReCAPTCHAToken: "token", RememberMe: true}
+		body := MFARequest{MFACode: mfaCode, ReCAPTCHAToken: reCAPTCHAToken, RememberMe: true}
+		validateMFASetup(deviceID, mfaCode, body.RememberMe)
+		userRoleLookupSetup(roleManagerMock, jwtManagerMock, user, true, userToken)
 
 		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
 		req.Header.Set(DeviceIDHeader, deviceID)
@@ -293,7 +268,33 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 		require.JSONEq(t, `{"token": "token123"}`, rw.Body.String())
 
 		// validate logs
-		require.Contains(t, buf.String(), "[UserLogin] - Logged in user with account ID user-id")
+		require.Contains(t, buf.String(), "[UserLogin] - Logged in user with account ID userID")
+	})
+
+	t.Run("Test MFA validation successful", func(t *testing.T) {
+		buf := new(strings.Builder)
+		log.DefaultLogger.SetOutput(buf)
+		log.SetLevel(log.InfoLevel)
+
+		body := MFARequest{MFACode: mfaCode, ReCAPTCHAToken: reCAPTCHAToken, RememberMe: true}
+		validateMFASetup(deviceID, mfaCode, body.RememberMe)
+		userRoleLookupSetup(roleManagerMock, jwtManagerMock, user, false, userToken)
+		reCAPTCHAValidatorMock.
+			On("IsTokenValid", mock.Anything, reCAPTCHAToken).
+			Return(true, nil).
+			Once()
+
+		req := httptest.NewRequest(http.MethodPost, mfaEndpoint, requestToJSON(t, &body))
+		req.Header.Set(DeviceIDHeader, deviceID)
+		rw := httptest.NewRecorder()
+
+		mfaHandler.ServeHTTP(rw, req)
+
+		require.Equal(t, http.StatusOK, rw.Code)
+		require.JSONEq(t, `{"token": "token123"}`, rw.Body.String())
+
+		// validate logs
+		require.Contains(t, buf.String(), "[UserLogin] - Logged in user with account ID userID")
 	})
 
 	authenticatorMock.AssertExpectations(t)

--- a/internal/serve/httphandler/user_handler.go
+++ b/internal/serve/httphandler/user_handler.go
@@ -99,9 +99,6 @@ func (upr UpdateRolesRequest) validate() *httperror.HTTPError {
 }
 
 func validateRoles(validator *validators.Validator, roles []data.UserRole) {
-	// NOTE: in the MVP, users should have only one role.
-	validator.Check(len(roles) == 1, "roles", "the number of roles required is exactly one")
-
 	// Validating the role of the request is a valid value
 	if _, ok := validator.Errors["roles"]; !ok {
 		role := roles[0]

--- a/internal/serve/httphandler/user_handler.go
+++ b/internal/serve/httphandler/user_handler.go
@@ -99,6 +99,7 @@ func (upr UpdateRolesRequest) validate() *httperror.HTTPError {
 }
 
 func validateRoles(validator *validators.Validator, roles []data.UserRole) {
+	validator.Check(len(roles) >= 1, "roles", "the number of roles required is greater than or equal to 1")
 	// Validating the role of the request is a valid value
 	if _, ok := validator.Errors["roles"]; !ok {
 		role := roles[0]

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -502,14 +502,6 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		var expectedRolesStr string
-		for i, role := range data.GetAllRoles() {
-			expectedRolesStr += role.String()
-			if i != len(data.GetAllRoles())-1 {
-				expectedRolesStr += " "
-			}
-		}
-
 		wantsBody = fmt.Sprintf(`
 			{
 				"error": "Request invalid",
@@ -517,7 +509,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [%s]"
 				}
 			}
-		`, expectedRolesStr)
+		`, enumerateRolesInString())
 
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
@@ -1094,14 +1086,6 @@ func Test_UserHandler_UpdateUserRoles(t *testing.T) {
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		var expectedRolesStr string
-		for i, role := range data.GetAllRoles() {
-			expectedRolesStr += role.String()
-			if i != len(data.GetAllRoles())-1 {
-				expectedRolesStr += " "
-			}
-		}
-
 		wantsBody = fmt.Sprintf(`
 			{
 				"error": "Request invalid",
@@ -1109,7 +1093,7 @@ func Test_UserHandler_UpdateUserRoles(t *testing.T) {
 					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [%s]"
 				}
 			}
-		`, expectedRolesStr)
+		`, enumerateRolesInString())
 
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
@@ -1720,4 +1704,16 @@ func Test_UserHandler_GetAllUsers(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
 	})
+}
+
+func enumerateRolesInString() string {
+	var rolesStr string
+	for i, role := range data.GetAllRoles() {
+		rolesStr += role.String()
+		if i != len(data.GetAllRoles())-1 {
+			rolesStr += " "
+		}
+	}
+
+	return rolesStr
 }

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -3,6 +3,7 @@ package httphandler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -501,14 +502,22 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		wantsBody = `
+		var expectedRolesStr string
+		for i, role := range data.GetAllRoles() {
+			expectedRolesStr += role.String()
+			if i != len(data.GetAllRoles())-1 {
+				expectedRolesStr += " "
+			}
+		}
+
+		wantsBody = fmt.Sprintf(`
 			{
 				"error": "Request invalid",
 				"extras": {
-					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [owner financial_controller developer business]"
+					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [%s]"
 				}
 			}
-		`
+		`, expectedRolesStr)
 
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))
@@ -1085,14 +1094,22 @@ func Test_UserHandler_UpdateUserRoles(t *testing.T) {
 		respBody, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		wantsBody = `
+		var expectedRolesStr string
+		for i, role := range data.GetAllRoles() {
+			expectedRolesStr += role.String()
+			if i != len(data.GetAllRoles())-1 {
+				expectedRolesStr += " "
+			}
+		}
+
+		wantsBody = fmt.Sprintf(`
 			{
 				"error": "Request invalid",
 				"extras": {
-					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [owner financial_controller developer business]"
+					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [%s]"
 				}
 			}
-		`
+		`, expectedRolesStr)
 
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.JSONEq(t, wantsBody, string(respBody))

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -234,7 +234,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.Get("/{id}", statisticsHandler.GetStatisticsByDisbursement)
 		})
 
-		r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole)).Route("/users", func(r chi.Router) {
+		r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole)).Route("/users", func(r chi.Router) {
 			userHandler := httphandler.UserHandler{
 				AuthManager:        authManager,
 				CrashTrackerClient: o.CrashTrackerClient,
@@ -264,29 +264,29 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 					DistributionAccountService: o.DistributionAccountService,
 				},
 			}
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Post("/", handler.PostDisbursement)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Post("/{id}/instructions", handler.PostDisbursementInstructions)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Get("/{id}/instructions", handler.GetDisbursementInstructions)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/", handler.GetDisbursements)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/{id}", handler.GetDisbursement)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/{id}/receivers", handler.GetDisbursementReceivers)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/{id}/status", handler.PatchDisbursementStatus)
 		})
 
-		r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).Route("/payments", func(r chi.Router) {
+		r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).Route("/payments", func(r chi.Router) {
 			paymentsHandler := httphandler.PaymentsHandler{
 				Models:                      o.Models,
 				DBConnectionPool:            o.MtnDBConnectionPool,
@@ -298,22 +298,22 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.Get("/", paymentsHandler.GetPayments)
 			r.Get("/{id}", paymentsHandler.GetPayment)
 			r.Patch("/retry", paymentsHandler.RetryPayments)
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/{id}/status", paymentsHandler.PatchPaymentStatus)
 		})
 
 		r.Route("/receivers", func(r chi.Router) {
 			receiversHandler := httphandler.ReceiverHandler{Models: o.Models, DBConnectionPool: o.MtnDBConnectionPool}
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/", receiversHandler.GetReceivers)
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/{id}", receiversHandler.GetReceiver)
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
 				Get("/verification-types", receiversHandler.GetReceiverVerificationTypes)
 
 			updateReceiverHandler := httphandler.UpdateReceiverHandler{Models: o.Models, DBConnectionPool: o.MtnDBConnectionPool}
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/{id}", updateReceiverHandler.UpdateReceiver)
 
 			receiverWalletHandler := httphandler.ReceiverWalletsHandler{
@@ -321,7 +321,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				CrashTrackerClient: o.CrashTrackerClient,
 				EventProducer:      o.EventProducer,
 			}
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/wallets/{receiver_wallet_id}", receiverWalletHandler.RetryInvitation)
 		})
 
@@ -338,11 +338,11 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
 				Get("/", assetsHandler.GetAssets)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.DeveloperUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.DeveloperUserRole)).
 				Post("/", assetsHandler.CreateAsset)
 
 			r.Route("/{id}", func(r chi.Router) {
-				r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.DeveloperUserRole)).Delete("/", assetsHandler.DeleteAsset)
+				r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.DeveloperUserRole)).Delete("/", assetsHandler.DeleteAsset)
 			})
 		})
 
@@ -353,7 +353,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				Post("/", walletsHandler.PostWallets)
 			r.With(middleware.AnyRoleMiddleware(authManager, data.DeveloperUserRole)).
 				Delete("/{id}", walletsHandler.DeleteWallet)
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole)).
 				Patch("/{id}", walletsHandler.PatchWallets)
 		})
 
@@ -378,7 +378,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		})
 
 		r.Route("/organization", func(r chi.Router) {
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/", profileHandler.PatchOrganizationProfile)
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
@@ -387,7 +387,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
 				Get("/logo", profileHandler.GetOrganizationLogo)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole)).
 				Patch("/circle-config", httphandler.CircleConfigHandler{
 					NetworkType:                 o.NetworkType,
 					CircleFactory:               circle.NewClient,

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -228,7 +228,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		r.Use(middleware.AuthenticateMiddleware(authManager, o.tenantManager))
 		r.Use(middleware.EnsureTenantMiddleware)
 
-		r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).Route("/statistics", func(r chi.Router) {
+		r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).Route("/statistics", func(r chi.Router) {
 			statisticsHandler := httphandler.StatisticsHandler{DBConnectionPool: o.MtnDBConnectionPool}
 			r.Get("/", statisticsHandler.GetStatistics)
 			r.Get("/{id}", statisticsHandler.GetStatisticsByDisbursement)
@@ -309,7 +309,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/{id}", receiversHandler.GetReceiver)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).
 				Get("/verification-types", receiversHandler.GetReceiverVerificationTypes)
 
 			updateReceiverHandler := httphandler.UpdateReceiverHandler{Models: o.Models, DBConnectionPool: o.MtnDBConnectionPool}
@@ -325,7 +325,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				Patch("/wallets/{receiver_wallet_id}", receiverWalletHandler.RetryInvitation)
 		})
 
-		r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).Route("/countries", func(r chi.Router) {
+		r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).Route("/countries", func(r chi.Router) {
 			r.Get("/", httphandler.CountriesHandler{Models: o.Models}.GetCountries)
 		})
 
@@ -335,7 +335,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				SubmitterEngine: o.SubmitterEngine,
 			}
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).
 				Get("/", assetsHandler.GetAssets)
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.DeveloperUserRole)).
@@ -346,7 +346,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			})
 		})
 
-		r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).Route("/wallets", func(r chi.Router) {
+		r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).Route("/wallets", func(r chi.Router) {
 			walletsHandler := httphandler.WalletsHandler{Models: o.Models}
 			r.Get("/", walletsHandler.GetWallets)
 			r.With(middleware.AnyRoleMiddleware(authManager, data.DeveloperUserRole)).
@@ -367,13 +367,13 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			PublicFilesFS:               publicfiles.PublicFiles,
 		}
 		r.Route("/profile", func(r chi.Router) {
-			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).
 				Get("/", profileHandler.GetProfile)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).
 				Patch("/", profileHandler.PatchUserProfile)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).
 				Patch("/reset-password", profileHandler.PatchUserPassword)
 		})
 
@@ -381,10 +381,10 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/", profileHandler.PatchOrganizationProfile)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).
 				Get("/", profileHandler.GetOrganizationInfo)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllBusinessRoles()...)).
 				Get("/logo", profileHandler.GetOrganizationLogo)
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole)).

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -234,7 +234,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.Get("/{id}", statisticsHandler.GetStatisticsByDisbursement)
 		})
 
-		r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole)).Route("/users", func(r chi.Router) {
+		r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole)).Route("/users", func(r chi.Router) {
 			userHandler := httphandler.UserHandler{
 				AuthManager:        authManager,
 				CrashTrackerClient: o.CrashTrackerClient,
@@ -264,29 +264,29 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 					DistributionAccountService: o.DistributionAccountService,
 				},
 			}
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Post("/", handler.PostDisbursement)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Post("/{id}/instructions", handler.PostDisbursementInstructions)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Get("/{id}/instructions", handler.GetDisbursementInstructions)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/", handler.GetDisbursements)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/{id}", handler.GetDisbursement)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/{id}/receivers", handler.GetDisbursementReceivers)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/{id}/status", handler.PatchDisbursementStatus)
 		})
 
-		r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).Route("/payments", func(r chi.Router) {
+		r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).Route("/payments", func(r chi.Router) {
 			paymentsHandler := httphandler.PaymentsHandler{
 				Models:                      o.Models,
 				DBConnectionPool:            o.MtnDBConnectionPool,
@@ -298,22 +298,22 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.Get("/", paymentsHandler.GetPayments)
 			r.Get("/{id}", paymentsHandler.GetPayment)
 			r.Patch("/retry", paymentsHandler.RetryPayments)
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/{id}/status", paymentsHandler.PatchPaymentStatus)
 		})
 
 		r.Route("/receivers", func(r chi.Router) {
 			receiversHandler := httphandler.ReceiverHandler{Models: o.Models, DBConnectionPool: o.MtnDBConnectionPool}
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/", receiversHandler.GetReceivers)
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole)).
 				Get("/{id}", receiversHandler.GetReceiver)
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
 				Get("/verification-types", receiversHandler.GetReceiverVerificationTypes)
 
 			updateReceiverHandler := httphandler.UpdateReceiverHandler{Models: o.Models, DBConnectionPool: o.MtnDBConnectionPool}
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/{id}", updateReceiverHandler.UpdateReceiver)
 
 			receiverWalletHandler := httphandler.ReceiverWalletsHandler{
@@ -321,7 +321,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				CrashTrackerClient: o.CrashTrackerClient,
 				EventProducer:      o.EventProducer,
 			}
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/wallets/{receiver_wallet_id}", receiverWalletHandler.RetryInvitation)
 		})
 
@@ -338,11 +338,11 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
 				Get("/", assetsHandler.GetAssets)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.DeveloperUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.DeveloperUserRole)).
 				Post("/", assetsHandler.CreateAsset)
 
 			r.Route("/{id}", func(r chi.Router) {
-				r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.DeveloperUserRole)).Delete("/", assetsHandler.DeleteAsset)
+				r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole, data.DeveloperUserRole)).Delete("/", assetsHandler.DeleteAsset)
 			})
 		})
 
@@ -353,7 +353,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				Post("/", walletsHandler.PostWallets)
 			r.With(middleware.AnyRoleMiddleware(authManager, data.DeveloperUserRole)).
 				Delete("/{id}", walletsHandler.DeleteWallet)
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole)).
 				Patch("/{id}", walletsHandler.PatchWallets)
 		})
 
@@ -378,7 +378,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		})
 
 		r.Route("/organization", func(r chi.Router) {
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/", profileHandler.PatchOrganizationProfile)
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
@@ -387,7 +387,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
 				Get("/logo", profileHandler.GetOrganizationLogo)
 
-			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole)).
+			r.With(middleware.AnyRoleMiddleware(authManager, data.APIOwnerUserRole, data.OwnerUserRole)).
 				Patch("/circle-config", httphandler.CircleConfigHandler{
 					NetworkType:                 o.NetworkType,
 					CircleFactory:               circle.NewClient,

--- a/internal/serve/validators/recaptcha.go
+++ b/internal/serve/validators/recaptcha.go
@@ -89,8 +89,8 @@ func NewGoogleReCAPTCHAValidator(siteSecretKey string, httpClient HTTPClient) *G
 	}
 }
 
-func UserRoleCanBypassReCAPTCHA(ctx context.Context, authManager auth.AuthManager, token string) (bool, error) {
-	canBypass, err := authManager.AnyRolesInTokenUser(ctx, token, []string{data.APIOwnerUserRole.String()})
+func TokenUserRoleCanBypassReCAPTCHA(ctx context.Context, authManager auth.AuthManager, token string) (bool, error) {
+	canBypass, err := authManager.AnyRolesInTokenUser(ctx, token, []string{data.APIUserRole.String()})
 	if err != nil {
 		return false, fmt.Errorf("error getting roles from token: %w", err)
 	}

--- a/internal/serve/validators/recaptcha.go
+++ b/internal/serve/validators/recaptcha.go
@@ -7,6 +7,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
 
 const (
@@ -84,4 +87,13 @@ func NewGoogleReCAPTCHAValidator(siteSecretKey string, httpClient HTTPClient) *G
 		VerifyTokenURL: verifyTokenURL,
 		HTTPClient:     httpClient,
 	}
+}
+
+func UserRoleCanBypassReCAPTCHA(ctx context.Context, authManager auth.AuthManager, token string) (bool, error) {
+	canBypass, err := authManager.AllRolesInTokenUser(ctx, token, []string{data.APIOwnerUserRole.String()})
+	if err != nil {
+		return false, fmt.Errorf("error getting roles from token: %w", err)
+	}
+
+	return canBypass, nil
 }

--- a/internal/serve/validators/recaptcha.go
+++ b/internal/serve/validators/recaptcha.go
@@ -7,9 +7,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
 
 const (
@@ -87,13 +84,4 @@ func NewGoogleReCAPTCHAValidator(siteSecretKey string, httpClient HTTPClient) *G
 		VerifyTokenURL: verifyTokenURL,
 		HTTPClient:     httpClient,
 	}
-}
-
-func TokenUserRoleCanBypassReCAPTCHA(ctx context.Context, authManager auth.AuthManager, token string) (bool, error) {
-	canBypass, err := authManager.AnyRolesInTokenUser(ctx, token, []string{data.APIUserRole.String()})
-	if err != nil {
-		return false, fmt.Errorf("error getting roles from token: %w", err)
-	}
-
-	return canBypass, nil
 }

--- a/internal/serve/validators/recaptcha.go
+++ b/internal/serve/validators/recaptcha.go
@@ -90,7 +90,7 @@ func NewGoogleReCAPTCHAValidator(siteSecretKey string, httpClient HTTPClient) *G
 }
 
 func UserRoleCanBypassReCAPTCHA(ctx context.Context, authManager auth.AuthManager, token string) (bool, error) {
-	canBypass, err := authManager.AllRolesInTokenUser(ctx, token, []string{data.APIOwnerUserRole.String()})
+	canBypass, err := authManager.AnyRolesInTokenUser(ctx, token, []string{data.APIOwnerUserRole.String()})
 	if err != nil {
 		return false, fmt.Errorf("error getting roles from token: %w", err)
 	}

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -328,6 +328,12 @@ func (am *defaultAuthManager) GetUserByEmail(ctx context.Context, email string) 
 		return nil, fmt.Errorf("getting user with email: %w", err)
 	}
 
+	roles, err := am.roleManager.GetUserRoles(ctx, user)
+	if err != nil {
+		return nil, fmt.Errorf("getting user ID %s roles: %w", user.ID, err)
+	}
+	user.Roles = roles
+
 	return user, nil
 }
 

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -23,6 +23,7 @@ type AuthManager interface {
 	GetUser(ctx context.Context, tokenString string) (*User, error)
 	GetUsersByID(ctx context.Context, userIDs []string) ([]*User, error)
 	GetUserByEmail(ctx context.Context, userID string) (*User, error)
+	GetUserByMFA(ctx context.Context, deviceID string) (*User, error)
 	GetUserID(ctx context.Context, tokenString string) (string, error)
 	GetTenantID(ctx context.Context, tokenString string) (string, error)
 	GetAllUsers(ctx context.Context, tokenString string) ([]User, error)
@@ -326,6 +327,26 @@ func (am *defaultAuthManager) GetUserByEmail(ctx context.Context, email string) 
 	user, err := am.authenticator.GetUserByEmail(ctx, email)
 	if err != nil {
 		return nil, fmt.Errorf("getting user with email: %w", err)
+	}
+
+	roles, err := am.roleManager.GetUserRoles(ctx, user)
+	if err != nil {
+		return nil, fmt.Errorf("getting user ID %s roles: %w", user.ID, err)
+	}
+	user.Roles = roles
+
+	return user, nil
+}
+
+func (am *defaultAuthManager) GetUserByMFA(ctx context.Context, deviceID string) (*User, error) {
+	userID, err := am.mfaManager.GetAuthUserID(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("getting user with MFA device ID: %w", err)
+	}
+
+	user, err := am.authenticator.GetUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("getting user ID %s: %w", userID, err)
 	}
 
 	roles, err := am.roleManager.GetUserRoles(ctx, user)

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -22,6 +22,7 @@ type AuthManager interface {
 	UpdatePassword(ctx context.Context, token, currentPassword, newPassword string) error
 	GetUser(ctx context.Context, tokenString string) (*User, error)
 	GetUsersByID(ctx context.Context, userIDs []string) ([]*User, error)
+	GetUserByEmail(ctx context.Context, userID string) (*User, error)
 	GetUserID(ctx context.Context, tokenString string) (string, error)
 	GetTenantID(ctx context.Context, tokenString string) (string, error)
 	GetAllUsers(ctx context.Context, tokenString string) ([]User, error)
@@ -319,6 +320,15 @@ func (am *defaultAuthManager) GetUsersByID(ctx context.Context, userIDs []string
 	}
 
 	return users, nil
+}
+
+func (am *defaultAuthManager) GetUserByEmail(ctx context.Context, email string) (*User, error) {
+	user, err := am.authenticator.GetUserByEmail(ctx, email)
+	if err != nil {
+		return nil, fmt.Errorf("getting user with email: %w", err)
+	}
+
+	return user, nil
 }
 
 func (am *defaultAuthManager) GetTenantID(ctx context.Context, tokenString string) (string, error) {

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -341,7 +341,7 @@ func (am *defaultAuthManager) GetUserByEmail(ctx context.Context, email string) 
 func (am *defaultAuthManager) GetUserByMFA(ctx context.Context, deviceID string) (*User, error) {
 	userID, err := am.mfaManager.GetAuthUserID(ctx, deviceID)
 	if err != nil {
-		return nil, fmt.Errorf("getting user with MFA device ID: %w", err)
+		return nil, fmt.Errorf("getting user with MFA device ID %s: %w", deviceID, err)
 	}
 
 	user, err := am.authenticator.GetUser(ctx, userID)

--- a/stellar-auth/pkg/auth/auth_test.go
+++ b/stellar-auth/pkg/auth/auth_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 )
 
 func Test_AuthManager_Authenticate(t *testing.T) {

--- a/stellar-auth/pkg/auth/auth_test.go
+++ b/stellar-auth/pkg/auth/auth_test.go
@@ -1461,7 +1461,7 @@ func Test_AuthManager_GetUserByEmail(t *testing.T) {
 	roleManagerMock.AssertExpectations(t)
 }
 
-func Test_AuthManager_GetUserByMFA(t *testing.T) {
+func Test_AuthManager_GetUserByDeviceID(t *testing.T) {
 	authenticatorMock := &AuthenticatorMock{}
 	roleManagerMock := &RoleManagerMock{}
 	mfaManagerMock := &MFAManagerMock{}
@@ -1483,35 +1483,29 @@ func Test_AuthManager_GetUserByMFA(t *testing.T) {
 	t.Run("returns error when MFA manager fails to find device by ID", func(t *testing.T) {
 		invalidDeviceID := "invalid-device"
 
-		mfaManagerMock.On("GetAuthUserID", ctx, invalidDeviceID).Return("", ErrMFADeviceNotFound).Once()
-		_, err := authManager.GetUserByMFA(ctx, invalidDeviceID)
+		mfaManagerMock.On("GetUserID", ctx, invalidDeviceID).Return("", ErrMFADeviceIDNotFound).Once()
+		_, err := authManager.GetUserByDeviceID(ctx, invalidDeviceID)
 
-		require.EqualError(t, err, fmt.Sprintf("getting user with MFA device ID %s: MFA device not found", invalidDeviceID))
+		require.EqualError(t, err, fmt.Sprintf("getting user with MFA device ID %s: MFA device ID not found", invalidDeviceID))
 	})
 
 	t.Run("returns error when authenticator fails to find user", func(t *testing.T) {
-		mfaManagerMock.On("GetAuthUserID", ctx, deviceID).Return(expectedUser.ID, nil).Once()
+		mfaManagerMock.On("GetUserID", ctx, deviceID).Return(expectedUser.ID, nil).Once()
 		authenticatorMock.On("GetUser", ctx, expectedUser.ID).Return(nil, ErrUserNotFound).Once()
-		_, err := authManager.GetUserByMFA(ctx, deviceID)
+		_, err := authManager.GetUserByDeviceID(ctx, deviceID)
 
 		require.EqualError(t, err, fmt.Sprintf("getting user ID %s: user not found", expectedUser.ID))
 	})
 
-	t.Run("returns error when role manager fails to get user roles", func(t *testing.T) {
-		mfaManagerMock.On("GetAuthUserID", ctx, deviceID).Return(expectedUser.ID, nil).Once()
-		authenticatorMock.On("GetUser", ctx, expectedUser.ID).Return(expectedUser, nil).Once()
-		roleManagerMock.On("GetUserRoles", ctx, expectedUser).Return(nil, errUnexpectedError).Once()
-		_, err := authManager.GetUserByMFA(ctx, deviceID)
-
-		require.EqualError(t, err, fmt.Sprintf("getting user ID %s roles: %s", expectedUser.ID, errUnexpectedError.Error()))
-	})
-
 	t.Run("gets user by MFA successfully", func(t *testing.T) {
-		expectedRoles := []string{data.OwnerUserRole.String()}
-		mfaManagerMock.On("GetAuthUserID", ctx, deviceID).Return(expectedUser.ID, nil).Once()
+		expectedUser = &User{
+			ID:    "user-id",
+			Email: "valid-email@email.com",
+			Roles: []string{data.OwnerUserRole.String()},
+		}
+		mfaManagerMock.On("GetUserID", ctx, deviceID).Return(expectedUser.ID, nil).Once()
 		authenticatorMock.On("GetUser", ctx, expectedUser.ID).Return(expectedUser, nil).Once()
-		roleManagerMock.On("GetUserRoles", ctx, expectedUser).Return(expectedRoles, nil).Once()
-		user, err := authManager.GetUserByMFA(ctx, deviceID)
+		user, err := authManager.GetUserByDeviceID(ctx, deviceID)
 
 		require.NoError(t, err)
 		require.Equal(t, expectedUser, user)

--- a/stellar-auth/pkg/auth/auth_test.go
+++ b/stellar-auth/pkg/auth/auth_test.go
@@ -1424,22 +1424,22 @@ func Test_AuthManager_GetUserByEmail(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("returns error when authenticator fails to find user by email", func(t *testing.T) {
-		email := "invalid-email@email.com"
+	email := "valid-email@email.com"
+	expectedUser := &User{
+		ID:    "user-id",
+		Email: email,
+	}
 
-		authenticatorMock.On("GetUserByEmail", ctx, email).Return(nil, ErrUserNotFound).Once()
-		_, err := authManager.GetUserByEmail(ctx, email)
+	t.Run("returns error when authenticator fails to find user by email", func(t *testing.T) {
+		invalidEmail := "invalid-email@email.com"
+
+		authenticatorMock.On("GetUserByEmail", ctx, invalidEmail).Return(nil, ErrUserNotFound).Once()
+		_, err := authManager.GetUserByEmail(ctx, invalidEmail)
 
 		require.EqualError(t, err, "getting user with email: user not found")
 	})
 
 	t.Run("returns error when role manager fails to get user roles", func(t *testing.T) {
-		email := "valid-email@email.com"
-
-		expectedUser := &User{
-			ID:    "user-id",
-			Email: email,
-		}
 		authenticatorMock.On("GetUserByEmail", ctx, email).Return(expectedUser, nil).Once()
 		roleManagerMock.On("GetUserRoles", ctx, expectedUser).Return(nil, errUnexpectedError).Once()
 		_, err := authManager.GetUserByEmail(ctx, email)
@@ -1448,11 +1448,6 @@ func Test_AuthManager_GetUserByEmail(t *testing.T) {
 	})
 
 	t.Run("gets user by email successfully", func(t *testing.T) {
-		email := "valid-email@email.com"
-		expectedUser := &User{
-			ID:    "user-id",
-			Email: email,
-		}
 		expectedRoles := []string{data.OwnerUserRole.String()}
 		authenticatorMock.On("GetUserByEmail", ctx, email).Return(expectedUser, nil).Once()
 		roleManagerMock.On("GetUserRoles", ctx, expectedUser).Return(expectedRoles, nil).Once()
@@ -1480,6 +1475,11 @@ func Test_AuthManager_GetUserByMFA(t *testing.T) {
 	ctx := context.Background()
 	deviceID := "device-ABC"
 
+	expectedUser := &User{
+		ID:    "user-id",
+		Email: "valid-email@email.com",
+	}
+
 	t.Run("returns error when MFA manager fails to find device by ID", func(t *testing.T) {
 		invalidDeviceID := "invalid-device"
 
@@ -1490,10 +1490,6 @@ func Test_AuthManager_GetUserByMFA(t *testing.T) {
 	})
 
 	t.Run("returns error when authenticator fails to find user", func(t *testing.T) {
-		expectedUser := &User{
-			ID:    "user-id",
-			Email: "valid-email@email.com",
-		}
 		mfaManagerMock.On("GetAuthUserID", ctx, deviceID).Return(expectedUser.ID, nil).Once()
 		authenticatorMock.On("GetUser", ctx, expectedUser.ID).Return(nil, ErrUserNotFound).Once()
 		_, err := authManager.GetUserByMFA(ctx, deviceID)
@@ -1502,12 +1498,6 @@ func Test_AuthManager_GetUserByMFA(t *testing.T) {
 	})
 
 	t.Run("returns error when role manager fails to get user roles", func(t *testing.T) {
-		email := "valid-email@email.com"
-
-		expectedUser := &User{
-			ID:    "user-id",
-			Email: email,
-		}
 		mfaManagerMock.On("GetAuthUserID", ctx, deviceID).Return(expectedUser.ID, nil).Once()
 		authenticatorMock.On("GetUser", ctx, expectedUser.ID).Return(expectedUser, nil).Once()
 		roleManagerMock.On("GetUserRoles", ctx, expectedUser).Return(nil, errUnexpectedError).Once()
@@ -1517,10 +1507,6 @@ func Test_AuthManager_GetUserByMFA(t *testing.T) {
 	})
 
 	t.Run("gets user by MFA successfully", func(t *testing.T) {
-		expectedUser := &User{
-			ID:    "user-id",
-			Email: "valid-email@email.com",
-		}
 		expectedRoles := []string{data.OwnerUserRole.String()}
 		mfaManagerMock.On("GetAuthUserID", ctx, deviceID).Return(expectedUser.ID, nil).Once()
 		authenticatorMock.On("GetUser", ctx, expectedUser.ID).Return(expectedUser, nil).Once()

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -66,6 +66,7 @@ func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, p
 			u.id,
 			u.first_name,
 			u.last_name,
+			u.encrypted_password
 		FROM
 			auth_users u
 		WHERE
@@ -540,7 +541,7 @@ func (a *defaultAuthenticator) GetUserByEmail(ctx context.Context, email string)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrUserNotFound
 		}
-		return nil, fmt.Errorf("error querying user email %s: %w", email, err)
+		return nil, fmt.Errorf("querying user email %s: %w", email, err)
 	}
 
 	return &User{

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -66,7 +66,7 @@ func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, p
 			u.id,
 			u.first_name,
 			u.last_name,
-			u.encrypted_password
+			u.encrypted_password,
 			u.roles
 		FROM
 			auth_users u

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -52,11 +52,12 @@ type defaultAuthenticator struct {
 }
 
 type authUser struct {
-	ID                string `db:"id"`
-	FirstName         string `db:"first_name"`
-	LastName          string `db:"last_name"`
-	Email             string `db:"email"`
-	EncryptedPassword string `db:"encrypted_password"`
+	ID                string         `db:"id"`
+	FirstName         string         `db:"first_name"`
+	LastName          string         `db:"last_name"`
+	Email             string         `db:"email"`
+	EncryptedPassword string         `db:"encrypted_password"`
+	Roles             pq.StringArray `db:"roles"`
 }
 
 func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, password string) (*User, error) {
@@ -66,6 +67,7 @@ func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, p
 			u.first_name,
 			u.last_name,
 			u.encrypted_password
+			u.roles
 		FROM
 			auth_users u
 		WHERE
@@ -95,6 +97,7 @@ func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, p
 		Email:     email,
 		FirstName: au.FirstName,
 		LastName:  au.LastName,
+		Roles:     au.Roles,
 	}, nil
 }
 
@@ -527,7 +530,8 @@ func (a *defaultAuthenticator) GetUserByEmail(ctx context.Context, email string)
 	const query = `
 		SELECT
 			id,
-			email
+			email,
+			roles
 		FROM
 			auth_users
 		WHERE
@@ -546,6 +550,7 @@ func (a *defaultAuthenticator) GetUserByEmail(ctx context.Context, email string)
 	return &User{
 		ID:    u.ID,
 		Email: email,
+		Roles: u.Roles,
 	}, nil
 }
 

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -52,12 +52,11 @@ type defaultAuthenticator struct {
 }
 
 type authUser struct {
-	ID                string         `db:"id"`
-	FirstName         string         `db:"first_name"`
-	LastName          string         `db:"last_name"`
-	Email             string         `db:"email"`
-	EncryptedPassword string         `db:"encrypted_password"`
-	Roles             pq.StringArray `db:"roles"`
+	ID                string `db:"id"`
+	FirstName         string `db:"first_name"`
+	LastName          string `db:"last_name"`
+	Email             string `db:"email"`
+	EncryptedPassword string `db:"encrypted_password"`
 }
 
 func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, password string) (*User, error) {
@@ -528,7 +527,7 @@ func (a *defaultAuthenticator) GetUserByEmail(ctx context.Context, email string)
 	const query = `
 		SELECT
 			id,
-			roles
+			email
 		FROM
 			auth_users
 		WHERE
@@ -547,7 +546,6 @@ func (a *defaultAuthenticator) GetUserByEmail(ctx context.Context, email string)
 	return &User{
 		ID:    u.ID,
 		Email: email,
-		Roles: u.Roles,
 	}, nil
 }
 

--- a/stellar-auth/pkg/auth/authenticator_test.go
+++ b/stellar-auth/pkg/auth/authenticator_test.go
@@ -1070,5 +1070,6 @@ func Test_DefaultAuthenticator_GetUserByEmail(t *testing.T) {
 
 		assert.Equal(t, randUser.ID, u.ID)
 		assert.Equal(t, randUser.Email, u.Email)
+		assert.Equal(t, randUser.Roles, u.Roles)
 	})
 }

--- a/stellar-auth/pkg/auth/authenticator_test.go
+++ b/stellar-auth/pkg/auth/authenticator_test.go
@@ -1070,6 +1070,5 @@ func Test_DefaultAuthenticator_GetUserByEmail(t *testing.T) {
 
 		assert.Equal(t, randUser.ID, u.ID)
 		assert.Equal(t, randUser.Email, u.Email)
-		assert.Equal(t, randUser.Roles, u.Roles)
 	})
 }

--- a/stellar-auth/pkg/auth/mfa_manager.go
+++ b/stellar-auth/pkg/auth/mfa_manager.go
@@ -197,7 +197,6 @@ func (m *defaultMFAManager) getByDeviceAndCode(ctx context.Context, deviceID, co
 	`
 	var mc mfaCode
 	err := m.dbConnectionPool.GetContext(ctx, &mc, query, deviceID, code)
-	log.Ctx(ctx).Info(deviceID, code)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrMFANoCodeForUserDevice

--- a/stellar-auth/pkg/auth/mfa_manager.go
+++ b/stellar-auth/pkg/auth/mfa_manager.go
@@ -19,7 +19,7 @@ type MFAManager interface {
 	GenerateMFACode(ctx context.Context, deviceID, userID string) (string, error)
 	ValidateMFACode(ctx context.Context, deviceID, code string) (string, error)
 	RememberDevice(ctx context.Context, deviceID, code string) error
-	GetAuthUserID(ctx context.Context, deviceID string) (string, error)
+	GetUserID(ctx context.Context, deviceID string) (string, error)
 }
 
 // defaultMFAManager
@@ -36,7 +36,7 @@ const (
 var (
 	ErrMFACodeInvalid         = errors.New("MFA code is invalid")
 	ErrMFANoCodeForUserDevice = errors.New("no MFA code for user and device")
-	ErrMFADeviceNotFound      = errors.New("MFA device not found")
+	ErrMFADeviceIDNotFound    = errors.New("MFA device ID not found")
 )
 
 type mfaCode struct {
@@ -149,7 +149,7 @@ func (m *defaultMFAManager) ForgetDevice(ctx context.Context, deviceID, userID s
 	return nil
 }
 
-func (m *defaultMFAManager) GetAuthUserID(ctx context.Context, deviceID string) (string, error) {
+func (m *defaultMFAManager) GetUserID(ctx context.Context, deviceID string) (string, error) {
 	if deviceID == "" {
 		return "", fmt.Errorf("device ID is required")
 	}
@@ -166,9 +166,9 @@ func (m *defaultMFAManager) GetAuthUserID(ctx context.Context, deviceID string) 
 	err := m.dbConnectionPool.GetContext(ctx, &userID, query, deviceID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", ErrMFADeviceNotFound
+			return "", ErrMFADeviceIDNotFound
 		}
-		return "", fmt.Errorf("error fetching user ID for device ID %s: %w", deviceID, err)
+		return "", fmt.Errorf("fetching user ID for device ID %s: %w", deviceID, err)
 	}
 
 	return userID, nil

--- a/stellar-auth/pkg/auth/mfa_manager.go
+++ b/stellar-auth/pkg/auth/mfa_manager.go
@@ -197,6 +197,7 @@ func (m *defaultMFAManager) getByDeviceAndCode(ctx context.Context, deviceID, co
 	`
 	var mc mfaCode
 	err := m.dbConnectionPool.GetContext(ctx, &mc, query, deviceID, code)
+	log.Ctx(ctx).Info(deviceID, code)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrMFANoCodeForUserDevice

--- a/stellar-auth/pkg/auth/mfa_manager_test.go
+++ b/stellar-auth/pkg/auth/mfa_manager_test.go
@@ -334,7 +334,7 @@ func Test_defaultMFAManager_ForgetDevice(t *testing.T) {
 	})
 }
 
-func Test_defaultMFAManager_GetAuthUserID(t *testing.T) {
+func Test_defaultMFAManager_GetUserID(t *testing.T) {
 	ctx := context.Background()
 
 	dbt := dbtest.Open(t)
@@ -352,12 +352,12 @@ func Test_defaultMFAManager_GetAuthUserID(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("returns error when device ID not found", func(t *testing.T) {
-		_, err = m.GetAuthUserID(ctx, "invalidDeviceID")
-		require.ErrorContains(t, err, "MFA device not found")
+		_, err = m.GetUserID(ctx, "invalidDeviceID")
+		require.ErrorContains(t, err, "MFA device ID not found")
 	})
 
 	t.Run("returns auth user ID when device ID is found", func(t *testing.T) {
-		userID, err := m.GetAuthUserID(ctx, testDeviceID)
+		userID, err := m.GetUserID(ctx, testDeviceID)
 		require.NoError(t, err)
 		assert.Equal(t, randUser.ID, userID)
 	})

--- a/stellar-auth/pkg/auth/mfa_manager_test.go
+++ b/stellar-auth/pkg/auth/mfa_manager_test.go
@@ -348,19 +348,15 @@ func Test_defaultMFAManager_GetAuthUserID(t *testing.T) {
 
 	m := newDefaultMFAManager(withMFADatabaseConnectionPool(dbConnectionPool))
 
-	_, err := m.GenerateMFACode(ctx, testDeviceID, randUser.ID)
+	_, err := m.generateAndUpdateMFACode(ctx, testDeviceID, randUser.ID)
 	require.NoError(t, err)
 
 	t.Run("returns error when device ID not found", func(t *testing.T) {
-		defer cleanup(t, ctx, dbConnectionPool)
-
 		_, err = m.GetAuthUserID(ctx, "invalidDeviceID")
 		require.ErrorContains(t, err, "MFA device not found")
 	})
 
 	t.Run("returns auth user ID when device ID is found", func(t *testing.T) {
-		defer cleanup(t, ctx, dbConnectionPool)
-
 		userID, err := m.GetAuthUserID(ctx, testDeviceID)
 		require.NoError(t, err)
 		assert.Equal(t, randUser.ID, userID)

--- a/stellar-auth/pkg/auth/mocks.go
+++ b/stellar-auth/pkg/auth/mocks.go
@@ -203,6 +203,11 @@ func (m *MFAManagerMock) RememberDevice(ctx context.Context, deviceID, code stri
 	return args.Error(0)
 }
 
+func (m *MFAManagerMock) GetAuthUserID(ctx context.Context, deviceID string) (string, error) {
+	args := m.Called(ctx, deviceID)
+	return args.Get(0).(string), args.Error(1)
+}
+
 var _ MFAManager = (*MFAManagerMock)(nil)
 
 // AuthManager
@@ -340,6 +345,14 @@ func (am *AuthManagerMock) GenerateMFACode(ctx context.Context, userID, deviceID
 func (am *AuthManagerMock) AuthenticateMFA(ctx context.Context, deviceID, code string, rememberMe bool) (string, error) {
 	args := am.Called(ctx, deviceID, code, rememberMe)
 	return args.Get(0).(string), args.Error(1)
+}
+
+func (am *AuthManagerMock) GetUserByMFA(ctx context.Context, userID string) (*User, error) {
+	args := am.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*User), args.Error(1)
 }
 
 var _ AuthManager = (*AuthManagerMock)(nil)

--- a/stellar-auth/pkg/auth/mocks.go
+++ b/stellar-auth/pkg/auth/mocks.go
@@ -134,6 +134,14 @@ func (am *AuthenticatorMock) GetUsers(ctx context.Context, userIDs []string) ([]
 	return args.Get(0).([]*User), args.Error(1)
 }
 
+func (am *AuthenticatorMock) GetUserByEmail(ctx context.Context, email string) (*User, error) {
+	args := am.Called(ctx, email)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*User), args.Error(1)
+}
+
 var _ Authenticator = (*AuthenticatorMock)(nil)
 
 type RoleManagerMock struct {
@@ -266,6 +274,14 @@ func (am *AuthManagerMock) GetUser(ctx context.Context, tokenString string) (*Us
 func (am *AuthManagerMock) GetUsersByID(ctx context.Context, tokenString []string) ([]*User, error) {
 	args := am.Called(ctx, tokenString)
 	return args.Get(0).([]*User), args.Error(1)
+}
+
+func (am *AuthManagerMock) GetUserByEmail(ctx context.Context, email string) (*User, error) {
+	args := am.Called(ctx, email)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*User), args.Error(1)
 }
 
 func (am *AuthManagerMock) GetUserID(ctx context.Context, userID string) (string, error) {

--- a/stellar-auth/pkg/auth/mocks.go
+++ b/stellar-auth/pkg/auth/mocks.go
@@ -203,7 +203,7 @@ func (m *MFAManagerMock) RememberDevice(ctx context.Context, deviceID, code stri
 	return args.Error(0)
 }
 
-func (m *MFAManagerMock) GetAuthUserID(ctx context.Context, deviceID string) (string, error) {
+func (m *MFAManagerMock) GetUserID(ctx context.Context, deviceID string) (string, error) {
 	args := m.Called(ctx, deviceID)
 	return args.Get(0).(string), args.Error(1)
 }
@@ -347,7 +347,7 @@ func (am *AuthManagerMock) AuthenticateMFA(ctx context.Context, deviceID, code s
 	return args.Get(0).(string), args.Error(1)
 }
 
-func (am *AuthManagerMock) GetUserByMFA(ctx context.Context, userID string) (*User, error) {
+func (am *AuthManagerMock) GetUserByDeviceID(ctx context.Context, userID string) (*User, error) {
 	args := am.Called(ctx, userID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)


### PR DESCRIPTION
### What
Completed:
- add role `APIUserRole` that could be concatenated with existing user roles to override reCAPTCHA validation
- local testing for all three endpoints `/login`, `/mfa`, and `/forgot-password` that would usually require reCAPTCHA validation normally
- fixes to existing unit tests and new tests for data access methods
- refactoring fixed unit tests to be less repetitive

##Tests
The following calls were made referring to users with the `api` role and without the recaptcha token in the request body

`/login`
request
```
{
    "email": "owner@bluecorp.local",
    "password": <REDACTED>
}
```
response
```
{
    "token": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoiOWI3OTI4MWEtY2E1OS00MDZjLWIwNmMtYTE3NWNhYmQ0ZDA5IiwiZmlyc3RfbmFtZSI6ImpvaG4iLCJsYXN0X25hbWUiOiJkb2UiLCJlbWFpbCI6Im93bmVyQGJsdWVjb3JwLmxvY2FsIiwiaXNfYWN0aXZlIjpmYWxzZSwicm9sZXMiOlsib3duZXIiXX0sInRlbmFudF9pZCI6ImFhYzFlY2ZjLTQzZDItNDlkYy1iMzE3LTJjOTA4MzRmMjM5YiIsImV4cCI6MTcyMTk0MTk2NH0.O_dDRFXGV9tWhE8gIuxSPn8SUMsmJphJkAyVYEQ-5CBMiZ3egKKMEe_BHZLfc3bp3TVhMMB4Dc4JjGNs-Ez2nw"
}
```

```
26e4ca25-94b7-40a0-97e4-31c4d7271826 | 9b79281a-ca59-406c-b06c-a175cabd4d09 |  123  | 2024-07-26 00:31:24.611207+00 | 2024-07-26 09:40:56.524779+00 | 2024-07-28 00:31:24.611207+00 |  
-- | -- | -- | -- | -- | -- | --
```

`/mfa`

request
```
{
    "mfa_code": "123",
    "remember_me": false
}
```

response
```
{
    "token": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoiOWI3OTI4MWEtY2E1OS00MDZjLWIwNmMtYTE3NWNhYmQ0ZDA5IiwiZmlyc3RfbmFtZSI6ImpvaG4iLCJsYXN0X25hbWUiOiJkb2UiLCJlbWFpbCI6Im93bmVyQGJsdWVjb3JwLmxvY2FsIiwiaXNfYWN0aXZlIjpmYWxzZSwicm9sZXMiOlsib3duZXIiXX0sInRlbmFudF9pZCI6ImFhYzFlY2ZjLTQzZDItNDlkYy1iMzE3LTJjOTA4MzRmMjM5YiIsImV4cCI6MTcyMTk1ODU0Nn0.aMqfzwTTt8tPTgbyyai5FurrWwol9LDnrI6KexnSPGshghGdtUlZCy_ssfGug96qS5D8RG3_qNnFW0-0lzGmpw"
}
```

`/forgot-password`
request
```
{
    "email": "owner@bluecorp.local"
}
```
response
```
{
    "message": "Password reset requested. If the email is registered, you'll receive a reset link shortly. Check your inbox and spam folders."
}
```

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
