### PR TITLE
[SDP-1316] Update send and auto-retry invitation scheduler job to work with both SMS and email

### DIFF
--- a/internal/message/mock_message_dispatcher_interface.go
+++ b/internal/message/mock_message_dispatcher_interface.go
@@ -49,21 +49,31 @@ func (_m *MockMessageDispatcher) RegisterClient(ctx context.Context, channel Mes
 }
 
 // SendMessage provides a mock function with given fields: ctx, message, channelPriority
-func (_m *MockMessageDispatcher) SendMessage(ctx context.Context, message Message, channelPriority []MessageChannel) error {
+func (_m *MockMessageDispatcher) SendMessage(ctx context.Context, message Message, channelPriority []MessageChannel) (MessengerType, error) {
 	ret := _m.Called(ctx, message, channelPriority)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendMessage")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, Message, []MessageChannel) error); ok {
+	var r0 MessengerType
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, Message, []MessageChannel) (MessengerType, error)); ok {
+		return rf(ctx, message, channelPriority)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, Message, []MessageChannel) MessengerType); ok {
 		r0 = rf(ctx, message, channelPriority)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(MessengerType)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, Message, []MessageChannel) error); ok {
+		r1 = rf(ctx, message, channelPriority)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // NewMockMessageDispatcher creates a new instance of MockMessageDispatcher. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -238,7 +238,7 @@ func (h ReceiverSendOTPHandler) sendOTP(ctx context.Context, contactType data.Re
 	truncatedContactInfo := utils.TruncateString(contactInfo, 3)
 	contactTypeStr := utils.Humanize(string(contactType))
 	log.Ctx(ctx).Infof("sending OTP message to %s %s...", contactTypeStr, truncatedContactInfo)
-	err = h.MessageDispatcher.SendMessage(ctx, msg, organization.MessageChannelPriority)
+	_, err = h.MessageDispatcher.SendMessage(ctx, msg, organization.MessageChannelPriority)
 	if err != nil {
 		return fmt.Errorf("cannot send OTP message through %s to %s: %w", contactTypeStr, truncatedContactInfo, err)
 	}


### PR DESCRIPTION
### What
* Change send invitation scheduler job to work with SMS and Email. 

### Why
https://stellarorg.atlassian.net/browse/SDP-1316

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
