### PR TITLE
[SDP-1292] Replace usage of `docker-compose` with `docker compose`

### DIFF
--- a/.github/workflows/anchor_platform_integration_check.yml
+++ b/.github/workflows/anchor_platform_integration_check.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run Docker Compose for SDP and Anchor Platform
         working-directory: dev
-        run: docker-compose -f docker-compose-sdp-anchor.yml down && docker-compose -f docker-compose-sdp-anchor.yml up --build -d
+        run: docker compose -f docker-compose-sdp-anchor.yml down && docker compose -f docker-compose-sdp-anchor.yml up --build -d
 
       - name: Install curl
         run: sudo apt-get update && sudo apt-get install -y curl
@@ -55,4 +55,4 @@ jobs:
       - name: Docker logs
         if: always()
         working-directory: dev
-        run: docker-compose -f docker-compose-sdp-anchor.yml logs && docker-compose -f docker-compose-sdp-anchor.yml down
+        run: docker compose -f docker-compose-sdp-anchor.yml logs && docker compose -f docker-compose-sdp-anchor.yml down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
         with:
           version: v1.56.2 # this is the golangci-lint version
           args: --timeout 5m0s
-          skip-build-cache: true
-          skip-pkg-cache: true
 
       - name: Run ./gomod.sh
         run: ./gomod.sh

--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -26,6 +26,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         platform:
           - "Stellar"

--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -46,12 +46,12 @@ jobs:
 
       - name: Cleanup data
         working-directory: internal/integrationtests/docker
-        run: docker-compose -f docker-compose-e2e-tests.yml down -v
+        run: docker compose -f docker-compose-e2e-tests.yml down -v
         shell: bash
 
       - name: Run Docker Compose for SDP, Anchor Platform and TSS
         working-directory: internal/integrationtests/docker
-        run: docker-compose -f docker-compose-e2e-tests.yml up --build -V -d
+        run: docker compose -f docker-compose-e2e-tests.yml up --build -V -d
         shell: bash
 
       - name: Install curl
@@ -98,5 +98,5 @@ jobs:
       - name: Docker logs
         if: always()
         working-directory: internal/integrationtests/docker
-        run: docker-compose -f docker-compose-e2e-tests.yml logs && docker-compose -f docker-compose-e2e-tests.yml down
+        run: docker compose -f docker-compose-e2e-tests.yml logs && docker compose -f docker-compose-e2e-tests.yml down
         shell: bash

--- a/.github/workflows/singletenant_to_multitenant_db_migration_test.yml
+++ b/.github/workflows/singletenant_to_multitenant_db_migration_test.yml
@@ -31,12 +31,12 @@ jobs:
 
       - name: Cleanup data
         working-directory: internal/integrationtests/docker
-        run: docker-compose -f docker-compose-e2e-tests.yml down -v
+        run: docker compose -f docker-compose-e2e-tests.yml down -v
         shell: bash
 
       - name: Run Docker Compose for SDP, Anchor Platform and TSS
         working-directory: internal/integrationtests/docker
-        run: docker-compose -f docker-compose-e2e-tests.yml up --build -V -d
+        run: docker compose -f docker-compose-e2e-tests.yml up --build -V -d
         shell: bash
 
       - name: Install curl
@@ -140,6 +140,6 @@ jobs:
         if: always()
         working-directory: internal/integrationtests/docker
         run: |
-          docker-compose -f docker-compose-e2e-tests.yml logs
-          docker-compose -f docker-compose-e2e-tests.yml down -v
+          docker compose -f docker-compose-e2e-tests.yml logs
+          docker compose -f docker-compose-e2e-tests.yml down -v
         shell: bash

--- a/dev/docker-compose-tss.yml
+++ b/dev/docker-compose-tss.yml
@@ -13,7 +13,7 @@ services:
       NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
       HORIZON_URL: "https://horizon-testnet.stellar.org"
       NUM_CHANNEL_ACCOUNTS: "3"
-      MAX_BASE_FEE: "100"
+      MAX_BASE_FEE: "1000000"
       TSS_METRICS_PORT: "9002"
       TSS_METRICS_TYPE: "TSS_PROMETHEUS"
       DISTRIBUTION_PUBLIC_KEY: ${DISTRIBUTION_PUBLIC_KEY}

