### PR TITLE
[SDP-1364] Add path validation to the readDisbursementCSV method used in integration tests

### DIFF
--- a/internal/integrationtests/utils.go
+++ b/internal/integrationtests/utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
 // logErrorResponses logs the response body for requests with error status.
@@ -24,16 +25,21 @@ func logErrorResponses(ctx context.Context, body io.ReadCloser) {
 }
 
 func readDisbursementCSV(disbursementFilePath string, disbursementFileName string) ([]*data.DisbursementInstruction, error) {
+	err := utils.ValidatePathIsNotTraversal(disbursementFileName)
+	if err != nil {
+		return nil, fmt.Errorf("validating file path: %w", err)
+	}
+
 	filePath := path.Join(disbursementFilePath, disbursementFileName)
 
 	csvBytes, err := fs.ReadFile(DisbursementCSVFiles, filePath)
 	if err != nil {
-		return nil, fmt.Errorf("error reading csv file: %w", err)
+		return nil, fmt.Errorf("reading csv file: %w", err)
 	}
 
 	instructions := []*data.DisbursementInstruction{}
 	if err = gocsv.UnmarshalBytes(csvBytes, &instructions); err != nil {
-		return nil, fmt.Errorf("error parsing csv file: %w", err)
+		return nil, fmt.Errorf("parsing csv file: %w", err)
 	}
 
 	return instructions, nil

--- a/internal/integrationtests/utils_test.go
+++ b/internal/integrationtests/utils_test.go
@@ -36,9 +36,17 @@ func Test_logErrorResponses(t *testing.T) {
 }
 
 func Test_readDisbursementCSV(t *testing.T) {
+	t.Run("error if file path is traversal", func(t *testing.T) {
+		expectedError := "validating file path: path cannot contain path traversal"
+
+		data, err := readDisbursementCSV("resources", "../invalid_traversal_path.csv")
+		require.EqualError(t, err, expectedError)
+		assert.Empty(t, data)
+	})
+
 	t.Run("error trying read csv file", func(t *testing.T) {
 		filePath := path.Join("resources", "invalid_file.csv")
-		expectedError := fmt.Sprintf("error reading csv file: open %s: file does not exist", filePath)
+		expectedError := fmt.Sprintf("reading csv file: open %s: file does not exist", filePath)
 
 		data, err := readDisbursementCSV("resources", "invalid_file.csv")
 		require.EqualError(t, err, expectedError)
@@ -47,7 +55,7 @@ func Test_readDisbursementCSV(t *testing.T) {
 
 	t.Run("error opening empty csv file", func(t *testing.T) {
 		data, err := readDisbursementCSV("resources", "empty_csv_file.csv")
-		require.EqualError(t, err, "error parsing csv file: empty csv file given")
+		require.EqualError(t, err, "parsing csv file: empty csv file given")
 		assert.Empty(t, data)
 	})
 


### PR DESCRIPTION
### What

Add path validation to the readDisbursementCSV method used in integration tests

### Why

Address https://stellarorg.atlassian.net/browse/SDP-1364.

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
