### PR TITLE
[SDP-1282] Add `YEAR_MONTH` as a verification type

### DIFF
--- a/db/migrations/sdp-migrations/2024-07-29.0-add-verification-type-year-month.sql
+++ b/db/migrations/sdp-migrations/2024-07-29.0-add-verification-type-year-month.sql
@@ -1,0 +1,37 @@
+-- This migration updates the verification_field column in the receiver_verifications table to include a new verification type called 'YEAR_MONTH'.
+-- +migrate Up
+ALTER TYPE verification_type ADD VALUE 'YEAR_MONTH';
+
+-- +migrate Down
+-- Create new type
+CREATE TYPE verification_type_new AS ENUM ('DATE_OF_BIRTH', 'PIN', 'NATIONAL_ID_NUMBER');
+
+-- Add a new column with the new type (receiver_verifications & disbursements)
+ALTER TABLE receiver_verifications ADD COLUMN verification_field_new verification_type_new;
+ALTER TABLE disbursements ADD COLUMN verification_field_new verification_type_new;
+
+-- Copy & transform data (receiver_verifications & disbursements)
+UPDATE receiver_verifications SET verification_field_new = 
+CASE 
+    WHEN verification_field = 'YEAR_MONTH' THEN 'DATE_OF_BIRTH'::verification_type_new
+    ELSE verification_field::text::verification_type_new
+END;
+UPDATE disbursements SET verification_field_new = 
+CASE 
+    WHEN verification_field = 'YEAR_MONTH' THEN 'DATE_OF_BIRTH'::verification_type_new
+    ELSE verification_field::text::verification_type_new
+END;
+
+-- Drop the old column (receiver_verifications & disbursements)
+ALTER TABLE receiver_verifications DROP COLUMN verification_field;
+ALTER TABLE disbursements DROP COLUMN verification_field;
+
+-- Rename the new column (receiver_verifications & disbursements)
+ALTER TABLE receiver_verifications RENAME COLUMN verification_field_new TO verification_field;
+ALTER TABLE disbursements RENAME COLUMN verification_field_new TO verification_field;
+
+-- Drop old type
+DROP TYPE verification_type;
+
+-- Rename new type
+ALTER TYPE verification_type_new RENAME TO verification_type;

--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -56,6 +56,7 @@ type VerificationField string
 
 const (
 	VerificationFieldDateOfBirth VerificationField = "DATE_OF_BIRTH"
+	VerificationFieldYearMonth   VerificationField = "YEAR_MONTH"
 	VerificationFieldPin         VerificationField = "PIN"
 	VerificationFieldNationalID  VerificationField = "NATIONAL_ID_NUMBER"
 )
@@ -64,6 +65,7 @@ const (
 func GetAllVerificationFields() []VerificationField {
 	return []VerificationField{
 		VerificationFieldDateOfBirth,
+		VerificationFieldYearMonth,
 		VerificationFieldPin,
 		VerificationFieldNationalID,
 	}

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -87,10 +87,15 @@ func Test_ReceiverVerificationModel_GetAllByReceiverId(t *testing.T) {
 		})
 		verification2 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
+			VerificationField: VerificationFieldYearMonth,
+			VerificationValue: "1990-01",
+		})
+		verification3 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
+			ReceiverID:        receiver.ID,
 			VerificationField: VerificationFieldPin,
 			VerificationValue: "1234",
 		})
-		verification3 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
+		verification4 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
 			VerificationField: VerificationFieldNationalID,
 			VerificationValue: "5678",
@@ -99,7 +104,7 @@ func Test_ReceiverVerificationModel_GetAllByReceiverId(t *testing.T) {
 		receiverVerificationModel := ReceiverVerificationModel{}
 		actualVerifications, err := receiverVerificationModel.GetAllByReceiverId(ctx, dbConnectionPool, receiver.ID)
 		require.NoError(t, err)
-		assert.Len(t, actualVerifications, 3)
+		assert.Len(t, actualVerifications, 4)
 
 		assert.Equal(t, []ReceiverVerification{
 			{
@@ -111,17 +116,24 @@ func Test_ReceiverVerificationModel_GetAllByReceiverId(t *testing.T) {
 			},
 			{
 				ReceiverID:        receiver.ID,
-				VerificationField: VerificationFieldPin,
+				VerificationField: VerificationFieldYearMonth,
 				HashedValue:       verification2.HashedValue,
 				CreatedAt:         verification2.CreatedAt,
 				UpdatedAt:         verification2.UpdatedAt,
 			},
 			{
 				ReceiverID:        receiver.ID,
-				VerificationField: VerificationFieldNationalID,
+				VerificationField: VerificationFieldPin,
 				HashedValue:       verification3.HashedValue,
 				CreatedAt:         verification3.CreatedAt,
 				UpdatedAt:         verification3.UpdatedAt,
+			},
+			{
+				ReceiverID:        receiver.ID,
+				VerificationField: VerificationFieldNationalID,
+				HashedValue:       verification4.HashedValue,
+				CreatedAt:         verification4.CreatedAt,
+				UpdatedAt:         verification4.UpdatedAt,
 			},
 		}, actualVerifications)
 	})

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -158,12 +158,19 @@ func Test_ReceiverVerificationModel_GetReceiverVerificationByReceiverId(t *testi
 
 		verification2 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: VerificationFieldPin,
-			VerificationValue: "1234",
+			VerificationField: VerificationFieldYearMonth,
+			VerificationValue: "1990-01",
 		})
 		verification2.UpdatedAt = earlierTime
 
 		verification3 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
