### PR TITLE
SDP-1283 Make PATCH /receivers/:id validation consistent

### DIFF
--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -865,7 +865,7 @@ func Test_DisbursementHandler_PostDisbursementInstructions(t *testing.T) {
 				{"+380445555555", "123456789", "100.5", "1990/01/01"},
 			},
 			expectedStatus:  http.StatusBadRequest,
-			expectedMessage: "invalid date of birth format. Correct format: 1990-01-01",
+			expectedMessage: "invalid date of birth format. Correct format: 1990-01-30",
 		},
 		{
 			name:           "invalid phone number",
@@ -891,7 +891,7 @@ func Test_DisbursementHandler_PostDisbursementInstructions(t *testing.T) {
 			expectedMessage: "could not parse file",
 		},
 		{
-			name:            "disbursement not in draft/ready starte",
+			name:            "disbursement not in draft/ready status",
 			disbursementID:  startedDisbursement.ID,
 			expectedStatus:  http.StatusBadRequest,
 			expectedMessage: "disbursement is not in draft or ready status",

--- a/internal/serve/validators/disbursement_instructions_validator.go
+++ b/internal/serve/validators/disbursement_instructions_validator.go
@@ -3,17 +3,9 @@ package validators
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
-)
-
-const (
-	VERIFICATION_FIELD_PIN_MIN_LENGTH = 4
-	VERIFICATION_FIELD_PIN_MAX_LENGTH = 8
-
-	VERIFICATION_FIELD_MAX_ID_LENGTH = 50
 )
 
 type DisbursementInstructionsValidator struct {
@@ -29,17 +21,19 @@ func NewDisbursementInstructionsValidator(verificationField data.VerificationFie
 }
 
 func (iv *DisbursementInstructionsValidator) ValidateInstruction(instruction *data.DisbursementInstruction, lineNumber int) {
-	phone := instruction.Phone
-	id := instruction.ID
-	amount := instruction.Amount
-	verification := instruction.VerificationValue
+	phone := strings.TrimSpace(instruction.Phone)
+	id := strings.TrimSpace(instruction.ID)
+	amount := strings.TrimSpace(instruction.Amount)
+	verification := strings.TrimSpace(instruction.VerificationValue)
 
 	// validate phone field
-	iv.CheckError(utils.ValidatePhoneNumber(phone), fmt.Sprintf("line %d - phone", lineNumber), "invalid phone format. Correct format: +380445555555")
-	iv.Check(strings.TrimSpace(phone) != "", fmt.Sprintf("line %d - phone", lineNumber), "phone cannot be empty")
+	iv.Check(phone != "", fmt.Sprintf("line %d - phone", lineNumber), "phone cannot be empty")
+	if phone != "" {
+		iv.CheckError(utils.ValidatePhoneNumber(phone), fmt.Sprintf("line %d - phone", lineNumber), "invalid phone format. Correct format: +380445555555")
+	}
 
 	// validate id field
-	iv.Check(strings.TrimSpace(id) != "", fmt.Sprintf("line %d - id", lineNumber), "id cannot be empty")
+	iv.Check(id != "", fmt.Sprintf("line %d - id", lineNumber), "id cannot be empty")
 
 	// validate amount field
 	iv.CheckError(utils.ValidateAmount(amount), fmt.Sprintf("line %d - amount", lineNumber), "invalid amount. Amount must be a positive number")
@@ -47,20 +41,11 @@ func (iv *DisbursementInstructionsValidator) ValidateInstruction(instruction *da
 	// validate verification field
 	switch iv.verificationField {
 	case data.VerificationFieldDateOfBirth:
-		// date of birth with format 2006-01-02
-		dob, err := time.Parse("2006-01-02", verification)
-		iv.CheckError(err, fmt.Sprintf("line %d - birthday", lineNumber), "invalid date of birth format. Correct format: 1990-01-01")
-
-		// check if date of birth is in the past
-		iv.Check(dob.Before(time.Now()), fmt.Sprintf("line %d - birthday", lineNumber), "date of birth cannot be in the future")
+		iv.CheckError(utils.ValidateDateOfBirthVerification(verification), fmt.Sprintf("line %d - date of birth", lineNumber), "")
 	case data.VerificationFieldPin:
-		if len(verification) < VERIFICATION_FIELD_PIN_MIN_LENGTH || len(verification) > VERIFICATION_FIELD_PIN_MAX_LENGTH {
-			iv.addError(fmt.Sprintf("line %d - pin", lineNumber), "invalid pin. Cannot have less than 4 or more than 8 characters in pin")
-		}
+		iv.CheckError(utils.ValidatePinVerification(verification), fmt.Sprintf("line %d - pin", lineNumber), "")
 	case data.VerificationFieldNationalID:
-		if len(verification) > VERIFICATION_FIELD_MAX_ID_LENGTH {
-			iv.addError(fmt.Sprintf("line %d - national id", lineNumber), "invalid national id. Cannot have more than 50 characters in national id")
-		}
+		iv.CheckError(utils.ValidateNationalIDVerification(verification), fmt.Sprintf("line %d - national id", lineNumber), "")
 	}
 }
 

--- a/internal/serve/validators/disbursement_instructions_validator_test.go
+++ b/internal/serve/validators/disbursement_instructions_validator_test.go
@@ -44,16 +44,16 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 			},
 		},
 		{
-			name:              "empty phone, id, amount and birthday",
+			name:              "empty phone, id, amount and date of birth",
 			actual:            &data.DisbursementInstruction{},
 			lineNumber:        2,
 			verificationField: data.VerificationFieldDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
-				"line 2 - amount":   "invalid amount. Amount must be a positive number",
-				"line 2 - birthday": "invalid date of birth format. Correct format: 1990-01-01",
-				"line 2 - id":       "id cannot be empty",
-				"line 2 - phone":    "phone cannot be empty",
+				"line 2 - amount":        "invalid amount. Amount must be a positive number",
+				"line 2 - date of birth": "date of birth cannot be empty",
+				"line 2 - id":            "id cannot be empty",
+				"line 2 - phone":         "phone cannot be empty",
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 			},
 		},
 		{
-			name: "invalid birthday format",
+			name: "invalid date of birth format",
 			actual: &data.DisbursementInstruction{
 				Phone:             "+380445555555",
 				ID:                "123456789",
@@ -113,7 +113,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 			verificationField: data.VerificationFieldDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
-				"line 3 - birthday": "invalid date of birth format. Correct format: 1990-01-01",
+				"line 3 - date of birth": "invalid date of birth format. Correct format: 1990-01-30",
 			},
 		},
 		{
@@ -128,7 +128,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 			verificationField: data.VerificationFieldDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
-				"line 3 - birthday": "date of birth cannot be in the future",
+				"line 3 - date of birth": "date of birth cannot be in the future",
 			},
 		},
 		{
@@ -155,7 +155,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 			verificationField: data.VerificationFieldPin,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
-				"line 3 - pin": "invalid pin. Cannot have less than 4 or more than 8 characters in pin",
+				"line 3 - pin": "invalid pin length. Cannot have less than 4 or more than 8 characters in pin",
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 			verificationField: data.VerificationFieldPin,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
-				"line 3 - pin": "invalid pin. Cannot have less than 4 or more than 8 characters in pin",
+				"line 3 - pin": "invalid pin length. Cannot have less than 4 or more than 8 characters in pin",
 			},
 		},
 		{

--- a/internal/serve/validators/receiver_registration_validator.go
+++ b/internal/serve/validators/receiver_registration_validator.go
@@ -2,7 +2,6 @@ package validators
 
 import (
 	"strings"
-	"time"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 
@@ -41,20 +40,11 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 	// validate verification fields
 	switch vt {
 	case data.VerificationFieldDateOfBirth:
-		// date of birth with format 2006-01-02
-		dob, err := time.Parse("2006-01-02", verification)
-		rv.CheckError(err, "verification", "invalid date of birth format. Correct format: 1990-01-01")
-
-		// check if date of birth is in the past
-		rv.Check(dob.Before(time.Now()), "verification", "date of birth cannot be in the future")
+		rv.CheckError(utils.ValidateDateOfBirthVerification(verification), "verification", "")
 	case data.VerificationFieldPin:
-		if len(verification) < VERIFICATION_FIELD_PIN_MIN_LENGTH || len(verification) > VERIFICATION_FIELD_PIN_MAX_LENGTH {
-			rv.addError("verification", "invalid pin. Cannot have less than 4 or more than 8 characters in pin")
-		}
+		rv.CheckError(utils.ValidatePinVerification(verification), "verification", "")
 	case data.VerificationFieldNationalID:
-		if len(verification) > VERIFICATION_FIELD_MAX_ID_LENGTH {
-			rv.addError("verification", "invalid national id. Cannot have more than 50 characters in national id")
-		}
+		rv.CheckError(utils.ValidateNationalIDVerification(verification), "verification", "")
 	}
 
 	receiverInfo.PhoneNumber = phone

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -81,7 +81,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 		validator.ValidateReceiver(&receiverInfo)
 
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid date of birth format. Correct format: 1990-01-01", validator.Errors["verification"])
+		assert.Equal(t, "invalid date of birth format. Correct format: 1990-01-30", validator.Errors["verification"])
 	})
 
 	t.Run("Invalid pin", func(t *testing.T) {
@@ -96,7 +96,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 		validator.ValidateReceiver(&receiverInfo)
 
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid pin. Cannot have less than 4 or more than 8 characters in pin", validator.Errors["verification"])
+		assert.Equal(t, "invalid pin length. Cannot have less than 4 or more than 8 characters in pin", validator.Errors["verification"])
 	})
 
 	t.Run("Invalid national ID number", func(t *testing.T) {

--- a/internal/serve/validators/receiver_update_validator.go
+++ b/internal/serve/validators/receiver_update_validator.go
@@ -2,7 +2,6 @@ package validators
 
 import (
 	"strings"
-	"time"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
@@ -40,18 +39,15 @@ func (ur *UpdateReceiverValidator) ValidateReceiver(updateReceiverRequest *Updat
 	externalID := strings.TrimSpace(updateReceiverRequest.ExternalID)
 
 	if dateOfBirth != "" {
-		_, err := time.Parse("2006-01-02", updateReceiverRequest.DateOfBirth)
-		ur.CheckError(err, "date_of_birth", "invalid date of birth format. Correct format: 1990-01-30")
+		ur.CheckError(utils.ValidateDateOfBirthVerification(dateOfBirth), "date_of_birth", "")
 	}
 
 	if updateReceiverRequest.Pin != "" {
-		// TODO: add new validation to PIN type.
-		ur.Check(pin != "", "pin", "invalid pin format")
+		ur.CheckError(utils.ValidatePinVerification(pin), "pin", "")
 	}
 
 	if updateReceiverRequest.NationalID != "" {
-		// TODO: add new validation to NationalID type.
-		ur.Check(nationalID != "", "national_id", "invalid national ID format")
+		ur.CheckError(utils.ValidateNationalIDVerification(nationalID), "national_id", "")
 	}
 
 	if updateReceiverRequest.Email != "" {

--- a/internal/serve/validators/receiver_update_validator_test.go
+++ b/internal/serve/validators/receiver_update_validator_test.go
@@ -38,7 +38,7 @@ func Test_UpdateReceiverValidator_ValidateReceiver(t *testing.T) {
 		validator.ValidateReceiver(&receiverInfo)
 
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid pin format", validator.Errors["pin"])
+		assert.Equal(t, "invalid pin length. Cannot have less than 4 or more than 8 characters in pin", validator.Errors["pin"])
 	})
 
 	t.Run("Invalid national ID", func(t *testing.T) {
@@ -50,7 +50,7 @@ func Test_UpdateReceiverValidator_ValidateReceiver(t *testing.T) {
 		validator.ValidateReceiver(&receiverInfo)
 
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid national ID format", validator.Errors["national_id"])
+		assert.Equal(t, "national id cannot be empty", validator.Errors["national_id"])
 	})
 
 	t.Run("invalid email", func(t *testing.T) {
@@ -90,7 +90,7 @@ func Test_UpdateReceiverValidator_ValidateReceiver(t *testing.T) {
 
 		receiverInfo := UpdateReceiverRequest{
 			DateOfBirth: "1999-01-01",
-			Pin:         "123   ",
+			Pin:         "1234   ",
 			NationalID:  "   12345CODE",
 			Email:       "receiver@email.com",
 			ExternalID:  "externalID",
@@ -99,7 +99,7 @@ func Test_UpdateReceiverValidator_ValidateReceiver(t *testing.T) {
 
 		assert.Equal(t, 0, len(validator.Errors))
 		assert.Equal(t, "1999-01-01", receiverInfo.DateOfBirth)
-		assert.Equal(t, "123", receiverInfo.Pin)
+		assert.Equal(t, "1234", receiverInfo.Pin)
 		assert.Equal(t, "12345CODE", receiverInfo.NationalID)
 	})
 }

--- a/internal/serve/validators/validator.go
+++ b/internal/serve/validators/validator.go
@@ -20,6 +20,9 @@ func (v *Validator) Check(ok bool, key, message string) {
 
 // CheckError is a convenience method for checking if an error is nil
 func (v *Validator) CheckError(err error, key, message string) {
+	if err != nil && message == "" {
+		message = err.Error()
+	}
 	v.Check(err == nil, key, message)
 }
 

--- a/internal/serve/validators/validator_test.go
+++ b/internal/serve/validators/validator_test.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +39,48 @@ func Test_addError(t *testing.T) {
 	assert.Equal(t, len(validator.Errors), 2)
 	assert.Equal(t, validator.Errors["key"], "error message")
 	assert.Equal(t, validator.Errors["key2"], "error message 2")
+}
+
+func Test_Validator_CheckError(t *testing.T) {
+	testCases := []struct {
+		name           string
+		err            error
+		key            string
+		message        string
+		expectedErrors map[string]interface{}
+	}{
+		{
+			name:    "error is not nil and message is not empty",
+			err:     fmt.Errorf("error message"),
+			key:     "key",
+			message: "real error message",
+			expectedErrors: map[string]interface{}{
+				"key": "real error message",
+			},
+		},
+		{
+			name:    "error is not nil and message is empty",
+			err:     fmt.Errorf("error message"),
+			key:     "key",
+			message: "",
+			expectedErrors: map[string]interface{}{
+				"key": "error message",
+			},
+		},
+		{
+			name:           "error is nil",
+			err:            nil,
+			key:            "key",
+			message:        "real error message",
+			expectedErrors: map[string]interface{}{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			validator := NewValidator()
+			validator.CheckError(tc.err, tc.key, tc.message)
+			assert.Equal(t, tc.expectedErrors, validator.Errors)
+		})
+	}
 }

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/nyaruka/phonenumbers"
@@ -15,6 +16,13 @@ var (
 	rxOTP                     = regexp.MustCompile(`^\d{6}$`)
 	ErrInvalidE164PhoneNumber = fmt.Errorf("the provided phone number is not a valid E.164 number")
 	ErrEmptyPhoneNumber       = fmt.Errorf("phone number cannot be empty")
+)
+
+const (
+	VerificationFieldPinMinLength = 4
+	VerificationFieldPinMaxLength = 8
+
+	VerificationFieldMaxIdLength = 50
 )
 
 // https://github.com/firebase/firebase-admin-go/blob/cef91acd46f2fc5d0b3408d8154a0005db5bdb0b/auth/user_mgt.go#L449-L457
@@ -86,6 +94,48 @@ func ValidateOTP(otp string) error {
 
 	if !rxOTP.MatchString(otp) {
 		return fmt.Errorf("the provided OTP is not a valid 6 digits value")
+	}
+
+	return nil
+}
+
+// ValidateDateOfBirthVerification will validate the date of birth field for receiver verification.
+func ValidateDateOfBirthVerification(dob string) error {
+	// make sure date of birth is not empty
+	if dob == "" {
+		return fmt.Errorf("date of birth cannot be empty")
+	}
+	// make sure date of birth with format 2006-01-02
+	dateOfBrith, err := time.Parse("2006-01-02", dob)
+	if err != nil {
+		return fmt.Errorf("invalid date of birth format. Correct format: 1990-01-30")
+	}
+
+	// check if date of birth is in the past
+	if dateOfBrith.After(time.Now()) {
+		return fmt.Errorf("date of birth cannot be in the future")
+	}
+
+	return nil
+}
+
+// ValidatePinVerification will validate the pin field for receiver verification.
+func ValidatePinVerification(pin string) error {
+	if len(pin) < VerificationFieldPinMinLength || len(pin) > VerificationFieldPinMaxLength {
+		return fmt.Errorf("invalid pin length. Cannot have less than %d or more than %d characters in pin", VerificationFieldPinMinLength, VerificationFieldPinMaxLength)
+	}
+
+	return nil
+}
+
+// ValidateNationalIDVerification will validate the national id field for receiver verification.
+func ValidateNationalIDVerification(nationalID string) error {
+	if nationalID == "" {
+		return fmt.Errorf("national id cannot be empty")
+	}
+
+	if len(nationalID) > VerificationFieldMaxIdLength {
+		return fmt.Errorf("invalid national id. Cannot have more than %d characters in national id", VerificationFieldMaxIdLength)
 	}
 
 	return nil

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -136,6 +137,67 @@ func Test_ValidateOTP(t *testing.T) {
 		t.Run(tc.otp, func(t *testing.T) {
 			gotError := ValidateOTP(tc.otp)
 			assert.Equalf(t, tc.wantErr, gotError, "ValidateOTP(%q) should be %v, but got %v", tc.otp, tc.wantErr, gotError)
+		})
+	}
+}
+
+func Test_ValidateDateOfBirthVerification(t *testing.T) {
+	tests := []struct {
+		name          string
+		dob           string
+		expectedError error
+	}{
+		{"valid DOB", "1990-01-30", nil},
+		{"invalid DOB - empty DOB", "", fmt.Errorf("date of birth cannot be empty")},
+		{"invalid DOB - invalid format", "30-01-1990", fmt.Errorf("invalid date of birth format. Correct format: 1990-01-30")},
+		{"invalid DOB - future date", time.Now().AddDate(1, 0, 0).Format("2006-01-02"), fmt.Errorf("date of birth cannot be in the future")},
+		{"invalid DOB - invalid day", "1990-01-32", fmt.Errorf("invalid date of birth format. Correct format: 1990-01-30")},
+		{"invalid DOB - invalid month", "1990-13-01", fmt.Errorf("invalid date of birth format. Correct format: 1990-01-30")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDateOfBirthVerification(tt.dob)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func Test_ValidatePinVerification(t *testing.T) {
+	tests := []struct {
+		name          string
+		pin           string
+		expectedError error
+	}{
+		{"valid PIN", "1234", nil},
+		{"invalid PIN - too short", "123", fmt.Errorf("invalid pin length. Cannot have less than %d or more than %d characters in pin", VerificationFieldPinMinLength, VerificationFieldPinMaxLength)},
+		{"invalid PIN - too long", "12345678901", fmt.Errorf("invalid pin length. Cannot have less than %d or more than %d characters in pin", VerificationFieldPinMinLength, VerificationFieldPinMaxLength)},
+		{"invalid PIN - empty", "", fmt.Errorf("invalid pin length. Cannot have less than %d or more than %d characters in pin", VerificationFieldPinMinLength, VerificationFieldPinMaxLength)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePinVerification(tt.pin)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func Test_ValidateNationalIDVerification(t *testing.T) {
+	tests := []struct {
+		name          string
+		nationalID    string
+		expectedError error
+	}{
+		{"valid National ID", "1234567890", nil},
+		{"invalid National ID - empty", "", fmt.Errorf("national id cannot be empty")},
+		{"invalid National ID - too long", fmt.Sprintf("%0*d", VerificationFieldMaxIdLength+1, 0), fmt.Errorf("invalid national id. Cannot have more than %d characters in national id", VerificationFieldMaxIdLength)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNationalIDVerification(tt.nationalID)
+			assert.Equal(t, tt.expectedError, err)
 		})
 	}
 }


### PR DESCRIPTION
### What
* Extract validation for receiver verification fields and make it consistent between disbursement instructions and patching receivers 
* Validate a receiver exists before patching them. 


### Why
* https://stellarorg.atlassian.net/browse/SDP-1283


### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