--- a/dev/main.sh
+++ b/dev/main.sh
@@ -34,11 +34,11 @@ fi
 
 # prepare
 echo $DIVIDER
-echo "====> 👀 start calling docker-compose -p sdp-multi-tenant down"
+echo "====> 👀 start calling docker compose -p sdp-multi-tenant down"
 docker ps -aq | xargs docker stop | xargs docker rm
-#docker-compose -p sdp-multi-tenant down
-docker-compose down
-echo "====> ✅ finish calling docker-compose down"
+#docker compose -p sdp-multi-tenant down
+docker compose down
+echo "====> ✅ finish calling docker compose down"
 
 # Run docker compose
 echo $DIVIDER
@@ -67,11 +67,11 @@ fi
 echo $DIVIDER
 echo "====> 👀calling docker compose up"
 export GIT_COMMIT="debug"
-docker-compose -p sdp-multi-tenant up -d --build
+docker compose -p sdp-multi-tenant up -d --build
 
 # Run docker compose
 echo $DIVIDER
-echo "====> ✅finish calling docker-compose up"
+echo "====> ✅finish calling docker compose up"
 
 
 # Initialize tenants
@@ -144,7 +144,7 @@ echo "====> ✅Step 3: finished initialization of tenants"
 echo $DIVIDER
 # Initialize test_users
 echo "====> Step 4: initialize test users..."
-docker-compose -p sdp-multi-tenant exec sdp-api ./dev/scripts/add_test_users.sh
+docker compose -p sdp-multi-tenant exec sdp-api ./dev/scripts/add_test_users.sh
 echo $DIVIDER
 
 echo "🎉🎉🎉🎉 SUCCESS! 🎉🎉🎉🎉"

--- a/internal/data/disbursement_instructions.go
+++ b/internal/data/disbursement_instructions.go
@@ -65,7 +65,7 @@ var (
 //	|    |    |--- Check if the receiver wallet exists.
 //	|    |    |    |--- If the receiver wallet does not exist, create one.
 //	|    |    |    |--- If the receiver wallet exists and it's not REGISTERED, retry the invitation SMS.
-//	|    |    |--- Delete all payments tied to this disbursement.
+//	|    |    |--- Delete all previously existing payments tied to this disbursement.
 //	|    |    |--- Create all payments passed in the instructions.
 func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, userID string, instructions []*DisbursementInstruction, disbursement *Disbursement, update *DisbursementUpdate, maxNumberOfInstructions int) error {
 	if len(instructions) > maxNumberOfInstructions {
@@ -85,6 +85,7 @@ func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, userID st
 			return fmt.Errorf("error fetching receivers by phone number: %w", err)
 		}
 
+		// Create a map of existing receivers for easy lookup
 		receiverMap := make(map[string]*Receiver)
 		for _, receiver := range existingReceivers {
 			receiverMap[receiver.PhoneNumber] = receiver
@@ -98,6 +99,7 @@ func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, userID st
 			}
 		}
 