+			ReceiverID:        receiver.ID,
+			VerificationField: VerificationFieldPin,
+			VerificationValue: "1234",
+		})
+		verification3.UpdatedAt = earlierTime
+
+		verification4 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
 			VerificationField: VerificationFieldNationalID,
 			VerificationValue: "5678",
@@ -177,9 +184,9 @@ func Test_ReceiverVerificationModel_GetReceiverVerificationByReceiverId(t *testi
 			ReceiverVerification{
 				ReceiverID:        receiver.ID,
 				VerificationField: VerificationFieldNationalID,
-				HashedValue:       verification3.HashedValue,
-				CreatedAt:         verification3.CreatedAt,
-				UpdatedAt:         verification3.UpdatedAt,
+				HashedValue:       verification4.HashedValue,
+				CreatedAt:         verification4.CreatedAt,
+				UpdatedAt:         verification4.UpdatedAt,
 			}, *actualVerification)
 	})
 }

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -164,7 +164,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		want := `{"error":"Verification field invalid", "extras": {"verification_field": "invalid parameter. valid values are: DATE_OF_BIRTH, PIN, NATIONAL_ID_NUMBER"}}`
+		want := `{"error":"Verification field invalid", "extras": {"verification_field": "invalid parameter. valid values are: [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]"}}`
 
 		assertPOSTResponse(t, ctx, handler, method, url, string(requestBody), want, http.StatusBadRequest)
 	})

