### PR TITLE
[SDP-1297] Add message channel priority to organizations table

### DIFF
--- a/db/migrations/sdp-migrations/2024-08-17.0-organizations-message-channel-priority.sql
+++ b/db/migrations/sdp-migrations/2024-08-17.0-organizations-message-channel-priority.sql
@@ -1,0 +1,64 @@
+-- This migration adds the message_channel type and the message_channel_priority column to the organizations table.
+-- +migrate Up
+
+-- Create the message_channel enum type
+CREATE TYPE message_channel AS ENUM ('SMS', 'EMAIL');
+
+-- Add the message_channel_priority column to the organizations table
+ALTER TABLE organizations
+    ADD COLUMN message_channel_priority message_channel[] NOT NULL
+        DEFAULT ARRAY['SMS'::message_channel, 'EMAIL'::message_channel];
+
+-- Create a function to check if all message_channel values are included and valid
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION check_message_channel_priority()
+    RETURNS TRIGGER AS $$
+DECLARE
+    all_channels message_channel[];
+    duplicate_channels message_channel[];
+BEGIN
+    -- Get all possible message_channel values
+    SELECT array_agg(enumlabel::message_channel)
+    INTO all_channels
+    FROM pg_enum
+    WHERE enumtypid = 'message_channel'::regtype;
+
+    -- Check if all channels are included in the new value
+    IF NOT (SELECT all_channels <@ NEW.message_channel_priority) THEN
+        RAISE EXCEPTION 'message_channel_priority must include all possible message_channel values';
+    END IF;
+
+    -- Check for duplicates
+    SELECT ARRAY(SELECT channel
+                 FROM unnest(NEW.message_channel_priority) channel
+                 GROUP BY channel
+                 HAVING COUNT(*) > 1)
+    INTO duplicate_channels;
+
+    IF array_length(duplicate_channels, 1) > 0 THEN
+        RAISE EXCEPTION 'message_channel_priority must not contain duplicate values: %', duplicate_channels;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+-- +migrate StatementEnd
+
+-- Create the trigger
+CREATE TRIGGER validate_organizations_message_channel_priority
+    BEFORE INSERT OR UPDATE OF message_channel_priority ON organizations
+    FOR EACH ROW EXECUTE FUNCTION check_message_channel_priority();
+
+-- +migrate Down
+
+-- Drop the trigger
+DROP TRIGGER IF EXISTS validate_organizations_message_channel_priority ON organizations;
+
+-- Drop the function
+DROP FUNCTION IF EXISTS check_message_channel_priority();
+
+-- Remove the message_channel_priority column
+ALTER TABLE organizations DROP COLUMN IF EXISTS message_channel_priority;
+
+-- Remove the message_channel enum type
+DROP TYPE IF EXISTS message_channel;

--- a/internal/data/organizations.go
+++ b/internal/data/organizations.go
@@ -258,6 +258,11 @@ func (om *OrganizationModel) Update(ctx context.Context, ou *OrganizationUpdate)
 
 type MessageChannelPriority []message.MessageChannel
 
