### PR TITLE
[SDP-1331] Fix inconsistency in field names

### DIFF
--- a/internal/data/disbursement_instructions_test.go
+++ b/internal/data/disbursement_instructions_test.go
@@ -79,7 +79,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		assertEqualReceivers(t, expectedPhoneNumbers, expectedExternalIDs, receivers)
 
 		// Verify ReceiverVerifications
-		receiverVerifications, err := di.receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, VerificationFieldDateOfBirth)
+		receiverVerifications, err := di.receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, VerificationTypeDateOfBirth)
 		require.NoError(t, err)
 		assertEqualVerifications(t, instructions, receiverVerifications, receivers)
 
@@ -128,7 +128,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		assertEqualReceivers(t, expectedPhoneNumbers, expectedExternalIDs, receivers)
 
 		// Verify ReceiverVerifications
-		receiverVerifications, err := di.receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, VerificationFieldDateOfBirth)
+		receiverVerifications, err := di.receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, VerificationTypeDateOfBirth)
 		require.NoError(t, err)
 		assertEqualVerifications(t, instructions, receiverVerifications, receivers)
 

--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -23,7 +23,7 @@ type Disbursement struct {
 	Wallet                         *Wallet                   `json:"wallet,omitempty" db:"wallet"`
 	Asset                          *Asset                    `json:"asset,omitempty" db:"asset"`
 	Status                         DisbursementStatus        `json:"status" db:"status"`
-	VerificationField              VerificationField         `json:"verification_field,omitempty" db:"verification_field"`
+	VerificationField              VerificationType          `json:"verification_field,omitempty" db:"verification_field"`
 	StatusHistory                  DisbursementStatusHistory `json:"status_history,omitempty" db:"status_history"`
 	SMSRegistrationMessageTemplate string                    `json:"sms_registration_message_template" db:"sms_registration_message_template"`
 	FileName                       string                    `json:"file_name,omitempty" db:"file_name"`
@@ -50,25 +50,6 @@ type DisbursementUpdate struct {
 	ID          string
 	FileName    string
 	FileContent []byte
-}
-
-type VerificationField string
-
-const (
-	VerificationFieldDateOfBirth VerificationField = "DATE_OF_BIRTH"
-	VerificationFieldYearMonth   VerificationField = "YEAR_MONTH"
-	VerificationFieldPin         VerificationField = "PIN"
-	VerificationFieldNationalID  VerificationField = "NATIONAL_ID_NUMBER"
-)
-
-// GetAllVerificationFields returns all verification fields
-func GetAllVerificationFields() []VerificationField {
-	return []VerificationField{
-		VerificationFieldDateOfBirth,
-		VerificationFieldYearMonth,
-		VerificationFieldPin,
-		VerificationFieldNationalID,
-	}
 }
 
 type DisbursementStatusHistoryEntry struct {

--- a/internal/data/disbursements_test.go
+++ b/internal/data/disbursements_test.go
@@ -43,7 +43,7 @@ func Test_DisbursementModelInsert(t *testing.T) {
 		Asset:                          asset,
 		Country:                        country,
 		Wallet:                         wallet,
-		VerificationField:              VerificationFieldDateOfBirth,
+		VerificationField:              VerificationTypeDateOfBirth,
 		SMSRegistrationMessageTemplate: smsTemplate,
 	}
 
@@ -73,7 +73,7 @@ func Test_DisbursementModelInsert(t *testing.T) {
 		assert.Equal(t, 1, len(actual.StatusHistory))
 		assert.Equal(t, DraftDisbursementStatus, actual.StatusHistory[0].Status)
 		assert.Equal(t, "user1", actual.StatusHistory[0].UserID)
-		assert.Equal(t, VerificationFieldDateOfBirth, actual.VerificationField)
+		assert.Equal(t, VerificationTypeDateOfBirth, actual.VerificationField)
 	})
 }
 