--- a/internal/serve/httphandler/receiver_handler_test.go
+++ b/internal/serve/httphandler/receiver_handler_test.go
@@ -1632,6 +1632,7 @@ func Test_ReceiverHandler_GetReceiverVerificatioTypes(t *testing.T) {
 	defer resp.Body.Close()
 	expectedBody := `[
 		"DATE_OF_BIRTH",
+		"YEAR_MONTH",
 		"PIN",
 		"NATIONAL_ID_NUMBER"
 	]`

--- a/internal/serve/httphandler/update_receiver_handler.go
+++ b/internal/serve/httphandler/update_receiver_handler.go
@@ -23,29 +23,27 @@ type UpdateReceiverHandler struct {
 
 func createVerificationInsert(updateReceiverInfo *validators.UpdateReceiverRequest, receiverID string) []data.ReceiverVerificationInsert {
 	receiverVerifications := []data.ReceiverVerificationInsert{}
-
-	if updateReceiverInfo.DateOfBirth != "" {
-		receiverVerifications = append(receiverVerifications, data.ReceiverVerificationInsert{
-			ReceiverID:        receiverID,
-			VerificationField: data.VerificationFieldDateOfBirth,
-			VerificationValue: updateReceiverInfo.DateOfBirth,
-		})
+	appendNewVerificationValue := func(verificationField data.VerificationField, verificationValue string) {
+		if verificationValue != "" {
+			receiverVerifications = append(receiverVerifications, data.ReceiverVerificationInsert{
+				ReceiverID:        receiverID,
+				VerificationField: verificationField,
+				VerificationValue: verificationValue,
+			})
+		}
 	}
 
-	if updateReceiverInfo.Pin != "" {
-		receiverVerifications = append(receiverVerifications, data.ReceiverVerificationInsert{
-			ReceiverID:        receiverID,
-			VerificationField: data.VerificationFieldPin,
-			VerificationValue: updateReceiverInfo.Pin,
-		})
-	}
-
-	if updateReceiverInfo.NationalID != "" {
-		receiverVerifications = append(receiverVerifications, data.ReceiverVerificationInsert{
-			ReceiverID:        receiverID,
-			VerificationField: data.VerificationFieldNationalID,
-			VerificationValue: updateReceiverInfo.NationalID,
-		})
+	for _, verificationField := range data.GetAllVerificationFields() {
+		switch verificationField {
+		case data.VerificationFieldDateOfBirth:
+			appendNewVerificationValue(verificationField, updateReceiverInfo.DateOfBirth)
+		case data.VerificationFieldYearMonth:
+			appendNewVerificationValue(verificationField, updateReceiverInfo.YearMonth)
+		case data.VerificationFieldPin:
+			appendNewVerificationValue(verificationField, updateReceiverInfo.Pin)
+		case data.VerificationFieldNationalID:
+			appendNewVerificationValue(verificationField, updateReceiverInfo.NationalID)
+		}
 	}
 
 	return receiverVerifications

--- a/internal/serve/httphandler/update_receiver_handler_test.go
+++ b/internal/serve/httphandler/update_receiver_handler_test.go
@@ -30,6 +30,12 @@ func Test_UpdateReceiverHandler_createVerificationInsert(t *testing.T) {
 		VerificationValue: "1999-01-01",
 	}
 
+	verificationYearMonth := data.ReceiverVerificationInsert{
+		ReceiverID:        receiverID,
+		VerificationField: data.VerificationFieldYearMonth,
+		VerificationValue: "1999-01",
+	}
+
 	verificationPIN := data.ReceiverVerificationInsert{
 		ReceiverID:        receiverID,
 		VerificationField: data.VerificationFieldPin,
@@ -56,6 +62,11 @@ func Test_UpdateReceiverHandler_createVerificationInsert(t *testing.T) {
 			name:                  "insert receiver verification date of birth",
 			updateReceiverRequest: validators.UpdateReceiverRequest{DateOfBirth: "1999-01-01"},
 			want:                  []data.ReceiverVerificationInsert{verificationDOB},
+		},
+		{
+			name:                  "insert receiver verification year month",
+			updateReceiverRequest: validators.UpdateReceiverRequest{YearMonth: "1999-01"},
+			want:                  []data.ReceiverVerificationInsert{verificationYearMonth},
 		},
 		{
 			name:                  "insert receiver verification pin",

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -237,7 +237,17 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			wantErrContains: "DATE_OF_BIRTH not found for receiver with phone number +38...333",
 		},
 		{
-			name:     "returns an error if the receiver does not have any receiverVerification row with the given verification type",
+			name:     "returns an error if the receiver does not have any receiverVerification row with the given verification type (YEAR_MONTH)",
+			receiver: *receiver,
+			registrationRequest: data.ReceiverRegistrationRequest{
+				PhoneNumber:       receiver.PhoneNumber,
+				VerificationType:  data.VerificationFieldYearMonth,
+				VerificationValue: "1999-12",
+			},
+			wantErrContains: "YEAR_MONTH not found for receiver with phone number +38...555",
+		},
+		{
+			name:     "returns an error if the receiver does not have any receiverVerification row with the given verification type (NATIONAL_ID_NUMBER)",
 			receiver: *receiver,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiver.PhoneNumber,

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -164,7 +164,7 @@ async function submitPhoneNumber(event) {
         verificationFieldInput.type = "date";
       }
       else if(verificationField === "YEAR_MONTH") {
-        verificationFieldTitle.textContent = "Year/Month";
+        verificationFieldTitle.textContent = "Date of birth (Year/Month)";
         verificationFieldInput.name = "year_month";
         verificationFieldInput.type = "month";
       }

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -163,6 +163,11 @@ async function submitPhoneNumber(event) {
         verificationFieldInput.name = "date_of_birth";
         verificationFieldInput.type = "date";
       }
+      else if(verificationField === "YEAR_MONTH") {
+        verificationFieldTitle.textContent = "Year/Month";
+        verificationFieldInput.name = "year_month";
+        verificationFieldInput.type = "month";
+      }
       else if(verificationField === "NATIONAL_ID_NUMBER") {
         verificationFieldTitle.textContent = "National ID number";
         verificationFieldInput.name = "national_id_number";

--- a/internal/serve/validators/disbursement_instructions_validator.go
+++ b/internal/serve/validators/disbursement_instructions_validator.go
@@ -42,6 +42,8 @@ func (iv *DisbursementInstructionsValidator) ValidateInstruction(instruction *da
 	switch iv.verificationField {
 	case data.VerificationFieldDateOfBirth:
 		iv.CheckError(utils.ValidateDateOfBirthVerification(verification), fmt.Sprintf("line %d - date of birth", lineNumber), "")
+	case data.VerificationFieldYearMonth:
+		iv.CheckError(utils.ValidateYearMonthVerification(verification), fmt.Sprintf("line %d - year/month", lineNumber), "")
 	case data.VerificationFieldPin:
 		iv.CheckError(utils.ValidatePinVerification(verification), fmt.Sprintf("line %d - pin", lineNumber), "")
 	case data.VerificationFieldNationalID:

--- a/internal/serve/validators/disbursement_request_validator.go
+++ b/internal/serve/validators/disbursement_request_validator.go
@@ -1,6 +1,11 @@
 package validators
 
-import "github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+import (
+	"fmt"
+	"slices"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+)
 
 type DisbursementRequestValidator struct {
 	verificationField data.VerificationField
@@ -16,11 +21,9 @@ func NewDisbursementRequestValidator(verificationField data.VerificationField) *
 
 // ValidateAndGetVerificationType validates if the verification type field is a valid value.
 func (dv *DisbursementRequestValidator) ValidateAndGetVerificationType() data.VerificationField {
-	switch dv.verificationField {
-	case data.VerificationFieldDateOfBirth, data.VerificationFieldPin, data.VerificationFieldNationalID:
-		return dv.verificationField
-	default:
-		dv.Check(false, "verification_field", "invalid parameter. valid values are: DATE_OF_BIRTH, PIN, NATIONAL_ID_NUMBER")
+	if !slices.Contains(data.GetAllVerificationFields(), dv.verificationField) {
+		dv.Check(false, "verification_field", fmt.Sprintf("invalid parameter. valid values are: %v", data.GetAllVerificationFields()))
 		return ""
 	}
+	return dv.verificationField
 }

--- a/internal/serve/validators/disbursement_request_validator_test.go
+++ b/internal/serve/validators/disbursement_request_validator_test.go
@@ -12,6 +12,7 @@ func Test_DisbursementRequestValidator_ValidateAndGetVerificationType(t *testing
 	t.Run("Valid verification type", func(t *testing.T) {
 		validField := []data.VerificationField{
 			data.VerificationFieldDateOfBirth,
+			data.VerificationFieldYearMonth,
 			data.VerificationFieldPin,
 			data.VerificationFieldNationalID,
 		}

--- a/internal/serve/validators/disbursement_request_validator_test.go
+++ b/internal/serve/validators/disbursement_request_validator_test.go
@@ -28,6 +28,6 @@ func Test_DisbursementRequestValidator_ValidateAndGetVerificationType(t *testing
 		actual := validator.ValidateAndGetVerificationType()
 		assert.Empty(t, actual)
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid parameter. valid values are: DATE_OF_BIRTH, PIN, NATIONAL_ID_NUMBER", validator.Errors["verification_field"])
+		assert.Equal(t, "invalid parameter. valid values are: [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]", validator.Errors["verification_field"])
 	})
 }

--- a/internal/serve/validators/receiver_registration_validator.go
+++ b/internal/serve/validators/receiver_registration_validator.go
@@ -43,6 +43,8 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 	switch vt {
 	case data.VerificationFieldDateOfBirth:
 		rv.CheckError(utils.ValidateDateOfBirthVerification(verification), "verification", "")
+	case data.VerificationFieldYearMonth:
+		rv.CheckError(utils.ValidateYearMonthVerification(verification), "verification", "")
 	case data.VerificationFieldPin:
 		rv.CheckError(utils.ValidatePinVerification(verification), "verification", "")
 	case data.VerificationFieldNationalID:

--- a/internal/serve/validators/receiver_registration_validator.go
+++ b/internal/serve/validators/receiver_registration_validator.go
@@ -1,6 +1,8 @@
 package validators
 
 import (
+	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
@@ -57,11 +59,9 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 func (rv *ReceiverRegistrationValidator) validateAndGetVerificationType(verificationType string) data.VerificationField {
 	vt := data.VerificationField(strings.ToUpper(verificationType))
 
-	switch vt {
-	case data.VerificationFieldDateOfBirth, data.VerificationFieldPin, data.VerificationFieldNationalID:
-		return vt
-	default:
-		rv.Check(false, "verification_type", "invalid parameter. valid values are: DATE_OF_BIRTH, PIN, NATIONAL_ID_NUMBER")
+	if !slices.Contains(data.GetAllVerificationFields(), vt) {
+		rv.Check(false, "verification_type", fmt.Sprintf("invalid parameter. valid values are: %v", data.GetAllVerificationFields()))
 		return ""
 	}
+	return vt
 }

--- a/internal/serve/validators/receiver_registration_validator.go
+++ b/internal/serve/validators/receiver_registration_validator.go
@@ -30,7 +30,7 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 
 	// validate phone field
 	rv.CheckError(utils.ValidatePhoneNumber(phone), "phone_number", "invalid phone format. Correct format: +380445555555")
-	rv.Check(strings.TrimSpace(phone) != "", "phone_number", "phone cannot be empty")
+	rv.Check(phone != "", "phone_number", "phone cannot be empty")
 
 	// validate otp field
 	rv.CheckError(utils.ValidateOTP(otp), "otp", "invalid otp format. Needs to be a 6 digit value")

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -80,6 +80,18 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 			expectedErrorKey: "verification",
 		},
 		{
+			name: "error if verification[YEAR_MONTH] is invalid",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "123456",
+				VerificationValue: "90/12",
+				VerificationType:  data.VerificationFieldYearMonth,
+			},
+			expectedErrorLen: 1,
+			expectedErrorMsg: "invalid year/month format. Correct format: 1990-12",
+			expectedErrorKey: "verification",
+		},
+		{
 			name: "error if verification[PIN] is invalid",
 			receiverInfo: data.ReceiverRegistrationRequest{
 				PhoneNumber:       "+380445555555",
@@ -117,6 +129,22 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
 				VerificationType:  data.VerificationFieldDateOfBirth,
+			},
+		},
+		{
+			name: "[YEAR_MONTH] valid receiver values",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555  ",
+				OTP:               "  123456  ",
+				VerificationValue: "1990-12  ",
+				VerificationType:  "year_month",
+			},
+			expectedErrorLen: 0,
+			expectedReceiver: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "123456",
+				VerificationValue: "1990-12",
+				VerificationType:  data.VerificationFieldYearMonth,
 			},
 		},
 		{

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -116,7 +116,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 			expectedErrorKey: "verification",
 		},
 		{
-			name: "[DATE_OF_BIRTH] valid receiver values",
+			name: "🎉 successfully validates receiver values [DATE_OF_BIRTH]",
 			receiverInfo: data.ReceiverRegistrationRequest{
 				PhoneNumber:       "+380445555555  ",
 				OTP:               "  123456  ",
@@ -132,7 +132,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 			},
 		},
 		{
-			name: "[YEAR_MONTH] valid receiver values",
+			name: "🎉 successfully validates receiver values [YEAR_MONTH]",
 			receiverInfo: data.ReceiverRegistrationRequest{
 				PhoneNumber:       "+380445555555  ",
 				OTP:               "  123456  ",
@@ -148,7 +148,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 			},
 		},
 		{
-			name: "[PIN] valid receiver values",
+			name: "🎉 successfully validates receiver values [PIN]",
 			receiverInfo: data.ReceiverRegistrationRequest{
 				PhoneNumber:       "+380445555555  ",
 				OTP:               "  123456  ",
@@ -164,7 +164,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 			},
 		},
 		{
-			name: "[NATIONAL_ID_NUMBER] valid receiver values",
+			name: "🎉 successfully validates receiver values [NATIONAL_ID_NUMBER]",
 			receiverInfo: data.ReceiverRegistrationRequest{
 				PhoneNumber:       "+380445555555  ",
 				OTP:               "  123456  ",

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -205,6 +205,7 @@ func Test_ReceiverRegistrationValidator_ValidateAndGetVerificationType(t *testin
 		validator := NewReceiverRegistrationValidator()
 		validField := []data.VerificationField{
 			data.VerificationFieldDateOfBirth,
+			data.VerificationFieldYearMonth,
 			data.VerificationFieldPin,
 			data.VerificationFieldNationalID,
 		}

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -9,144 +9,167 @@ import (
 )
 
 func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
-	t.Run("Invalid phone number", func(t *testing.T) {
-		validator := NewReceiverRegistrationValidator()
+	type testCase struct {
+		name             string
+		receiverInfo     data.ReceiverRegistrationRequest
+		expectedErrorLen int
+		expectedErrorMsg string
+		expectedErrorKey string
+		expectedReceiver data.ReceiverRegistrationRequest
+	}
 
-		receiverInfo := data.ReceiverRegistrationRequest{
-			PhoneNumber:       "invalid",
-			OTP:               "123456",
-			VerificationValue: "1990-01-01",
-			VerificationType:  "DATE_OF_BIRTH",
-		}
-		validator.ValidateReceiver(&receiverInfo)
+	testCases := []testCase{
+		{
+			name: "error if phone number is invalid",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "invalid",
+				OTP:               "123456",
+				VerificationValue: "1990-01-01",
+				VerificationType:  data.VerificationFieldDateOfBirth,
+			},
+			expectedErrorLen: 1,
+			expectedErrorMsg: "invalid phone format. Correct format: +380445555555",
+			expectedErrorKey: "phone_number",
+		},
+		{
+			name: "error if phone number is empty",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "",
+				OTP:               "123456",
+				VerificationValue: "1990-01-01",
+				VerificationType:  data.VerificationFieldDateOfBirth,
+			},
+			expectedErrorLen: 1,
+			expectedErrorMsg: "phone cannot be empty",
+			expectedErrorKey: "phone_number",
+		},
+		{
+			name: "error if OTP is invalid",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "12mock",
+				VerificationValue: "1990-01-01",
+				VerificationType:  data.VerificationFieldDateOfBirth,
+			},
+			expectedErrorLen: 1,
+			expectedErrorMsg: "invalid otp format. Needs to be a 6 digit value",
+			expectedErrorKey: "otp",
+		},
+		{
+			name: "error if verification type is invalid",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "123456",
+				VerificationValue: "1990-01-01",
+				VerificationType:  "mock_type",
+			},
+			expectedErrorLen: 1,
+			expectedErrorMsg: "invalid parameter. valid values are: [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]",
+			expectedErrorKey: "verification_type",
+		},
+		{
+			name: "error if verification[DATE_OF_BIRTH] is invalid",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "123456",
+				VerificationValue: "90/01/01",
+				VerificationType:  data.VerificationFieldDateOfBirth,
+			},
+			expectedErrorLen: 1,
+			expectedErrorMsg: "invalid date of birth format. Correct format: 1990-01-30",
+			expectedErrorKey: "verification",
+		},
+		{
+			name: "error if verification[PIN] is invalid",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "123456",
+				VerificationValue: "ABCDE1234",
+				VerificationType:  data.VerificationFieldPin,
+			},
+			expectedErrorLen: 1,
+			expectedErrorMsg: "invalid pin length. Cannot have less than 4 or more than 8 characters in pin",
+			expectedErrorKey: "verification",
+		},
+		{
+			name: "error if verification[NATIONAL_ID_NUMBER] is invalid",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "123456",
+				VerificationValue: "6UZMB56FWTKV4U0PJ21TBR6VOQVYSGIMZG2HW2S0L7EK5K83W78XXXXX",
+				VerificationType:  data.VerificationFieldNationalID,
+			},
+			expectedErrorLen: 1,
+			expectedErrorMsg: "invalid national id. Cannot have more than 50 characters in national id",
+			expectedErrorKey: "verification",
+		},
+		{
+			name: "[DATE_OF_BIRTH] valid receiver values",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555  ",
+				OTP:               "  123456  ",
+				VerificationValue: "1990-01-01  ",
+				VerificationType:  "date_of_birth",
+			},
+			expectedErrorLen: 0,
+			expectedReceiver: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "123456",
+				VerificationValue: "1990-01-01",
+				VerificationType:  data.VerificationFieldDateOfBirth,
+			},
+		},
+		{
+			name: "[PIN] valid receiver values",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555  ",
+				OTP:               "  123456  ",
+				VerificationValue: "1234  ",
+				VerificationType:  "pin",
+			},
+			expectedErrorLen: 0,
+			expectedReceiver: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "123456",
+				VerificationValue: "1234",
+				VerificationType:  data.VerificationFieldPin,
+			},
+		},
+		{
+			name: "[NATIONAL_ID_NUMBER] valid receiver values",
+			receiverInfo: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555  ",
+				OTP:               "  123456  ",
+				VerificationValue: "  NATIONALIDNUMBER123",
+				VerificationType:  "national_id_number",
+			},
+			expectedErrorLen: 0,
+			expectedReceiver: data.ReceiverRegistrationRequest{
+				PhoneNumber:       "+380445555555",
+				OTP:               "123456",
+				VerificationValue: "NATIONALIDNUMBER123",
+				VerificationType:  data.VerificationFieldNationalID,
+			},
+		},
+	}
 
-		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid phone format. Correct format: +380445555555", validator.Errors["phone_number"])
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			validator := NewReceiverRegistrationValidator()
+			validator.ValidateReceiver(&tc.receiverInfo)
 
-	t.Run("Empty phone number", func(t *testing.T) {
-		validator := NewReceiverRegistrationValidator()
+			assert.Equal(t, tc.expectedErrorLen, len(validator.Errors))
 
-		receiverInfo := data.ReceiverRegistrationRequest{
-			PhoneNumber:       "",
-			OTP:               "123456",
-			VerificationValue: "1990-01-01",
-			VerificationType:  "DATE_OF_BIRTH",
-		}
-		validator.ValidateReceiver(&receiverInfo)
-
-		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "phone cannot be empty", validator.Errors["phone_number"])
-	})
-
-	t.Run("Invalid otp", func(t *testing.T) {
-		validator := NewReceiverRegistrationValidator()
-
-		receiverInfo := data.ReceiverRegistrationRequest{
-			PhoneNumber:       "+380445555555",
-			OTP:               "12mock",
-			VerificationValue: "1990-01-01",
-			VerificationType:  "DATE_OF_BIRTH",
-		}
-		validator.ValidateReceiver(&receiverInfo)
-
-		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid otp format. Needs to be a 6 digit value", validator.Errors["otp"])
-	})
-
-	t.Run("Invalid verification type", func(t *testing.T) {
-		validator := NewReceiverRegistrationValidator()
-
-		receiverInfo := data.ReceiverRegistrationRequest{
-			PhoneNumber:       "+380445555555",
-			OTP:               "123456",
-			VerificationValue: "1990-01-01",
-			VerificationType:  "mock_type",
-		}
-		validator.ValidateReceiver(&receiverInfo)
-
-		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid parameter. valid values are: [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]", validator.Errors["verification_type"])
-	})
-
-	t.Run("Invalid date of birth", func(t *testing.T) {
-		validator := NewReceiverRegistrationValidator()
-
-		receiverInfo := data.ReceiverRegistrationRequest{
-			PhoneNumber:       "+380445555555",
-			OTP:               "123456",
-			VerificationValue: "90/01/01",
-			VerificationType:  "DATE_OF_BIRTH",
-		}
-		validator.ValidateReceiver(&receiverInfo)
-
-		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid date of birth format. Correct format: 1990-01-30", validator.Errors["verification"])
-	})
-
-	t.Run("Invalid pin", func(t *testing.T) {
-		validator := NewReceiverRegistrationValidator()
-
-		receiverInfo := data.ReceiverRegistrationRequest{
-			PhoneNumber:       "+380445555555",
-			OTP:               "123456",
-			VerificationValue: "ABCDE1234",
-			VerificationType:  "PIN",
-		}
-		validator.ValidateReceiver(&receiverInfo)
-
-		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid pin length. Cannot have less than 4 or more than 8 characters in pin", validator.Errors["verification"])
-	})
-
-	t.Run("Invalid national ID number", func(t *testing.T) {
-		validator := NewReceiverRegistrationValidator()
-
-		receiverInfo := data.ReceiverRegistrationRequest{
-			PhoneNumber:       "+380445555555",
-			OTP:               "123456",
-			VerificationValue: "6UZMB56FWTKV4U0PJ21TBR6VOQVYSGIMZG2HW2S0L7EK5K83W78XXXXX",
-			VerificationType:  "NATIONAL_ID_NUMBER",
-		}
-		validator.ValidateReceiver(&receiverInfo)
-
-		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid national id. Cannot have more than 50 characters in national id", validator.Errors["verification"])
-	})
-
-	t.Run("Valid receiver values", func(t *testing.T) {
-		validator := NewReceiverRegistrationValidator()
-
-		receiverInfo := data.ReceiverRegistrationRequest{
-			PhoneNumber:       "+380445555555  ",
-			OTP:               "  123456  ",
-			VerificationValue: "1990-01-01  ",
-			VerificationType:  "date_of_birth",
-		}
-		validator.ValidateReceiver(&receiverInfo)
-
-		assert.Equal(t, 0, len(validator.Errors))
-		assert.Equal(t, "+380445555555", receiverInfo.PhoneNumber)
-		assert.Equal(t, "123456", receiverInfo.OTP)
-		assert.Equal(t, "1990-01-01", receiverInfo.VerificationValue)
-		assert.Equal(t, data.VerificationField("DATE_OF_BIRTH"), receiverInfo.VerificationType)
-
-		receiverInfo.VerificationValue = "1234"
-		receiverInfo.VerificationType = "pin"
-		validator.ValidateReceiver(&receiverInfo)
-
-		assert.Equal(t, 0, len(validator.Errors))
-		assert.Equal(t, "1234", receiverInfo.VerificationValue)
-		assert.Equal(t, data.VerificationField("PIN"), receiverInfo.VerificationType)
-
-		receiverInfo.VerificationValue = "NATIONALIDNUMBER123"
-		receiverInfo.VerificationType = "national_id_number"
-		validator.ValidateReceiver(&receiverInfo)
-
-		assert.Equal(t, 0, len(validator.Errors))
-		assert.Equal(t, "NATIONALIDNUMBER123", receiverInfo.VerificationValue)
-		assert.Equal(t, data.VerificationField("NATIONAL_ID_NUMBER"), receiverInfo.VerificationType)
-	})
+			if tc.expectedErrorLen > 0 {
+				assert.Equal(t, tc.expectedErrorMsg, validator.Errors[tc.expectedErrorKey])
+			} else {
+				assert.Equal(t, tc.expectedReceiver.PhoneNumber, tc.receiverInfo.PhoneNumber)
+				assert.Equal(t, tc.expectedReceiver.OTP, tc.receiverInfo.OTP)
+				assert.Equal(t, tc.expectedReceiver.VerificationValue, tc.receiverInfo.VerificationValue)
+				assert.Equal(t, tc.expectedReceiver.VerificationType, tc.receiverInfo.VerificationType)
+			}
+		})
+	}
 }
 
 func Test_ReceiverRegistrationValidator_ValidateAndGetVerificationType(t *testing.T) {

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -66,7 +66,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 		validator.ValidateReceiver(&receiverInfo)
 
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid parameter. valid values are: DATE_OF_BIRTH, PIN, NATIONAL_ID_NUMBER", validator.Errors["verification_type"])
+		assert.Equal(t, "invalid parameter. valid values are: [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]", validator.Errors["verification_type"])
 	})
 
 	t.Run("Invalid date of birth", func(t *testing.T) {
@@ -169,6 +169,6 @@ func Test_ReceiverRegistrationValidator_ValidateAndGetVerificationType(t *testin
 		actual := validator.validateAndGetVerificationType(invalidStatus)
 		assert.Empty(t, actual)
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid parameter. valid values are: DATE_OF_BIRTH, PIN, NATIONAL_ID_NUMBER", validator.Errors["verification_type"])
+		assert.Equal(t, "invalid parameter. valid values are: [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]", validator.Errors["verification_type"])
 	})
 }