+var DefaultMessageChannelPriority = MessageChannelPriority{
+	message.MessageChannelSMS,
+	message.MessageChannelEmail,
+}
+
 func (mcp *MessageChannelPriority) Scan(src interface{}) error {
 	if src == nil {
 		*mcp = nil
@@ -283,6 +288,8 @@ func (mcp *MessageChannelPriority) Scan(src interface{}) error {
 	return nil
 }
 
+var _ sql.Scanner = (*MessageChannelPriority)(nil)
+
 func (mcp MessageChannelPriority) Value() (driver.Value, error) {
 	if len(mcp) == 0 {
 		return "{}", nil
@@ -295,3 +302,5 @@ func (mcp MessageChannelPriority) Value() (driver.Value, error) {
 
 	return "{" + strings.Join(channels, ",") + "}", nil
 }
+
+var _ driver.Valuer = MessageChannelPriority{}

--- a/internal/data/organizations.go
+++ b/internal/data/organizations.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"image"
@@ -20,6 +21,7 @@ import (
 	_ "image/png"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 )
 
 const (
@@ -42,12 +44,13 @@ type Organization struct {
 	// When the {{.OTP}} is not found in the message, it's added at the beginning of the message.
 	// Example:
 	//	{{.OTP}} OTPMessageTemplate
-	OTPMessageTemplate string    `json:"otp_message_template" db:"otp_message_template"`
-	PrivacyPolicyLink  *string   `json:"privacy_policy_link" db:"privacy_policy_link"`
-	Logo               []byte    `db:"logo"`
-	IsApprovalRequired bool      `json:"is_approval_required" db:"is_approval_required"`
-	CreatedAt          time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt          time.Time `json:"updated_at" db:"updated_at"`
+	OTPMessageTemplate     string                 `json:"otp_message_template" db:"otp_message_template"`
+	PrivacyPolicyLink      *string                `json:"privacy_policy_link" db:"privacy_policy_link"`
+	Logo                   []byte                 `db:"logo"`
+	IsApprovalRequired     bool                   `json:"is_approval_required" db:"is_approval_required"`
+	MessageChannelPriority MessageChannelPriority `json:"message_channel_priority" db:"message_channel_priority"`
+	CreatedAt              time.Time              `json:"created_at" db:"created_at"`
+	UpdatedAt              time.Time              `json:"updated_at" db:"updated_at"`
 }
 
 type OrganizationUpdate struct {
@@ -251,4 +254,44 @@ func (om *OrganizationModel) Update(ctx context.Context, ou *OrganizationUpdate)
 	}
 
 	return nil
+}
+
+type MessageChannelPriority []message.MessageChannel
+
+func (mcp *MessageChannelPriority) Scan(src interface{}) error {
+	if src == nil {
+		*mcp = nil
+		return nil
+	}
+
+	byteValue, ok := src.([]byte)
+	if !ok {
+		return fmt.Errorf("unexpected type for MessageChannelPriority %T", src)
+	}
+
+	// Convert []byte to string and remove the curly braces. E.g. `{SMS,EMAIL}`
+	strValue := strings.Trim(string(byteValue), "{}")
+
+	// Split the string into individual channel values. E.g. `SMS,EMAIL` -> ["SMS", "EMAIL"]
+	channels := strings.Split(strValue, ",")
+
+	*mcp = make(MessageChannelPriority, len(channels))
+	for i, ch := range channels {
+		(*mcp)[i] = message.MessageChannel(strings.TrimSpace(ch))
+	}
+
+	return nil
+}
+
+func (mcp MessageChannelPriority) Value() (driver.Value, error) {
+	if len(mcp) == 0 {
+		return "{}", nil
+	}
+
+	channels := make([]string, len(mcp))
+	for i, ch := range mcp {
+		channels[i] = string(ch)
+	}
+
+	return "{" + strings.Join(channels, ",") + "}", nil
 }

--- a/internal/data/organizations_test.go
+++ b/internal/data/organizations_test.go
@@ -488,7 +488,7 @@ func TestOrganizationModel_UpdateMessageChannelPriority(t *testing.T) {
 	t.Run("succeeds when all channels are included", func(t *testing.T) {
 		defer resetOrganizationInfo(t, ctx, dbConnectionPool)
 
-		_, err := dbConnectionPool.ExecContext(ctx, "UPDATE organizations SET message_channel_priority = '{\"SMS\", \"EMAIL\"}'")
+		_, err := dbConnectionPool.ExecContext(ctx, "UPDATE organizations SET message_channel_priority = $1", DefaultMessageChannelPriority)
 		require.NoError(t, err)
 
 		// Verify the update
@@ -500,7 +500,7 @@ func TestOrganizationModel_UpdateMessageChannelPriority(t *testing.T) {
 	t.Run("fails when not all channels are included", func(t *testing.T) {
 		defer resetOrganizationInfo(t, ctx, dbConnectionPool)
 
-		_, err := dbConnectionPool.ExecContext(ctx, "UPDATE organizations SET message_channel_priority = '{\"SMS\"}'")
+		_, err := dbConnectionPool.ExecContext(ctx, "UPDATE organizations SET message_channel_priority = $1", MessageChannelPriority{"SMS"})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "message_channel_priority must include all possible message_channel values")
 	})
@@ -508,7 +508,7 @@ func TestOrganizationModel_UpdateMessageChannelPriority(t *testing.T) {
 	t.Run("fails when duplicate channels are included", func(t *testing.T) {
 		defer resetOrganizationInfo(t, ctx, dbConnectionPool)
 
-		_, err := dbConnectionPool.ExecContext(ctx, "UPDATE organizations SET message_channel_priority = '{\"SMS\", \"EMAIL\", \"SMS\"}'")
+		_, err := dbConnectionPool.ExecContext(ctx, "UPDATE organizations SET message_channel_priority = $1", MessageChannelPriority{"SMS", "EMAIL", "SMS"})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "message_channel_priority must not contain duplicate values: {SMS}")
 	})
@@ -516,7 +516,7 @@ func TestOrganizationModel_UpdateMessageChannelPriority(t *testing.T) {
 	t.Run("fails when invalid channel is included", func(t *testing.T) {
 		defer resetOrganizationInfo(t, ctx, dbConnectionPool)
 
-		_, err := dbConnectionPool.ExecContext(ctx, "UPDATE organizations SET message_channel_priority = '{\"SMS\", \"EMAIL\", \"WHATSAPP\"}'")
+		_, err := dbConnectionPool.ExecContext(ctx, "UPDATE organizations SET message_channel_priority = $1", MessageChannelPriority{"SMS", "WHATSAPP"})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "invalid input value for enum message_channel: \"WHATSAPP\"")
 	})

--- a/internal/message/aws_ses_client_test.go
+++ b/internal/message/aws_ses_client_test.go
@@ -57,7 +57,7 @@ func Test_NewAWSSESClient(t *testing.T) {
 func Test_AWSSES_SendMessage_messageIsInvalid(t *testing.T) {
 	var mAWS MessengerClient = &awsSESClient{}
 	err := mAWS.SendMessage(Message{})
-	require.EqualError(t, err, "validating message to send an email through AWS: invalid message: email cannot be empty")
+	require.EqualError(t, err, "validating message to send an email through AWS: invalid e-mail: invalid email format: email cannot be empty")
 }
 
 func Test_AWSSES_SendMessage_errorIsHandledCorrectly(t *testing.T) {

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -15,7 +15,7 @@ type Message struct {
 }
 
 // ValidateFor validates if the message object is valid for the given messengerType.
-func (s *Message) ValidateFor(messengerType MessengerType) error {
+func (s Message) ValidateFor(messengerType MessengerType) error {
 	if messengerType.IsSMS() {
 		if err := utils.ValidatePhoneNumber(s.ToPhoneNumber); err != nil {
 			return fmt.Errorf("invalid message: %w", err)
@@ -23,12 +23,8 @@ func (s *Message) ValidateFor(messengerType MessengerType) error {
 	}
 
 	if messengerType.IsEmail() {
-		if err := utils.ValidateEmail(s.ToEmail); err != nil {
-			return fmt.Errorf("invalid message: %w", err)
-		}
-
-		if strings.Trim(s.Title, " ") == "" {
-			return fmt.Errorf("title is empty")
+		if err := s.IsValidForEmail(); err != nil {
+			return fmt.Errorf("invalid e-mail: %w", err)
 		}
 	}
 
@@ -37,4 +33,37 @@ func (s *Message) ValidateFor(messengerType MessengerType) error {
 	}
 
 	return nil
+}
+
+func (s Message) IsValidForEmail() error {
+	if err := utils.ValidateEmail(s.ToEmail); err != nil {
+		return fmt.Errorf("invalid email format: %w", err)
+	}
+
+	if strings.TrimSpace(s.Title) == "" {
+		return fmt.Errorf("title is empty")
+	}
+	return nil
+}
+
+func (s Message) SupportedChannels() []MessageChannel {
+	var supportedChannels []MessageChannel
+
+	if utils.ValidatePhoneNumber(s.ToPhoneNumber) == nil {
+		supportedChannels = append(supportedChannels, MessageChannelSMS)
+	}
+
+	if err := s.IsValidForEmail(); err == nil {
+		supportedChannels = append(supportedChannels, MessageChannelEmail)
+	}
+
+	return supportedChannels
+}
+
+func (s Message) String() string {
+	return fmt.Sprintf("Message{ToPhoneNumber: %s, ToEmail: %s, Message: %s, Title: %s}",
+		utils.TruncateString(s.ToPhoneNumber, 3),
+		utils.TruncateString(s.ToEmail, 3),
+		utils.TruncateString(s.Message, 3),
+		utils.TruncateString(s.Title, 3))
 }

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -50,19 +50,19 @@ func Test_message_Validate(t *testing.T) {
 			name:          "Email types need a non-empty email address",
 			messengerType: MessengerTypeAWSEmail,
 			message:       Message{},
-			wantErr:       fmt.Errorf("invalid message: email cannot be empty"),
+			wantErr:       fmt.Errorf("invalid e-mail: invalid email format: email cannot be empty"),
 		},
 		{
 			name:          "Email types need a valid email address",
 			messengerType: MessengerTypeAWSEmail,
 			message:       Message{ToEmail: "invalid-email"},
-			wantErr:       fmt.Errorf("invalid message: the provided email is not valid"),
+			wantErr:       fmt.Errorf("invalid e-mail: invalid email format: the provided email is not valid"),
 		},
 		{
 			name:          "Email types need a title",
 			messengerType: MessengerTypeAWSEmail,
 			message:       Message{ToEmail: "foo@test.com", Title: "   "},
-			wantErr:       fmt.Errorf("title is empty"),
+			wantErr:       fmt.Errorf("invalid e-mail: title is empty"),
 		},
 		{
 			name:          "[sms] message cannot be empty",
@@ -86,6 +86,93 @@ func Test_message_Validate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestMessage_SupportedChannels(t *testing.T) {
+	testCases := []struct {
+		name         string
+		message      Message
+		wantChannels []MessageChannel
+	}{
+		{
+			name:         "sms only",
+			message:      Message{ToPhoneNumber: "+14152111111", Message: "Hello"},
+			wantChannels: []MessageChannel{MessageChannelSMS},
+		},
+		{
+			name:         "e-mail only",
+			message:      Message{ToEmail: "test@example.com", Title: "Test", Message: "Hello"},
+			wantChannels: []MessageChannel{MessageChannelEmail},
+		},
+		{
+			name:         "both sms and e-mail",
+			message:      Message{ToPhoneNumber: "+14152111111", ToEmail: "test@example.com", Title: "Test", Message: "Hello"},
+			wantChannels: []MessageChannel{MessageChannelSMS, MessageChannelEmail},
+		},
+		{
+			name:         "neither sms nor e-mail",
+			message:      Message{Message: "Hello"},
+			wantChannels: []MessageChannel{},
+		},
+		{
+			name:         "invalid phone number",
+			message:      Message{ToPhoneNumber: "invalid", ToEmail: "test@example.com", Title: "Test", Message: "Hello"},
+			wantChannels: []MessageChannel{MessageChannelEmail},
+		},
+		{
+			name:         "invalid email",
+			message:      Message{ToPhoneNumber: "+14152111111", ToEmail: "invalid", Title: "Test", Message: "Hello"},
+			wantChannels: []MessageChannel{MessageChannelSMS},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotChannels := tc.message.SupportedChannels()
+			require.ElementsMatch(t, tc.wantChannels, gotChannels)
+		})
+	}
+}
+
+func TestMessage_String(t *testing.T) {
+	testCases := []struct {
+		name               string
+		message            Message
+		wantRepresentation string
+	}{
+		{
+			name:               "all fields present",
+			message:            Message{ToPhoneNumber: "+14152111111", ToEmail: "test@example.com", Title: "Test Title", Message: "Hello, World!"},
+			wantRepresentation: "Message{ToPhoneNumber: +14...111, ToEmail: tes...com, Message: Hel...ld!, Title: Tes...tle}",
+		},
+		{
+			name:               "only phone number",
+			message:            Message{ToPhoneNumber: "+14152111111", Message: "Hello"},
+			wantRepresentation: "Message{ToPhoneNumber: +14...111, ToEmail: , Message: Hello, Title: }",
+		},
+		{
+			name:               "only email",
+			message:            Message{ToEmail: "test@example.com", Title: "Test", Message: "Hello"},
+			wantRepresentation: "Message{ToPhoneNumber: , ToEmail: tes...com, Message: Hello, Title: Test}",
+		},
+		{
+			name:               "empty message",
+			message:            Message{},
+			wantRepresentation: "Message{ToPhoneNumber: , ToEmail: , Message: , Title: }",
+		},
+		{
+			name:               "long fields",
+			message:            Message{ToPhoneNumber: "+14152111111", ToEmail: "very.long.email@example.com", Title: "This is a very long title", Message: "This is a very long message that should be truncated"},
+			wantRepresentation: "Message{ToPhoneNumber: +14...111, ToEmail: ver...com, Message: Thi...ted, Title: Thi...tle}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRepresentation := tc.message.String()
+			require.Equal(t, tc.wantRepresentation, gotRepresentation)
 		})
 	}
 }

--- a/internal/message/mock_message_dispatcher_interface.go
+++ b/internal/message/mock_message_dispatcher_interface.go
@@ -48,17 +48,17 @@ func (_m *MockMessageDispatcher) RegisterClient(ctx context.Context, channel Mes
 	_m.Called(ctx, channel, client)
 }
 
-// SendMessage provides a mock function with given fields: message, channel
-func (_m *MockMessageDispatcher) SendMessage(message Message, channel MessageChannel) error {
-	ret := _m.Called(message, channel)
+// SendMessage provides a mock function with given fields: ctx, message, channelPriority
+func (_m *MockMessageDispatcher) SendMessage(ctx context.Context, message Message, channelPriority []MessageChannel) error {
+	ret := _m.Called(ctx, message, channelPriority)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendMessage")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(Message, MessageChannel) error); ok {
-		r0 = rf(message, channel)
+	if rf, ok := ret.Get(0).(func(context.Context, Message, []MessageChannel) error); ok {
+		r0 = rf(ctx, message, channelPriority)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
+++ b/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
@@ -233,16 +234,16 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 			On("GetClient", message.MessageChannelSMS).
 			Return(messengerClientMock, nil).
 			Twice().
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver1.PhoneNumber,
 				Message:       contentWallet1,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(mockErr).
 			Once().
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver2.PhoneNumber,
 				Message:       contentWallet2,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once()
 		messengerClientMock.

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -367,6 +367,7 @@ func (h ProfileHandler) GetOrganizationInfo(rw http.ResponseWriter, req *http.Re
 		"sms_resend_interval":              0,
 		"payment_cancellation_period_days": 0,
 		"privacy_policy_link":              org.PrivacyPolicyLink,
+		"message_channel_priority":         org.MessageChannelPriority,
 	}
 
 	if org.SMSRegistrationMessageTemplate != data.DefaultSMSRegistrationMessageTemplate {

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -1135,7 +1135,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"is_approval_required": false,
 				"privacy_policy_link": null,
 				"sms_resend_interval": 0,
-				"payment_cancellation_period_days": 0
+				"payment_cancellation_period_days": 0,
+				"message_channel_priority": ["SMS", "EMAIL"]
 			}
 		`, newDistAccountJSON(t, defaultTenantDistAcc), defaultTenantDistAcc)
 
@@ -1173,7 +1174,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"sms_registration_message_template": "My custom receiver wallet registration invite. MyOrg 👋",
 				"sms_resend_interval": 0,
 				"payment_cancellation_period_days": 0,
-				"privacy_policy_link": null
+				"privacy_policy_link": null,
+				"message_channel_priority": ["SMS", "EMAIL"]
 			}
 		`, newDistAccountJSON(t, defaultTenantDistAcc), defaultTenantDistAcc)
 
@@ -1208,7 +1210,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"otp_message_template": "Here's your OTP Code to complete your registration. MyOrg 👋",
 				"sms_resend_interval": 0,
 				"payment_cancellation_period_days": 0,
-				"privacy_policy_link": null
+				"privacy_policy_link": null,
+				"message_channel_priority": ["SMS", "EMAIL"]
 			}
 		`, newDistAccountJSON(t, defaultTenantDistAcc), defaultTenantDistAcc)
 
@@ -1247,7 +1250,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"is_approval_required":false,
 				"sms_resend_interval": 2,
 				"payment_cancellation_period_days": 0,
-				"privacy_policy_link": null
+				"privacy_policy_link": null,
+				"message_channel_priority": ["SMS", "EMAIL"]
 			}
 		`, newDistAccountJSON(t, defaultTenantDistAcc), defaultTenantDistAcc)
 
@@ -1286,7 +1290,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"is_approval_required":false,
 				"sms_resend_interval": 0,
 				"payment_cancellation_period_days": 5,
-				"privacy_policy_link": null
+				"privacy_policy_link": null,
+				"message_channel_priority": ["SMS", "EMAIL"]
 			}
 		`, newDistAccountJSON(t, defaultTenantDistAcc), defaultTenantDistAcc)
 
@@ -1325,7 +1330,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"is_approval_required":false,
 				"sms_resend_interval": 0,
 				"payment_cancellation_period_days": 0,
-				"privacy_policy_link": "https://example.com/privacy-policy"
+				"privacy_policy_link": "https://example.com/privacy-policy",
+				"message_channel_priority": ["SMS", "EMAIL"]
 			}
 		`, newDistAccountJSON(t, defaultTenantDistAcc), defaultTenantDistAcc)
 

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -158,7 +158,7 @@ func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 		// TODO: SDP-1296 - support multiple channels for OTP
 		log.Ctx(ctx).Infof("sending OTP message to phone number: %s", truncatedPhoneNumber)
-		err = h.MessageDispatcher.SendMessage(msg, message.MessageChannelSMS)
+		err = h.MessageDispatcher.SendMessage(ctx, msg, organization.MessageChannelPriority)
 		if err != nil {
 			httperror.InternalError(ctx, "Cannot send OTP message", err, nil).Render(w)
 			return

--- a/internal/serve/httphandler/receiver_send_otp_handler_test.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler_test.go
@@ -168,11 +168,15 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 		}
 		req = req.WithContext(context.WithValue(req.Context(), anchorplatform.SEP24ClaimsContextKey, validClaims))
 
-		mockMessageDispatcher.On("SendMessage", mock.AnythingOfType("message.Message"), message.MessageChannelSMS).
+		mockMessageDispatcher.
+			On("SendMessage",
+				mock.Anything,
+				mock.AnythingOfType("message.Message"),
+				[]message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once().
 			Run(func(args mock.Arguments) {
-				msg := args.Get(0).(message.Message)
+				msg := args.Get(1).(message.Message)
 				assert.Contains(t, msg.Message, "is your MyCustomAid phone verification code.")
 				assert.Regexp(t, regexp.MustCompile(`^\d{6}\s.+$`), msg.Message)
 			})
@@ -212,11 +216,15 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 		err = models.Organizations.Update(ctx, &data.OrganizationUpdate{OTPMessageTemplate: &customOTPMessage})
 		require.NoError(t, err)
 
-		mockMessageDispatcher.On("SendMessage", mock.AnythingOfType("message.Message"), message.MessageChannelSMS).
+		mockMessageDispatcher.
+			On("SendMessage",
+				mock.Anything,
+				mock.AnythingOfType("message.Message"),
+				[]message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once().
 			Run(func(args mock.Arguments) {
-				msg := args.Get(0).(message.Message)
+				msg := args.Get(1).(message.Message)
 				assert.Contains(t, msg.Message, customOTPMessage)
 				assert.Regexp(t, regexp.MustCompile(`^\d{6}\s.+$`), msg.Message)
 			})
@@ -251,7 +259,11 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 		}
 		req = req.WithContext(context.WithValue(req.Context(), anchorplatform.SEP24ClaimsContextKey, validClaims))
 
-		mockMessageDispatcher.On("SendMessage", mock.AnythingOfType("message.Message"), message.MessageChannelSMS).
+		mockMessageDispatcher.
+			On("SendMessage",
+				mock.Anything,
+				mock.AnythingOfType("message.Message"),
+				[]message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(errors.New("error sending message")).
 			Once()
 

--- a/internal/services/send_receiver_wallets_invite_service.go
+++ b/internal/services/send_receiver_wallets_invite_service.go
@@ -182,7 +182,7 @@ func (s SendReceiverWalletInviteService) SendInvite(ctx context.Context, receive
 
 		// We assume that the message will be sent at first
 		msgToInsert.Status = data.SuccessMessageStatus
-		if err := s.messageDispatcher.SendMessage(msg, messageChannel); err != nil {
+		if err := s.messageDispatcher.SendMessage(ctx, msg, organization.MessageChannelPriority); err != nil {
 			msg := fmt.Sprintf(
 				"error sending message to receiver ID %s for receiver wallet ID %s using messenger type %s",
 				rwa.ReceiverWallet.Receiver.ID, rwa.ReceiverWallet.ID, messageType,

--- a/internal/services/send_receiver_wallets_invite_service_test.go
+++ b/internal/services/send_receiver_wallets_invite_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stellar/go/support/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
@@ -160,16 +161,16 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 
 		mockErr := errors.New("unexpected error")
 		messageDispatcherMock.
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver1.PhoneNumber,
 				Message:       contentWallet1,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(errors.New("unexpected error")).
 			Once().
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver2.PhoneNumber,
 				Message:       contentWallet2,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once()
 
@@ -299,16 +300,16 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		contentWallet2 := fmt.Sprintf("You have a payment waiting for you from the MyCustomAid. Click %s to register.", deepLink2)
 
 		messageDispatcherMock.
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver1.PhoneNumber,
 				Message:       contentWallet1,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once().
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver2.PhoneNumber,
 				Message:       contentWallet2,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once()
 
@@ -434,16 +435,16 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		contentWallet2 := fmt.Sprintf("%s %s", customInvitationMessage, deepLink2)
 
 		messageDispatcherMock.
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver1.PhoneNumber,
 				Message:       contentWallet1,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once().
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver2.PhoneNumber,
 				Message:       contentWallet2,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once()
 
@@ -727,10 +728,10 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		contentWallet1 := fmt.Sprintf("You have a payment waiting for you from the MyCustomAid. Click %s to register.", deepLink1)
 
 		messageDispatcherMock.
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver1.PhoneNumber,
 				Message:       contentWallet1,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once()
 
@@ -845,16 +846,16 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		contentDisbursement4 := fmt.Sprintf("%s %s", disbursement4.SMSRegistrationMessageTemplate, deepLink2)
 
 		messageDispatcherMock.
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver1.PhoneNumber,
 				Message:       contentDisbursement3,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once().
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver2.PhoneNumber,
 				Message:       contentDisbursement4,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once()
 
@@ -974,10 +975,10 @@ func Test_SendReceiverWalletInviteService(t *testing.T) {
 		contentDisbursement := fmt.Sprintf("%s %s", disbursement.SMSRegistrationMessageTemplate, deepLink1)
 
 		messageDispatcherMock.
-			On("SendMessage", message.Message{
+			On("SendMessage", mock.Anything, message.Message{
 				ToPhoneNumber: receiver1.PhoneNumber,
 				Message:       contentDisbursement,
-			}, message.MessageChannelSMS).
+			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(nil).
 			Once()
 


### PR DESCRIPTION
### What
* add `message_channel_priority` to `organizations` table 
* add trigger to validate the channel priority 
* modify `SendMessage` in `MessageDispatcher` to incorporate channel priority


### Why
* add ability to handle both `sms` and `e-mail` when messaging receivers. 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
