### PR TITLE
[SDP-1307] track verification channel

### DIFF
--- a/db/migrations/sdp-migrations/2024-08-20.0-alter-receiver-verifications-table-add-verification-channel.sql
+++ b/db/migrations/sdp-migrations/2024-08-20.0-alter-receiver-verifications-table-add-verification-channel.sql
@@ -4,7 +4,7 @@ ALTER TABLE receiver_verifications
 
 UPDATE receiver_verifications rv
     SET verification_channel = 'SMS'::message_channel
-    WHERE rv.verification_channel IS NULL;
+    WHERE rv.verification_channel IS NULL AND confirmed_at IS NOT NULL;
 
 -- +migrate Down
 

--- a/db/migrations/sdp-migrations/2024-08-20.0-alter-receiver-verifications-table-add-verification-channel.sql
+++ b/db/migrations/sdp-migrations/2024-08-20.0-alter-receiver-verifications-table-add-verification-channel.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+ALTER TABLE receiver_verifications
+    ADD COLUMN verification_channel message_channel;
+
+UPDATE receiver_verifications rv
+    SET verification_channel = 'SMS'::message_channel
+    WHERE rv.verification_channel IS NULL;
+
+-- +migrate Down
+
+ALTER TABLE receiver_verifications
+    DROP COLUMN verification_channel;

--- a/internal/data/receivers.go
+++ b/internal/data/receivers.go
@@ -26,6 +26,8 @@ type Receiver struct {
 }
 
 type ReceiverRegistrationRequest struct {
+	// TODO: SDP-1296 - Update `/wallet-registration/otp` to support multiple contact information types and send OTPs accordingly
+	Email             string            `json:"email"`
 	PhoneNumber       string            `json:"phone_number"`
 	OTP               string            `json:"otp"`
 	VerificationValue string            `json:"verification"`

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -27,9 +27,11 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -207,7 +209,12 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 		VerificationValue: "1990-01-01",
 	})
 	receiverVerificationExceededAttempts.Attempts = data.MaxAttemptsAllowed
-	err = models.ReceiverVerification.UpdateReceiverVerification(ctx, *receiverVerificationExceededAttempts, dbConnectionPool)
+	err = models.ReceiverVerification.UpdateReceiverVerification(ctx, data.ReceiverVerificationUpdate{
+		ReceiverID:          receiverWithExceededAttempts.ID,
+		VerificationField:   data.VerificationFieldDateOfBirth,
+		Attempts:            utils.IntPtr(data.MaxAttemptsAllowed),
+		VerificationChannel: message.MessageChannelSMS,
+	}, dbConnectionPool)
 	require.NoError(t, err)
 
 	// receiver with receiver_verification row:
@@ -902,7 +909,12 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 			VerificationValue: "1990-01-01",
 		})
 		receiverVerificationExceededAttempts.Attempts = data.MaxAttemptsAllowed
-		err = models.ReceiverVerification.UpdateReceiverVerification(ctx, *receiverVerificationExceededAttempts, dbConnectionPool)
+		err = models.ReceiverVerification.UpdateReceiverVerification(ctx, data.ReceiverVerificationUpdate{
+			ReceiverID:          receiverWithExceededAttempts.ID,
+			VerificationField:   data.VerificationFieldDateOfBirth,
+			Attempts:            utils.IntPtr(data.MaxAttemptsAllowed),
+			VerificationChannel: message.MessageChannelSMS,
+		}, dbConnectionPool)
 		require.NoError(t, err)
 
 		// set the logger to a buffer so we can check the error message

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -95,6 +95,11 @@ func StringPtr(s string) *string {
 	return &s
 }
 
+// IntPtr returns a pointer to an int
+func IntPtr(i int) *int {
+	return &i
+}
+
 func TimePtr(t time.Time) *time.Time {
 	return &t
 }


### PR DESCRIPTION
### What
* database migration
   * All already registered receivers should be updated with their verification field to phone_number, so we don’t lose any data
* Update the code to include that field when verifying the receiver wallet

### Why
* https://stellarorg.atlassian.net/browse/SDP-1307

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [ ] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR title and description are clear enough for anyone to review it.
* [ ] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [ ] This PR adds tests for the new functionality or fixes.
* [ ] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [ ] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [ ] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [ ] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [ ] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [ ] This is not a breaking change.
* [ ] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
