### PR TITLE
[SDP-1339] Remove the word `phone` from the default organization's otp_message_template

### DIFF
--- a/db/migrations/sdp-migrations/2024-10-18.0-update-default-value-of-otp-message-template.sql
+++ b/db/migrations/sdp-migrations/2024-10-18.0-update-default-value-of-otp-message-template.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+
+ALTER TABLE organizations
+    ALTER COLUMN otp_message_template SET DEFAULT '{{.OTP}} is your {{.OrganizationName}} verification code.';
+
+UPDATE organizations
+    SET otp_message_template = '{{.OTP}} is your {{.OrganizationName}} verification code.'
+    WHERE otp_message_template = '{{.OTP}} is your {{.OrganizationName}} phone verification code.';
+
+-- +migrate Down
+
+ALTER TABLE organizations
+    ALTER COLUMN otp_message_template SET DEFAULT '{{.OTP}} is your {{.OrganizationName}} phone verification code.';
+
+UPDATE organizations
+    SET otp_message_template = '{{.OTP}} is your {{.OrganizationName}} phone verification code.'
+    WHERE otp_message_template = '{{.OTP}} is your {{.OrganizationName}} verification code.';

--- a/internal/data/organizations.go
+++ b/internal/data/organizations.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	DefaultReceiverRegistrationMessageTemplate = "You have a payment waiting for you from the {{.OrganizationName}}. Click {{.RegistrationLink}} to register."
-	DefaultOTPMessageTemplate                  = "{{.OTP}} is your {{.OrganizationName}} phone verification code."
+	DefaultOTPMessageTemplate                  = "{{.OTP}} is your {{.OrganizationName}} verification code."
 )
 
 type Organization struct {

--- a/internal/data/organizations_test.go
+++ b/internal/data/organizations_test.go
@@ -364,7 +364,7 @@ func Test_Organizations_Update(t *testing.T) {
 	t.Run("updates the organization's OTPMessageTemplate", func(t *testing.T) {
 		defer resetOrganizationInfo(t, ctx, dbConnectionPool)
 
-		defaultMessage := "{{.OTP}} is your {{.OrganizationName}} phone verification code."
+		defaultMessage := "{{.OTP}} is your {{.OrganizationName}} verification code."
 		o, err := organizationModel.Get(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, defaultMessage, o.OTPMessageTemplate)

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -402,7 +402,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 			},
 			resultingFieldsToCompare: map[string]interface{}{
 				"ReceiverRegistrationMessageTemplate":  "You have a payment waiting for you from the {{.OrganizationName}}. Click {{.RegistrationLink}} to register.",
-				"OTPMessageTemplate":                   "{{.OTP}} is your {{.OrganizationName}} phone verification code.",
+				"OTPMessageTemplate":                   "{{.OTP}} is your {{.OrganizationName}} verification code.",
 				"ReceiverInvitationResendIntervalDays": nilInt64,
 				"PaymentCancellationPeriodDays":        nilInt64,
 				"PrivacyPolicyLink":                    nilString,

--- a/internal/serve/httphandler/receiver_send_otp_handler_test.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler_test.go
@@ -321,7 +321,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP_otpHandlerIsCalled(t *testing.T) {
 							Once().
 							Run(func(args mock.Arguments) {
 								msg := args.Get(1).(message.Message)
-								assert.Contains(t, msg.Message, "is your MyCustomAid phone verification code.")
+								assert.Contains(t, msg.Message, "is your MyCustomAid verification code.")
 								assert.Regexp(t, regexp.MustCompile(`^\d{6}\s.+$`), msg.Message)
 							})
 					},
@@ -373,7 +373,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP_otpHandlerIsCalled(t *testing.T) {
 							Once().
 							Run(func(args mock.Arguments) {
 								msg := args.Get(1).(message.Message)
-								assert.Contains(t, msg.Message, "is your MyCustomAid phone verification code.")
+								assert.Contains(t, msg.Message, "is your MyCustomAid verification code.")
 								assert.Regexp(t, regexp.MustCompile(`^\d{6}\s.+$`), msg.Message)
 							})
 					},
@@ -480,12 +480,12 @@ func Test_ReceiverSendOTPHandler_sendOTP(t *testing.T) {
 		{
 			name:                   "dispacher fails",
 			overrideOrgOTPTemplate: defaultOTPMessageTemplate,
-			wantMessage:            fmt.Sprintf("246810 is your %s phone verification code. If you did not request this code, please ignore. Do not share your code with anyone.", organization.Name),
+			wantMessage:            fmt.Sprintf("246810 is your %s verification code. If you did not request this code, please ignore. Do not share your code with anyone.", organization.Name),
 		},
 		{
 			name:                   "🎉 successful with default message",
 			overrideOrgOTPTemplate: defaultOTPMessageTemplate,
-			wantMessage:            fmt.Sprintf("246810 is your %s phone verification code. If you did not request this code, please ignore. Do not share your code with anyone.", organization.Name),
+			wantMessage:            fmt.Sprintf("246810 is your %s verification code. If you did not request this code, please ignore. Do not share your code with anyone.", organization.Name),
 		},
 		{
 			name:                   "🎉 successful with custom message and pre-existing OTP tag",


### PR DESCRIPTION
### What

Remove the word `phone` from the default organization's otp_message_template

### Why

Since we now allow email as a form of delivery of the OTP,
This PR addresses https://stellarorg.atlassian.net/browse/SDP-1339.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
