### PR TITLE
[Fix] Email case sensitivity when sending user invites 

### DIFF
--- a/db/migrations/auth-migrations/2024-08-20.0-alter-email-lowercase-index.sql
+++ b/db/migrations/auth-migrations/2024-08-20.0-alter-email-lowercase-index.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+
+CREATE UNIQUE INDEX lower_case_email ON auth_users (LOWER(email));
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS lower_case_email;

--- a/internal/data/receivers.go
+++ b/internal/data/receivers.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 )
 
 type Receiver struct {
@@ -348,7 +348,7 @@ func (r *ReceiverModel) Update(ctx context.Context, sqlExec db.SQLExecuter, ID s
 	args := []interface{}{}
 	fields := []string{}
 	if receiverUpdate.Email != "" {
-		sanitizedEmail, err := utils.SanitizeAndValidateEmail(receiverUpdate.Email)
+		sanitizedEmail, err := authUtils.SanitizeAndValidateEmail(receiverUpdate.Email)
 		if err != nil {
 			return fmt.Errorf("error validating email: %w", err)
 		}

--- a/internal/data/receivers.go
+++ b/internal/data/receivers.go
@@ -348,9 +348,11 @@ func (r *ReceiverModel) Update(ctx context.Context, sqlExec db.SQLExecuter, ID s
 	args := []interface{}{}
 	fields := []string{}
 	if receiverUpdate.Email != "" {
-		if err := utils.ValidateEmail(receiverUpdate.Email); err != nil {
+		sanitizedEmail, err := utils.SanitizeAndValidateEmail(receiverUpdate.Email)
+		if err != nil {
 			return fmt.Errorf("error validating email: %w", err)
 		}
+		receiverUpdate.Email = sanitizedEmail
 
 		fields = append(fields, "email = ?")
 		args = append(args, receiverUpdate.Email)

--- a/internal/data/receivers_test.go
+++ b/internal/data/receivers_test.go
@@ -1133,11 +1133,12 @@ func Test_ReceiversModel_Update(t *testing.T) {
 	t.Run("returns error when email is invalid", func(t *testing.T) {
 		resetReceiver(t, ctx, dbConnectionPool, receiver.ID)
 
+		const invalidEmail = "invalid-email"
 		err = receiverModel.Update(ctx, dbConnectionPool, receiver.ID, ReceiverUpdate{
-			Email:      "invalid",
+			Email:      invalidEmail,
 			ExternalId: "",
 		})
-		assert.EqualError(t, err, `error validating email: the provided email is not valid`)
+		assert.EqualError(t, err, fmt.Sprintf(`error validating email: the provided email %q is not valid`, invalidEmail))
 	})
 
 	t.Run("updates email name successfully", func(t *testing.T) {

--- a/internal/message/aws_ses_client.go
+++ b/internal/message/aws_ses_client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 )
 
 // awsSESInterface is used to send emails.
@@ -96,7 +97,7 @@ func NewAWSSESClient(accessKeyID, secretAccessKey, region, senderID string) (*aw
 		return nil, fmt.Errorf("aws region is empty")
 	}
 
-	senderID, err := utils.SanitizeAndValidateEmail(senderID)
+	senderID, err := authUtils.SanitizeAndValidateEmail(senderID)
 	if err != nil {
 		return nil, fmt.Errorf("aws SES (email) senderID is invalid: %w", err)
 	}

--- a/internal/message/aws_ses_client.go
+++ b/internal/message/aws_ses_client.go
@@ -96,8 +96,8 @@ func NewAWSSESClient(accessKeyID, secretAccessKey, region, senderID string) (*aw
 		return nil, fmt.Errorf("aws region is empty")
 	}
 
-	senderID = strings.TrimSpace(senderID)
-	if err := utils.ValidateEmail(senderID); err != nil {
+	senderID, err := utils.SanitizeAndValidateEmail(senderID)
+	if err != nil {
 		return nil, fmt.Errorf("aws SES (email) senderID is invalid: %w", err)
 	}
 

--- a/internal/message/aws_ses_client_test.go
+++ b/internal/message/aws_ses_client_test.go
@@ -51,7 +51,7 @@ func Test_NewAWSSESClient(t *testing.T) {
 	// [email] type needs a valid email as a sender ID:
 	gotAWSSESClient, err = NewAWSSESClient("accessKeyID", "secretAccessKey", "region", "invalid-email")
 	require.Nil(t, gotAWSSESClient)
-	require.EqualError(t, err, "aws SES (email) senderID is invalid: the provided email is not valid")
+	require.EqualError(t, err, fmt.Sprintf("aws SES (email) senderID is invalid: the provided email %q is not valid", "invalid-email"))
 
 	// [email] all fields are present 🎉
 	gotAWSSESClient, err = NewAWSSESClient("accessKeyID", "secretAccessKey", "region", "fOO@test.com  ")

--- a/internal/message/aws_ses_client_test.go
+++ b/internal/message/aws_ses_client_test.go
@@ -43,15 +43,21 @@ func Test_NewAWSSESClient(t *testing.T) {
 	require.Nil(t, gotAWSSESClient)
 	require.EqualError(t, err, "aws region is empty")
 
+	// [email] type needs a non-empty email as a sender ID:
+	gotAWSSESClient, err = NewAWSSESClient("accessKeyID", "secretAccessKey", "region", "")
+	require.Nil(t, gotAWSSESClient)
+	require.EqualError(t, err, "aws SES (email) senderID is invalid: email cannot be empty")
+
 	// [email] type needs a valid email as a sender ID:
 	gotAWSSESClient, err = NewAWSSESClient("accessKeyID", "secretAccessKey", "region", "invalid-email")
 	require.Nil(t, gotAWSSESClient)
 	require.EqualError(t, err, "aws SES (email) senderID is invalid: the provided email is not valid")
 
 	// [email] all fields are present 🎉
-	gotAWSSESClient, err = NewAWSSESClient("accessKeyID", "secretAccessKey", "region", "foo@test.com")
+	gotAWSSESClient, err = NewAWSSESClient("accessKeyID", "secretAccessKey", "region", "fOO@test.com  ")
 	require.NoError(t, err)
 	require.NotNil(t, gotAWSSESClient)
+	require.Equal(t, "foo@test.com", gotAWSSESClient.senderID)
 }
 
 func Test_AWSSES_SendMessage_messageIsInvalid(t *testing.T) {

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 )
 
 type Message struct {
@@ -36,7 +37,7 @@ func (s *Message) ValidateFor(messengerType MessengerType) error {
 }
 
 func (s *Message) IsValidForEmail() error {
-	sanitizedEmail, err := utils.SanitizeAndValidateEmail(s.ToEmail)
+	sanitizedEmail, err := authUtils.SanitizeAndValidateEmail(s.ToEmail)
 	if err != nil {
 		return fmt.Errorf("invalid email format: %w", err)
 	}

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -38,11 +38,11 @@ func (s *Message) ValidateFor(messengerType MessengerType) error {
 func (s *Message) IsValidForEmail() error {
 	sanitizedEmail, err := utils.SanitizeAndValidateEmail(s.ToEmail)
 	if err != nil {
-		return fmt.Errorf("invalid message: %w", err)
+		return fmt.Errorf("invalid email format: %w", err)
 	}
 	s.ToEmail = sanitizedEmail
 
-	if strings.Trim(s.Title, " ") == "" {
+	if strings.TrimSpace(s.Title) == "" {
 		return fmt.Errorf("title is empty")
 	}
 

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -61,19 +62,19 @@ func Test_message_Validate(t *testing.T) {
 		{
 			name:          "Email types need a title",
 			messengerType: MessengerTypeAWSEmail,
-			message:       Message{ToEmail: "foo@test.com", Title: "   "},
+			message:       Message{ToEmail: "FOO@test.com", Title: "   "},
 			wantErr:       fmt.Errorf("invalid e-mail: title is empty"),
 		},
 		{
 			name:          "[sms] message cannot be empty",
 			messengerType: MessengerTypeAWSEmail,
-			message:       Message{ToEmail: "foo@test.com", Title: "My title"},
+			message:       Message{ToEmail: "FOO@test.com", Title: "My title"},
 			wantErr:       fmt.Errorf("message is empty"),
 		},
 		{
 			name:          "[email] all fields are present for AWS email 🎉",
 			messengerType: MessengerTypeAWSEmail,
-			message:       Message{ToEmail: "foo@test.com", Title: "My title", Message: "foo bar"},
+			message:       Message{ToEmail: "FOO@test.com", Title: "My title", Message: "foo bar"},
 			wantErr:       nil,
 		},
 	}
@@ -85,6 +86,9 @@ func Test_message_Validate(t *testing.T) {
 				require.EqualError(t, err, tc.wantErr.Error())
 			} else {
 				require.NoError(t, err)
+				if !slices.Contains([]string{"", "invalid-email"}, tc.message.ToEmail) {
+					require.Equal(t, "foo@test.com", tc.message.ToEmail)
+				}
 			}
 		})
 	}

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -57,7 +57,7 @@ func Test_message_Validate(t *testing.T) {
 			name:          "Email types need a valid email address",
 			messengerType: MessengerTypeAWSEmail,
 			message:       Message{ToEmail: "invalid-email"},
-			wantErr:       fmt.Errorf("invalid e-mail: invalid email format: the provided email is not valid"),
+			wantErr:       fmt.Errorf("invalid e-mail: invalid email format: the provided email %q is not valid", "invalid-email"),
 		},
 		{
 			name:          "Email types need a title",

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -76,13 +76,17 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	// validate request
 	v := validators.NewValidator()
-	/*forgotPasswordRequest.Email, err = utils.SanitizeAndValidateEmail(forgotPasswordRequest.Email)
-	v.CheckError(err, "email", "email is invalid")*/
-
-	v.Check(forgotPasswordRequest.Email != "", "email", "email is required")
+	forgotPasswordRequest.Email, err = utils.SanitizeAndValidateEmail(forgotPasswordRequest.Email)
+	if err != nil {
+		if errors.Is(err, utils.ErrEmptyEmail) {
+			v.Check(true, "email", "email is required")
+		} else {
+			v.CheckError(err, "email", "email is invalid")
+		}
+	}
 
 	if v.HasErrors() {
-		httperror.BadRequest("request invalid", err, v.Errors).Render(w)
+		httperror.BadRequest("Request invalid", err, v.Errors).Render(w)
 		return
 	}
 

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -80,7 +80,7 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	forgotPasswordRequest.Email, err = authUtils.SanitizeAndValidateEmail(forgotPasswordRequest.Email)
 	if err != nil {
 		if errors.Is(err, authUtils.ErrEmptyEmail) {
-			v.Check(true, "email", "email is required")
+			v.Check(false, "email", "email is required")
 		} else {
 			v.CheckError(err, "email", "email is invalid")
 		}

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -76,6 +76,8 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	// validate request
 	v := validators.NewValidator()
+	/*forgotPasswordRequest.Email, err = utils.SanitizeAndValidateEmail(forgotPasswordRequest.Email)
+	v.CheckError(err, "email", "email is invalid")*/
 
 	v.Check(forgotPasswordRequest.Email != "", "email", "email is required")
 

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
@@ -76,9 +77,9 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	// validate request
 	v := validators.NewValidator()
-	forgotPasswordRequest.Email, err = utils.SanitizeAndValidateEmail(forgotPasswordRequest.Email)
+	forgotPasswordRequest.Email, err = authUtils.SanitizeAndValidateEmail(forgotPasswordRequest.Email)
 	if err != nil {
-		if errors.Is(err, utils.ErrEmptyEmail) {
+		if errors.Is(err, authUtils.ErrEmptyEmail) {
 			v.Check(true, "email", "email is required")
 		} else {
 			v.CheckError(err, "email", "email is invalid")

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -318,6 +318,40 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 		assert.JSONEq(t, expectedBody, string(respBody))
 	})
 
+	t.Run("Should return http status 400 when invalid email is provided", func(t *testing.T) {
+		requestBody := `
+		{ 
+			"email": "invalid",
+			"recaptcha_token": "validToken"
+		}`
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
+		require.NoError(t, err)
+
+		reCAPTCHAValidatorMock.
+			On("IsTokenValid", mock.Anything, "validToken").
+			Return(true, nil).
+			Once()
+
+		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
+
+		resp := rr.Result()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		expectedBody := `
+			{
+				"error": "Request invalid",
+				"extras": {
+					"email": "email is invalid"
+				}
+			}
+		`
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.JSONEq(t, expectedBody, string(respBody))
+	})
+
 	t.Run("Should return http status 500 when reCAPTCHA validator returns an error", func(t *testing.T) {
 		requestBody := `
 		{ 

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -218,7 +218,7 @@ func Test_ForgotPasswordHandler(t *testing.T) {
 
 		expectedBody := `
 			{
-				"error":"request invalid",
+				"error":"Request invalid",
 				"extras": {
 					"email":"email is required"
 				}

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -33,7 +33,7 @@ func (r *LoginRequest) validate() *httperror.HTTPError {
 	sanitizedEmail, err := authUtils.SanitizeAndValidateEmail(r.Email)
 	if err != nil {
 		if errors.Is(err, authUtils.ErrEmptyEmail) {
-			validator.Check(true, "email", "email is required")
+			validator.Check(false, "email", "email is required")
 		} else {
 			validator.CheckError(err, "email", "email is invalid")
 		}

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -26,7 +26,7 @@ type LoginRequest struct {
 	ReCAPTCHAToken string `json:"recaptcha_token"`
 }
 
-func (r *LoginRequest) validate() *httperror.HTTPError {
+func (r LoginRequest) validate() *httperror.HTTPError {
 	validator := validators.NewValidator()
 
 	/*var err error
@@ -55,7 +55,7 @@ type LoginHandler struct {
 	MFADisabled        bool
 }
 
-func (h *LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var reqBody LoginRequest

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 )
 
 const mfaMessageTitle = "Verification code to access your account"
@@ -29,9 +30,9 @@ type LoginRequest struct {
 func (r *LoginRequest) validate() *httperror.HTTPError {
 	validator := validators.NewValidator()
 
-	sanitizedEmail, err := utils.SanitizeAndValidateEmail(r.Email)
+	sanitizedEmail, err := authUtils.SanitizeAndValidateEmail(r.Email)
 	if err != nil {
-		if errors.Is(err, utils.ErrEmptyEmail) {
+		if errors.Is(err, authUtils.ErrEmptyEmail) {
 			validator.Check(true, "email", "email is required")
 		} else {
 			validator.CheckError(err, "email", "email is invalid")

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -26,9 +26,12 @@ type LoginRequest struct {
 	ReCAPTCHAToken string `json:"recaptcha_token"`
 }
 
-func (r LoginRequest) validate() *httperror.HTTPError {
+func (r *LoginRequest) validate() *httperror.HTTPError {
 	validator := validators.NewValidator()
 
+	/*var err error
+	r.Email, err = utils.SanitizeAndValidateEmail(r.Email)
+	validator.CheckError(err, "email", "email is invalid")*/
 	validator.Check(r.Email != "", "email", "email is required")
 	validator.Check(r.Password != "", "password", "password is required")
 
@@ -52,7 +55,7 @@ type LoginHandler struct {
 	MFADisabled        bool
 }
 
-func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+func (h *LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var reqBody LoginRequest

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -38,7 +38,21 @@ func Test_LoginRequest_validate(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 
 	lr = LoginRequest{
-		Email:          "email@email.com",
+		Email:          "invalid",
+		Password:       "",
+		ReCAPTCHAToken: "",
+	}
+
+	extras = map[string]interface{}{"email": "email is invalid", "password": "password is required"}
+	expectedErr = httperror.BadRequest("Request invalid", nil, extras)
+
+	err = lr.validate()
+	assert.Equal(t, expectedErr, err)
+
+	const sanitizedEmail = "email@email.com"
+
+	lr = LoginRequest{
+		Email:          sanitizedEmail,
 		Password:       "",
 		ReCAPTCHAToken: "XyZ",
 	}
@@ -48,6 +62,16 @@ func Test_LoginRequest_validate(t *testing.T) {
 
 	err = lr.validate()
 	assert.Equal(t, expectedErr, err)
+
+	tlr := LoginRequest{
+		Email:          " EMAIL@EMAIL.com ",
+		Password:       "p@ssword",
+		ReCAPTCHAToken: "XyZ",
+	}
+
+	err = tlr.validate()
+	assert.Nil(t, err)
+	assert.Equal(t, sanitizedEmail, tlr.Email)
 }
 
 func Test_LoginHandler(t *testing.T) {

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -105,7 +105,7 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 
 	// limiting the amount of memory allocated in the server to handle the request
 	if err := req.ParseMultipartForm(h.MaxMemoryAllocation); err != nil {
-		err = fmt.Errorf("error parsing multipart form: %w", err)
+		err = fmt.Errorf("parsing multipart form: %w", err)
 		log.Ctx(ctx).Error(err)
 		httperror.BadRequest("could not parse multipart form data", err, map[string]interface{}{
 			"details": "request too large. Max size 2MB.",
@@ -115,7 +115,7 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 
 	multipartFile, _, err := req.FormFile("logo")
 	if err != nil && !errors.Is(err, http.ErrMissingFile) {
-		err = fmt.Errorf("error parsing logo file: %w", err)
+		err = fmt.Errorf("parsing logo file: %w", err)
 		log.Ctx(ctx).Error(err)
 		httperror.BadRequest("could not parse request logo", err, nil).Render(rw)
 		return
@@ -145,7 +145,7 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 	var reqBody PatchOrganizationProfileRequest
 	d := req.FormValue("data")
 	if err = json.Unmarshal([]byte(d), &reqBody); err != nil {
-		err = fmt.Errorf("error decoding data: %w", err)
+		err = fmt.Errorf("decoding data: %w", err)
 		log.Ctx(ctx).Error(err)
 		httperror.BadRequest("", err, nil).Render(rw)
 		return
@@ -219,6 +219,7 @@ func (h ProfileHandler) PatchUserProfile(rw http.ResponseWriter, req *http.Reque
 			}).Render(rw)
 			return
 		}
+
 		reqBody.Email = sanitizedEmail
 		log.Ctx(ctx).Warnf("[PatchUserProfile] - Will update email for userID %s to %s", user.ID, utils.TruncateString(reqBody.Email, 3))
 	}

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -212,7 +212,7 @@ func (h ProfileHandler) PatchUserProfile(rw http.ResponseWriter, req *http.Reque
 	}
 
 	if reqBody.Email != "" {
-		sanitizedEmail, err := utils.SanitizeAndValidateEmail(reqBody.Email)
+		sanitizedEmail, err := authUtils.SanitizeAndValidateEmail(reqBody.Email)
 		if err != nil {
 			httperror.BadRequest("", nil, map[string]interface{}{
 				"email": "invalid email provided",

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -212,12 +212,14 @@ func (h ProfileHandler) PatchUserProfile(rw http.ResponseWriter, req *http.Reque
 	}
 
 	if reqBody.Email != "" {
-		if err := utils.ValidateEmail(reqBody.Email); err != nil {
+		sanitizedEmail, err := utils.SanitizeAndValidateEmail(reqBody.Email)
+		if err != nil {
 			httperror.BadRequest("", nil, map[string]interface{}{
 				"email": "invalid email provided",
 			}).Render(rw)
 			return
 		}
+		reqBody.Email = sanitizedEmail
 		log.Ctx(ctx).Warnf("[PatchUserProfile] - Will update email for userID %s to %s", user.ID, utils.TruncateString(reqBody.Email, 3))
 	}
 

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -532,7 +532,7 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			},
 			wantStatusCode: http.StatusBadRequest,
 			wantRespBody: `{
-				"error": "The request was invalid in some way.", 
+				"error": "Request invalid", 
 				"extras": {
 					"email": "invalid email provided"
 				}
@@ -550,9 +550,9 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			},
 			wantStatusCode: http.StatusBadRequest,
 			wantRespBody: `{
-				"error": "The request was invalid in some way.",
+				"error": "Request invalid",
 				"extras": {
-					"details":"provide at least first_name, last_name or email."
+					"details":"provide at least first_name, last_name or email"
 				}
 			}`,
 		},

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -582,7 +582,7 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			reqBody: `{
 				"first_name": "First",
 				"last_name": "Last",
-				"email": "email@email.com"
+				"email": "EMAIL@email.com"
 			}`,
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.

--- a/internal/serve/validators/receiver_update_validator.go
+++ b/internal/serve/validators/receiver_update_validator.go
@@ -57,7 +57,9 @@ func (ur *UpdateReceiverValidator) ValidateReceiver(updateReceiverRequest *Updat
 	}
 
 	if updateReceiverRequest.Email != "" {
-		ur.Check(utils.ValidateEmail(email) == nil, "email", "invalid email format")
+		var err error
+		email, err = utils.SanitizeAndValidateEmail(email)
+		ur.Check(err == nil, "email", "invalid email format")
 	}
 
 	if updateReceiverRequest.ExternalID != "" {

--- a/internal/serve/validators/receiver_update_validator.go
+++ b/internal/serve/validators/receiver_update_validator.go
@@ -59,7 +59,7 @@ func (ur *UpdateReceiverValidator) ValidateReceiver(updateReceiverRequest *Updat
 	if updateReceiverRequest.Email != "" {
 		var err error
 		email, err = utils.SanitizeAndValidateEmail(email)
-		ur.Check(err == nil, "email", "invalid email format")
+		ur.CheckError(err, "email", "invalid email format")
 	}
 
 	if updateReceiverRequest.ExternalID != "" {

--- a/internal/serve/validators/receiver_update_validator.go
+++ b/internal/serve/validators/receiver_update_validator.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 )
 
 type UpdateReceiverRequest struct {
@@ -58,7 +59,7 @@ func (ur *UpdateReceiverValidator) ValidateReceiver(updateReceiverRequest *Updat
 
 	if updateReceiverRequest.Email != "" {
 		var err error
-		email, err = utils.SanitizeAndValidateEmail(email)
+		email, err = authUtils.SanitizeAndValidateEmail(email)
 		ur.CheckError(err, "email", "invalid email format")
 	}
 

--- a/internal/serve/validators/receiver_update_validator_test.go
+++ b/internal/serve/validators/receiver_update_validator_test.go
@@ -92,7 +92,7 @@ func Test_UpdateReceiverValidator_ValidateReceiver(t *testing.T) {
 			DateOfBirth: "1999-01-01",
 			Pin:         "1234   ",
 			NationalID:  "   12345CODE",
-			Email:       "receiver@email.com",
+			Email:       "   RECEIVER@email.com   ",
 			ExternalID:  "externalID",
 		}
 		validator.ValidateReceiver(&receiverInfo)
@@ -101,5 +101,6 @@ func Test_UpdateReceiverValidator_ValidateReceiver(t *testing.T) {
 		assert.Equal(t, "1999-01-01", receiverInfo.DateOfBirth)
 		assert.Equal(t, "1234", receiverInfo.Pin)
 		assert.Equal(t, "12345CODE", receiverInfo.NationalID)
+		assert.Equal(t, "receiver@email.com", receiverInfo.Email)
 	})
 }

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/asaskevich/govalidator"
@@ -17,7 +16,6 @@ var (
 	rxOTP                     = regexp.MustCompile(`^\d{6}$`)
 	ErrInvalidE164PhoneNumber = fmt.Errorf("the provided phone number is not a valid E.164 number")
 	ErrEmptyPhoneNumber       = fmt.Errorf("phone number cannot be empty")
-	ErrEmptyEmail             = fmt.Errorf("email cannot be empty")
 )
 
 const (
@@ -67,18 +65,9 @@ func ValidateAmount(amount string) error {
 // It's free to use under the [MIT Licence](https://opensource.org/licenses/MIT).
 var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 
-func SanitizeAndValidateEmail(email string) (string, error) {
-	email = SanitizeEmail(email)
-	return email, ValidateEmail(email)
-}
-
-func SanitizeEmail(email string) string {
-	return strings.ToLower(strings.TrimSpace(email))
-}
-
 func ValidateEmail(email string) error {
 	if email == "" {
-		return ErrEmptyEmail
+		return fmt.Errorf("email cannot be empty")
 	}
 
 	if !rxEmail.MatchString(email) {

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/asaskevich/govalidator"
@@ -64,6 +65,12 @@ func ValidateAmount(amount string) error {
 // RxEmail is a regex used to validate e-mail addresses, according with the reference https://www.alexedwards.net/blog/validation-snippets-for-go#email-validation.
 // It's free to use under the [MIT Licence](https://opensource.org/licenses/MIT).
 var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+
+func SanitizeAndValidateEmail(email string) (string, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+
+	return email, ValidateEmail(email)
+}
 
 func ValidateEmail(email string) error {
 	if email == "" {

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -17,6 +17,7 @@ var (
 	rxOTP                     = regexp.MustCompile(`^\d{6}$`)
 	ErrInvalidE164PhoneNumber = fmt.Errorf("the provided phone number is not a valid E.164 number")
 	ErrEmptyPhoneNumber       = fmt.Errorf("phone number cannot be empty")
+	ErrEmptyEmail             = fmt.Errorf("email cannot be empty")
 )
 
 const (
@@ -67,14 +68,17 @@ func ValidateAmount(amount string) error {
 var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 
 func SanitizeAndValidateEmail(email string) (string, error) {
-	email = strings.ToLower(strings.TrimSpace(email))
-
+	email = SanitizeEmail(email)
 	return email, ValidateEmail(email)
+}
+
+func SanitizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
 }
 
 func ValidateEmail(email string) error {
 	if email == "" {
-		return fmt.Errorf("email cannot be empty")
+		return ErrEmptyEmail
 	}
 
 	if !rxEmail.MatchString(email) {

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -413,7 +413,7 @@ func (a *defaultAuthenticator) GetAllUsers(ctx context.Context) ([]User, error) 
 			id,
 			first_name,
 			last_name,
-			LOWER(email),
+			LOWER(email) as email,
 			roles,
 			is_owner,
 			is_active
@@ -456,7 +456,7 @@ func (a *defaultAuthenticator) GetUser(ctx context.Context, userID string) (*Use
 		SELECT
 			first_name,
 			last_name,
-			LOWER(email)
+			LOWER(email) as email
 		FROM
 			auth_users
 		WHERE

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
+	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 )
 
 var (
@@ -173,7 +174,7 @@ func (a *defaultAuthenticator) UpdateUser(ctx context.Context, ID, firstName, la
 	}
 
 	if email != "" {
-		sanitizedEmail, err := utils.SanitizeAndValidateEmail(email)
+		sanitizedEmail, err := authUtils.SanitizeAndValidateEmail(email)
 		if err != nil {
 			return fmt.Errorf("error validating email: %w", err)
 		}

--- a/stellar-auth/pkg/auth/fixtures.go
+++ b/stellar-auth/pkg/auth/fixtures.go
@@ -74,7 +74,7 @@ func CreateRandomAuthUserFixture(t *testing.T, ctx context.Context, sqlExec db.S
 	`
 
 	user := &RandomAuthUser{
-		Email:             email,
+		Email:             strings.ToLower(email),
 		FirstName:         firstName,
 		LastName:          lastName,
 		Password:          password,
@@ -85,8 +85,6 @@ func CreateRandomAuthUserFixture(t *testing.T, ctx context.Context, sqlExec db.S
 	}
 	err = sqlExec.QueryRowxContext(ctx, query, email, encryptedPassword, isAdmin, pq.Array(roles), firstName, lastName).Scan(&user.ID, &user.CreatedAt)
 	require.NoError(t, err)
-	// this will help us avoid having to cast to lowercase everytime in tests
-	user.Email = strings.ToLower(user.Email)
 
 	return user
 }

--- a/stellar-auth/pkg/auth/fixtures.go
+++ b/stellar-auth/pkg/auth/fixtures.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,7 +68,7 @@ func CreateRandomAuthUserFixture(t *testing.T, ctx context.Context, sqlExec db.S
 		INSERT INTO auth_users
 			(email, encrypted_password, is_owner, roles, first_name, last_name)
 		VALUES
-			($1, $2, $3, $4, $5, $6)
+			(LOWER($1), $2, $3, $4, $5, $6)
 		RETURNING
 			id, created_at
 	`
@@ -84,6 +85,8 @@ func CreateRandomAuthUserFixture(t *testing.T, ctx context.Context, sqlExec db.S
 	}
 	err = sqlExec.QueryRowxContext(ctx, query, email, encryptedPassword, isAdmin, pq.Array(roles), firstName, lastName).Scan(&user.ID, &user.CreatedAt)
 	require.NoError(t, err)
+	// this will help us avoid having to cast to lowercase everytime in tests
+	user.Email = strings.ToLower(user.Email)
 
 	return user
 }

--- a/stellar-auth/pkg/auth/manager.go
+++ b/stellar-auth/pkg/auth/manager.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
+	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 )
 
 const defaultExpirationTimeInMinutes = 15
@@ -22,9 +22,9 @@ type User struct {
 }
 
 func (u *User) Validate() error {
-	sanitizedEmail, err := utils.SanitizeAndValidateEmail(u.Email)
+	sanitizedEmail, err := authUtils.SanitizeAndValidateEmail(u.Email)
 	if err != nil {
-		if errors.Is(err, utils.ErrEmptyEmail) {
+		if errors.Is(err, authUtils.ErrEmptyEmail) {
 			return fmt.Errorf("email is required")
 		}
 		return fmt.Errorf("email is invalid: %w", err)

--- a/stellar-auth/pkg/auth/manager.go
+++ b/stellar-auth/pkg/auth/manager.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -21,12 +22,11 @@ type User struct {
 }
 
 func (u *User) Validate() error {
-	if u.Email == "" {
-		return fmt.Errorf("email is required")
-	}
-
 	sanitizedEmail, err := utils.SanitizeAndValidateEmail(u.Email)
 	if err != nil {
+		if errors.Is(err, utils.ErrEmptyEmail) {
+			return fmt.Errorf("email is required")
+		}
 		return fmt.Errorf("email is invalid: %w", err)
 	}
 	u.Email = sanitizedEmail

--- a/stellar-auth/pkg/auth/manager.go
+++ b/stellar-auth/pkg/auth/manager.go
@@ -23,9 +23,13 @@ type User struct {
 func (u *User) Validate() error {
 	if u.Email == "" {
 		return fmt.Errorf("email is required")
-	} else if err := utils.ValidateEmail(u.Email); err != nil {
+	}
+
+	sanitizedEmail, err := utils.SanitizeAndValidateEmail(u.Email)
+	if err != nil {
 		return fmt.Errorf("email is invalid: %w", err)
 	}
+	u.Email = sanitizedEmail
 
 	if u.FirstName == "" {
 		return fmt.Errorf("first name is required")

--- a/stellar-auth/pkg/auth/manager_test.go
+++ b/stellar-auth/pkg/auth/manager_test.go
@@ -29,4 +29,8 @@ func Test_User_Validate(t *testing.T) {
 
 	user.LastName = "Last"
 	assert.NoError(t, user.Validate())
+
+	user.Email = " EMAIL@email.com "
+	assert.NoError(t, user.Validate())
+	assert.Equal(t, "email@email.com", user.Email)
 }

--- a/stellar-auth/pkg/utils/utils.go
+++ b/stellar-auth/pkg/utils/utils.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+var (
+	ErrEmptyEmail = fmt.Errorf("email cannot be empty")
+)
+
 const (
 	// Default charset to be used with StringWithCharset function
 	DefaultCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -35,13 +39,12 @@ var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9
 
 func SanitizeAndValidateEmail(email string) (string, error) {
 	email = strings.ToLower(strings.TrimSpace(email))
-
 	return email, ValidateEmail(email)
 }
 
 func ValidateEmail(email string) error {
 	if email == "" {
-		return fmt.Errorf("email cannot be empty")
+		return ErrEmptyEmail
 	}
 
 	if !rxEmail.MatchString(email) {

--- a/stellar-auth/pkg/utils/utils.go
+++ b/stellar-auth/pkg/utils/utils.go
@@ -8,9 +8,7 @@ import (
 	"strings"
 )
 
-var (
-	ErrEmptyEmail = fmt.Errorf("email cannot be empty")
-)
+var ErrEmptyEmail = fmt.Errorf("email cannot be empty")
 
 const (
 	// Default charset to be used with StringWithCharset function

--- a/stellar-auth/pkg/utils/utils.go
+++ b/stellar-auth/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -31,6 +32,12 @@ func StringWithCharset(length int, charset string) (string, error) {
 // RxEmail is a regex used to validate e-mail addresses, according with the reference https://www.alexedwards.net/blog/validation-snippets-for-go#email-validation.
 // It's free to use under the [MIT License](https://opensource.org/licenses/MIT)
 var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+
+func SanitizeAndValidateEmail(email string) (string, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+
+	return email, ValidateEmail(email)
+}
 
 func ValidateEmail(email string) error {
 	if email == "" {

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -388,7 +388,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 				"error": "invalid request body",
 				"extras": {
 					"name": "invalid tenant name. It should only contains lower case letters and dash (-)",
-					"owner_email": "invalid email",
+					"owner_email": "owner_email is required",
 					"owner_first_name": "owner_first_name is required",
 					"owner_last_name": "owner_last_name is required",
 					"organization_name": "organization_name is required",

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -58,14 +58,18 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 	}
 
 	tv.Check(validTenantName.MatchString(reqBody.Name), "name", "invalid tenant name. It should only contains lower case letters and dash (-)")
-	tv.CheckError(utils.ValidateEmail(reqBody.OwnerEmail), "owner_email", "invalid email")
 	tv.Check(reqBody.OwnerFirstName != "", "owner_first_name", "owner_first_name is required")
 	tv.Check(reqBody.OwnerLastName != "", "owner_last_name", "owner_last_name is required")
 	tv.Check(reqBody.OrganizationName != "", "organization_name", "organization_name is required")
 
 	tv.validateDistributionAccountType(reqBody.DistributionAccountType)
 
-	var err error
+	sanitizedEmail, err := utils.SanitizeAndValidateEmail(reqBody.OwnerEmail)
+	if err != nil {
+		tv.addError("owner_email", "invalid email")
+	}
+	reqBody.OwnerEmail = sanitizedEmail
+
 	if reqBody.BaseURL != nil {
 		if _, err = url.ParseRequestURI(*reqBody.BaseURL); err != nil {
 			tv.Check(false, "base_url", "invalid base URL value")

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
+	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
@@ -64,7 +65,7 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 
 	tv.validateDistributionAccountType(reqBody.DistributionAccountType)
 
-	sanitizedEmail, err := utils.SanitizeAndValidateEmail(reqBody.OwnerEmail)
+	sanitizedEmail, err := authUtils.SanitizeAndValidateEmail(reqBody.OwnerEmail)
 	if err != nil {
 		tv.addError("owner_email", "invalid email")
 	}

--- a/stellar-multitenant/internal/validators/tenant_validator.go
+++ b/stellar-multitenant/internal/validators/tenant_validator.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -67,7 +68,11 @@ func (tv *TenantValidator) ValidateCreateTenantRequest(reqBody *TenantRequest) *
 
 	sanitizedEmail, err := authUtils.SanitizeAndValidateEmail(reqBody.OwnerEmail)
 	if err != nil {
-		tv.addError("owner_email", "invalid email")
+		if errors.Is(err, authUtils.ErrEmptyEmail) {
+			tv.addError("owner_email", "owner_email is required")
+		} else {
+			tv.addError("owner_email", "owner_email is invalid")
+		}
 	}
 	reqBody.OwnerEmail = sanitizedEmail
 

--- a/stellar-multitenant/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/internal/validators/tenant_validator_test.go
@@ -29,7 +29,7 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
 			"name":                      "invalid tenant name. It should only contains lower case letters and dash (-)",
-			"owner_email":               "invalid email",
+			"owner_email":               "owner_email is required",
 			"owner_first_name":          "owner_first_name is required",
 			"owner_last_name":           "owner_last_name is required",
 			"organization_name":         "organization_name is required",
@@ -41,7 +41,7 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"owner_email":               "invalid email",
+			"owner_email":               "owner_email is required",
 			"owner_first_name":          "owner_first_name is required",
 			"owner_last_name":           "owner_last_name is required",
 			"organization_name":         "organization_name is required",
@@ -85,7 +85,7 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv.ValidateCreateTenantRequest(reqBody)
 		assert.True(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{
-			"owner_email":       "invalid email",
+			"owner_email":       "owner_email is invalid",
 			"owner_first_name":  "owner_first_name is required",
 			"owner_last_name":   "owner_last_name is required",
 			"organization_name": "organization_name is required",

--- a/stellar-multitenant/internal/validators/tenant_validator_test.go
+++ b/stellar-multitenant/internal/validators/tenant_validator_test.go
@@ -154,7 +154,7 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		tv := NewTenantValidator()
 		reqBody := &TenantRequest{
 			Name:                    "aid-org",
-			OwnerEmail:              "owner@email.org",
+			OwnerEmail:              "   OWNER@email.org   ",
 			OwnerFirstName:          "Owner",
 			OwnerLastName:           "Owner",
 			OrganizationName:        "Aid Org",
@@ -162,6 +162,7 @@ func TestTenantValidator_ValidateCreateTenantRequest(t *testing.T) {
 		}
 
 		tv.ValidateCreateTenantRequest(reqBody)
+		assert.Equal(t, "owner@email.org", reqBody.OwnerEmail)
 		assert.False(t, tv.HasErrors())
 		assert.Equal(t, map[string]interface{}{}, tv.Errors)
 	})


### PR DESCRIPTION
### What
Provisioning user through `POST /tenants`

request body
```
{
    "name": "redcorp",
    "organization_name": "redcorp",
    "owner_email": "   OWNER@redcorp.LOCAL",
    "owner_first_name": "john",
    "owner_last_name": "doe",
    "distribution_account_type": "DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT"
}
```


db entry for user provisioned through above request, email is properly sanitized
87c7f4ef-36f6-4ae5-b05c-75244dbf6880 | $2a$10$zCSK7rza1WIH6qNCGaNJtePZe57uKudra4OIHIzL/1JAGNvuDBmWi | owner@redcorp.local | TRUE | 2024-08-22 21:23:55.422581+00 | {owner} | TRUE | john | doe
-- | -- | -- | -- | -- | -- | -- | -- | --

attempting to request forgot password email,
<img width="456" alt="Screenshot 2024-08-22 at 3 03 28 PM" src="https://github.com/user-attachments/assets/0c8fa257-df6f-4bd9-bd63-fb6af032ecfe">

input is sanitized and email is sent
```
2024-08-22 14:34:37 -------------------------------------------------------------------------------
2024-08-22 14:34:37 Recipient: owner@redcorp.local
2024-08-22 14:34:37 Subject: Reset Account Password
2024-08-22 14:34:37 Content: <!DOCTYPE html>
2024-08-22 14:34:37 <html lang="en">
2024-08-22 14:34:37 <head>
2024-08-22 14:34:37     <meta charset="UTF-8">
2024-08-22 14:34:37     <title>Password Reset</title>
2024-08-22 14:34:37     <style>
2024-08-22 14:34:37         body {
2024-08-22 14:34:37             font-family: Arial, sans-serif;
2024-08-22 14:34:37             line-height: 1.6;
2024-08-22 14:34:37         }
2024-08-22 14:34:37         a {
2024-08-22 14:34:37             color: #3498db;
2024-08-22 14:34:37             text-decoration: none;
2024-08-22 14:34:37         }
2024-08-22 14:34:37         a:hover {
2024-08-22 14:34:37             text-decoration: underline;
2024-08-22 14:34:37         }
2024-08-22 14:34:37     </style>
2024-08-22 14:34:37 </head>
2024-08-22 14:34:37 <body>
2024-08-22 14:34:37     <p>Hello,</p>
2024-08-22 14:34:37     <p>We received a request to reset your Stellar Disbursement Platform account password. Please use the confirmation token <strong>LCkczEoU6q</strong> on the <a href="http://redcorp.stellar.local:3000/reset-password">reset password page</a> to create a new password.</p>
2024-08-22 14:34:37     <p>If you did not request a password reset, please ignore this message or reach out to your organization's administrator with any questions or concerns.</p>
2024-08-22 14:34:37     <p>Best regards,</p>
2024-08-22 14:34:37     <p>The redcorp Team</p>
2024-08-22 14:34:37 </body>
2024-08-22 14:34:37 </html>
2024-08-22 14:34:37 
2024-08-22 14:34:37 -------------------------------------------------------------------------------
```

attempting to login using case-sensitive email works as well
<img width="440" alt="Screenshot 2024-08-22 at 3 10 19 PM" src="https://github.com/user-attachments/assets/1cea46dd-255a-4f04-a3f4-e634b153df93">

update user profile 
<img width="621" alt="Screenshot 2024-08-22 at 3 20 15 PM" src="https://github.com/user-attachments/assets/9bc99c78-5133-43fe-ae9d-a24877eac8c3">

87c7f4ef-36f6-4ae5-b05c-75244dbf6880 | $2a$10$ntkpMddrJf9LpCDKYVc8KOQ0IMjZJ8wZ2945Qp1h8GgfwdnLci5Ma | owner1@redcorp.local | TRUE | 2024-08-22 21:23:55.422581+00 | {owner} | TRUE | john | doe
-- | -- | -- | -- | -- | -- | -- | -- | --

updating receiver info - email

<img width="668" alt="Screenshot 2024-08-22 at 3 37 40 PM" src="https://github.com/user-attachments/assets/3ed346b2-7b85-409a-aa0f-452c4251f3be">

badcf0f8-0651-468f-aded-596efad977df | 2024-08-22 22:37:02.824515+00 | +15101234567 | hellow0rld@sdf.org | 2024-08-22 22:37:42.067153+00 | ghi
-- | -- | -- | -- | -- | --


### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
