### PR TITLE
[SDP-1355] increase token refresh window

### DIFF
--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -11,6 +11,8 @@ var ErrInvalidToken = errors.New("invalid token")
 
 type AuthManager interface {
 	Authenticate(ctx context.Context, email, pass string) (string, error)
+	// RefreshToken generates a new token if the current token is going to expire in less than `tokenRefreshWindow` minutes.
+	// Otherwise, it returns the same token.
 	RefreshToken(ctx context.Context, tokenString string) (string, error)
 	ValidateToken(ctx context.Context, tokenString string) (bool, error)
 	AllRolesInTokenUser(ctx context.Context, tokenString string, roleNames []string) (bool, error)

--- a/stellar-auth/pkg/auth/jwt_manager.go
+++ b/stellar-auth/pkg/auth/jwt_manager.go
@@ -13,7 +13,9 @@ import (
 	jwtgo "github.com/golang-jwt/jwt/v4"
 )
 
-const defaultRefreshTimeoutInMinutes = 2
+// tokenRefreshWindow is the time window in minutes that we allow to refresh a token. If the token is going to expire in
+// less than this time, we generate a new token, otherwise we return the same token.
+const tokenRefreshWindow = 3
 
 type JWTManager interface {
 	GenerateToken(ctx context.Context, user *User, expiresAt time.Time) (string, error)
@@ -100,7 +102,7 @@ func (m *defaultJWTManager) RefreshToken(ctx context.Context, tokenString string
 
 	// We only generate new tokens when enough time
 	// is elapsed.
-	if time.Until(c.ExpiresAt.Time) > defaultRefreshTimeoutInMinutes*time.Minute {
+	if time.Until(c.ExpiresAt.Time) > tokenRefreshWindow*time.Minute {
 		return tokenString, nil
 	}
 

--- a/stellar-auth/pkg/auth/jwt_manager.go
+++ b/stellar-auth/pkg/auth/jwt_manager.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"time"
 
+	jwtgo "github.com/golang-jwt/jwt/v4"
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
-
-	jwtgo "github.com/golang-jwt/jwt/v4"
 )
 
 // tokenRefreshWindow is the time window in minutes that we allow to refresh a token. If the token is going to expire in
@@ -19,6 +18,8 @@ const tokenRefreshWindow = 3
 
 type JWTManager interface {
 	GenerateToken(ctx context.Context, user *User, expiresAt time.Time) (string, error)
+	// RefreshToken generates a new token if the current token is going to expire in less than `tokenRefreshWindow` minutes.
+	// Otherwise, it returns the same token.
 	RefreshToken(ctx context.Context, token string, expiresAt time.Time) (string, error)
 	ValidateToken(ctx context.Context, token string) (bool, error)
 	GetUserFromToken(ctx context.Context, token string) (*User, error)
@@ -94,6 +95,8 @@ func (m *defaultJWTManager) GenerateToken(ctx context.Context, user *User, expir
 	return tokenString, nil
 }
 
+// RefreshToken generates a new token if the current token is going to expire in less than `tokenRefreshWindow` minutes.
+// Otherwise, it returns the same token.
 func (m *defaultJWTManager) RefreshToken(ctx context.Context, tokenString string, expiresAt time.Time) (string, error) {
 	_, c, err := m.parseToken(tokenString)
 	if err != nil {

--- a/stellar-auth/pkg/auth/jwt_manager_test.go
+++ b/stellar-auth/pkg/auth/jwt_manager_test.go
@@ -117,7 +117,7 @@ func Test_DefaultJWTManager_RefreshToken(t *testing.T) {
 	ctx := tenant.SaveTenantInContext(context.Background(), &currentTenant)
 
 	t.Run("returns the same token when is above the refresh period", func(t *testing.T) {
-		expiresAt := time.Now().Add(time.Minute * (defaultRefreshTimeoutInMinutes + 1))
+		expiresAt := time.Now().Add(time.Minute * (tokenRefreshWindow + 1))
 		token, err := jwtManager.GenerateToken(ctx, &User{}, expiresAt)
 		require.NoError(t, err)
 
@@ -129,7 +129,7 @@ func Test_DefaultJWTManager_RefreshToken(t *testing.T) {
 	})
 
 	t.Run("returns a refreshed token", func(t *testing.T) {
-		expiresAt := time.Now().Add(time.Minute * defaultRefreshTimeoutInMinutes)
+		expiresAt := time.Now().Add(time.Minute * tokenRefreshWindow)
 		token, err := jwtManager.GenerateToken(ctx, &User{}, expiresAt)
 		require.NoError(t, err)
 


### PR DESCRIPTION
### What

Increase token refresh window.

### Why

It was too short and causing the session to expire very often. We're changing it with this frontend change, where we add a token refresher to the frontend codebase.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
