### PR TITLE
[Chore] Add tenant provisioning error details to response 

### DIFF
--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -96,13 +96,17 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 	// sending the invitation message
 	tntSDPUIBaseURL, err := h.generateTenantURL(reqBody.SDPUIBaseURL, h.SDPUIBaseURL, reqBody.Name)
 	if err != nil {
-		httperror.InternalError(ctx, fmt.Sprintf("Could not generate SDP UI URL: %v", err), err, nil).Render(rw)
+		httperror.InternalError(ctx, "Could not generate SDP UI URL", err, map[string]interface{}{
+			"error_details": err.Error(),
+		}).Render(rw)
 		return
 	}
 
 	tntBaseURL, err := h.generateTenantURL(reqBody.BaseURL, h.BaseURL, reqBody.Name)
 	if err != nil {
-		httperror.InternalError(ctx, fmt.Sprintf("Could not generate URL: %v", err), err, nil).Render(rw)
+		httperror.InternalError(ctx, "Could not generate URL", err, map[string]interface{}{
+			"error_details": err.Error(),
+		}).Render(rw)
 		return
 	}
 
@@ -122,7 +126,9 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 			httperror.BadRequest("Tenant name already exists", err, nil).Render(rw)
 			return
 		}
-		httperror.InternalError(ctx, fmt.Sprintf("Could not provision a new tenant: %v", err), err, nil).Render(rw)
+		httperror.InternalError(ctx, "Could not provision a new tenant", err, map[string]interface{}{
+			"error_details": err.Error(),
+		}).Render(rw)
 		return
 	}
 

--- a/stellar-multitenant/internal/httphandler/tenants_handler.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler.go
@@ -96,13 +96,13 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 	// sending the invitation message
 	tntSDPUIBaseURL, err := h.generateTenantURL(reqBody.SDPUIBaseURL, h.SDPUIBaseURL, reqBody.Name)
 	if err != nil {
-		httperror.InternalError(ctx, "Could not generate SDP UI URL", err, nil).Render(rw)
+		httperror.InternalError(ctx, fmt.Sprintf("Could not generate SDP UI URL: %v", err), err, nil).Render(rw)
 		return
 	}
 
 	tntBaseURL, err := h.generateTenantURL(reqBody.BaseURL, h.BaseURL, reqBody.Name)
 	if err != nil {
-		httperror.InternalError(ctx, "Could not generate URL", err, nil).Render(rw)
+		httperror.InternalError(ctx, fmt.Sprintf("Could not generate URL: %v", err), err, nil).Render(rw)
 		return
 	}
 
@@ -122,7 +122,7 @@ func (h TenantsHandler) Post(rw http.ResponseWriter, req *http.Request) {
 			httperror.BadRequest("Tenant name already exists", err, nil).Render(rw)
 			return
 		}
-		httperror.InternalError(ctx, "Could not provision a new tenant", err, nil).Render(rw)
+		httperror.InternalError(ctx, fmt.Sprintf("Could not provision a new tenant: %v", err), err, nil).Render(rw)
 		return
 	}
 


### PR DESCRIPTION
### What
Add tenant provisioning error details to API response for better debugging experience
```
Server response: {
  "error": "Could not generate SDP UI URL",
  "extras": {
    "error_details": "base URL must have at least two domain parts localhost:3000"
  }
}
```
```
Server response: {
  "error": "Could not generate SDP UI URL",
  "extras": {
    "error_details": "base URL must have at least two domain parts localhost:3000"
  }
}
```
```
Server response: {
  "error": "Could not provision a new tenant",
  "extras": {
    "error_details": "provisioning error: database schema creation for tenant failed: creating tenant redcorp database schema: creating schema for tenant sdp_redcorp: pq: schema \"sdp_redcorp\" already exists"
  }
}
```

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
