### PR TITLE
[SDP-1343] Fix HTML escaping for emails

### DIFF
--- a/internal/htmltemplate/htmltemplate.go
+++ b/internal/htmltemplate/htmltemplate.go
@@ -26,7 +26,7 @@ func ExecuteHTMLTemplate(templateName string, data interface{}) (string, error) 
 }
 
 type EmptyBodyEmailTemplate struct {
-	Body string
+	Body template.HTML
 }
 
 func ExecuteHTMLTemplateForEmailEmptyBody(data EmptyBodyEmailTemplate) (string, error) {

--- a/internal/htmltemplate/htmltemplate_test.go
+++ b/internal/htmltemplate/htmltemplate_test.go
@@ -3,6 +3,7 @@ package htmltemplate
 import (
 	"crypto/rand"
 	"fmt"
+	"html/template"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +44,7 @@ func Test_ExecuteHTMLTemplateForEmailEmptyBody(t *testing.T) {
 	randomStr := fmt.Sprintf("%x", b)[:10]
 
 	// check if the random string is imprinted in the template
-	inputData := EmptyBodyEmailTemplate{Body: randomStr}
+	inputData := EmptyBodyEmailTemplate{Body: template.HTML(randomStr)}
 	templateStr, err := ExecuteHTMLTemplateForEmailEmptyBody(inputData)
 	require.NoError(t, err)
 	require.Contains(t, templateStr, randomStr)

--- a/internal/message/aws_ses_client.go
+++ b/internal/message/aws_ses_client.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"fmt"
+	"html/template"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -51,7 +52,7 @@ func (a *awsSESClient) SendMessage(message Message) error {
 
 // generateAWSEmail generates the email object to send an email through AWS SES.
 func generateAWSEmail(message Message, sender string) (*ses.SendEmailInput, error) {
-	html, err := htmltemplate.ExecuteHTMLTemplateForEmailEmptyBody(htmltemplate.EmptyBodyEmailTemplate{Body: message.Message})
+	html, err := htmltemplate.ExecuteHTMLTemplateForEmailEmptyBody(htmltemplate.EmptyBodyEmailTemplate{Body: template.HTML(message.Message)})
 	if err != nil {
 		return nil, fmt.Errorf("generating html template: %w", err)
 	}


### PR DESCRIPTION
### What
When testing this with AWS SES, it looked like the whole email was escaped. In order to resolve this, we need to mark the HTML part of the template as safe by wrapping it with `template.HTML` 
<img width="1469" alt="Screenshot 2024-09-17 at 3 21 15 PM" src="https://github.com/user-attachments/assets/443682fa-9889-4632-8dc3-72d8b51cb151">

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