--- a/internal/serve/validators/receiver_update_validator.go
+++ b/internal/serve/validators/receiver_update_validator.go
@@ -34,6 +34,7 @@ func (ur *UpdateReceiverValidator) ValidateReceiver(updateReceiverRequest *Updat
 	}
 
 	dateOfBirth := strings.TrimSpace(updateReceiverRequest.DateOfBirth)
+	yearMonth := strings.TrimSpace(updateReceiverRequest.YearMonth)
 	pin := strings.TrimSpace(updateReceiverRequest.Pin)
 	nationalID := strings.TrimSpace(updateReceiverRequest.NationalID)
 	email := strings.TrimSpace(updateReceiverRequest.Email)
@@ -41,6 +42,10 @@ func (ur *UpdateReceiverValidator) ValidateReceiver(updateReceiverRequest *Updat
 
 	if dateOfBirth != "" {
 		ur.CheckError(utils.ValidateDateOfBirthVerification(dateOfBirth), "date_of_birth", "")
+	}
+
+	if yearMonth != "" {
+		ur.CheckError(utils.ValidateYearMonthVerification(yearMonth), "year_month", "")
 	}
 
 	if updateReceiverRequest.Pin != "" {
@@ -60,6 +65,7 @@ func (ur *UpdateReceiverValidator) ValidateReceiver(updateReceiverRequest *Updat
 	}
 
 	updateReceiverRequest.DateOfBirth = dateOfBirth
+	updateReceiverRequest.YearMonth = yearMonth
 	updateReceiverRequest.Pin = pin
 	updateReceiverRequest.NationalID = nationalID
 	updateReceiverRequest.Email = email

--- a/internal/serve/validators/receiver_update_validator.go
+++ b/internal/serve/validators/receiver_update_validator.go
@@ -8,6 +8,7 @@ import (
 
 type UpdateReceiverRequest struct {
 	DateOfBirth string `json:"date_of_birth"`
+	YearMonth   string `json:"year_month"`
 	Pin         string `json:"pin"`
 	NationalID  string `json:"national_id"`
 	Email       string `json:"email"`

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -119,6 +119,27 @@ func ValidateDateOfBirthVerification(dob string) error {
 	return nil
 }
 
+// ValidateYearMonthVerification will validate the year/month field for receiver verification.
+func ValidateYearMonthVerification(yearMonth string) error {
+	// make sure year/month is not empty
+	if yearMonth == "" {
+		return fmt.Errorf("year/month cannot be empty")
+	}
+
+	// make sure year/month with format 2006-01
+	ym, err := time.Parse("2006-01", yearMonth)
+	if err != nil {
+		return fmt.Errorf("invalid year/month format. Correct format: 1990-12")
+	}
+
+	// check if year/month is in the past
+	if ym.After(time.Now()) {
+		return fmt.Errorf("year/month cannot be in the future")
+	}
+
+	return nil
+}
+
 // ValidatePinVerification will validate the pin field for receiver verification.
 func ValidatePinVerification(pin string) error {
 	if len(pin) < VerificationFieldPinMinLength || len(pin) > VerificationFieldPinMaxLength {

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -163,6 +163,27 @@ func Test_ValidateDateOfBirthVerification(t *testing.T) {
 	}
 }
 
+func Test_ValidateYearMonthVerification(t *testing.T) {
+	tests := []struct {
+		name          string
+		yearMonth     string
+		expectedError error
+	}{
+		{"valid yearMonth", "1990-12", nil},
+		{"invalid yearMonth - yearMonth DOB", "", fmt.Errorf("year/month cannot be empty")},
+		{"invalid yearMonth - invalid format", "01-1990", fmt.Errorf("invalid year/month format. Correct format: 1990-12")},
+		{"invalid yearMonth - future date", time.Now().AddDate(1, 0, 0).Format("2006-01"), fmt.Errorf("year/month cannot be in the future")},
+		{"invalid yearMonth - invalid month", "1990-13", fmt.Errorf("invalid year/month format. Correct format: 1990-12")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateYearMonthVerification(tt.yearMonth)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
 func Test_ValidatePinVerification(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
### What

Add `YEAR_MONTH` as a verification type.

### Screenshots

#### New Disbursement

![Screenshot 2024-07-29 at 2 21 53 PM](https://github.com/user-attachments/assets/8da05319-8726-4092-9ce2-d9de1c7f6444)

#### Edit a Receiver

![Screenshot 2024-07-29 at 2 22 07 PM](https://github.com/user-attachments/assets/339feda8-b41b-484a-ad2a-5281550bac19)
![Screenshot 2024-07-29 at 2 22 14 PM](https://github.com/user-attachments/assets/1f844ebf-2711-4f93-be6e-04495c604620)

#### SEP-24 Verification Flow

![Screenshot 2024-07-29 at 2 55 20 PM](https://github.com/user-attachments/assets/c0557175-14e4-4942-bb6b-99a525507f5d)

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