@@ -539,7 +539,7 @@ func Test_DisbursementModel_CompleteDisbursements(t *testing.T) {
 			Asset:             asset,
 			Wallet:            wallet,
 			Country:           country,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		_ = CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{
@@ -567,7 +567,7 @@ func Test_DisbursementModel_CompleteDisbursements(t *testing.T) {
 			Asset:             asset,
 			Wallet:            wallet,
 			Country:           country,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		_ = CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{
@@ -605,7 +605,7 @@ func Test_DisbursementModel_CompleteDisbursements(t *testing.T) {
 			Asset:             asset,
 			Wallet:            wallet,
 			Country:           country,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		_ = CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{
@@ -624,7 +624,7 @@ func Test_DisbursementModel_CompleteDisbursements(t *testing.T) {
 			Asset:             asset,
 			Wallet:            wallet,
 			Country:           country,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		_ = CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -541,7 +541,7 @@ func CreateDisbursementFixture(t *testing.T, ctx context.Context, sqlExec db.SQL
 		d.Country = GetCountryFixture(t, ctx, sqlExec, FixtureCountryUKR)
 	}
 	if d.VerificationField == "" {
-		d.VerificationField = VerificationFieldDateOfBirth
+		d.VerificationField = VerificationTypeDateOfBirth
 	}
 
 	// insert disbursement
@@ -614,7 +614,7 @@ func CreateDraftDisbursementFixture(t *testing.T, ctx context.Context, sqlExec d
 	}
 
 	if insert.VerificationField == "" {
-		insert.VerificationField = VerificationFieldDateOfBirth
+		insert.VerificationField = VerificationTypeDateOfBirth
 	}
 
 	id, err := model.Insert(ctx, &insert)

--- a/internal/data/payments_test.go
+++ b/internal/data/payments_test.go
@@ -721,7 +721,7 @@ func Test_PaymentModelRetryFailedPayments(t *testing.T) {
 		Wallet:            wallet,
 		Asset:             asset,
 		Status:            ReadyDisbursementStatus,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 	})
 
 	t.Run("does not update payments when no payments IDs is given", func(t *testing.T) {
@@ -992,7 +992,7 @@ func Test_PaymentModelCancelPayment(t *testing.T) {
 		Wallet:            wallet,
 		Asset:             asset,
 		Status:            ReadyDisbursementStatus,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 	})
 
 	t.Run("no ready payment for more than 5 days won't cancel any", func(t *testing.T) {
@@ -1251,7 +1251,7 @@ func Test_PaymentModel_GetReadyByDisbursementID(t *testing.T) {
 		Wallet:            wallet,
 		Asset:             asset,
 		Status:            StartedDisbursementStatus,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 	})
 
 	t.Run("returns empty array when there's no payment ready", func(t *testing.T) {
@@ -1317,7 +1317,7 @@ func Test_PaymentModel_GetReadyByPaymentsID(t *testing.T) {
 		Wallet:            wallet,
 		Asset:             asset,
 		Status:            StartedDisbursementStatus,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 	})
 
 	t.Run("returns empty array when there's no payment ready", func(t *testing.T) {
@@ -1391,7 +1391,7 @@ func Test_PaymentModel_GetReadyByReceiverWalletID(t *testing.T) {
 		Wallet:            wallet,
 		Asset:             asset,
 		Status:            StartedDisbursementStatus,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 	})
 
 	t.Run("returns empty array when there's no payment ready", func(t *testing.T) {
@@ -1475,7 +1475,7 @@ func Test_PaymentModel_GetAllReadyToPatchCompletionAnchorTransactions(t *testing
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            StartedDisbursementStatus,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		// It's not possible to have a payment in a end state when the receiver wallet is not registered yet
@@ -1510,7 +1510,7 @@ func Test_PaymentModel_GetAllReadyToPatchCompletionAnchorTransactions(t *testing
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            StartedDisbursementStatus,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		_ = CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{
@@ -1545,7 +1545,7 @@ func Test_PaymentModel_GetAllReadyToPatchCompletionAnchorTransactions(t *testing
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            StartedDisbursementStatus,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		paymentReceiver1 := CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{
@@ -1596,7 +1596,7 @@ func Test_PaymentModel_GetAllReadyToPatchCompletionAnchorTransactions(t *testing
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            StartedDisbursementStatus,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		disbursement2 := CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &Disbursement{
@@ -1604,7 +1604,7 @@ func Test_PaymentModel_GetAllReadyToPatchCompletionAnchorTransactions(t *testing
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            StartedDisbursementStatus,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		payment1 := CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{
@@ -1657,7 +1657,7 @@ func Test_PaymentModel_GetAllReadyToPatchCompletionAnchorTransactions(t *testing
 			Wallet:            wallet1,
 			Asset:             asset,
 			Status:            StartedDisbursementStatus,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		disbursement2 := CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &Disbursement{
@@ -1665,7 +1665,7 @@ func Test_PaymentModel_GetAllReadyToPatchCompletionAnchorTransactions(t *testing
 			Wallet:            wallet2,
 			Asset:             asset,
 			Status:            StartedDisbursementStatus,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		payment1 := CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{
@@ -1730,7 +1730,7 @@ func Test_PaymentModel_GetAllReadyToPatchCompletionAnchorTransactions(t *testing
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            StartedDisbursementStatus,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 		})
 
 		payment := CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{

--- a/internal/data/receiver_verification.go
+++ b/internal/data/receiver_verification.go
@@ -18,7 +18,7 @@ import (
 
 type ReceiverVerification struct {
 	ReceiverID          string                  `json:"receiver_id" db:"receiver_id"`
-	VerificationField   VerificationField       `json:"verification_field" db:"verification_field"`
+	VerificationField   VerificationType        `json:"verification_field" db:"verification_field"`
 	HashedValue         string                  `json:"hashed_value" db:"hashed_value"`
 	Attempts            int                     `json:"attempts" db:"attempts"`
 	CreatedAt           time.Time               `json:"created_at" db:"created_at"`
@@ -33,9 +33,9 @@ type ReceiverVerificationModel struct {
 }
 
 type ReceiverVerificationInsert struct {
-	ReceiverID        string            `db:"receiver_id"`
-	VerificationField VerificationField `db:"verification_field"`
-	VerificationValue string            `db:"hashed_value"`
+	ReceiverID        string           `db:"receiver_id"`
+	VerificationField VerificationType `db:"verification_field"`
+	VerificationValue string           `db:"hashed_value"`
 }
 
 const MaxAttemptsAllowed = 15
@@ -54,7 +54,7 @@ func (rvi *ReceiverVerificationInsert) Validate() error {
 }
 
 // GetByReceiverIDsAndVerificationField returns receiver verifications by receiver IDs and verification type.
-func (m *ReceiverVerificationModel) GetByReceiverIDsAndVerificationField(ctx context.Context, sqlExec db.SQLExecuter, receiverIds []string, verificationField VerificationField) ([]*ReceiverVerification, error) {
+func (m *ReceiverVerificationModel) GetByReceiverIDsAndVerificationField(ctx context.Context, sqlExec db.SQLExecuter, receiverIds []string, verificationField VerificationType) ([]*ReceiverVerification, error) {
 	receiverVerifications := []*ReceiverVerification{}
 	query := `
 		SELECT 
@@ -156,7 +156,7 @@ func (m *ReceiverVerificationModel) Insert(ctx context.Context, sqlExec db.SQLEx
 func (m *ReceiverVerificationModel) UpdateVerificationValue(ctx context.Context,
 	sqlExec db.SQLExecuter,
 	receiverID string,
-	verificationField VerificationField,
+	verificationField VerificationType,
 	verificationValue string,
 ) error {
 	log.Ctx(ctx).Infof("Calling UpdateVerificationValue for receiver %s and verification field %s", receiverID, verificationField)
@@ -181,7 +181,7 @@ func (m *ReceiverVerificationModel) UpdateVerificationValue(ctx context.Context,
 
 // UpsertVerificationValue creates or updates the receiver's verification. In case the verification exists and it's already confirmed by the receiver
 // it's not updated.
-func (m *ReceiverVerificationModel) UpsertVerificationValue(ctx context.Context, sqlExec db.SQLExecuter, receiverID string, verificationField VerificationField, verificationValue string) error {
+func (m *ReceiverVerificationModel) UpsertVerificationValue(ctx context.Context, sqlExec db.SQLExecuter, receiverID string, verificationField VerificationType, verificationValue string) error {
 	log.Ctx(ctx).Infof("Calling UpsertVerificationValue for receiver %s and verification field %s", receiverID, verificationField)
 	hashedValue, err := HashVerificationValue(verificationValue)
 	if err != nil {
@@ -211,7 +211,7 @@ func (m *ReceiverVerificationModel) UpsertVerificationValue(ctx context.Context,
 
 type ReceiverVerificationUpdate struct {
 	ReceiverID          string                 `db:"receiver_id"`
-	VerificationField   VerificationField      `db:"verification_field"`
+	VerificationField   VerificationType       `db:"verification_field"`
 	VerificationChannel message.MessageChannel `db:"verification_channel"`
 	Attempts            *int                   `db:"attempts"`
 	ConfirmedAt         *time.Time             `db:"confirmed_at"`

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -31,17 +31,17 @@ func Test_ReceiverVerificationModel_GetByReceiverIDsAndVerificationField(t *test
 
 	verification1 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 		ReceiverID:        receiver1.ID,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 		VerificationValue: "1990-01-01",
 	})
 	verification2 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 		ReceiverID:        receiver2.ID,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 		VerificationValue: "1990-01-02",
 	})
 	CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 		ReceiverID:        receiver3.ID,
-		VerificationField: VerificationFieldPin,
+		VerificationField: VerificationTypePin,
 		VerificationValue: "1990-01-03",
 	})
 
@@ -50,11 +50,11 @@ func Test_ReceiverVerificationModel_GetByReceiverIDsAndVerificationField(t *test
 
 	receiverVerificationModel := ReceiverVerificationModel{}
 
-	actualVerifications, err := receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receiver1.ID, receiver2.ID, receiver3.ID}, VerificationFieldDateOfBirth)
+	actualVerifications, err := receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receiver1.ID, receiver2.ID, receiver3.ID}, VerificationTypeDateOfBirth)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(actualVerifications))
 	for _, v := range actualVerifications {
-		assert.Equal(t, VerificationFieldDateOfBirth, v.VerificationField)
+		assert.Equal(t, VerificationTypeDateOfBirth, v.VerificationField)
 		assert.Contains(t, verifiedReceivers, v.ReceiverID)
 		assert.Contains(t, verifieldValues, v.HashedValue)
 	}
@@ -84,22 +84,22 @@ func Test_ReceiverVerificationModel_GetAllByReceiverId(t *testing.T) {
 	t.Run("returns all when the receiver has verifications registered", func(t *testing.T) {
 		verification1 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 			VerificationValue: "1990-01-01",
 		})
 		verification2 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: VerificationFieldYearMonth,
+			VerificationField: VerificationTypeYearMonth,
 			VerificationValue: "1990-01",
 		})
 		verification3 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: VerificationFieldPin,
+			VerificationField: VerificationTypePin,
 			VerificationValue: "1234",
 		})
 		verification4 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: VerificationFieldNationalID,
+			VerificationField: VerificationTypeNationalID,
 			VerificationValue: "5678",
 		})
 
@@ -111,28 +111,28 @@ func Test_ReceiverVerificationModel_GetAllByReceiverId(t *testing.T) {
 		assert.Equal(t, []ReceiverVerification{
 			{
 				ReceiverID:        receiver.ID,
-				VerificationField: VerificationFieldDateOfBirth,
+				VerificationField: VerificationTypeDateOfBirth,
 				HashedValue:       verification1.HashedValue,
 				CreatedAt:         verification1.CreatedAt,
 				UpdatedAt:         verification1.UpdatedAt,
 			},
 			{
 				ReceiverID:        receiver.ID,
-				VerificationField: VerificationFieldYearMonth,
+				VerificationField: VerificationTypeYearMonth,
 				HashedValue:       verification2.HashedValue,
 				CreatedAt:         verification2.CreatedAt,
 				UpdatedAt:         verification2.UpdatedAt,
 			},
 			{
 				ReceiverID:        receiver.ID,
-				VerificationField: VerificationFieldPin,
+				VerificationField: VerificationTypePin,
 				HashedValue:       verification3.HashedValue,
 				CreatedAt:         verification3.CreatedAt,
 				UpdatedAt:         verification3.UpdatedAt,
 			},
 			{
 				ReceiverID:        receiver.ID,
-				VerificationField: VerificationFieldNationalID,
+				VerificationField: VerificationTypeNationalID,
 				HashedValue:       verification4.HashedValue,
 				CreatedAt:         verification4.CreatedAt,
 				UpdatedAt:         verification4.UpdatedAt,
@@ -165,28 +165,28 @@ func Test_ReceiverVerificationModel_GetReceiverVerificationByReceiverId(t *testi
 		earlierTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 		verification1 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: VerificationFieldDateOfBirth,
+			VerificationField: VerificationTypeDateOfBirth,
 			VerificationValue: "1990-01-01",
 		})
 		verification1.UpdatedAt = earlierTime
 
 		verification2 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: VerificationFieldYearMonth,
+			VerificationField: VerificationTypeYearMonth,
 			VerificationValue: "1990-01",
 		})
 		verification2.UpdatedAt = earlierTime
 
 		verification3 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: VerificationFieldPin,
+			VerificationField: VerificationTypePin,
 			VerificationValue: "1234",
 		})
 		verification3.UpdatedAt = earlierTime
 
 		verification4 := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: VerificationFieldNationalID,
+			VerificationField: VerificationTypeNationalID,
 			VerificationValue: "5678",
 		})
 
@@ -197,7 +197,7 @@ func Test_ReceiverVerificationModel_GetReceiverVerificationByReceiverId(t *testi
 		assert.Equal(t,
 			ReceiverVerification{
 				ReceiverID:        receiver.ID,
-				VerificationField: VerificationFieldNationalID,
+				VerificationField: VerificationTypeNationalID,
 				HashedValue:       verification4.HashedValue,
 				CreatedAt:         verification4.CreatedAt,
 				UpdatedAt:         verification4.UpdatedAt,
@@ -221,14 +221,14 @@ func Test_ReceiverVerificationModel_Insert(t *testing.T) {
 
 	verification := ReceiverVerificationInsert{
 		ReceiverID:        receiver.ID,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 		VerificationValue: "1990-01-01",
 	}
 
 	_, err = receiverVerificationModel.Insert(ctx, dbConnectionPool, verification)
 	require.NoError(t, err)
 
-	actualVerification, err := receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receiver.ID}, VerificationFieldDateOfBirth)
+	actualVerification, err := receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receiver.ID}, VerificationTypeDateOfBirth)
 	require.NoError(t, err)
 	verified := CompareVerificationValue(actualVerification[0].HashedValue, verification.VerificationValue)
 	assert.True(t, verified)
@@ -253,7 +253,7 @@ func Test_ReceiverVerificationModel_UpdateVerificationValue(t *testing.T) {
 	oldExpectedValue := "1990-01-01"
 	actualBeforeUpdate, err := receiverVerificationModel.Insert(ctx, dbConnectionPool, ReceiverVerificationInsert{
 		ReceiverID:        receiver.ID,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 		VerificationValue: oldExpectedValue,
 	})
 	require.NoError(t, err)
@@ -262,10 +262,10 @@ func Test_ReceiverVerificationModel_UpdateVerificationValue(t *testing.T) {
 	assert.True(t, verified)
 
 	newExpectedValue := "1990-01-02"
-	err = receiverVerificationModel.UpdateVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldDateOfBirth, newExpectedValue)
+	err = receiverVerificationModel.UpdateVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypeDateOfBirth, newExpectedValue)
 	require.NoError(t, err)
 
-	actualAfterUpdate, err := receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receiver.ID}, VerificationFieldDateOfBirth)
+	actualAfterUpdate, err := receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receiver.ID}, VerificationTypeDateOfBirth)
 	require.NoError(t, err)
 	verified = CompareVerificationValue(actualAfterUpdate[0].HashedValue, newExpectedValue)
 	assert.True(t, verified)
@@ -282,7 +282,7 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 	ctx := context.Background()
 	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{})
 	receiverVerificationModel := ReceiverVerificationModel{}
-	getReceiverVerificationHashedValue := func(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, receiverID string, verificationField VerificationField) string {
+	getReceiverVerificationHashedValue := func(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, receiverID string, verificationField VerificationType) string {
 		const q = "SELECT hashed_value FROM receiver_verifications WHERE receiver_id = $1 AND verification_field = $2"
 		var hashedValue string
 		qErr := dbConnectionPool.GetContext(ctx, &hashedValue, q, receiverID, verificationField)
@@ -293,20 +293,20 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 	t.Run("upserts the verification value successfully", func(t *testing.T) {
 		// Inserts the verification value
 		firstVerificationValue := "123456"
-		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldPin, firstVerificationValue)
+		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypePin, firstVerificationValue)
 		require.NoError(t, err)
 
-		currentHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationFieldPin)
+		currentHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationTypePin)
 		assert.NotEmpty(t, currentHashedValue)
 		verified := CompareVerificationValue(currentHashedValue, firstVerificationValue)
 		assert.True(t, verified)
 
 		// Updates the verification value
 		newVerificationValue := "654321"
-		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldPin, newVerificationValue)
+		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypePin, newVerificationValue)
 		require.NoError(t, err)
 
-		afterUpdateHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationFieldPin)
+		afterUpdateHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationTypePin)
 		assert.NotEmpty(t, afterUpdateHashedValue)
 
 		// Checking if the hashed value is NOT the first one.
@@ -320,10 +320,10 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 	t.Run("doesn't update the verification value when it was confirmed by the receiver", func(t *testing.T) {
 		// Inserts the verification value
 		firstVerificationValue := "0301016957187"
-		err := receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldNationalID, firstVerificationValue)
+		err := receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID, firstVerificationValue)
 		require.NoError(t, err)
 
-		currentHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationFieldNationalID)
+		currentHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID)
 		assert.NotEmpty(t, currentHashedValue)
 		verified := CompareVerificationValue(currentHashedValue, firstVerificationValue)
 		assert.True(t, verified)
@@ -332,17 +332,17 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 		now := time.Now()
 		err = receiverVerificationModel.UpdateReceiverVerification(ctx, ReceiverVerificationUpdate{
 			ReceiverID:          receiver.ID,
-			VerificationField:   VerificationFieldNationalID,
+			VerificationField:   VerificationTypeNationalID,
 			ConfirmedAt:         &now,
 			VerificationChannel: message.MessageChannelSMS,
 		}, dbConnectionPool)
 		require.NoError(t, err)
 
 		newVerificationValue := "0301017821085"
-		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldNationalID, newVerificationValue)
+		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID, newVerificationValue)
 		require.NoError(t, err)
 
-		afterUpdateHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationFieldNationalID)
+		afterUpdateHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID)
 		assert.NotEmpty(t, currentHashedValue)
 
 		// Checking if the hashed value is NOT the new one.
@@ -371,7 +371,7 @@ func Test_ReceiverVerificationModel_UpdateReceiverVerification(t *testing.T) {
 
 	verification := CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 		ReceiverID:        receiver.ID,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 		VerificationValue: "1990-01-01",
 	})
 
@@ -382,7 +382,7 @@ func Test_ReceiverVerificationModel_UpdateReceiverVerification(t *testing.T) {
 	date := time.Date(2023, 1, 10, 23, 40, 20, 1000, time.UTC)
 	verificationUpdate := ReceiverVerificationUpdate{
 		ReceiverID:          receiver.ID,
-		VerificationField:   VerificationFieldDateOfBirth,
+		VerificationField:   VerificationTypeDateOfBirth,
 		Attempts:            utils.IntPtr(5),
 		ConfirmedAt:         &date,
 		FailedAt:            &date,
@@ -424,7 +424,7 @@ func Test_ReceiverVerificationUpdate_Validate(t *testing.T) {
 			name: "valid update",
 			update: ReceiverVerificationUpdate{
 				ReceiverID:          "receiver-id",
-				VerificationField:   VerificationFieldDateOfBirth,
+				VerificationField:   VerificationTypeDateOfBirth,
 				VerificationChannel: message.MessageChannelSMS,
 			},
 			wantErr: nil,
@@ -445,7 +445,7 @@ func Test_ReceiverVerificationUpdate_Validate(t *testing.T) {
 			name: "invalid update with empty verification channel",
 			update: ReceiverVerificationUpdate{
 				ReceiverID:        "receiver-id",
-				VerificationField: VerificationFieldDateOfBirth,
+				VerificationField: VerificationTypeDateOfBirth,
 			},
 			wantErr: fmt.Errorf("verification channel is required"),
 		},
@@ -492,15 +492,15 @@ func Test_ReceiverVerificationModel_GetLatestByPhoneNumber(t *testing.T) {
 	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{})
 	receiverVerificationModel := ReceiverVerificationModel{dbConnectionPool: dbConnectionPool}
 
-	err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldDateOfBirth, "1990-01-01")
+	err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypeDateOfBirth, "1990-01-01")
 	require.NoError(t, err)
-	err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationFieldPin, "123456")
+	err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypePin, "123456")
 	require.NoError(t, err)
 
 	verification, err := receiverVerificationModel.GetLatestByPhoneNumber(ctx, receiver.PhoneNumber)
 	require.NoError(t, err)
 
-	assert.Equal(t, VerificationFieldPin, verification.VerificationField)
+	assert.Equal(t, VerificationTypePin, verification.VerificationField)
 	assert.True(t, CompareVerificationValue(verification.HashedValue, "123456"))
 }
 

--- a/internal/data/receivers.go
+++ b/internal/data/receivers.go
@@ -27,12 +27,12 @@ type Receiver struct {
 
 type ReceiverRegistrationRequest struct {
 	// TODO: SDP-1296 - Update `/wallet-registration/otp` to support multiple contact information types and send OTPs accordingly
-	Email             string            `json:"email"`
-	PhoneNumber       string            `json:"phone_number"`
-	OTP               string            `json:"otp"`
-	VerificationValue string            `json:"verification"`
-	VerificationField VerificationField `json:"verification_field"`
-	ReCAPTCHAToken    string            `json:"recaptcha_token"`
+	Email             string           `json:"email"`
+	PhoneNumber       string           `json:"phone_number"`
+	OTP               string           `json:"otp"`
+	VerificationValue string           `json:"verification"`
+	VerificationField VerificationType `json:"verification_field"`
+	ReCAPTCHAToken    string           `json:"recaptcha_token"`
 }
 
 type ReceiverStats struct {

--- a/internal/data/receivers.go
+++ b/internal/data/receivers.go
@@ -31,7 +31,7 @@ type ReceiverRegistrationRequest struct {
 	PhoneNumber       string            `json:"phone_number"`
 	OTP               string            `json:"otp"`
 	VerificationValue string            `json:"verification"`
-	VerificationType  VerificationField `json:"verification_type"`
+	VerificationField VerificationField `json:"verification_field"`
 	ReCAPTCHAToken    string            `json:"recaptcha_token"`
 }
 

--- a/internal/data/receivers_test.go
+++ b/internal/data/receivers_test.go
@@ -929,7 +929,7 @@ func Test_DeleteByPhoneNumber(t *testing.T) {
 	receiverWalletX := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiverX.ID, wallet.ID, DraftReceiversWalletStatus)
 	_ = CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 		ReceiverID:        receiverX.ID,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 		VerificationValue: "1990-01-01",
 	})
 	messageX := CreateMessageFixture(t, ctx, dbConnectionPool, &Message{
@@ -960,7 +960,7 @@ func Test_DeleteByPhoneNumber(t *testing.T) {
 	receiverWalletY := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiverY.ID, wallet.ID, DraftReceiversWalletStatus)
 	_ = CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, ReceiverVerificationInsert{
 		ReceiverID:        receiverY.ID,
-		VerificationField: VerificationFieldDateOfBirth,
+		VerificationField: VerificationTypeDateOfBirth,
 		VerificationValue: "1990-01-01",
 	})
 	messageY := CreateMessageFixture(t, ctx, dbConnectionPool, &Message{

--- a/internal/data/verification_type.go
+++ b/internal/data/verification_type.go
@@ -1,0 +1,20 @@
+package data
+
+type VerificationType string
+
+const (
+	VerificationTypeDateOfBirth VerificationType = "DATE_OF_BIRTH"
+	VerificationTypeYearMonth   VerificationType = "YEAR_MONTH"
+	VerificationTypePin         VerificationType = "PIN"
+	VerificationTypeNationalID  VerificationType = "NATIONAL_ID_NUMBER"
+)
+
+// GetAllVerificationTypes returns all the available verification types.
+func GetAllVerificationTypes() []VerificationType {
+	return []VerificationType{
+		VerificationTypeDateOfBirth,
+		VerificationTypeYearMonth,
+		VerificationTypePin,
+		VerificationTypeNationalID,
+	}
+}

--- a/internal/integrationtests/integration_tests.go
+++ b/internal/integrationtests/integration_tests.go
@@ -180,7 +180,7 @@ func (it *IntegrationTestsService) StartIntegrationTests(ctx context.Context, op
 		CountryCode:       "USA",
 		WalletID:          wallet.ID,
 		AssetID:           asset.ID,
-		VerificationField: data.VerificationFieldDateOfBirth,
+		VerificationField: data.VerificationTypeDateOfBirth,
 	})
 	if err != nil {
 		return fmt.Errorf("creating disbursement: %w", err)

--- a/internal/integrationtests/integration_tests.go
+++ b/internal/integrationtests/integration_tests.go
@@ -254,7 +254,7 @@ func (it *IntegrationTestsService) StartIntegrationTests(ctx context.Context, op
 		OTP:               data.TestnetAlwaysValidOTP,
 		PhoneNumber:       disbursementData[0].Phone,
 		VerificationValue: disbursementData[0].VerificationValue,
-		VerificationType:  disbursement.VerificationField,
+		VerificationField: disbursement.VerificationField,
 		ReCAPTCHAToken:    opts.RecaptchaSiteKey,
 	})
 	if err != nil {

--- a/internal/integrationtests/server_api_test.go
+++ b/internal/integrationtests/server_api_test.go
@@ -307,7 +307,7 @@ func Test_ReceiverRegistration(t *testing.T) {
 		PhoneNumber:       "+18554212274",
 		OTP:               "123456",
 		VerificationValue: "1999-01-30",
-		VerificationType:  "date_of_birth",
+		VerificationField: "date_of_birth",
 		ReCAPTCHAToken:    "captchtoken",
 	}
 

--- a/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
+++ b/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
@@ -149,7 +149,7 @@ func Test_PatchAnchorPlatformTransactionsCompletionJob_Execute(t *testing.T) {
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -37,12 +37,12 @@ type DisbursementHandler struct {
 }
 
 type PostDisbursementRequest struct {
-	Name                           string                 `json:"name"`
-	CountryCode                    string                 `json:"country_code"`
-	WalletID                       string                 `json:"wallet_id"`
-	AssetID                        string                 `json:"asset_id"`
-	VerificationField              data.VerificationField `json:"verification_field"`
-	SMSRegistrationMessageTemplate string                 `json:"sms_registration_message_template"`
+	Name                           string                `json:"name"`
+	CountryCode                    string                `json:"country_code"`
+	WalletID                       string                `json:"wallet_id"`
+	AssetID                        string                `json:"asset_id"`
+	VerificationField              data.VerificationType `json:"verification_field"`
+	SMSRegistrationMessageTemplate string                `json:"sms_registration_message_template"`
 }
 
 type PatchDisbursementStatusRequest struct {
@@ -438,7 +438,7 @@ func (d DisbursementHandler) GetDisbursementInstructions(w http.ResponseWriter, 
 	}
 }
 
-func parseInstructionsFromCSV(ctx context.Context, file io.Reader, verificationField data.VerificationField) ([]*data.DisbursementInstruction, *validators.DisbursementInstructionsValidator) {
+func parseInstructionsFromCSV(ctx context.Context, file io.Reader, verificationField data.VerificationType) ([]*data.DisbursementInstruction, *validators.DisbursementInstructionsValidator) {
 	validator := validators.NewDisbursementInstructionsValidator(verificationField)
 
 	instructions := []*data.DisbursementInstruction{}

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -175,7 +175,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 			CountryCode:       country.Code,
 			AssetID:           asset.ID,
 			WalletID:          "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
 
@@ -191,7 +191,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 			CountryCode:       country.Code,
 			AssetID:           asset.ID,
 			WalletID:          disabledWallet.ID,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
 
@@ -206,7 +206,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 			CountryCode:       country.Code,
 			AssetID:           "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
 			WalletID:          enabledWallet.ID,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
 
@@ -221,7 +221,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 			CountryCode:       "AAA",
 			AssetID:           asset.ID,
 			WalletID:          enabledWallet.ID,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
 
@@ -244,7 +244,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 			CountryCode:       country.Code,
 			AssetID:           asset.ID,
 			WalletID:          enabledWallet.ID,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
 
@@ -265,7 +265,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 			CountryCode:                    country.Code,
 			AssetID:                        asset.ID,
 			WalletID:                       enabledWallet.ID,
-			VerificationField:              data.VerificationFieldDateOfBirth,
+			VerificationField:              data.VerificationTypeDateOfBirth,
 			SMSRegistrationMessageTemplate: smsTemplate,
 		})
 		require.NoError(t, err)

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -803,7 +803,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 		Wallet:            wallet,
 		Asset:             asset,
 		Status:            data.StartedDisbursementStatus,
-		VerificationField: data.VerificationFieldDateOfBirth,
+		VerificationField: data.VerificationTypeDateOfBirth,
 	})
 
 	t.Run("returns Unauthorized when no token in the context", func(t *testing.T) {

--- a/internal/serve/httphandler/receiver_handler.go
+++ b/internal/serve/httphandler/receiver_handler.go
@@ -137,5 +137,5 @@ func (rh ReceiverHandler) GetReceivers(w http.ResponseWriter, r *http.Request) {
 
 // GetReceiverVerification returns a list of verification types
 func (rh ReceiverHandler) GetReceiverVerificationTypes(w http.ResponseWriter, r *http.Request) {
-	httpjson.Render(w, data.GetAllVerificationFields(), httpjson.JSON)
+	httpjson.Render(w, data.GetAllVerificationTypes(), httpjson.JSON)
 }

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -44,7 +44,6 @@ type ReceiverSendOTPResponseBody struct {
 	VerificationField data.VerificationField `json:"verification_field"`
 }
 
-// FIXME! /wallet-registration/otp returns a JSON with the field named `verification_field` but /wallet-registration/verification expects the field to be named `verification_type`. This inconsistency should be fixed.
 func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -40,8 +40,8 @@ type ReceiverSendOTPRequest struct {
 }
 
 type ReceiverSendOTPResponseBody struct {
-	Message           string                 `json:"message"`
-	VerificationField data.VerificationField `json:"verification_field"`
+	Message           string                `json:"message"`
+	VerificationField data.VerificationType `json:"verification_field"`
 }
 
 func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -97,7 +97,7 @@ func (h ReceiverSendOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	verificationField := data.VerificationFieldDateOfBirth
+	verificationField := data.VerificationTypeDateOfBirth
 	receiverVerification, err := h.Models.ReceiverVerification.GetLatestByPhoneNumber(ctx, receiverSendOTPRequest.PhoneNumber)
 	if err != nil {
 		err = fmt.Errorf("cannot find latest receiver verification for phone number %s: %w", truncatedPhoneNumber, err)

--- a/internal/serve/httphandler/receiver_send_otp_handler_test.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler_test.go
@@ -47,7 +47,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP(t *testing.T) {
 	wallet1 := data.CreateWalletFixture(t, ctx, dbConnectionPool, "testWallet", "https://home.page", "home.page", "wallet123://")
 	data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 		ReceiverID:        receiver1.ID,
-		VerificationField: data.VerificationFieldDateOfBirth,
+		VerificationField: data.VerificationTypeDateOfBirth,
 	})
 
 	_ = data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver1.ID, wallet1.ID, data.RegisteredReceiversWalletStatus)

--- a/internal/serve/httphandler/update_receiver_handler.go
+++ b/internal/serve/httphandler/update_receiver_handler.go
@@ -23,7 +23,7 @@ type UpdateReceiverHandler struct {
 
 func createVerificationInsert(updateReceiverInfo *validators.UpdateReceiverRequest, receiverID string) []data.ReceiverVerificationInsert {
 	receiverVerifications := []data.ReceiverVerificationInsert{}
-	appendNewVerificationValue := func(verificationField data.VerificationField, verificationValue string) {
+	appendNewVerificationValue := func(verificationField data.VerificationType, verificationValue string) {
 		if verificationValue != "" {
 			receiverVerifications = append(receiverVerifications, data.ReceiverVerificationInsert{
 				ReceiverID:        receiverID,
@@ -33,15 +33,15 @@ func createVerificationInsert(updateReceiverInfo *validators.UpdateReceiverReque
 		}
 	}
 
-	for _, verificationField := range data.GetAllVerificationFields() {
+	for _, verificationField := range data.GetAllVerificationTypes() {
 		switch verificationField {
-		case data.VerificationFieldDateOfBirth:
+		case data.VerificationTypeDateOfBirth:
 			appendNewVerificationValue(verificationField, updateReceiverInfo.DateOfBirth)
-		case data.VerificationFieldYearMonth:
+		case data.VerificationTypeYearMonth:
 			appendNewVerificationValue(verificationField, updateReceiverInfo.YearMonth)
-		case data.VerificationFieldPin:
+		case data.VerificationTypePin:
 			appendNewVerificationValue(verificationField, updateReceiverInfo.Pin)
-		case data.VerificationFieldNationalID:
+		case data.VerificationTypeNationalID:
 			appendNewVerificationValue(verificationField, updateReceiverInfo.NationalID)
 		}
 	}

--- a/internal/serve/httphandler/update_receiver_handler_test.go
+++ b/internal/serve/httphandler/update_receiver_handler_test.go
@@ -26,25 +26,25 @@ func Test_UpdateReceiverHandler_createVerificationInsert(t *testing.T) {
 
 	verificationDOB := data.ReceiverVerificationInsert{
 		ReceiverID:        receiverID,
-		VerificationField: data.VerificationFieldDateOfBirth,
+		VerificationField: data.VerificationTypeDateOfBirth,
 		VerificationValue: "1999-01-01",
 	}
 
 	verificationYearMonth := data.ReceiverVerificationInsert{
 		ReceiverID:        receiverID,
-		VerificationField: data.VerificationFieldYearMonth,
+		VerificationField: data.VerificationTypeYearMonth,
 		VerificationValue: "1999-01",
 	}
 
 	verificationPIN := data.ReceiverVerificationInsert{
 		ReceiverID:        receiverID,
-		VerificationField: data.VerificationFieldPin,
+		VerificationField: data.VerificationTypePin,
 		VerificationValue: "123",
 	}
 
 	verificationNationalID := data.ReceiverVerificationInsert{
 		ReceiverID:        receiverID,
-		VerificationField: data.VerificationFieldNationalID,
+		VerificationField: data.VerificationTypeNationalID,
 		VerificationValue: "12345CODE",
 	}
 
@@ -268,7 +268,7 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 	t.Run("update date of birth value", func(t *testing.T) {
 		data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 			VerificationValue: "2000-01-01",
 		})
 
@@ -297,7 +297,7 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 		`
 
 		newReceiverVerification := data.ReceiverVerification{}
-		err = dbConnectionPool.GetContext(ctx, &newReceiverVerification, query, receiver.ID, data.VerificationFieldDateOfBirth)
+		err = dbConnectionPool.GetContext(ctx, &newReceiverVerification, query, receiver.ID, data.VerificationTypeDateOfBirth)
 		require.NoError(t, err)
 
 		assert.True(t, data.CompareVerificationValue(newReceiverVerification.HashedValue, "1999-01-01"))
@@ -312,7 +312,7 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 	t.Run("update year/month value", func(t *testing.T) {
 		data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldYearMonth,
+			VerificationField: data.VerificationTypeYearMonth,
 			VerificationValue: "2000-01",
 		})
 
@@ -341,7 +341,7 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 		`
 
 		newReceiverVerification := data.ReceiverVerification{}
-		err = dbConnectionPool.GetContext(ctx, &newReceiverVerification, query, receiver.ID, data.VerificationFieldYearMonth)
+		err = dbConnectionPool.GetContext(ctx, &newReceiverVerification, query, receiver.ID, data.VerificationTypeYearMonth)
 		require.NoError(t, err)
 
 		assert.True(t, data.CompareVerificationValue(newReceiverVerification.HashedValue, "1999-01"))
@@ -356,7 +356,7 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 	t.Run("update pin value", func(t *testing.T) {
 		data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldPin,
+			VerificationField: data.VerificationTypePin,
 			VerificationValue: "8901",
 		})
 
@@ -385,7 +385,7 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 		`
 
 		newReceiverVerification := data.ReceiverVerification{}
-		err = dbConnectionPool.GetContext(ctx, &newReceiverVerification, query, receiver.ID, data.VerificationFieldPin)
+		err = dbConnectionPool.GetContext(ctx, &newReceiverVerification, query, receiver.ID, data.VerificationTypePin)
 		require.NoError(t, err)
 
 		assert.True(t, data.CompareVerificationValue(newReceiverVerification.HashedValue, "1234"))
@@ -400,7 +400,7 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 	t.Run("update national ID value", func(t *testing.T) {
 		data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldNationalID,
+			VerificationField: data.VerificationTypeNationalID,
 			VerificationValue: "OLDID890",
 		})
 
@@ -429,7 +429,7 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 		`
 
 		newReceiverVerification := data.ReceiverVerification{}
-		err = dbConnectionPool.GetContext(ctx, &newReceiverVerification, query, receiver.ID, data.VerificationFieldNationalID)
+		err = dbConnectionPool.GetContext(ctx, &newReceiverVerification, query, receiver.ID, data.VerificationTypeNationalID)
 		require.NoError(t, err)
 
 		assert.True(t, data.CompareVerificationValue(newReceiverVerification.HashedValue, "NEWID123"))
@@ -446,25 +446,25 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 
 		data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 			VerificationValue: "2000-01-01",
 		})
 
 		data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldYearMonth,
+			VerificationField: data.VerificationTypeYearMonth,
 			VerificationValue: "2000-01",
 		})
 
 		data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldPin,
+			VerificationField: data.VerificationTypePin,
 			VerificationValue: "8901",
 		})
 
 		data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldNationalID,
+			VerificationField: data.VerificationTypeNationalID,
 			VerificationValue: "OLDID890",
 		})
 
@@ -498,27 +498,27 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 		`
 
 		receiverVerifications := []struct {
-			verificationField    data.VerificationField
+			verificationField    data.VerificationType
 			newVerificationValue string
 			oldVerificationValue string
 		}{
 			{
-				verificationField:    data.VerificationFieldDateOfBirth,
+				verificationField:    data.VerificationTypeDateOfBirth,
 				newVerificationValue: "1999-01-01",
 				oldVerificationValue: "2000-01-01",
 			},
 			{
-				verificationField:    data.VerificationFieldYearMonth,
+				verificationField:    data.VerificationTypeYearMonth,
 				newVerificationValue: "1999-01",
 				oldVerificationValue: "2000-01",
 			},
 			{
-				verificationField:    data.VerificationFieldPin,
+				verificationField:    data.VerificationTypePin,
 				newVerificationValue: "1234",
 				oldVerificationValue: "8901",
 			},
 			{
-				verificationField:    data.VerificationFieldNationalID,
+				verificationField:    data.VerificationTypeNationalID,
 				newVerificationValue: "NEWID123",
 				oldVerificationValue: "OLDID890",
 			},
@@ -571,27 +571,27 @@ func Test_UpdateReceiverHandler(t *testing.T) {
 		`
 
 		receiverVerifications := []struct {
-			verificationField    data.VerificationField
+			verificationField    data.VerificationType
 			newVerificationValue string
 			oldVerificationValue string
 		}{
 			{
-				verificationField:    data.VerificationFieldDateOfBirth,
+				verificationField:    data.VerificationTypeDateOfBirth,
 				newVerificationValue: "1999-01-01",
 				oldVerificationValue: "2000-01-01",
 			},
 			{
-				verificationField:    data.VerificationFieldYearMonth,
+				verificationField:    data.VerificationTypeYearMonth,
 				newVerificationValue: "1999-01",
 				oldVerificationValue: "",
 			},
 			{
-				verificationField:    data.VerificationFieldPin,
+				verificationField:    data.VerificationTypePin,
 				newVerificationValue: "1234",
 				oldVerificationValue: "",
 			},
 			{
-				verificationField:    data.VerificationFieldNationalID,
+				verificationField:    data.VerificationTypeNationalID,
 				newVerificationValue: "NEWID123",
 				oldVerificationValue: "",
 			},

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler.go
@@ -119,16 +119,16 @@ func (v VerifyReceiverRegistrationHandler) processReceiverVerificationPII(
 	truncatedPhoneNumber := utils.TruncateString(receiver.PhoneNumber, 3)
 
 	// STEP 1: find the receiverVerification entry that matches the pair [receiverID, verificationType]
-	receiverVerifications, err := v.Models.ReceiverVerification.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{receiver.ID}, receiverRegistrationRequest.VerificationType)
+	receiverVerifications, err := v.Models.ReceiverVerification.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{receiver.ID}, receiverRegistrationRequest.VerificationField)
 	if err != nil {
-		return fmt.Errorf("error retrieving receiver verification for verification type %s: %w", receiverRegistrationRequest.VerificationType, err)
+		return fmt.Errorf("error retrieving receiver verification for verification type %s: %w", receiverRegistrationRequest.VerificationField, err)
 	}
 	if len(receiverVerifications) == 0 {
-		err = fmt.Errorf("%s not found for receiver with phone number %s", receiverRegistrationRequest.VerificationType, truncatedPhoneNumber)
+		err = fmt.Errorf("%s not found for receiver with phone number %s", receiverRegistrationRequest.VerificationField, truncatedPhoneNumber)
 		return &ErrorInformationNotFound{cause: err}
 	}
 	if len(receiverVerifications) > 1 {
-		log.Ctx(ctx).Warnf("receiver with id %s has more than one verification saved in the database for type %s", receiver.ID, receiverRegistrationRequest.VerificationType)
+		log.Ctx(ctx).Warnf("receiver with id %s has more than one verification saved in the database for type %s", receiver.ID, receiverRegistrationRequest.VerificationField)
 	}
 	receiverVerification := receiverVerifications[0]
 
@@ -155,7 +155,7 @@ func (v VerifyReceiverRegistrationHandler) processReceiverVerificationPII(
 	}
 
 	if !data.CompareVerificationValue(receiverVerification.HashedValue, receiverRegistrationRequest.VerificationValue) {
-		baseErrMsg := fmt.Sprintf("%s value does not match for user with phone number %s", receiverRegistrationRequest.VerificationType, truncatedPhoneNumber)
+		baseErrMsg := fmt.Sprintf("%s value does not match for user with phone number %s", receiverRegistrationRequest.VerificationField, truncatedPhoneNumber)
 		// update the receiver verification with the confirmation that the value was checked
 		rvu.Attempts = utils.IntPtr(receiverVerification.Attempts + 1)
 		rvu.FailedAt = &now

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -102,7 +102,7 @@ func Test_VerifyReceiverRegistrationHandler_validate(t *testing.T) {
 				"phone_number": "+380445555555",
 				"otp": "",
 				"verification": "1990-01-01",
-				"verification_type": "date_of_birth",
+				"verification_field": "date_of_birth",
 				"reCAPTCHA_token": "token"
 			}`,
 			isRecaptchaValidFnResponse: []interface{}{true, nil},
@@ -115,7 +115,7 @@ func Test_VerifyReceiverRegistrationHandler_validate(t *testing.T) {
 				"phone_number": "+380445555555",
 				"otp": "123456",
 				"verification": "1990-01-01",
-				"verification_type": "date_of_birth",
+				"verification_field": "date_of_birth",
 				"reCAPTCHA_token": "token"
 			}`,
 			isRecaptchaValidFnResponse: []interface{}{true, nil},
@@ -124,7 +124,7 @@ func Test_VerifyReceiverRegistrationHandler_validate(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 				ReCAPTCHAToken:    "token",
 			},
 		},
@@ -240,7 +240,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiverMissingReceiverVerification,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiverMissingReceiverVerification.PhoneNumber,
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 				VerificationValue: "1990-01-01",
 			},
 			wantErrContains: "DATE_OF_BIRTH not found for receiver with phone number +38...333",
@@ -250,7 +250,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiver,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiver.PhoneNumber,
-				VerificationType:  data.VerificationFieldYearMonth,
+				VerificationField: data.VerificationFieldYearMonth,
 				VerificationValue: "1999-12",
 			},
 			wantErrContains: "YEAR_MONTH not found for receiver with phone number +38...555",
@@ -260,7 +260,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiver,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiver.PhoneNumber,
-				VerificationType:  data.VerificationFieldNationalID,
+				VerificationField: data.VerificationFieldNationalID,
 				VerificationValue: "123456",
 			},
 			wantErrContains: "NATIONAL_ID_NUMBER not found for receiver with phone number +38...555",
@@ -270,7 +270,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiverWithExceededAttempts,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiverWithExceededAttempts.PhoneNumber,
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 				VerificationValue: "1990-01-01",
 			},
 			wantErrContains: "the number of attempts to confirm the verification value exceededs the max attempts",
@@ -280,7 +280,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiver,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiver.PhoneNumber,
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 				VerificationValue: "1990-11-11", // <--- different from the DB one (1990-01-01)
 			},
 			shouldAssertAttemptsCount: true,
@@ -291,7 +291,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiver,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiver.PhoneNumber,
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 				VerificationValue: "1990-01-01",
 			},
 			shouldAssertAttemptsCount: true,
@@ -310,7 +310,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			var receiverVerifications []*data.ReceiverVerification
 			var receiverVerificationInitial *data.ReceiverVerification
 			if tc.shouldAssertAttemptsCount {
-				receiverVerifications, err = models.ReceiverVerification.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{tc.receiver.ID}, tc.registrationRequest.VerificationType)
+				receiverVerifications, err = models.ReceiverVerification.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{tc.receiver.ID}, tc.registrationRequest.VerificationField)
 				require.NoError(t, err)
 				require.Len(t, receiverVerifications, 1)
 				receiverVerificationInitial = receiverVerifications[0]
@@ -319,7 +319,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			err = handler.processReceiverVerificationPII(ctx, dbTx, tc.receiver, tc.registrationRequest)
 
 			if tc.wantErrContains == "" {
-				receiverVerifications, err = models.ReceiverVerification.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{tc.receiver.ID}, tc.registrationRequest.VerificationType)
+				receiverVerifications, err = models.ReceiverVerification.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{tc.receiver.ID}, tc.registrationRequest.VerificationField)
 				require.NoError(t, err)
 				require.Len(t, receiverVerifications, 1)
 				receiverVerification := receiverVerifications[0]
@@ -328,7 +328,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			} else {
 				require.ErrorContains(t, err, tc.wantErrContains)
 				if tc.shouldAssertAttemptsCount {
-					receiverVerifications, err = models.ReceiverVerification.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{tc.receiver.ID}, tc.registrationRequest.VerificationType)
+					receiverVerifications, err = models.ReceiverVerification.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{tc.receiver.ID}, tc.registrationRequest.VerificationField)
 					require.NoError(t, err)
 					require.Len(t, receiverVerifications, 1)
 					receiverVerification := receiverVerifications[0]
@@ -779,7 +779,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		PhoneNumber:       phoneNumber,
 		OTP:               "123456",
 		VerificationValue: "1990-01-01",
-		VerificationType:  "date_of_birth",
+		VerificationField: "date_of_birth",
 		ReCAPTCHAToken:    "token",
 	}
 	reqBody, err := json.Marshal(receiverRegistrationRequest)

--- a/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verifiy_receiver_registration_handler_test.go
@@ -124,7 +124,7 @@ func Test_VerifyReceiverRegistrationHandler_validate(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 				ReCAPTCHAToken:    "token",
 			},
 		},
@@ -205,13 +205,13 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 	receiverWithExceededAttempts := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: "+380446666666"})
 	receiverVerificationExceededAttempts := data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 		ReceiverID:        receiverWithExceededAttempts.ID,
-		VerificationField: data.VerificationFieldDateOfBirth,
+		VerificationField: data.VerificationTypeDateOfBirth,
 		VerificationValue: "1990-01-01",
 	})
 	receiverVerificationExceededAttempts.Attempts = data.MaxAttemptsAllowed
 	err = models.ReceiverVerification.UpdateReceiverVerification(ctx, data.ReceiverVerificationUpdate{
 		ReceiverID:          receiverWithExceededAttempts.ID,
-		VerificationField:   data.VerificationFieldDateOfBirth,
+		VerificationField:   data.VerificationTypeDateOfBirth,
 		Attempts:            utils.IntPtr(data.MaxAttemptsAllowed),
 		VerificationChannel: message.MessageChannelSMS,
 	}, dbConnectionPool)
@@ -221,7 +221,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 	receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: "+380445555555"})
 	_ = data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 		ReceiverID:        receiver.ID,
-		VerificationField: data.VerificationFieldDateOfBirth,
+		VerificationField: data.VerificationTypeDateOfBirth,
 		VerificationValue: "1990-01-01",
 	})
 
@@ -240,7 +240,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiverMissingReceiverVerification,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiverMissingReceiverVerification.PhoneNumber,
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 				VerificationValue: "1990-01-01",
 			},
 			wantErrContains: "DATE_OF_BIRTH not found for receiver with phone number +38...333",
@@ -250,7 +250,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiver,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiver.PhoneNumber,
-				VerificationField: data.VerificationFieldYearMonth,
+				VerificationField: data.VerificationTypeYearMonth,
 				VerificationValue: "1999-12",
 			},
 			wantErrContains: "YEAR_MONTH not found for receiver with phone number +38...555",
@@ -260,7 +260,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiver,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiver.PhoneNumber,
-				VerificationField: data.VerificationFieldNationalID,
+				VerificationField: data.VerificationTypeNationalID,
 				VerificationValue: "123456",
 			},
 			wantErrContains: "NATIONAL_ID_NUMBER not found for receiver with phone number +38...555",
@@ -270,7 +270,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiverWithExceededAttempts,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiverWithExceededAttempts.PhoneNumber,
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 				VerificationValue: "1990-01-01",
 			},
 			wantErrContains: "the number of attempts to confirm the verification value exceededs the max attempts",
@@ -280,7 +280,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiver,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiver.PhoneNumber,
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 				VerificationValue: "1990-11-11", // <--- different from the DB one (1990-01-01)
 			},
 			shouldAssertAttemptsCount: true,
@@ -291,7 +291,7 @@ func Test_VerifyReceiverRegistrationHandler_processReceiverVerificationPII(t *te
 			receiver: *receiver,
 			registrationRequest: data.ReceiverRegistrationRequest{
 				PhoneNumber:       receiver.PhoneNumber,
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 				VerificationValue: "1990-01-01",
 			},
 			shouldAssertAttemptsCount: true,
@@ -905,13 +905,13 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		receiverWithExceededAttempts := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: phoneNumber})
 		receiverVerificationExceededAttempts := data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiverWithExceededAttempts.ID,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 			VerificationValue: "1990-01-01",
 		})
 		receiverVerificationExceededAttempts.Attempts = data.MaxAttemptsAllowed
 		err = models.ReceiverVerification.UpdateReceiverVerification(ctx, data.ReceiverVerificationUpdate{
 			ReceiverID:          receiverWithExceededAttempts.ID,
-			VerificationField:   data.VerificationFieldDateOfBirth,
+			VerificationField:   data.VerificationTypeDateOfBirth,
 			Attempts:            utils.IntPtr(data.MaxAttemptsAllowed),
 			VerificationChannel: message.MessageChannelSMS,
 		}, dbConnectionPool)
@@ -960,7 +960,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: phoneNumber})
 		_ = data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 			VerificationValue: "1990-01-01",
 		})
 
@@ -1020,7 +1020,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: phoneNumber})
 		_ = data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 			ReceiverID:        receiver.ID,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 			VerificationValue: "1990-01-01",
 		})
 		_ = data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
@@ -1100,7 +1100,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 				receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: phoneNumber})
 				_ = data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 					ReceiverID:        receiver.ID,
-					VerificationField: data.VerificationFieldDateOfBirth,
+					VerificationField: data.VerificationTypeDateOfBirth,
 					VerificationValue: "1990-01-01",
 				})
 				receiverWallet := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
@@ -1205,7 +1205,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 				receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: phoneNumber})
 				_ = data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 					ReceiverID:        receiver.ID,
-					VerificationField: data.VerificationFieldDateOfBirth,
+					VerificationField: data.VerificationTypeDateOfBirth,
 					VerificationValue: "1990-01-01",
 				})
 				receiverWallet := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
@@ -1323,7 +1323,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 				receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{PhoneNumber: phoneNumber})
 				_ = data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 					ReceiverID:        receiver.ID,
-					VerificationField: data.VerificationFieldDateOfBirth,
+					VerificationField: data.VerificationTypeDateOfBirth,
 					VerificationValue: "1990-01-01",
 				})
 				receiverWallet := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)

--- a/internal/serve/publicfiles/js/receiver_registration.js
+++ b/internal/serve/publicfiles/js/receiver_registration.js
@@ -304,7 +304,7 @@ async function handleVerificationInfoSubmitted() {
         [contactMethod]: contactValue,
         otp: otp,
         recaptcha_token: reCAPTCHAToken,
-        verification_type: WalletRegistration.verificationField,
+        verification_field: WalletRegistration.verificationField,
         verification: verificationFieldValue,
       }),
     });

--- a/internal/serve/validators/disbursement_instructions_validator.go
+++ b/internal/serve/validators/disbursement_instructions_validator.go
@@ -9,11 +9,11 @@ import (
 )
 
 type DisbursementInstructionsValidator struct {
-	verificationField data.VerificationField
+	verificationField data.VerificationType
 	*Validator
 }
 
-func NewDisbursementInstructionsValidator(verificationField data.VerificationField) *DisbursementInstructionsValidator {
+func NewDisbursementInstructionsValidator(verificationField data.VerificationType) *DisbursementInstructionsValidator {
 	return &DisbursementInstructionsValidator{
 		verificationField: verificationField,
 		Validator:         NewValidator(),
@@ -40,13 +40,13 @@ func (iv *DisbursementInstructionsValidator) ValidateInstruction(instruction *da
 
 	// validate verification field
 	switch iv.verificationField {
-	case data.VerificationFieldDateOfBirth:
+	case data.VerificationTypeDateOfBirth:
 		iv.CheckError(utils.ValidateDateOfBirthVerification(verification), fmt.Sprintf("line %d - date of birth", lineNumber), "")
-	case data.VerificationFieldYearMonth:
+	case data.VerificationTypeYearMonth:
 		iv.CheckError(utils.ValidateYearMonthVerification(verification), fmt.Sprintf("line %d - year/month", lineNumber), "")
-	case data.VerificationFieldPin:
+	case data.VerificationTypePin:
 		iv.CheckError(utils.ValidatePinVerification(verification), fmt.Sprintf("line %d - pin", lineNumber), "")
-	case data.VerificationFieldNationalID:
+	case data.VerificationTypeNationalID:
 		iv.CheckError(utils.ValidateNationalIDVerification(verification), fmt.Sprintf("line %d - national id", lineNumber), "")
 	}
 }

--- a/internal/serve/validators/disbursement_instructions_validator_test.go
+++ b/internal/serve/validators/disbursement_instructions_validator_test.go
@@ -13,7 +13,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 		name              string
 		instruction       *data.DisbursementInstruction
 		lineNumber        int
-		verificationField data.VerificationField
+		verificationField data.VerificationType
 		hasErrors         bool
 		expectedErrors    map[string]interface{}
 	}{
@@ -25,7 +25,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "1990-01-01",
 			},
 			lineNumber:        2,
-			verificationField: data.VerificationFieldDateOfBirth,
+			verificationField: data.VerificationTypeDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 2 - phone": "phone cannot be empty",
@@ -35,7 +35,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 			name:              "error with all fields empty (phone, id, amount, date of birth)",
 			instruction:       &data.DisbursementInstruction{},
 			lineNumber:        2,
-			verificationField: data.VerificationFieldDateOfBirth,
+			verificationField: data.VerificationTypeDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 2 - amount":        "invalid amount. Amount must be a positive number",
@@ -53,7 +53,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "1990-01-01",
 			},
 			lineNumber:        2,
-			verificationField: data.VerificationFieldDateOfBirth,
+			verificationField: data.VerificationTypeDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 2 - phone": "invalid phone format. Correct format: +380445555555",
@@ -68,7 +68,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "1990-01-01",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldDateOfBirth,
+			verificationField: data.VerificationTypeDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 3 - amount": "invalid amount. Amount must be a positive number",
@@ -83,7 +83,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "1990-01-01",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldDateOfBirth,
+			verificationField: data.VerificationTypeDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 3 - amount": "invalid amount. Amount must be a positive number",
@@ -98,7 +98,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "1990/01/01",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldDateOfBirth,
+			verificationField: data.VerificationTypeDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 3 - date of birth": "invalid date of birth format. Correct format: 1990-01-30",
@@ -113,7 +113,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "2090-01-01",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldDateOfBirth,
+			verificationField: data.VerificationTypeDateOfBirth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 3 - date of birth": "date of birth cannot be in the future",
@@ -128,7 +128,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "1990/01",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldYearMonth,
+			verificationField: data.VerificationTypeYearMonth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 3 - year/month": "invalid year/month format. Correct format: 1990-12",
@@ -143,7 +143,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "2090-01",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldYearMonth,
+			verificationField: data.VerificationTypeYearMonth,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 3 - year/month": "year/month cannot be in the future",
@@ -158,7 +158,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "123",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldPin,
+			verificationField: data.VerificationTypePin,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 3 - pin": "invalid pin length. Cannot have less than 4 or more than 8 characters in pin",
@@ -173,7 +173,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "123456789",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldPin,
+			verificationField: data.VerificationTypePin,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 3 - pin": "invalid pin length. Cannot have less than 4 or more than 8 characters in pin",
@@ -188,7 +188,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "6UZMB56FWTKV4U0PJ21TBR6VOQVYSGIMZG2HW2S0L7EK5K83W78",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldNationalID,
+			verificationField: data.VerificationTypeNationalID,
 			hasErrors:         true,
 			expectedErrors: map[string]interface{}{
 				"line 3 - national id": "invalid national id. Cannot have more than 50 characters in national id",
@@ -204,7 +204,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "1990-01-01",
 			},
 			lineNumber:        1,
-			verificationField: data.VerificationFieldDateOfBirth,
+			verificationField: data.VerificationTypeDateOfBirth,
 			hasErrors:         false,
 		},
 		{
@@ -216,7 +216,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "1990-01",
 			},
 			lineNumber:        1,
-			verificationField: data.VerificationFieldYearMonth,
+			verificationField: data.VerificationTypeYearMonth,
 			hasErrors:         false,
 		},
 		{
@@ -228,7 +228,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "ABCD123",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldNationalID,
+			verificationField: data.VerificationTypeNationalID,
 			hasErrors:         false,
 		},
 		{
@@ -240,7 +240,7 @@ func Test_DisbursementInstructionsValidator_ValidateAndGetInstruction(t *testing
 				VerificationValue: "1234",
 			},
 			lineNumber:        3,
-			verificationField: data.VerificationFieldPin,
+			verificationField: data.VerificationTypePin,
 			hasErrors:         false,
 		},
 	}
@@ -304,7 +304,7 @@ func Test_DisbursementInstructionsValidator_SanitizeInstruction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			iv := NewDisbursementInstructionsValidator(data.VerificationFieldDateOfBirth)
+			iv := NewDisbursementInstructionsValidator(data.VerificationTypeDateOfBirth)
 			sanitizedInstruction := iv.SanitizeInstruction(tt.actual)
 
 			assert.Equal(t, tt.expectedInstruction, sanitizedInstruction)

--- a/internal/serve/validators/disbursement_request_validator.go
+++ b/internal/serve/validators/disbursement_request_validator.go
@@ -8,11 +8,11 @@ import (
 )
 
 type DisbursementRequestValidator struct {
-	verificationField data.VerificationField
+	verificationField data.VerificationType
 	*Validator
 }
 
-func NewDisbursementRequestValidator(verificationField data.VerificationField) *DisbursementRequestValidator {
+func NewDisbursementRequestValidator(verificationField data.VerificationType) *DisbursementRequestValidator {
 	return &DisbursementRequestValidator{
 		verificationField: verificationField,
 		Validator:         NewValidator(),
@@ -20,9 +20,9 @@ func NewDisbursementRequestValidator(verificationField data.VerificationField) *
 }
 
 // ValidateAndGetVerificationType validates if the verification type field is a valid value.
-func (dv *DisbursementRequestValidator) ValidateAndGetVerificationType() data.VerificationField {
-	if !slices.Contains(data.GetAllVerificationFields(), dv.verificationField) {
-		dv.Check(false, "verification_field", fmt.Sprintf("invalid parameter. valid values are: %v", data.GetAllVerificationFields()))
+func (dv *DisbursementRequestValidator) ValidateAndGetVerificationType() data.VerificationType {
+	if !slices.Contains(data.GetAllVerificationTypes(), dv.verificationField) {
+		dv.Check(false, "verification_field", fmt.Sprintf("invalid parameter. valid values are: %v", data.GetAllVerificationTypes()))
 		return ""
 	}
 	return dv.verificationField

--- a/internal/serve/validators/disbursement_request_validator_test.go
+++ b/internal/serve/validators/disbursement_request_validator_test.go
@@ -10,11 +10,11 @@ import (
 
 func Test_DisbursementRequestValidator_ValidateAndGetVerificationType(t *testing.T) {
 	t.Run("Valid verification type", func(t *testing.T) {
-		validField := []data.VerificationField{
-			data.VerificationFieldDateOfBirth,
-			data.VerificationFieldYearMonth,
-			data.VerificationFieldPin,
-			data.VerificationFieldNationalID,
+		validField := []data.VerificationType{
+			data.VerificationTypeDateOfBirth,
+			data.VerificationTypeYearMonth,
+			data.VerificationTypePin,
+			data.VerificationTypeNationalID,
 		}
 		for _, field := range validField {
 			validator := NewDisbursementRequestValidator(field)
@@ -23,7 +23,7 @@ func Test_DisbursementRequestValidator_ValidateAndGetVerificationType(t *testing
 	})
 
 	t.Run("Invalid verification type", func(t *testing.T) {
-		field := data.VerificationField("field")
+		field := data.VerificationType("field")
 		validator := NewDisbursementRequestValidator(field)
 
 		actual := validator.ValidateAndGetVerificationType()

--- a/internal/serve/validators/receiver_registration_validator.go
+++ b/internal/serve/validators/receiver_registration_validator.go
@@ -41,13 +41,13 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 
 	// validate verification fields
 	switch vf {
-	case data.VerificationFieldDateOfBirth:
+	case data.VerificationTypeDateOfBirth:
 		rv.CheckError(utils.ValidateDateOfBirthVerification(verification), "verification", "")
-	case data.VerificationFieldYearMonth:
+	case data.VerificationTypeYearMonth:
 		rv.CheckError(utils.ValidateYearMonthVerification(verification), "verification", "")
-	case data.VerificationFieldPin:
+	case data.VerificationTypePin:
 		rv.CheckError(utils.ValidatePinVerification(verification), "verification", "")
-	case data.VerificationFieldNationalID:
+	case data.VerificationTypeNationalID:
 		rv.CheckError(utils.ValidateNationalIDVerification(verification), "verification", "")
 	}
 
@@ -58,11 +58,11 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 }
 
 // validateAndGetVerificationType validates if the verification type field is a valid value.
-func (rv *ReceiverRegistrationValidator) validateAndGetVerificationType(verificationType string) data.VerificationField {
-	vt := data.VerificationField(strings.ToUpper(verificationType))
+func (rv *ReceiverRegistrationValidator) validateAndGetVerificationType(verificationType string) data.VerificationType {
+	vt := data.VerificationType(strings.ToUpper(verificationType))
 
-	if !slices.Contains(data.GetAllVerificationFields(), vt) {
-		rv.Check(false, "verification_field", fmt.Sprintf("invalid parameter. valid values are: %v", data.GetAllVerificationFields()))
+	if !slices.Contains(data.GetAllVerificationTypes(), vt) {
+		rv.Check(false, "verification_field", fmt.Sprintf("invalid parameter. valid values are: %v", data.GetAllVerificationTypes()))
 		return ""
 	}
 	return vt

--- a/internal/serve/validators/receiver_registration_validator.go
+++ b/internal/serve/validators/receiver_registration_validator.go
@@ -26,7 +26,7 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 	phone := strings.TrimSpace(receiverInfo.PhoneNumber)
 	otp := strings.TrimSpace(receiverInfo.OTP)
 	verification := strings.TrimSpace(receiverInfo.VerificationValue)
-	verificationType := strings.TrimSpace(string(receiverInfo.VerificationType))
+	verificationField := strings.TrimSpace(string(receiverInfo.VerificationField))
 
 	// validate phone field
 	rv.CheckError(utils.ValidatePhoneNumber(phone), "phone_number", "invalid phone format. Correct format: +380445555555")
@@ -36,11 +36,11 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 	rv.CheckError(utils.ValidateOTP(otp), "otp", "invalid otp format. Needs to be a 6 digit value")
 
 	// validate verification type field
-	rv.Check(verificationType != "", "verification_type", "verification type cannot be empty")
-	vt := rv.validateAndGetVerificationType(verificationType)
+	rv.Check(verificationField != "", "verification_field", "verification type cannot be empty")
+	vf := rv.validateAndGetVerificationType(verificationField)
 
 	// validate verification fields
-	switch vt {
+	switch vf {
 	case data.VerificationFieldDateOfBirth:
 		rv.CheckError(utils.ValidateDateOfBirthVerification(verification), "verification", "")
 	case data.VerificationFieldYearMonth:
@@ -54,7 +54,7 @@ func (rv *ReceiverRegistrationValidator) ValidateReceiver(receiverInfo *data.Rec
 	receiverInfo.PhoneNumber = phone
 	receiverInfo.OTP = otp
 	receiverInfo.VerificationValue = verification
-	receiverInfo.VerificationType = vt
+	receiverInfo.VerificationField = vf
 }
 
 // validateAndGetVerificationType validates if the verification type field is a valid value.
@@ -62,7 +62,7 @@ func (rv *ReceiverRegistrationValidator) validateAndGetVerificationType(verifica
 	vt := data.VerificationField(strings.ToUpper(verificationType))
 
 	if !slices.Contains(data.GetAllVerificationFields(), vt) {
-		rv.Check(false, "verification_type", fmt.Sprintf("invalid parameter. valid values are: %v", data.GetAllVerificationFields()))
+		rv.Check(false, "verification_field", fmt.Sprintf("invalid parameter. valid values are: %v", data.GetAllVerificationFields()))
 		return ""
 	}
 	return vt

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -25,7 +25,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "invalid",
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid phone format. Correct format: +380445555555",
@@ -37,7 +37,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "",
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "phone cannot be empty",
@@ -49,7 +49,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "12mock",
 				VerificationValue: "1990-01-01",
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid otp format. Needs to be a 6 digit value",
@@ -73,7 +73,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "90/01/01",
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid date of birth format. Correct format: 1990-01-30",
@@ -85,7 +85,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "90/12",
-				VerificationField: data.VerificationFieldYearMonth,
+				VerificationField: data.VerificationTypeYearMonth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid year/month format. Correct format: 1990-12",
@@ -97,7 +97,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "ABCDE1234",
-				VerificationField: data.VerificationFieldPin,
+				VerificationField: data.VerificationTypePin,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid pin length. Cannot have less than 4 or more than 8 characters in pin",
@@ -109,7 +109,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "6UZMB56FWTKV4U0PJ21TBR6VOQVYSGIMZG2HW2S0L7EK5K83W78XXXXX",
-				VerificationField: data.VerificationFieldNationalID,
+				VerificationField: data.VerificationTypeNationalID,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid national id. Cannot have more than 50 characters in national id",
@@ -128,7 +128,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
-				VerificationField: data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationTypeDateOfBirth,
 			},
 		},
 		{
@@ -144,7 +144,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "1990-12",
-				VerificationField: data.VerificationFieldYearMonth,
+				VerificationField: data.VerificationTypeYearMonth,
 			},
 		},
 		{
@@ -160,7 +160,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "1234",
-				VerificationField: data.VerificationFieldPin,
+				VerificationField: data.VerificationTypePin,
 			},
 		},
 		{
@@ -176,7 +176,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "NATIONALIDNUMBER123",
-				VerificationField: data.VerificationFieldNationalID,
+				VerificationField: data.VerificationTypeNationalID,
 			},
 		},
 	}
@@ -203,11 +203,11 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 func Test_ReceiverRegistrationValidator_ValidateAndGetVerificationType(t *testing.T) {
 	t.Run("Valid verification type", func(t *testing.T) {
 		validator := NewReceiverRegistrationValidator()
-		validField := []data.VerificationField{
-			data.VerificationFieldDateOfBirth,
-			data.VerificationFieldYearMonth,
-			data.VerificationFieldPin,
-			data.VerificationFieldNationalID,
+		validField := []data.VerificationType{
+			data.VerificationTypeDateOfBirth,
+			data.VerificationTypeYearMonth,
+			data.VerificationTypePin,
+			data.VerificationTypeNationalID,
 		}
 		for _, field := range validField {
 			assert.Equal(t, field, validator.validateAndGetVerificationType(string(field)))

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -25,7 +25,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "invalid",
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid phone format. Correct format: +380445555555",
@@ -37,7 +37,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "",
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "phone cannot be empty",
@@ -49,7 +49,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "12mock",
 				VerificationValue: "1990-01-01",
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid otp format. Needs to be a 6 digit value",
@@ -61,11 +61,11 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
-				VerificationType:  "mock_type",
+				VerificationField: "mock_type",
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid parameter. valid values are: [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]",
-			expectedErrorKey: "verification_type",
+			expectedErrorKey: "verification_field",
 		},
 		{
 			name: "error if verification[DATE_OF_BIRTH] is invalid",
@@ -73,7 +73,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "90/01/01",
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid date of birth format. Correct format: 1990-01-30",
@@ -85,7 +85,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "90/12",
-				VerificationType:  data.VerificationFieldYearMonth,
+				VerificationField: data.VerificationFieldYearMonth,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid year/month format. Correct format: 1990-12",
@@ -97,7 +97,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "ABCDE1234",
-				VerificationType:  data.VerificationFieldPin,
+				VerificationField: data.VerificationFieldPin,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid pin length. Cannot have less than 4 or more than 8 characters in pin",
@@ -109,7 +109,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "6UZMB56FWTKV4U0PJ21TBR6VOQVYSGIMZG2HW2S0L7EK5K83W78XXXXX",
-				VerificationType:  data.VerificationFieldNationalID,
+				VerificationField: data.VerificationFieldNationalID,
 			},
 			expectedErrorLen: 1,
 			expectedErrorMsg: "invalid national id. Cannot have more than 50 characters in national id",
@@ -121,14 +121,14 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555  ",
 				OTP:               "  123456  ",
 				VerificationValue: "1990-01-01  ",
-				VerificationType:  "date_of_birth",
+				VerificationField: "date_of_birth",
 			},
 			expectedErrorLen: 0,
 			expectedReceiver: data.ReceiverRegistrationRequest{
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "1990-01-01",
-				VerificationType:  data.VerificationFieldDateOfBirth,
+				VerificationField: data.VerificationFieldDateOfBirth,
 			},
 		},
 		{
@@ -137,14 +137,14 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555  ",
 				OTP:               "  123456  ",
 				VerificationValue: "1990-12  ",
-				VerificationType:  "year_month",
+				VerificationField: "year_month",
 			},
 			expectedErrorLen: 0,
 			expectedReceiver: data.ReceiverRegistrationRequest{
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "1990-12",
-				VerificationType:  data.VerificationFieldYearMonth,
+				VerificationField: data.VerificationFieldYearMonth,
 			},
 		},
 		{
@@ -153,14 +153,14 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555  ",
 				OTP:               "  123456  ",
 				VerificationValue: "1234  ",
-				VerificationType:  "pin",
+				VerificationField: "pin",
 			},
 			expectedErrorLen: 0,
 			expectedReceiver: data.ReceiverRegistrationRequest{
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "1234",
-				VerificationType:  data.VerificationFieldPin,
+				VerificationField: data.VerificationFieldPin,
 			},
 		},
 		{
@@ -169,14 +169,14 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				PhoneNumber:       "+380445555555  ",
 				OTP:               "  123456  ",
 				VerificationValue: "  NATIONALIDNUMBER123",
-				VerificationType:  "national_id_number",
+				VerificationField: "national_id_number",
 			},
 			expectedErrorLen: 0,
 			expectedReceiver: data.ReceiverRegistrationRequest{
 				PhoneNumber:       "+380445555555",
 				OTP:               "123456",
 				VerificationValue: "NATIONALIDNUMBER123",
-				VerificationType:  data.VerificationFieldNationalID,
+				VerificationField: data.VerificationFieldNationalID,
 			},
 		},
 	}
@@ -194,7 +194,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				assert.Equal(t, tc.expectedReceiver.PhoneNumber, tc.receiverInfo.PhoneNumber)
 				assert.Equal(t, tc.expectedReceiver.OTP, tc.receiverInfo.OTP)
 				assert.Equal(t, tc.expectedReceiver.VerificationValue, tc.receiverInfo.VerificationValue)
-				assert.Equal(t, tc.expectedReceiver.VerificationType, tc.receiverInfo.VerificationType)
+				assert.Equal(t, tc.expectedReceiver.VerificationField, tc.receiverInfo.VerificationField)
 			}
 		})
 	}
@@ -221,6 +221,6 @@ func Test_ReceiverRegistrationValidator_ValidateAndGetVerificationType(t *testin
 		actual := validator.validateAndGetVerificationType(invalidStatus)
 		assert.Empty(t, actual)
 		assert.Equal(t, 1, len(validator.Errors))
-		assert.Equal(t, "invalid parameter. valid values are: [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]", validator.Errors["verification_type"])
+		assert.Equal(t, "invalid parameter. valid values are: [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]", validator.Errors["verification_field"])
 	})
 }

--- a/internal/services/patch_anchor_platform_transactions_completion_test.go
+++ b/internal/services/patch_anchor_platform_transactions_completion_test.go
@@ -78,7 +78,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -115,7 +115,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -186,7 +186,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -240,7 +240,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -305,7 +305,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -370,7 +370,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionForP
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -454,7 +454,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -518,7 +518,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -578,7 +578,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -641,7 +641,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		disbursement2 := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
@@ -649,7 +649,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
@@ -725,7 +725,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		disbursement2 := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
@@ -733,7 +733,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		disbursement3 := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
@@ -741,7 +741,7 @@ func Test_PatchAnchorPlatformTransactionCompletionService_PatchAPTransactionsFor
 			Wallet:            wallet,
 			Asset:             asset,
 			Status:            data.StartedDisbursementStatus,
-			VerificationField: data.VerificationFieldDateOfBirth,
+			VerificationField: data.VerificationTypeDateOfBirth,
 		})
 
 		payment1 := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{

--- a/internal/services/ready_payments_cancelation_service_test.go
+++ b/internal/services/ready_payments_cancelation_service_test.go
@@ -48,7 +48,7 @@ func Test_ReadyPaymentsCancellationService_CancelReadyPaymentsService(t *testing
 		Wallet:            wallet,
 		Asset:             asset,
 		Status:            data.ReadyDisbursementStatus,
-		VerificationField: data.VerificationFieldDateOfBirth,
+		VerificationField: data.VerificationTypeDateOfBirth,
 	})
 
 	t.Run("automatic payment cancellation is deactivated", func(t *testing.T) {


### PR DESCRIPTION
### What

Fix inconsistency in the usage of verification_field vs verification_type:
1. The JSON response from `/wallet-registration/otp` contains a field named `verification_field`, while `/wallet-registration/verification` was expecting that same field to be named `verification_type`. This was fixed in https://github.com/stellar/stellar-disbursement-platform-backend/commit/f06f8d62121311e1bd64988a1a11b6e56fc7b0bc.
2. Renamed the enum `VerificationField*` to `VerificationType*`. Fixed in https://github.com/stellar/stellar-disbursement-platform-backend/commit/2350f5f1742b8cbdad53cafd95ad7458461a0537.

FYI: I tested the disbursement end2end with this change and it works as expected. Nothing was broken.

### Why

The database has the following naming structure:
- The enum for **type** is called `verification_type`, and it can contain values like DATE_OF_BIRTH, PIN, NATIONAL_ID and YEAR_AND_MONTH is called.
- The column names that adhere to that type are called `verification_field`.

That caused some confusion and led to some naming mistakes in the code.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