+		// Create missing receivers
 		for _, instruction := range instructions {
 			_, exists := receiverMap[instruction.Phone]
 			if !exists {

--- a/internal/integrationtests/docker/docker-compose-e2e-tests.yml
+++ b/internal/integrationtests/docker/docker-compose-e2e-tests.yml
@@ -124,7 +124,7 @@ services:
       NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
       HORIZON_URL: "https://horizon-testnet.stellar.org"
       NUM_CHANNEL_ACCOUNTS: "1"
-      MAX_BASE_FEE: "100000"
+      MAX_BASE_FEE: "1000000"
       TSS_METRICS_PORT: "9002"
       TSS_METRICS_TYPE: "TSS_PROMETHEUS"
       DISTRIBUTION_PUBLIC_KEY: ${DISTRIBUTION_PUBLIC_KEY}

--- a/internal/integrationtests/scripts/e2e_integration_test.sh
+++ b/internal/integrationtests/scripts/e2e_integration_test.sh
@@ -41,7 +41,7 @@ for accountType in "${accountTypes[@]}"; do
   # Run docker compose
   echo $DIVIDER
   echo "====> 👀Step 2: build sdp-api, anchor-platform and tss"
-  docker-compose -f ../docker/docker-compose-e2e-tests.yml up --build -d
+  docker compose -f ../docker/docker-compose-e2e-tests.yml up --build -d
   wait_for_server "http://localhost:8000/health" 20
   echo "====> ✅Step 2: finishing build"
 

--- a/internal/integrationtests/scripts/singletenant_to_multitenant_db_migration_test.sh
+++ b/internal/integrationtests/scripts/singletenant_to_multitenant_db_migration_test.sh
@@ -33,7 +33,7 @@ echo "====> ✅Step 1: finish preparation"
 # Run docker compose
 echo $DIVIDER
 echo "====> 👀Step 2: build sdp-api, anchor-platform and tss"
-docker-compose -f ../docker/docker-compose-e2e-tests.yml up --build -d
+docker compose -f ../docker/docker-compose-e2e-tests.yml up --build -d
 wait_for_server "http://localhost:8000/health" 20
 echo "====> ✅Step 2: finishing build"
 

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -203,7 +204,7 @@ func (d DisbursementHandler) PostDisbursementInstructions(w http.ResponseWriter,
 	}
 
 	// check if disbursement is in draft, ready status
-	if disbursement.Status != data.DraftDisbursementStatus && disbursement.Status != data.ReadyDisbursementStatus {
+	if !slices.Contains([]data.DisbursementStatus{data.DraftDisbursementStatus, data.ReadyDisbursementStatus}, disbursement.Status) {
 		httperror.BadRequest("disbursement is not in draft or ready status", nil, nil).Render(w)
 		return
 	}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -469,7 +469,11 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			}.ServeHTTP) // This loads the SEP-24 PII registration webpage.
 
 			sep24HeaderTokenAuthenticationMiddleware := anchorplatform.SEP24HeaderTokenAuthenticateMiddleware(o.sep24JWTManager, o.NetworkPassphrase, o.tenantManager, o.SingleTenantMode)
-			r.With(sep24HeaderTokenAuthenticationMiddleware).Post("/otp", httphandler.ReceiverSendOTPHandler{Models: o.Models, SMSMessengerClient: o.SMSMessengerClient, ReCAPTCHAValidator: reCAPTCHAValidator}.ServeHTTP)
+			r.With(sep24HeaderTokenAuthenticationMiddleware).Post("/otp", httphandler.ReceiverSendOTPHandler{
+				Models:             o.Models,
+				SMSMessengerClient: o.SMSMessengerClient,
+				ReCAPTCHAValidator: reCAPTCHAValidator,
+			}.ServeHTTP)
 			r.With(sep24HeaderTokenAuthenticationMiddleware).Post("/verification", httphandler.VerifyReceiverRegistrationHandler{
 				AnchorPlatformAPIService:    o.AnchorPlatformAPIService,
 				Models:                      o.Models,

--- a/v1_compatibility/database_migration_compatibility.sh
+++ b/v1_compatibility/database_migration_compatibility.sh
@@ -17,8 +17,8 @@ echo "====> ✅Step 1: finish cloning SDP v1 (stellar/stellar-relief-backoffice-
 # Run docker compose
 echo $DIVIDER
 echo "====> 👀Step 2: start calling docker compose up"
-docker compose down && docker-compose up --abort-on-container-exit
-echo "====> ✅Step 2: finish calling docker-compose up"
+docker compose down && docker compose up --abort-on-container-exit
+echo "====> ✅Step 2: finish calling docker compose up"
 
 echo $DIVIDER
 echo "🎉🎉🎉🎉 SUCCESS! 🎉🎉🎉🎉"


### PR DESCRIPTION
### What

Replace usage of `docker-compose` with `docker compose` in the CI workflows and the `*.sh` scripts.

### Why

`docker-compose`, AKA Compose V1, stopped receiving updates on July 2023 and the [Docker official documentation says](https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2) it should be replaced by `docker compose`, AKA Compose V2:

<img width="826" alt="Screenshot 2024-08-02 at 3 32 16 PM" src="https://github.com/user-attachments/assets/6ff7291f-9e7e-423d-b8e9-fcf9a07089d8">

Sinde the versions of our CI actions were updated by dependabot, our CI jobs that used docker-compose started failing, surfacing the problem now that the latest docker versions stopped supporting docker-compose.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
