### PR TITLE
[SDP-1203] Add Circle Metrics

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -631,6 +631,7 @@ func (c *ServeCommand) Command(serverService ServerServiceInterface, monitorServ
 				NetworkType:          serveOpts.NetworkType,
 				EncryptionPassphrase: serveOpts.DistAccEncryptionPassphrase,
 				TenantManager:        tenant.NewManager(tenant.WithDatabase(serveOpts.AdminDBConnectionPool)),
+				MonitorService:       serveOpts.MonitorService,
 			})
 			if err != nil {
 				log.Ctx(ctx).Fatalf("error creating Circle service: %v", err)

--- a/dev/README.md
+++ b/dev/README.md
@@ -20,6 +20,7 @@
       - [Ensure Docker Containers are Running:](#ensure-docker-containers-are-running)
       - [Using VS Code:](#using-vs-code)
       - [Using IntelliJ GoLang:](#using-intellij-golang)
+    - [Monitoring the SDP](#monitoring-the-sdp)
   - [Troubleshooting](#troubleshooting)
       - [Sample Tenant Management Postman collection](#sample-tenant-management-postman-collection)
       - [Distribution account out of funds](#distribution-account-out-of-funds)
@@ -285,6 +286,32 @@ Make sure the Docker containers are up and running by executing the `main.sh` sc
      - **Local Path:** /${workspaceFolder}/stellar-disbursement-platform-backend
 
 The debugger should now attach to the running Docker container, and you should be able to hit breakpoints and debug your code.
+
+### Monitoring the SDP
+
+The SDP supports monitoring via Prometheus and Grafana. 
+
+#### Start Prometheus and Grafana containers 
+
+The containers can be started by running the following command from the `dev` directory:
+
+```sh
+docker compose -p sdp-multi-tenant -f docker-compose-monitoring.yml up -d
+```
+
+This will start the following services:
+* `prometheus`: Prometheus service running on port `9090`.
+* `grafana`: Grafana service running on port `3002`. 
+
+#### Load the SDP Grafana Dashboard
+
+1. Access the Grafana dashboard by opening a browser and going to [http://localhost:3002](http://localhost:3002).
+2. Log in with the default credentials:
+   - Username: `admin`
+   - Password: `admin`
+3. Click on the `+` icon on the left sidebar and select `Import Dashboard`.
+4. Copy the contents of the [dashboard.json](../resources/grafana/dashboard.json) file and paste it into the `Import via dashboard JSON model` text box.
+
 
 ## Troubleshooting
 

--- a/dev/docker-compose-monitoring.yml
+++ b/dev/docker-compose-monitoring.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus:/etc/prometheus/
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3002:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-storage:/var/lib/grafana
+      - ./grafana/datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml
+
+volumes:
+  grafana-storage:

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -51,12 +51,12 @@ services:
       SINGLE_TENANT_MODE: "false"
 
       # scheduler options
-      #ENABLE_SCHEDULER: "false" # set to disabled to use kafka for this.
-      #SCHEDULER_RECEIVER_INVITATION_JOB_SECONDS: "10"
-      #SCHEDULER_PAYMENT_JOB_SECONDS: "10"
+      ENABLE_SCHEDULER: "true" # set to disabled to use kafka for this.
+      SCHEDULER_RECEIVER_INVITATION_JOB_SECONDS: "10"
+      SCHEDULER_PAYMENT_JOB_SECONDS: "10"
 
       # Kafka Configuration - only used if ENABLE_SCHEDULER is set to "false"
-      EVENT_BROKER_TYPE: "KAFKA"
+      EVENT_BROKER_TYPE: "NONE"
       BROKER_URLS: "kafka:9092"
       CONSUMER_GROUP_ID: "group-id"
       KAFKA_SECURITY_PROTOCOL: "PLAINTEXT"
@@ -118,7 +118,7 @@ services:
       DATA_DATABASE: postgres
       DATA_FLYWAY_ENABLED: "true"
       DATA_DDL_AUTO: update
-      METRICS_ENABLED: "false"  # Metrics would be available at port 8082
+      METRICS_ENABLED: "true"  # Metrics would be available at port 8082
       METRICS_EXTRAS_ENABLED: "false"
       SEP10_ENABLED: "true"
       SEP10_HOME_DOMAINS: "localhost:8000, *.stellar.local:8000" # Comma separated list of home domains

--- a/dev/grafana/datasource.yaml
+++ b/dev/grafana/datasource.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: prometheus
+    type: prometheus
+    access: proxy
+    url: http://host.docker.internal:9090
+    isDefault: true
+    editable: true

--- a/dev/prometheus/prometheus.yml
+++ b/dev/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'application'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['host.docker.internal:8002']

--- a/internal/circle/client.go
+++ b/internal/circle/client.go
@@ -49,23 +49,30 @@ type Client struct {
 }
 
 // ClientFactory is a function that creates a ClientInterface.
-type ClientFactory func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface, monitorSvc monitor.MonitorServiceInterface) ClientInterface
+type ClientFactory func(opts ClientOptions) ClientInterface
 
 var _ ClientFactory = NewClient
 
+type ClientOptions struct {
+	NetworkType    utils.NetworkType
+	APIKey         string
+	TenantManager  tenant.ManagerInterface
+	MonitorService monitor.MonitorServiceInterface
+}
+
 // NewClient creates a new instance of Circle Client.
-func NewClient(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface, monitorSvc monitor.MonitorServiceInterface) ClientInterface {
+func NewClient(opts ClientOptions) ClientInterface {
 	circleEnv := Sandbox
-	if networkType == utils.PubnetNetworkType {
+	if opts.NetworkType == utils.PubnetNetworkType {
 		circleEnv = Production
 	}
 
 	return &Client{
 		BasePath:       string(circleEnv),
-		APIKey:         apiKey,
+		APIKey:         opts.APIKey,
 		httpClient:     httpclient.DefaultClient(),
-		tenantManager:  tntManager,
-		monitorService: monitorSvc,
+		tenantManager:  opts.TenantManager,
+		monitorService: opts.MonitorService,
 	}
 }
 
@@ -315,7 +322,7 @@ func (client *Client) handleError(ctx context.Context, resp *http.Response) erro
 		return fmt.Errorf("parsing API error: %w", err)
 	}
 
-	return fmt.Errorf("circle API error: %w", apiError) //nolint:golint,unused
+	return fmt.Errorf("circle API error: %w", apiError)
 }
 
 var _ ClientInterface = (*Client)(nil)

--- a/internal/circle/client_test.go
+++ b/internal/circle/client_test.go
@@ -26,7 +26,12 @@ func Test_NewClient(t *testing.T) {
 	mockTntManager := &tenant.TenantManagerMock{}
 	mMonitorService := monitorMocks.NewMockMonitorService(t)
 	t.Run("production environment", func(t *testing.T) {
-		clientInterface := NewClient(utils.PubnetNetworkType, "test-key", mockTntManager, mMonitorService)
+		clientInterface := NewClient(ClientOptions{
+			NetworkType:    utils.PubnetNetworkType,
+			APIKey:         "test-key",
+			TenantManager:  mockTntManager,
+			MonitorService: mMonitorService,
+		})
 		cc, ok := clientInterface.(*Client)
 		assert.True(t, ok)
 		assert.Equal(t, string(Production), cc.BasePath)
@@ -34,7 +39,12 @@ func Test_NewClient(t *testing.T) {
 	})
 
 	t.Run("sandbox environment", func(t *testing.T) {
-		clientInterface := NewClient(utils.TestnetNetworkType, "test-key", mockTntManager, mMonitorService)
+		clientInterface := NewClient(ClientOptions{
+			NetworkType:    utils.TestnetNetworkType,
+			APIKey:         "test-key",
+			TenantManager:  mockTntManager,
+			MonitorService: mMonitorService,
+		})
 		cc, ok := clientInterface.(*Client)
 		assert.True(t, ok)
 		assert.Equal(t, string(Sandbox), cc.BasePath)

--- a/internal/circle/client_test.go
+++ b/internal/circle/client_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
@@ -14,6 +15,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
+	monitorMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/monitor/mocks"
 	httpclientMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
@@ -21,8 +24,9 @@ import (
 
 func Test_NewClient(t *testing.T) {
 	mockTntManager := &tenant.TenantManagerMock{}
+	mMonitorService := monitorMocks.NewMockMonitorService(t)
 	t.Run("production environment", func(t *testing.T) {
-		clientInterface := NewClient(utils.PubnetNetworkType, "test-key", mockTntManager)
+		clientInterface := NewClient(utils.PubnetNetworkType, "test-key", mockTntManager, mMonitorService)
 		cc, ok := clientInterface.(*Client)
 		assert.True(t, ok)
 		assert.Equal(t, string(Production), cc.BasePath)
@@ -30,7 +34,7 @@ func Test_NewClient(t *testing.T) {
 	})
 
 	t.Run("sandbox environment", func(t *testing.T) {
-		clientInterface := NewClient(utils.TestnetNetworkType, "test-key", mockTntManager)
+		clientInterface := NewClient(utils.TestnetNetworkType, "test-key", mockTntManager, mMonitorService)
 		cc, ok := clientInterface.(*Client)
 		assert.True(t, ok)
 		assert.Equal(t, string(Sandbox), cc.BasePath)
@@ -42,9 +46,9 @@ func Test_Client_Ping(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("ping error", func(t *testing.T) {
-		cc, httpClientMock, _ := newClientWithMocks(t)
+		cc, cMocks := newClientWithMocks(t)
 		testError := errors.New("test error")
-		httpClientMock.
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(nil, testError).
 			Once()
@@ -55,8 +59,8 @@ func Test_Client_Ping(t *testing.T) {
 	})
 
 	t.Run("ping successful", func(t *testing.T) {
-		cc, httpClientMock, _ := newClientWithMocks(t)
-		httpClientMock.
+		cc, cMocks := newClientWithMocks(t)
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(&http.Response{
 				StatusCode: http.StatusOK,
@@ -88,9 +92,9 @@ func Test_Client_PostTransfer(t *testing.T) {
 	}
 
 	t.Run("post transfer error", func(t *testing.T) {
-		cc, httpClientMock, _ := newClientWithMocks(t)
+		cc, cMocks := newClientWithMocks(t)
 		testError := errors.New("test error")
-		httpClientMock.
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(nil, testError).
 			Once()
@@ -101,7 +105,7 @@ func Test_Client_PostTransfer(t *testing.T) {
 	})
 
 	t.Run("post transfer fails to validate request", func(t *testing.T) {
-		cc, _, _ := newClientWithMocks(t)
+		cc, _ := newClientWithMocks(t)
 		transfer, err := cc.PostTransfer(ctx, TransferRequest{})
 		assert.EqualError(t, err, fmt.Errorf("validating transfer request: %w", errors.New("source type must be provided")).Error())
 		assert.Nil(t, transfer)
@@ -109,29 +113,45 @@ func Test_Client_PostTransfer(t *testing.T) {
 
 	t.Run("post transfer fails auth", func(t *testing.T) {
 		unauthorizedResponse := `{"code": 401, "message": "Malformed key. Does it contain three parts?"}`
-		cc, httpClientMock, tntManagerMock := newClientWithMocks(t)
-		tnt := &tenant.Tenant{ID: "test-id"}
+		cc, cMocks := newClientWithMocks(t)
+		tnt := &tenant.Tenant{ID: "test-id", Name: "test-tenant"}
 		ctx = tenant.SaveTenantInContext(ctx, tnt)
 
-		httpClientMock.
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(&http.Response{
 				StatusCode: http.StatusUnauthorized,
 				Body:       io.NopCloser(bytes.NewBufferString(unauthorizedResponse)),
 			}, nil).
 			Once()
-		tntManagerMock.
+		cMocks.tenantManagerMock.
 			On("DeactivateTenantDistributionAccount", mock.Anything, tnt.ID).
+			Return(nil).Once()
+		expectedLabels := map[string]string{
+			"endpoint":    transferPath,
+			"method":      http.MethodPost,
+			"status":      "success",
+			"status_code": strconv.Itoa(http.StatusUnauthorized),
+			"tenant_name": tnt.Name,
+		}
+		cMocks.monitorServiceMock.
+			On("MonitorHistogram", mock.Anything, monitor.CircleAPIRequestDurationTag, expectedLabels).
+			Return(nil).Once()
+		cMocks.monitorServiceMock.
+			On("MonitorCounters", monitor.CircleAPIRequestsTotalTag, expectedLabels).
 			Return(nil).Once()
 
 		transfer, err := cc.PostTransfer(ctx, validTransferReq)
-		assert.EqualError(t, err, "handling API response error: Circle API error: APIError: Code=401, Message=Malformed key. Does it contain three parts?, Errors=[], StatusCode=401")
+		assert.EqualError(t, err, "handling API response error: circle API error: APIError: Code=401, Message=Malformed key. Does it contain three parts?, Errors=[], StatusCode=401")
 		assert.Nil(t, transfer)
 	})
 
 	t.Run("post transfer successful", func(t *testing.T) {
-		cc, httpClientMock, _ := newClientWithMocks(t)
-		httpClientMock.
+		cc, cMocks := newClientWithMocks(t)
+		tnt := &tenant.Tenant{ID: "test-id", Name: "test-tenant"}
+		ctx = tenant.SaveTenantInContext(ctx, tnt)
+
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(&http.Response{
 				StatusCode: http.StatusCreated,
@@ -148,6 +168,20 @@ func Test_Client_PostTransfer(t *testing.T) {
 			}).
 			Once()
 
+		expectedLabels := map[string]string{
+			"endpoint":    transferPath,
+			"method":      http.MethodPost,
+			"status":      "success",
+			"status_code": strconv.Itoa(http.StatusCreated),
+			"tenant_name": "test-tenant",
+		}
+		cMocks.monitorServiceMock.
+			On("MonitorHistogram", mock.Anything, monitor.CircleAPIRequestDurationTag, expectedLabels).
+			Return(nil).Once()
+		cMocks.monitorServiceMock.
+			On("MonitorCounters", monitor.CircleAPIRequestsTotalTag, expectedLabels).
+			Return(nil).Once()
+
 		transfer, err := cc.PostTransfer(ctx, validTransferReq)
 		assert.NoError(t, err)
 		assert.Equal(t, "test-id", transfer.ID)
@@ -157,9 +191,9 @@ func Test_Client_PostTransfer(t *testing.T) {
 func Test_Client_GetTransferByID(t *testing.T) {
 	ctx := context.Background()
 	t.Run("get transfer by id error", func(t *testing.T) {
-		cc, httpClientMock, _ := newClientWithMocks(t)
+		cc, cMocks := newClientWithMocks(t)
 		testError := errors.New("test error")
-		httpClientMock.
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(nil, testError).
 			Once()
@@ -171,29 +205,45 @@ func Test_Client_GetTransferByID(t *testing.T) {
 
 	t.Run("get transfer by id fails auth", func(t *testing.T) {
 		unauthorizedResponse := `{"code": 401, "message": "Malformed key. Does it contain three parts?"}`
-		cc, httpClientMock, tntManagerMock := newClientWithMocks(t)
-		tnt := &tenant.Tenant{ID: "test-id"}
+		cc, cMocks := newClientWithMocks(t)
+		tnt := &tenant.Tenant{ID: "test-id", Name: "test-tenant"}
 		ctx = tenant.SaveTenantInContext(ctx, tnt)
 
-		httpClientMock.
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(&http.Response{
 				StatusCode: http.StatusUnauthorized,
 				Body:       io.NopCloser(bytes.NewBufferString(unauthorizedResponse)),
 			}, nil).
 			Once()
-		tntManagerMock.
+		cMocks.tenantManagerMock.
 			On("DeactivateTenantDistributionAccount", mock.Anything, tnt.ID).
+			Return(nil).Once()
+		expectedLabels := map[string]string{
+			"endpoint":    transferPath,
+			"method":      http.MethodGet,
+			"status":      "success",
+			"status_code": strconv.Itoa(http.StatusUnauthorized),
+			"tenant_name": tnt.Name,
+		}
+		cMocks.monitorServiceMock.
+			On("MonitorHistogram", mock.Anything, monitor.CircleAPIRequestDurationTag, expectedLabels).
+			Return(nil).Once()
+		cMocks.monitorServiceMock.
+			On("MonitorCounters", monitor.CircleAPIRequestsTotalTag, expectedLabels).
 			Return(nil).Once()
 
 		transfer, err := cc.GetTransferByID(ctx, "test-id")
-		assert.EqualError(t, err, "handling API response error: Circle API error: APIError: Code=401, Message=Malformed key. Does it contain three parts?, Errors=[], StatusCode=401")
+		assert.EqualError(t, err, "handling API response error: circle API error: APIError: Code=401, Message=Malformed key. Does it contain three parts?, Errors=[], StatusCode=401")
 		assert.Nil(t, transfer)
 	})
 
 	t.Run("get transfer by id successful", func(t *testing.T) {
-		cc, httpClientMock, _ := newClientWithMocks(t)
-		httpClientMock.
+		cc, cMocks := newClientWithMocks(t)
+		tnt := &tenant.Tenant{ID: "test-id", Name: "test-tenant"}
+		ctx = tenant.SaveTenantInContext(ctx, tnt)
+
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(&http.Response{
 				StatusCode: http.StatusOK,
@@ -209,6 +259,20 @@ func Test_Client_GetTransferByID(t *testing.T) {
 			}).
 			Once()
 
+		expectedLabels := map[string]string{
+			"endpoint":    transferPath,
+			"method":      http.MethodGet,
+			"status":      "success",
+			"status_code": strconv.Itoa(http.StatusOK),
+			"tenant_name": tnt.Name,
+		}
+		cMocks.monitorServiceMock.
+			On("MonitorHistogram", mock.Anything, monitor.CircleAPIRequestDurationTag, expectedLabels).
+			Return(nil).Once()
+		cMocks.monitorServiceMock.
+			On("MonitorCounters", monitor.CircleAPIRequestsTotalTag, expectedLabels).
+			Return(nil).Once()
+
 		transfer, err := cc.GetTransferByID(ctx, "test-id")
 		assert.NoError(t, err)
 		assert.Equal(t, "test-id", transfer.ID)
@@ -218,9 +282,9 @@ func Test_Client_GetTransferByID(t *testing.T) {
 func Test_Client_GetWalletByID(t *testing.T) {
 	ctx := context.Background()
 	t.Run("get wallet by id error", func(t *testing.T) {
-		cc, httpClientMock, _ := newClientWithMocks(t)
+		cc, cMocks := newClientWithMocks(t)
 		testError := errors.New("test error")
-		httpClientMock.
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Run(func(args mock.Arguments) {
 				req, ok := args.Get(0).(*http.Request)
@@ -243,23 +307,36 @@ func Test_Client_GetWalletByID(t *testing.T) {
 			"code": 401,
 			"message": "Malformed key. Does it contain three parts?"
 		}`
-		cc, httpClientMock, tntManagerMock := newClientWithMocks(t)
+		cc, cMocks := newClientWithMocks(t)
 		tnt := &tenant.Tenant{ID: "test-id"}
 		ctx = tenant.SaveTenantInContext(ctx, tnt)
 
-		httpClientMock.
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(&http.Response{
 				StatusCode: http.StatusUnauthorized,
 				Body:       io.NopCloser(bytes.NewBufferString(unauthorizedResponse)),
 			}, nil).
 			Once()
-		tntManagerMock.
+		cMocks.tenantManagerMock.
 			On("DeactivateTenantDistributionAccount", mock.Anything, tnt.ID).
+			Return(nil).Once()
+		expectedLabels := map[string]string{
+			"endpoint":    walletPath,
+			"method":      http.MethodGet,
+			"status":      "success",
+			"status_code": strconv.Itoa(http.StatusUnauthorized),
+			"tenant_name": tnt.Name,
+		}
+		cMocks.monitorServiceMock.
+			On("MonitorHistogram", mock.Anything, monitor.CircleAPIRequestDurationTag, expectedLabels).
+			Return(nil).Once()
+		cMocks.monitorServiceMock.
+			On("MonitorCounters", monitor.CircleAPIRequestsTotalTag, expectedLabels).
 			Return(nil).Once()
 
 		transfer, err := cc.GetWalletByID(ctx, "test-id")
-		assert.EqualError(t, err, "handling API response error: Circle API error: APIError: Code=401, Message=Malformed key. Does it contain three parts?, Errors=[], StatusCode=401")
+		assert.EqualError(t, err, "handling API response error: circle API error: APIError: Code=401, Message=Malformed key. Does it contain three parts?, Errors=[], StatusCode=401")
 		assert.Nil(t, transfer)
 	})
 
@@ -278,8 +355,10 @@ func Test_Client_GetWalletByID(t *testing.T) {
 				]
 			}
 		}`
-		cc, httpClientMock, _ := newClientWithMocks(t)
-		httpClientMock.
+		cc, cMocks := newClientWithMocks(t)
+		tnt := &tenant.Tenant{ID: "test-id", Name: "test-tenant"}
+		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(&http.Response{
 				StatusCode: http.StatusOK,
@@ -294,7 +373,19 @@ func Test_Client_GetWalletByID(t *testing.T) {
 				assert.Equal(t, "Bearer test-key", req.Header.Get("Authorization"))
 			}).
 			Once()
-
+		expectedLabels := map[string]string{
+			"endpoint":    walletPath,
+			"method":      http.MethodGet,
+			"status":      "success",
+			"status_code": strconv.Itoa(http.StatusOK),
+			"tenant_name": tnt.Name,
+		}
+		cMocks.monitorServiceMock.
+			On("MonitorHistogram", mock.Anything, monitor.CircleAPIRequestDurationTag, expectedLabels).
+			Return(nil).Once()
+		cMocks.monitorServiceMock.
+			On("MonitorCounters", monitor.CircleAPIRequestsTotalTag, expectedLabels).
+			Return(nil).Once()
 		wallet, err := cc.GetWalletByID(ctx, "test-id")
 		assert.NoError(t, err)
 		wantWallet := &Wallet{
@@ -315,11 +406,11 @@ func Test_Client_handleError(t *testing.T) {
 	tnt := &tenant.Tenant{ID: "test-id"}
 	ctx = tenant.SaveTenantInContext(ctx, tnt)
 
-	cc, _, tntManagerMock := newClientWithMocks(t)
+	cc, cMocks := newClientWithMocks(t)
 
 	t.Run("deactivate tenant distribution account error", func(t *testing.T) {
 		testError := errors.New("foo")
-		tntManagerMock.
+		cMocks.tenantManagerMock.
 			On("DeactivateTenantDistributionAccount", mock.Anything, tnt.ID).
 			Return(testError).Once()
 
@@ -332,12 +423,12 @@ func Test_Client_handleError(t *testing.T) {
 			StatusCode: http.StatusUnauthorized,
 			Body:       io.NopCloser(bytes.NewBufferString(`{"code": 401, "message": "Unauthorized"}`)),
 		}
-		tntManagerMock.
+		cMocks.tenantManagerMock.
 			On("DeactivateTenantDistributionAccount", mock.Anything, tnt.ID).
 			Return(nil).Once()
 
 		err := cc.handleError(ctx, unauthorizedResponse)
-		assert.EqualError(t, fmt.Errorf("Circle API error: %w", errors.New("APIError: Code=401, Message=Unauthorized, Errors=[], StatusCode=401")), err.Error())
+		assert.EqualError(t, fmt.Errorf("circle API error: %w", errors.New("APIError: Code=401, Message=Unauthorized, Errors=[], StatusCode=401")), err.Error())
 	})
 
 	t.Run("deactivates tenant distribution account if Circle error response is forbidden", func(t *testing.T) {
@@ -345,12 +436,12 @@ func Test_Client_handleError(t *testing.T) {
 			StatusCode: http.StatusForbidden,
 			Body:       io.NopCloser(bytes.NewBufferString(`{"code": 403, "message": "Forbidden"}`)),
 		}
-		tntManagerMock.
+		cMocks.tenantManagerMock.
 			On("DeactivateTenantDistributionAccount", mock.Anything, tnt.ID).
 			Return(nil).Once()
 
 		err := cc.handleError(ctx, unauthorizedResponse)
-		assert.EqualError(t, fmt.Errorf("Circle API error: %w", errors.New("APIError: Code=403, Message=Forbidden, Errors=[], StatusCode=403")), err.Error())
+		assert.EqualError(t, fmt.Errorf("circle API error: %w", errors.New("APIError: Code=403, Message=Forbidden, Errors=[], StatusCode=403")), err.Error())
 	})
 
 	t.Run("does not deactivate tenant distribution account if Circle error response is not unauthorized or forbidden", func(t *testing.T) {
@@ -360,7 +451,7 @@ func Test_Client_handleError(t *testing.T) {
 		}
 
 		err := cc.handleError(ctx, unauthorizedResponse)
-		assert.EqualError(t, fmt.Errorf("Circle API error: %w", errors.New("APIError: Code=400, Message=Bad Request, Errors=[], StatusCode=400")), err.Error())
+		assert.EqualError(t, fmt.Errorf("circle API error: %w", errors.New("APIError: Code=400, Message=Bad Request, Errors=[], StatusCode=400")), err.Error())
 	})
 
 	t.Run("records error correctly when not proper json", func(t *testing.T) {
@@ -370,10 +461,10 @@ func Test_Client_handleError(t *testing.T) {
 		}
 
 		err := cc.handleError(ctx, unauthorizedResponse)
-		assert.EqualError(t, fmt.Errorf("Circle API error: %w", errors.New("APIError: Code=0, Message=error code: 1015, Errors=[], StatusCode=429")), err.Error())
+		assert.EqualError(t, fmt.Errorf("circle API error: %w", errors.New("APIError: Code=0, Message=error code: 1015, Errors=[], StatusCode=429")), err.Error())
 	})
 
-	tntManagerMock.AssertExpectations(t)
+	cMocks.tenantManagerMock.AssertExpectations(t)
 }
 
 func Test_Client_request(t *testing.T) {
@@ -433,7 +524,8 @@ func Test_Client_request(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cc, httpClientMock, _ := newClientWithMocks(t)
+			cc, cMocks := newClientWithMocks(t)
+			httpClientMock := cMocks.httpClientMock
 
 			ctx := context.Background()
 			u := "https://api-sandbox.circle.com/test"
@@ -442,12 +534,12 @@ func Test_Client_request(t *testing.T) {
 			body := []byte("test-body")
 
 			for _, resp := range tt.responses {
-				httpClientMock.
+				cMocks.httpClientMock.
 					On("Do", mock.Anything).
 					Return(&resp, nil).Once()
 			}
 
-			resp, err := cc.request(ctx, u, method, isAuthed, body)
+			resp, err := cc.request(ctx, "/test", u, method, isAuthed, body)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)
@@ -470,14 +562,26 @@ func Test_Client_request(t *testing.T) {
 	}
 }
 
-func newClientWithMocks(t *testing.T) (Client, *httpclientMocks.HttpClientMock, *tenant.TenantManagerMock) {
+func newClientWithMocks(t *testing.T) (Client, *clientMocks) {
 	httpClientMock := httpclientMocks.NewHttpClientMock(t)
 	tntManagerMock := tenant.NewTenantManagerMock(t)
+	monitorSvcMock := monitorMocks.NewMockMonitorService(t)
 
 	return Client{
-		BasePath:      "http://localhost:8080",
-		APIKey:        "test-key",
-		httpClient:    httpClientMock,
-		tenantManager: tntManagerMock,
-	}, httpClientMock, tntManagerMock
+			BasePath:       "http://localhost:8080",
+			APIKey:         "test-key",
+			httpClient:     httpClientMock,
+			tenantManager:  tntManagerMock,
+			monitorService: monitorSvcMock,
+		}, &clientMocks{
+			httpClientMock:     httpClientMock,
+			tenantManagerMock:  tntManagerMock,
+			monitorServiceMock: monitorSvcMock,
+		}
+}
+
+type clientMocks struct {
+	httpClientMock     *httpclientMocks.HttpClientMock
+	tenantManagerMock  *tenant.TenantManagerMock
+	monitorServiceMock *monitorMocks.MockMonitorService
 }

--- a/internal/circle/service.go
+++ b/internal/circle/service.go
@@ -119,7 +119,12 @@ func (s *Service) getClientForTenantInContext(ctx context.Context) (ClientInterf
 	if err != nil {
 		return nil, fmt.Errorf("retrieving decrypted Circle API key: %w", err)
 	}
-	return s.ClientFactory(s.NetworkType, apiKey, s.TenantManager, s.MonitorService), nil
+	return s.ClientFactory(ClientOptions{
+		APIKey:         apiKey,
+		NetworkType:    s.NetworkType,
+		TenantManager:  s.TenantManager,
+		MonitorService: s.MonitorService,
+	}), nil
 }
 
 func (s *Service) Ping(ctx context.Context) (bool, error) {

--- a/internal/circle/service.go
+++ b/internal/circle/service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stellar/go/strkey"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -16,6 +17,7 @@ type Service struct {
 	NetworkType          utils.NetworkType
 	EncryptionPassphrase string
 	TenantManager        tenant.ManagerInterface
+	MonitorService       monitor.MonitorServiceInterface
 }
 
 const StellarChainCode = "XLM"
@@ -36,6 +38,7 @@ type ServiceOptions struct {
 	TenantManager        tenant.ManagerInterface
 	NetworkType          utils.NetworkType
 	EncryptionPassphrase string
+	MonitorService       monitor.MonitorServiceInterface
 }
 
 func (o ServiceOptions) Validate() error {
@@ -49,6 +52,10 @@ func (o ServiceOptions) Validate() error {
 
 	if o.TenantManager == nil {
 		return fmt.Errorf("TenantManager is required")
+	}
+
+	if o.MonitorService == nil {
+		return fmt.Errorf("MonitorService is required")
 	}
 
 	err := o.NetworkType.Validate()
@@ -75,6 +82,7 @@ func NewService(opts ServiceOptions) (*Service, error) {
 		NetworkType:          opts.NetworkType,
 		EncryptionPassphrase: opts.EncryptionPassphrase,
 		TenantManager:        opts.TenantManager,
+		MonitorService:       opts.MonitorService,
 	}, nil
 }
 
@@ -111,7 +119,7 @@ func (s *Service) getClientForTenantInContext(ctx context.Context) (ClientInterf
 	if err != nil {
 		return nil, fmt.Errorf("retrieving decrypted Circle API key: %w", err)
 	}
-	return s.ClientFactory(s.NetworkType, apiKey, s.TenantManager), nil
+	return s.ClientFactory(s.NetworkType, apiKey, s.TenantManager, s.MonitorService), nil
 }
 
 func (s *Service) Ping(ctx context.Context) (bool, error) {

--- a/internal/circle/service_test.go
+++ b/internal/circle/service_test.go
@@ -9,16 +9,19 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
+	monitorMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/monitor/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_ServiceOptions_Validate(t *testing.T) {
-	var clientFactory ClientFactory = func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface) ClientInterface {
+	var clientFactory ClientFactory = func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface, monitorService monitor.MonitorServiceInterface) ClientInterface {
 		return nil
 	}
 	circleClientConfigModel := &ClientConfigModel{}
 	mockTenantManager := &tenant.TenantManagerMock{}
+	mockMonitorSvc := monitorMocks.NewMockMonitorService(t)
 
 	testCases := []struct {
 		name                string
@@ -41,11 +44,17 @@ func Test_ServiceOptions_Validate(t *testing.T) {
 			expectedErrContains: "TenantManager is required",
 		},
 		{
+			name:                "MonitorService validation fails",
+			opts:                ServiceOptions{ClientFactory: clientFactory, ClientConfigModel: circleClientConfigModel, TenantManager: mockTenantManager},
+			expectedErrContains: "MonitorService is required",
+		},
+		{
 			name: "NetworkType validation fails",
 			opts: ServiceOptions{
 				ClientFactory:     clientFactory,
 				ClientConfigModel: circleClientConfigModel,
 				TenantManager:     mockTenantManager,
+				MonitorService:    mockMonitorSvc,
 				NetworkType:       utils.NetworkType("FOOBAR"),
 			},
 			expectedErrContains: `validating NetworkType: invalid network type "FOOBAR"`,
@@ -56,6 +65,7 @@ func Test_ServiceOptions_Validate(t *testing.T) {
 				ClientFactory:        clientFactory,
 				ClientConfigModel:    circleClientConfigModel,
 				TenantManager:        mockTenantManager,
+				MonitorService:       mockMonitorSvc,
 				NetworkType:          utils.TestnetNetworkType,
 				EncryptionPassphrase: "FOO BAR",
 			},
@@ -68,6 +78,7 @@ func Test_ServiceOptions_Validate(t *testing.T) {
 				ClientConfigModel:    circleClientConfigModel,
 				TenantManager:        mockTenantManager,
 				NetworkType:          utils.TestnetNetworkType,
+				MonitorService:       mockMonitorSvc,
 				EncryptionPassphrase: "SCW5I426WV3IDTLSTLQEHC6BMXWI2Z6C4DXAOC4ZA2EIHTAZQ6VD3JI6",
 			},
 		},
@@ -93,11 +104,12 @@ func Test_NewService(t *testing.T) {
 	})
 
 	t.Run("🎉 successfully creates a new Service", func(t *testing.T) {
-		clientFactory := func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface) ClientInterface {
+		clientFactory := func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface, monitorService monitor.MonitorServiceInterface) ClientInterface {
 			return nil
 		}
 		clientConfigModel := &ClientConfigModel{}
 		mockTntManager := &tenant.TenantManagerMock{}
+		mockMonitorSvc := monitorMocks.NewMockMonitorService(t)
 		networkType := utils.TestnetNetworkType
 		encryptionPassphrase := "SCW5I426WV3IDTLSTLQEHC6BMXWI2Z6C4DXAOC4ZA2EIHTAZQ6VD3JI6"
 
@@ -107,6 +119,7 @@ func Test_NewService(t *testing.T) {
 			TenantManager:        mockTntManager,
 			NetworkType:          networkType,
 			EncryptionPassphrase: encryptionPassphrase,
+			MonitorService:       mockMonitorSvc,
 		})
 		assert.NoError(t, err)
 
@@ -117,7 +130,8 @@ func Test_NewService(t *testing.T) {
 			NetworkType:          networkType,
 			EncryptionPassphrase: encryptionPassphrase,
 		}
-		assert.Equal(t, wantService.ClientFactory(networkType, "FOO BAR", mockTntManager), svc.ClientFactory(networkType, "FOO BAR", mockTntManager))
+
+		assert.Equal(t, wantService.ClientFactory(networkType, "FOO BAR", mockTntManager, mockMonitorSvc), svc.ClientFactory(networkType, "FOO BAR", mockTntManager, mockMonitorSvc))
 		assert.Equal(t, wantService.ClientConfigModel, svc.ClientConfigModel)
 		assert.Equal(t, wantService.NetworkType, svc.NetworkType)
 		assert.Equal(t, wantService.EncryptionPassphrase, svc.EncryptionPassphrase)
@@ -140,6 +154,7 @@ func Test_Service_getClient(t *testing.T) {
 	networkType := utils.TestnetNetworkType
 	clientConfigModel := NewClientConfigModel(dbConnectionPool)
 	mockTntManager := &tenant.TenantManagerMock{}
+	mMonitorService := monitorMocks.NewMockMonitorService(t)
 
 	// Add a client config to the database.
 	err = clientConfigModel.Upsert(ctx, ClientConfigUpdate{
@@ -156,12 +171,13 @@ func Test_Service_getClient(t *testing.T) {
 		TenantManager:        mockTntManager,
 		NetworkType:          networkType,
 		EncryptionPassphrase: encryptionPassphrase,
+		MonitorService:       mMonitorService,
 	})
 	assert.NoError(t, err)
 
 	circleClient, err := svc.getClientForTenantInContext(ctx)
 	assert.NoError(t, err)
-	wantCircleClient := NewClient(networkType, apiKey, &tenant.TenantManagerMock{})
+	wantCircleClient := NewClient(networkType, apiKey, &tenant.TenantManagerMock{}, mMonitorService)
 	assert.Equal(t, wantCircleClient, circleClient)
 }
 
@@ -192,13 +208,14 @@ func Test_Service_allMethods(t *testing.T) {
 	// Method used to spin up a service with a mock client.
 	createService := func(t *testing.T, mCircleClient *MockClient) *Service {
 		svc, err := NewService(ServiceOptions{
-			ClientFactory: func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface) ClientInterface {
+			ClientFactory: func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface, monitorSvc monitor.MonitorServiceInterface) ClientInterface {
 				return mCircleClient
 			},
 			ClientConfigModel:    clientConfigModel,
 			TenantManager:        mockTntManager,
 			NetworkType:          networkType,
 			EncryptionPassphrase: encryptionPassphrase,
+			MonitorService:       monitorMocks.NewMockMonitorService(t),
 		})
 		require.NoError(t, err)
 		return svc

--- a/internal/dependencyinjection/circle_service_test.go
+++ b/internal/dependencyinjection/circle_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
+	monitorMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/monitor/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -21,6 +22,7 @@ func Test_NewCircleService(t *testing.T) {
 		TenantManager:        &tenant.TenantManagerMock{},
 		NetworkType:          utils.TestnetNetworkType,
 		EncryptionPassphrase: keypair.MustRandom().Seed(),
+		MonitorService:       monitorMocks.NewMockMonitorService(t),
 	}
 
 	t.Run("should create and return the same instance on the second call", func(t *testing.T) {

--- a/internal/monitor/main.go
+++ b/internal/monitor/main.go
@@ -34,7 +34,7 @@ type MetricOptions struct {
 func GetClient(opts MetricOptions) (MonitorClient, error) {
 	switch opts.MetricType {
 	case MetricTypePrometheus:
-		return NewPrometheusClient()
+		return newPrometheusClient()
 	case MetricTypeTSSPrometheus:
 		return NewTSSPrometheusClient()
 	default:

--- a/internal/monitor/metric_tags.go
+++ b/internal/monitor/metric_tags.go
@@ -11,6 +11,9 @@ const (
 	// AnchorPlatformAuthProtection
 	AnchorPlatformAuthProtectionEnsuredCounterTag MetricTag = "anchor_platform_auth_protection_ensured_counter"
 	AnchorPlatformAuthProtectionMissingCounterTag MetricTag = "anchor_platform_auth_protection_missing_counter"
+	// Circle API Requests
+	CircleAPIRequestDurationTag MetricTag = "circle_api_request_duration_seconds"
+	CircleAPIRequestsTotalTag   MetricTag = "circle_api_requests_total"
 )
 
 func (m MetricTag) ListAll() []MetricTag {
@@ -21,5 +24,7 @@ func (m MetricTag) ListAll() []MetricTag {
 		DisbursementsCounterTag,
 		AnchorPlatformAuthProtectionEnsuredCounterTag,
 		AnchorPlatformAuthProtectionMissingCounterTag,
+		CircleAPIRequestDurationTag,
+		CircleAPIRequestsTotalTag,
 	}
 }

--- a/internal/monitor/monitor_labels.go
+++ b/internal/monitor/monitor_labels.go
@@ -23,3 +23,23 @@ func (d DisbursementLabels) ToMap() map[string]string {
 		"wallet":  d.Wallet,
 	}
 }
+
+type CircleLabels struct {
+	Method     string
+	Endpoint   string
+	Status     string
+	StatusCode string
+	TenantName string
+}
+
+func (c CircleLabels) ToMap() map[string]string {
+	return map[string]string{
+		"method":      c.Method,
+		"endpoint":    c.Endpoint,
+		"status":      c.Status,
+		"status_code": c.StatusCode,
+		"tenant_name": c.TenantName,
+	}
+}
+
+var CircleLabelNames = []string{"method", "endpoint", "status", "status_code", "tenant_name"}

--- a/internal/monitor/prometheus_client_test.go
+++ b/internal/monitor/prometheus_client_test.go
@@ -185,7 +185,7 @@ func Test_PrometheusClient_MonitorCounters(t *testing.T) {
 		assert.NotEmpty(t, data)
 		body := string(data)
 
-		metric := `sdp_bussiness_disbursements_counter{asset="USDC",country="UKR",wallet="Mock Wallet"} 1`
+		metric := `sdp_business_disbursements_counter{asset="USDC",country="UKR",wallet="Mock Wallet"} 1`
 
 		assert.Contains(t, body, metric)
 

--- a/internal/monitor/prometheus_metrics.go
+++ b/internal/monitor/prometheus_metrics.go
@@ -1,6 +1,30 @@
 package monitor
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func PrometheusMetrics() map[MetricTag]prometheus.Collector {
+	metrics := make(map[MetricTag]prometheus.Collector)
+
+	for tag, summaryVec := range SummaryVecMetrics {
+		metrics[tag] = summaryVec
+	}
+
+	for tag, counter := range CounterMetrics {
+		metrics[tag] = counter
+	}
+
+	for tag, histogramVec := range HistogramVecMetrics {
+		metrics[tag] = histogramVec
+	}
+
+	for tag, counterVec := range CounterVecMetrics {
+		metrics[tag] = counterVec
+	}
+
+	return metrics
+}
 
 var SummaryVecMetrics = map[MetricTag]*prometheus.SummaryVec{
 	HttpRequestDurationTag: prometheus.NewSummaryVec(prometheus.SummaryOpts{
@@ -34,13 +58,26 @@ var CounterMetrics = map[MetricTag]prometheus.Counter{
 	}),
 }
 
-var HistogramVecMetrics map[MetricTag]prometheus.HistogramVec
+var HistogramVecMetrics = map[MetricTag]*prometheus.HistogramVec{
+	CircleAPIRequestDurationTag: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "sdp", Subsystem: "circle", Name: string(CircleAPIRequestDurationTag),
+		Help: "A histogram of the Circle API request durations",
+	},
+		CircleLabelNames,
+	),
+}
 
 var CounterVecMetrics = map[MetricTag]*prometheus.CounterVec{
 	DisbursementsCounterTag: prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "sdp", Subsystem: "bussiness", Name: string(DisbursementsCounterTag),
+		Namespace: "sdp", Subsystem: "business", Name: string(DisbursementsCounterTag),
 		Help: "Disbursements Counter",
 	},
 		[]string{"asset", "country", "wallet"},
+	),
+	CircleAPIRequestsTotalTag: prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sdp", Subsystem: "circle", Name: string(CircleAPIRequestsTotalTag),
+		Help: "A counter of the Circle API requests",
+	},
+		CircleLabelNames,
 	),
 }

--- a/internal/monitor/utils.go
+++ b/internal/monitor/utils.go
@@ -1,0 +1,19 @@
+package monitor
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	noHTTPStatus  = "0"
+	successStatus = "success"
+	errorStatus   = "error"
+)
+
+func ParseHTTPResponseStatus(resp *http.Response, reqErr error) (status, statusCode string) {
+	if reqErr != nil {
+		return errorStatus, noHTTPStatus
+	}
+	return successStatus, fmt.Sprint(resp.StatusCode)
+}

--- a/internal/serve/httphandler/circle_config_handler.go
+++ b/internal/serve/httphandler/circle_config_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go/support/render/httpjson"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	sdpUtils "github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
@@ -26,6 +27,7 @@ type CircleConfigHandler struct {
 	EncryptionPassphrase        string
 	CircleClientConfigModel     circle.ClientConfigModelInterface
 	DistributionAccountResolver signing.DistributionAccountResolver
+	MonitorService              monitor.MonitorServiceInterface
 }
 
 type PatchCircleConfigRequest struct {
@@ -160,7 +162,7 @@ func (h CircleConfigHandler) validateConfigWithCircle(ctx context.Context, patch
 		}
 	}
 
-	circleClient := h.CircleFactory(h.NetworkType, apiKey, h.TenantManager)
+	circleClient := h.CircleFactory(h.NetworkType, apiKey, h.TenantManager, h.MonitorService)
 
 	// validate incoming APIKey
 	if patchRequest.APIKey != nil {

--- a/internal/serve/httphandler/circle_config_handler.go
+++ b/internal/serve/httphandler/circle_config_handler.go
@@ -162,7 +162,12 @@ func (h CircleConfigHandler) validateConfigWithCircle(ctx context.Context, patch
 		}
 	}
 
-	circleClient := h.CircleFactory(h.NetworkType, apiKey, h.TenantManager, h.MonitorService)
+	circleClient := h.CircleFactory(circle.ClientOptions{
+		NetworkType:    h.NetworkType,
+		APIKey:         apiKey,
+		TenantManager:  h.TenantManager,
+		MonitorService: h.MonitorService,
+	})
 
 	// validate incoming APIKey
 	if patchRequest.APIKey != nil {

--- a/internal/serve/httphandler/circle_config_handler_test.go
+++ b/internal/serve/httphandler/circle_config_handler_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
@@ -195,7 +194,7 @@ func TestCircleConfigHandler_Patch(t *testing.T) {
 				tc.prepareMocksFn(t, mDistributionAccountResolver, mCircleClient, mTenantManager)
 
 				handler.DistributionAccountResolver = mDistributionAccountResolver
-				handler.CircleFactory = func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface, monitorSvc monitor.MonitorServiceInterface) circle.ClientInterface {
+				handler.CircleFactory = func(clientOpts circle.ClientOptions) circle.ClientInterface {
 					return mCircleClient
 				}
 				handler.TenantManager = mTenantManager
@@ -367,7 +366,7 @@ func Test_CircleConfigHandler_validateConfigWithCircle(t *testing.T) {
 
 				handler.Encrypter = mEncrypter
 				handler.CircleClientConfigModel = mCircleClientConfigModel
-				handler.CircleFactory = func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface, monitorSvc monitor.MonitorServiceInterface) circle.ClientInterface {
+				handler.CircleFactory = func(clientOpts circle.ClientOptions) circle.ClientInterface {
 					return mCircleClient
 				}
 			}

--- a/internal/serve/httphandler/circle_config_handler_test.go
+++ b/internal/serve/httphandler/circle_config_handler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
@@ -194,7 +195,7 @@ func TestCircleConfigHandler_Patch(t *testing.T) {
 				tc.prepareMocksFn(t, mDistributionAccountResolver, mCircleClient, mTenantManager)
 
 				handler.DistributionAccountResolver = mDistributionAccountResolver
-				handler.CircleFactory = func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface) circle.ClientInterface {
+				handler.CircleFactory = func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface, monitorSvc monitor.MonitorServiceInterface) circle.ClientInterface {
 					return mCircleClient
 				}
 				handler.TenantManager = mTenantManager
@@ -366,7 +367,7 @@ func Test_CircleConfigHandler_validateConfigWithCircle(t *testing.T) {
 
 				handler.Encrypter = mEncrypter
 				handler.CircleClientConfigModel = mCircleClientConfigModel
-				handler.CircleFactory = func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface) circle.ClientInterface {
+				handler.CircleFactory = func(networkType utils.NetworkType, apiKey string, tntManager tenant.ManagerInterface, monitorSvc monitor.MonitorServiceInterface) circle.ClientInterface {
 					return mCircleClient
 				}
 			}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -396,6 +396,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 					EncryptionPassphrase:        o.DistAccEncryptionPassphrase,
 					CircleClientConfigModel:     circle.NewClientConfigModel(o.MtnDBConnectionPool),
 					DistributionAccountResolver: o.SubmitterEngine.DistributionAccountResolver,
+					MonitorService:              o.MonitorService,
 				}.Patch)
 		})
 

--- a/resources/grafana/dashboard.json
+++ b/resources/grafana/dashboard.json
@@ -39,10 +39,7 @@
       "id": 2,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Rate request per second in a 5 min interval. Filtered by route, method, status and instance.",
           "fieldConfig": {
             "defaults": {
@@ -140,10 +137,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "rate(sdp_http_requests_duration_seconds_count{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"}[5m])",
               "legendFormat": "{{method}} {{route}}: {{status}} {{instance}}",
@@ -155,10 +149,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Average request time duration in a 5 min interval. Filtered by route, method, status and instance.",
           "fieldConfig": {
             "defaults": {
@@ -229,10 +220,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "1000 * (rate(sdp_http_requests_duration_seconds_sum{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"}[5m]) / rate(sdp_http_requests_duration_seconds_count{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"}[5m]))",
               "legendFormat": "{{method}} {{route}}: {{status}} {{instance}}",
@@ -244,10 +232,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Average rate request per second in a 5 min interval aggregate by instance. Filtered by route, method, status.",
           "fieldConfig": {
             "defaults": {
@@ -320,10 +305,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "avg(rate(sdp_http_requests_duration_seconds_count{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"}[5m])) by (route, method, status)",
               "legendFormat": "{{method}} {{route}}: {{status}}",
@@ -335,10 +317,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Average request time duration in a 5 min interval aggregate by instances. Filtered by route, method, status.",
           "fieldConfig": {
             "defaults": {
@@ -409,10 +388,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "1000 * avg((rate(sdp_http_requests_duration_seconds_sum{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"}[5m]) / rate(sdp_http_requests_duration_seconds_count{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"}[5m]))) by (route, method, status)",
               "legendFormat": "{{method}} {{route}}: {{status}}",
@@ -424,10 +400,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -523,10 +496,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "1000 * sdp_http_requests_duration_seconds{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"}",
               "legendFormat": "q{{quantile}} {{method}} {{route}}: {{status}} {{instance}}",
@@ -538,10 +508,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Total number of requests filtered by route, method, status and instance.",
           "fieldConfig": {
             "defaults": {
@@ -584,10 +551,7 @@
           "pluginVersion": "9.3.8",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "sum(sdp_http_requests_duration_seconds_count{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"})",
               "legendFormat": "__auto",
@@ -599,10 +563,7 @@
           "type": "stat"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Total average time duration from a request. Filtered by route, method, status and instance",
           "fieldConfig": {
             "defaults": {
@@ -645,10 +606,7 @@
           "pluginVersion": "9.3.8",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "1000 * avg(sdp_http_requests_duration_seconds_sum{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"} / sdp_http_requests_duration_seconds_count{route=~\"$route\", method=~\"$method\", status=~\"$status\", instance=~\"$instance\"})",
               "legendFormat": "__auto",
@@ -674,10 +632,7 @@
       "id": 14,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Rate successful query per second in a 5 min interval. Filtered by query_type and instance.",
           "fieldConfig": {
             "defaults": {
@@ -751,10 +706,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "rate(sdp_db_successful_queries_duration_count{query_type=~\"$query_type\", instance=~\"$instance\"}[5m])",
               "legendFormat": "{{query_type}} {{instance}}",
@@ -766,10 +718,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Average successful query duration in a 5 min interval. Filtered by query_type and instance.",
           "fieldConfig": {
             "defaults": {
@@ -843,10 +792,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "1000 * (rate(sdp_db_successful_queries_duration_sum{query_type=~\"$query_type\", instance=~\"$instance\"}[5m]) / rate(sdp_db_successful_queries_duration_count{query_type=~\"$query_type\", instance=~\"$instance\"}[5m]))",
               "legendFormat": "{{query_type}} {{instance}}",
@@ -858,10 +804,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Average rate successful query per second in a 5 min interval. Filtered by query_type.",
           "fieldConfig": {
             "defaults": {
@@ -935,10 +878,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "avg(rate(sdp_db_successful_queries_duration_count{query_type=~\"$query_type\", instance=~\"$instance\"}[5m])) by (query_type)",
               "legendFormat": "{{query_type}}",
@@ -950,10 +890,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Average successful query duration in a 5 min interval aggregate by instances. Filtered by query_type.",
           "fieldConfig": {
             "defaults": {
@@ -1027,10 +964,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "avg(1000 * (rate(sdp_db_successful_queries_duration_sum{query_type=~\"$query_type\", instance=~\"$instance\"}[5m]) / rate(sdp_db_successful_queries_duration_count{query_type=~\"$query_type\", instance=~\"$instance\"}[5m]))) by (query_type)",
               "legendFormat": "{{query_type}}",
@@ -1042,10 +976,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1119,10 +1050,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "1000 * sdp_db_successful_queries_duration{query_type=~\"$query_type\", instance=~\"$instance\"}",
               "legendFormat": "q{{quantile}} {{query_type}} {{instance}}",
@@ -1134,10 +1062,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Rate failure query per second in a 5 min interval. Filtered by query_type and instance.",
           "fieldConfig": {
             "defaults": {
@@ -1210,10 +1135,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "rate(sdp_db_failure_queries_duration_count{query_type=~\"$query_type\", instance=~\"$instance\"}[5m])",
               "legendFormat": "{{query_type}} {{instance}}",
@@ -1225,10 +1147,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Average failure query duration in a 5 min interval. Filtered by query_type and instance.",
           "fieldConfig": {
             "defaults": {
@@ -1301,10 +1220,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "1000 * (rate(sdp_db_failure_queries_duration_sum{query_type=~\"$query_type\", instance=~\"$instance\"}[5m]) / rate(sdp_db_failure_queries_duration_count{query_type=~\"$query_type\", instance=~\"$instance\"}[5m]))",
               "legendFormat": "{{query_type}} {{instance}}",
@@ -1316,10 +1232,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Average rate failure query per second in a 5 min interval. Filtered by query_type.",
           "fieldConfig": {
             "defaults": {
@@ -1392,10 +1305,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "avg(rate(sdp_db_failure_queries_duration_count{query_type=~\"$query_type\", instance=~\"$instance\"}[5m])) by (query_type)",
               "legendFormat": "{{query_type}}",
@@ -1407,10 +1317,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "description": "Average failure query duration in a 5 min interval aggregate by instances. Filtered by query_type.",
           "fieldConfig": {
             "defaults": {
@@ -1483,10 +1390,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "avg(1000 * (rate(sdp_db_failure_queries_duration_sum{query_type=~\"$query_type\", instance=~\"$instance\"}[5m]) / rate(sdp_db_failure_queries_duration_count{query_type=~\"$query_type\", instance=~\"$instance\"}[5m]))) by (query_type)",
               "legendFormat": "{{query_type}}",
@@ -1498,10 +1402,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "NJaP9W-4z"
-          },
+         "datasource": "prometheus",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1575,10 +1476,7 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "NJaP9W-4z"
-              },
+              "datasource": "prometheus",
               "editorMode": "code",
               "expr": "1000 * sdp_db_failure_queries_duration{query_type=~\"$query_type\", instance=~\"$instance\"}",
               "legendFormat": "q{{quantile}} {{query_type}} {{instance}}",
@@ -1591,6 +1489,361 @@
         }
       ],
       "title": "DB Metrics",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 28,
+      "panels": [    {
+        "datasource": "prometheus",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-GrYlRd"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 0,
+          "y": 2
+        },
+        "id": 30,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.1.3",
+        "targets": [
+          {
+            "datasource": "prometheus",
+            "editorMode": "code",
+            "expr": "100 * (sum(sdp_circle_circle_api_requests_total{status=\"error\"}) \n/\nsum(sdp_circle_circle_api_requests_total)\nor vector(0))",
+            "interval": "",
+            "legendFormat": "Total Requests",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Circle API - Error Rate",
+        "type": "stat"
+      },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 2
+          },
+          "id": 32,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.1.3",
+          "targets": [
+            {
+              "expr": "sum(sdp_circle_circle_api_requests_total)",
+              "legendFormat": "Total Requests",
+              "refId": "A"
+            }
+          ],
+          "title": "Circle API - Request Count",
+          "type": "stat"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 85
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 33,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.1.3",
+          "targets": [
+            {
+              "datasource": "prometheus",
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.95, sum by (le, endpoint, method) (rate(sdp_circle_circle_api_request_duration_seconds_bucket[1m]) or vector(0)) ) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Circle API - 95th Percentile Request Duration by Endpoint and Method",
+          "type": "gauge"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 31,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "show": true,
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "prometheus",
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(sdp_circle_circle_api_request_duration_seconds_sum[5m])) by (endpoint,method) / sum(rate(sdp_circle_circle_api_request_duration_seconds_count[5m])) by (endpoint,method)",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{method, endpoint}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Circle API - Average Request Duration by Method and Endpoint",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "prometheus",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "fillOpacity": 70,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 0,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 29,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "show": true,
+              "showLegend": true
+            },
+            "tooltip": {
+              "show": true,
+              "showHistogram": true
+            }
+          },
+          "targets": [
+            {
+              "datasource": "prometheus",
+              "editorMode": "code",
+              "expr": "sum by (le, endpoint, method) (rate(sdp_circle_circle_api_request_duration_seconds_bucket[1m]))",
+              "format": "heatmap",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Circle API - Histogram of Request Durations",
+          "type": "histogram"
+        }],
+      "title": "Cicle Metrics",
       "type": "row"
     }
   ],
@@ -1605,10 +1858,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "NJaP9W-4z"
-        },
+        "datasource": "prometheus",
         "definition": "query_result(sdp_http_requests_duration_seconds_count)",
         "description": "",
         "hide": 0,
@@ -1636,10 +1886,7 @@
             "GET"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "NJaP9W-4z"
-        },
+        "datasource": "prometheus",
         "definition": "query_result(sdp_http_requests_duration_seconds_count)",
         "hide": 0,
         "includeAll": true,
@@ -1666,10 +1913,7 @@
             "200"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "NJaP9W-4z"
-        },
+        "datasource": "prometheus",
         "definition": "query_result(sdp_http_requests_duration_seconds_count)",
         "hide": 0,
         "includeAll": true,
@@ -1692,10 +1936,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "NJaP9W-4z"
-        },
+        "datasource": "prometheus",
         "definition": "query_result(sdp_http_requests_duration_seconds_count)",
         "hide": 0,
         "includeAll": true,
@@ -1719,10 +1960,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "NJaP9W-4z"
-        },
+        "datasource": "prometheus",
         "definition": "query_result(sdp_db_failure_queries_duration_count or sdp_db_successful_queries_duration_count)",
         "hide": 0,
         "includeAll": true,
@@ -1749,7 +1987,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Dashboard SDPV2",
-  "uid": "XIR0jW-4k",
   "version": 40,
   "weekStart": ""
 }


### PR DESCRIPTION
### What
* Added Metrics for Circle requests 
* Added optional docker containers for starting Prometheus and Grafana 
* Configured Grafana with the prometheus Data source 
* Removed fixed IDs from the Grafana dashboard and added new panels for monitoring Circle 
* Added Golang Metrics  

#### Circle API Metrics
![Screenshot 2024-08-08 at 6 04 26 PM](https://github.com/user-attachments/assets/4f1169c6-ccef-4c8d-b740-b3c998fb8aed)

#### Golang Metrics
![Screenshot 2024-08-09 at 11 14 58 AM](https://github.com/user-attachments/assets/399c934c-cb64-4f23-9fa6-1ac0ef095a61)

### Why
Monitor Requests made to the Circle API and detect any latency issues. 

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
