### PR TITLE
[Fix] Add draft payments count to disbursements stats in API response 

### DIFF
--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -255,7 +255,7 @@ func (d *DisbursementModel) populateStatistics(ctx context.Context, disbursement
 			sum(case when status = 'FAILED' then 1 else 0 end) as total_payments_failed,
 			sum(case when status = 'CANCELED' then 1 else 0 end) as total_payments_canceled,
 			sum(case when status = 'DRAFT' then 1 else 0 end) as total_payments_draft,
-			sum(case when status IN ('READY', 'PENDING', 'PAUSED')  then 1 else 0 end) as total_payments_remaining,
+			sum(case when status IN ('DRAFT', 'READY', 'PENDING', 'PAUSED')  then 1 else 0 end) as total_payments_remaining,
 			ROUND(SUM(CASE WHEN status = 'SUCCESS' THEN amount ELSE 0 END), 2) as amount_disbursed,
 			ROUND(SUM(amount), 2) as total_amount,
 			ROUND(avg(amount), 2) as average_amount

--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -40,6 +40,7 @@ type DisbursementStats struct {
 	SuccessfulPayments int    `json:"total_payments_sent" db:"total_payments_sent"`
 	FailedPayments     int    `json:"total_payments_failed" db:"total_payments_failed"`
 	CanceledPayments   int    `json:"total_payments_canceled" db:"total_payments_canceled"`
+	DraftPayments      int    `json:"total_payments_draft" db:"total_payments_draft"`
 	RemainingPayments  int    `json:"total_payments_remaining" db:"total_payments_remaining"`
 	AmountDisbursed    string `json:"amount_disbursed" db:"amount_disbursed"`
 	TotalAmount        string `json:"total_amount" db:"total_amount"`
@@ -253,7 +254,8 @@ func (d *DisbursementModel) populateStatistics(ctx context.Context, disbursement
 			sum(case when status = 'SUCCESS' then 1 else 0 end) as total_payments_sent,
 			sum(case when status = 'FAILED' then 1 else 0 end) as total_payments_failed,
 			sum(case when status = 'CANCELED' then 1 else 0 end) as total_payments_canceled,
-			sum(case when status IN ('DRAFT', 'READY', 'PENDING', 'PAUSED')  then 1 else 0 end) as total_payments_remaining,
+			sum(case when status = 'DRAFT' then 1 else 0 end) as total_payments_draft,
+			sum(case when status IN ('READY', 'PENDING', 'PAUSED')  then 1 else 0 end) as total_payments_remaining,
 			ROUND(SUM(CASE WHEN status = 'SUCCESS' THEN amount ELSE 0 END), 2) as amount_disbursed,
 			ROUND(SUM(amount), 2) as total_amount,
 			ROUND(avg(amount), 2) as average_amount
@@ -281,6 +283,7 @@ func (d *DisbursementModel) populateStatistics(ctx context.Context, disbursement
 			&stats.SuccessfulPayments,
 			&stats.FailedPayments,
 			&stats.CanceledPayments,
+			&stats.DraftPayments,
 			&stats.RemainingPayments,
 			&stats.AmountDisbursed,
 			&stats.TotalAmount,

--- a/internal/data/disbursements_test.go
+++ b/internal/data/disbursements_test.go
@@ -419,7 +419,7 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 		expectedStats.FailedPayments = 1
 		expectedStats.CanceledPayments = 1
 		expectedStats.DraftPayments = 1
-		expectedStats.RemainingPayments = 1
+		expectedStats.RemainingPayments = 2
 		expectedStats.TotalAmount = "381.05"
 		expectedStats.AmountDisbursed = "100.00"
 		expectedStats.AverageAmount = "76.21"

--- a/internal/data/disbursements_test.go
+++ b/internal/data/disbursements_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 )
 
-func Test_DisbursementModelInsert(t *testing.T) {
+func Test_DisbursementModel_Insert(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 
@@ -77,7 +77,7 @@ func Test_DisbursementModelInsert(t *testing.T) {
 	})
 }
 
-func Test_DisbursementModelCount(t *testing.T) {
+func Test_DisbursementModel_Count(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 
@@ -142,7 +142,7 @@ func Test_DisbursementModelCount(t *testing.T) {
 	})
 }
 
-func Test_DisbursementModelGet(t *testing.T) {
+func Test_DisbursementModel_Get(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 
@@ -395,6 +395,13 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 			ReceiverWallet: receiverWallet,
 			Disbursement:   expectedDisbursement,
 			Asset:          *asset,
+			Amount:         "90",
+			Status:         ReadyPaymentStatus,
+		})
+		CreatePaymentFixture(t, ctx, dbConnectionPool, &paymentModel, &Payment{
+			ReceiverWallet: receiverWallet,
+			Disbursement:   expectedDisbursement,
+			Asset:          *asset,
 			Amount:         "020.50",
 			Status:         FailedPaymentStatus,
 		})
@@ -407,14 +414,15 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 		})
 
 		expectedStats := &DisbursementStats{}
-		expectedStats.TotalPayments = 4
+		expectedStats.TotalPayments = 5
 		expectedStats.SuccessfulPayments = 1
 		expectedStats.FailedPayments = 1
 		expectedStats.CanceledPayments = 1
+		expectedStats.DraftPayments = 1
 		expectedStats.RemainingPayments = 1
-		expectedStats.TotalAmount = "291.05"
+		expectedStats.TotalAmount = "381.05"
 		expectedStats.AmountDisbursed = "100.00"
-		expectedStats.AverageAmount = "72.76"
+		expectedStats.AverageAmount = "76.21"
 
 		expectedDisbursement.DisbursementStats = expectedStats
 


### PR DESCRIPTION
### What
- ~~Remove draft payments count in `total_payments_remaining` when calculating total successful payments % on the FE dashboard.~~
- Introduce a field to response `total_payments_draft` separately.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
