### PR TITLE
[SDP-1287] PaymentReadyToPay for Circle not submitted to correct topic

### DIFF
--- a/internal/events/message.go
+++ b/internal/events/message.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
@@ -53,6 +54,20 @@ func NewMessage(ctx context.Context, topic, key, messageType string, data any) (
 		Type:     messageType,
 		Data:     data,
 	}, nil
+}
+
+// NewPaymentReadyToPayMessage returns a new message for the `PaymentReadyToPayTopic` topic or `CirclePaymentReadyToPayTopic` topic.
+func NewPaymentReadyToPayMessage(ctx context.Context, platform schema.Platform, key, messageType string) (*Message, error) {
+	var targetTopic string
+	switch platform {
+	case schema.StellarPlatform:
+		targetTopic = PaymentReadyToPayTopic
+	case schema.CirclePlatform:
+		targetTopic = CirclePaymentReadyToPayTopic
+	default:
+		return nil, fmt.Errorf("unsupported platform: %s", platform)
+	}
+	return NewMessage(ctx, targetTopic, key, messageType, nil)
 }
 
 func NewHandlerError(hError error, handlerName string) HandlerError {

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -224,7 +224,12 @@ func (p PaymentsHandler) buildPaymentsReadyEventMessage(ctx context.Context, pay
 		return nil, nil
 	}
 
-	msg, err := events.NewMessage(ctx, events.PaymentReadyToPayTopic, "", events.PaymentReadyToPayRetryFailedPayment, nil)
+	distAccount, err := p.DistributionAccountResolver.DistributionAccountFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving distribution account: %w", err)
+	}
+
+	msg, err := events.NewPaymentReadyToPayMessage(ctx, distAccount.Type.Platform(), "", events.PaymentReadyToPayRetryFailedPayment)
 	if err != nil {
 		return nil, fmt.Errorf("creating a new message: %w", err)
 	}

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
+	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
@@ -567,7 +569,6 @@ func Test_VerifyReceiverRegistrationHandler_buildPaymentsReadyToPayEventMessage(
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
-	handler := VerifyReceiverRegistrationHandler{Models: models}
 
 	data.DeleteAllFixtures(t, ctx, dbConnectionPool)
 
@@ -580,6 +581,10 @@ func Test_VerifyReceiverRegistrationHandler_buildPaymentsReadyToPayEventMessage(
 	t.Run("doesn't return error when there's no payment", func(t *testing.T) {
 		defer data.DeleteAllDisbursementFixtures(t, ctx, dbConnectionPool)
 		defer data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
+
+		handler := VerifyReceiverRegistrationHandler{
+			Models: models,
+		}
 
 		pausedDisbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
 			Wallet:  wallet,
@@ -611,6 +616,15 @@ func Test_VerifyReceiverRegistrationHandler_buildPaymentsReadyToPayEventMessage(
 		defer data.DeleteAllDisbursementFixtures(t, ctx, dbConnectionPool)
 		defer data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
 		ctxWithoutTenant := context.Background()
+		distAccountResolverMock := sigMocks.NewMockDistributionAccountResolver(t)
+		distAccountResolverMock.
+			On("DistributionAccountFromContext", mock.Anything).
+			Return(schema.TransactionAccount{Type: schema.DistributionAccountStellarEnv}, nil).
+			Once()
+		handler := VerifyReceiverRegistrationHandler{
+			Models:                      models,
+			DistributionAccountResolver: distAccountResolverMock,
+		}
 
 		disbursement := data.CreateDisbursementFixture(t, ctxWithoutTenant, dbConnectionPool, models.Disbursements, &data.Disbursement{
 			Wallet:  wallet,
@@ -632,9 +646,19 @@ func Test_VerifyReceiverRegistrationHandler_buildPaymentsReadyToPayEventMessage(
 		assert.Nil(t, msg)
 	})
 
-	t.Run("🎉 successfully builds the message", func(t *testing.T) {
+	t.Run("🎉 successfully builds the message for stellar payment", func(t *testing.T) {
 		defer data.DeleteAllDisbursementFixtures(t, ctx, dbConnectionPool)
 		defer data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
+
+		distAccountResolverMock := sigMocks.NewMockDistributionAccountResolver(t)
+		distAccountResolverMock.
+			On("DistributionAccountFromContext", mock.Anything).
+			Return(schema.TransactionAccount{Type: schema.DistributionAccountStellarEnv}, nil).
+			Once()
+		handler := VerifyReceiverRegistrationHandler{
+			Models:                      models,
+			DistributionAccountResolver: distAccountResolverMock,
+		}
 
 		disbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
 			Wallet:  wallet,
@@ -653,6 +677,55 @@ func Test_VerifyReceiverRegistrationHandler_buildPaymentsReadyToPayEventMessage(
 
 		expectedMessage := events.Message{
 			Topic:    events.PaymentReadyToPayTopic,
+			Key:      rw.ID,
+			TenantID: tnt.ID,
+			Type:     events.PaymentReadyToPayReceiverVerificationCompleted,
+			Data: schemas.EventPaymentsReadyToPayData{
+				TenantID: tnt.ID,
+				Payments: []schemas.PaymentReadyToPay{
+					{
+						ID: payment.ID,
+					},
+				},
+			},
+		}
+
+		msg, err := handler.buildPaymentsReadyToPayEventMessage(ctx, dbConnectionPool, rw)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedMessage, *msg)
+	})
+
+	t.Run("🎉 successfully builds the message for circle payment", func(t *testing.T) {
+		defer data.DeleteAllDisbursementFixtures(t, ctx, dbConnectionPool)
+		defer data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
+
+		distAccountResolverMock := sigMocks.NewMockDistributionAccountResolver(t)
+		distAccountResolverMock.
+			On("DistributionAccountFromContext", mock.Anything).
+			Return(schema.TransactionAccount{Type: schema.DistributionAccountCircleDBVault}, nil).
+			Once()
+		handler := VerifyReceiverRegistrationHandler{
+			Models:                      models,
+			DistributionAccountResolver: distAccountResolverMock,
+		}
+
+		disbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
+			Wallet:  wallet,
+			Asset:   asset,
+			Country: country,
+			Status:  data.StartedDisbursementStatus,
+		})
+
+		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+			Amount:         "100",
+			Status:         data.ReadyPaymentStatus,
+			Disbursement:   disbursement,
+			Asset:          *asset,
+			ReceiverWallet: rw,
+		})
+
+		expectedMessage := events.Message{
+			Topic:    events.CirclePaymentReadyToPayTopic,
 			Key:      rw.ID,
 			TenantID: tnt.ID,
 			Type:     events.PaymentReadyToPayReceiverVerificationCompleted,
@@ -1281,6 +1354,13 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 				mockCrashTracker := &crashtracker.MockCrashTrackerClient{}
 				defer mockCrashTracker.AssertExpectations(t)
 				mockEventProducer := events.NewMockProducer(t)
+
+				distAccountResolverMock := sigMocks.NewMockDistributionAccountResolver(t)
+				distAccountResolverMock.
+					On("DistributionAccountFromContext", mock.Anything).
+					Return(schema.TransactionAccount{Type: schema.DistributionAccountStellarEnv}, nil).
+					Maybe()
+
 				if tc.produccesEventSuccessfully {
 					mockEventProducer.
 						On("WriteMessages", mock.Anything, []events.Message{
@@ -1310,11 +1390,12 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 
 				// create handler
 				handler := &VerifyReceiverRegistrationHandler{
-					Models:                   models,
-					ReCAPTCHAValidator:       reCAPTCHAValidator,
-					AnchorPlatformAPIService: mockAnchorPlatformService,
-					EventProducer:            mockEventProducer,
-					CrashTrackerClient:       mockCrashTracker,
+					Models:                      models,
+					ReCAPTCHAValidator:          reCAPTCHAValidator,
+					AnchorPlatformAPIService:    mockAnchorPlatformService,
+					EventProducer:               mockEventProducer,
+					CrashTrackerClient:          mockCrashTracker,
+					DistributionAccountResolver: distAccountResolverMock,
 				}
 
 				// setup router and execute request

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -471,12 +471,13 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			sep24HeaderTokenAuthenticationMiddleware := anchorplatform.SEP24HeaderTokenAuthenticateMiddleware(o.sep24JWTManager, o.NetworkPassphrase, o.tenantManager, o.SingleTenantMode)
 			r.With(sep24HeaderTokenAuthenticationMiddleware).Post("/otp", httphandler.ReceiverSendOTPHandler{Models: o.Models, SMSMessengerClient: o.SMSMessengerClient, ReCAPTCHAValidator: reCAPTCHAValidator}.ServeHTTP)
 			r.With(sep24HeaderTokenAuthenticationMiddleware).Post("/verification", httphandler.VerifyReceiverRegistrationHandler{
-				AnchorPlatformAPIService: o.AnchorPlatformAPIService,
-				Models:                   o.Models,
-				ReCAPTCHAValidator:       reCAPTCHAValidator,
-				NetworkPassphrase:        o.NetworkPassphrase,
-				EventProducer:            o.EventProducer,
-				CrashTrackerClient:       o.CrashTrackerClient,
+				AnchorPlatformAPIService:    o.AnchorPlatformAPIService,
+				Models:                      o.Models,
+				ReCAPTCHAValidator:          reCAPTCHAValidator,
+				NetworkPassphrase:           o.NetworkPassphrase,
+				EventProducer:               o.EventProducer,
+				CrashTrackerClient:          o.CrashTrackerClient,
+				DistributionAccountResolver: o.SubmitterEngine.DistributionAccountResolver,
 			}.VerifyReceiverRegistration)
 		})
 

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -419,21 +419,10 @@ func (s *DisbursementManagementService) PauseDisbursement(ctx context.Context, d
 
 // preparePaymentMessages prepares the messages to be sent to the event producer for the payments that are ready to pay.
 func preparePaymentMessages(ctx context.Context, disbursementID string, payments []*data.Payment, distributionAccount *schema.TransactionAccount) ([]*events.Message, error) {
-	// Resolve target topic based on the distribution account type.
-	var targetTopic string
-	switch distributionAccount.Type.Platform() {
-	case schema.StellarPlatform:
-		targetTopic = events.PaymentReadyToPayTopic
-	case schema.CirclePlatform:
-		targetTopic = events.CirclePaymentReadyToPayTopic
-	default:
-		return nil, fmt.Errorf("unsupported platform: %s", distributionAccount.Type.Platform())
-	}
-
 	// Prepare the messages to be sent to the event producer.
 	msgs := make([]*events.Message, 0)
 	if len(payments) != 0 {
-		paymentsReadyToPayMsg, msgErr := events.NewMessage(ctx, targetTopic, disbursementID, events.PaymentReadyToPayDisbursementStarted, nil)
+		paymentsReadyToPayMsg, msgErr := events.NewPaymentReadyToPayMessage(ctx, distributionAccount.Type.Platform(), disbursementID, events.PaymentReadyToPayDisbursementStarted)
 		if msgErr != nil {
 			return nil, fmt.Errorf("creating new message: %w", msgErr)
 		}


### PR DESCRIPTION
### What
* Submit `paymentReadyToPay` to Circle topic for Registration and Retry 
* Have a unified way of submitting this message to avoid future errors

### Why
* The change introduced in https://github.com/stellar/stellar-disbursement-platform-backend/pull/371 only switches this topic for submitting events when disbursement starts. There are two other scenarios that were missed. 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
