### PR TITLE
[SDP-1370] Update `POST /disbursements` and `GET /disbursements` APIs to persist and return the Registration Contact Type

### DIFF
--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -31,17 +31,19 @@ jobs:
         include:
           - platform: "Stellar-phone"
             environment: "Receiver Registration - E2E Integration Tests (Stellar)"
-            # TODO: ADD VALIDATION TYPE in this test and the envs used by the integration tests, defaulting to phone number when not provided
             DISTRIBUTION_ACCOUNT_TYPE: "DISTRIBUTION_ACCOUNT.STELLAR.ENV"
             DISBURSEMENT_CSV_FILE_NAME: "disbursement_instructions_phone.csv"
+            REGISTRATION_CONTACT_TYPE: "PHONE_NUMBER"
           - platform: "Stellar-email"
             environment: "Receiver Registration - E2E Integration Tests (Stellar)"
             DISTRIBUTION_ACCOUNT_TYPE: "DISTRIBUTION_ACCOUNT.STELLAR.ENV"
             DISBURSEMENT_CSV_FILE_NAME: "disbursement_instructions_email.csv"
+            REGISTRATION_CONTACT_TYPE: "EMAIL"
           - platform: "Circle-phone"
             environment: "Receiver Registration - E2E Integration Tests (Circle)"
             DISTRIBUTION_ACCOUNT_TYPE: "DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT"
             DISBURSEMENT_CSV_FILE_NAME: "disbursement_instructions_phone.csv"
+            REGISTRATION_CONTACT_TYPE: "PHONE_NUMBER"
     environment: ${{ matrix.environment }}
     env:
       DISTRIBUTION_ACCOUNT_TYPE: ${{ matrix.DISTRIBUTION_ACCOUNT_TYPE }}

--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -31,6 +31,7 @@ jobs:
         include:
           - platform: "Stellar-phone"
             environment: "Receiver Registration - E2E Integration Tests (Stellar)"
+            # TODO: ADD VALIDATION TYPE in this test and the envs used by the integration tests, defaulting to phone number when not provided
             DISTRIBUTION_ACCOUNT_TYPE: "DISTRIBUTION_ACCOUNT.STELLAR.ENV"
             DISBURSEMENT_CSV_FILE_NAME: "disbursement_instructions_phone.csv"
           - platform: "Stellar-email"

--- a/cmd/integration_tests.go
+++ b/cmd/integration_tests.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"go/types"
 
 	"github.com/spf13/cobra"
@@ -8,6 +9,7 @@ import (
 	"github.com/stellar/go/support/log"
 
 	cmdUtils "github.com/stellar/stellar-disbursement-platform-backend/cmd/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/integrationtests"
 )
 
@@ -104,6 +106,15 @@ func (c *IntegrationTestsCommand) Command() *cobra.Command {
 			OptType:   types.String,
 			ConfigKey: &integrationTestsOpts.ServerApiBaseURL,
 			Required:  true,
+		},
+		{
+			Name:           "registration-contact-type",
+			Usage:          fmt.Sprintf("The registration contact type used when creating a new disbursement. Options: %v", data.AllRegistrationContactTypes()),
+			OptType:        types.String,
+			CustomSetValue: cmdUtils.SetRegistrationContactType,
+			ConfigKey:      &integrationTestsOpts.RegistrationContactType,
+			Required:       true,
+			FlagDefault:    data.RegistrationContactTypePhone.String(),
 		},
 	}
 	integrationTestsCmd := &cobra.Command{

--- a/cmd/utils/custom_set_value.go
+++ b/cmd/utils/custom_set_value.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
@@ -285,5 +286,18 @@ func SetConfigOptionKafkaSecurityProtocol(co *config.ConfigOption) error {
 	}
 
 	*(co.ConfigKey.(*events.KafkaSecurityProtocol)) = protocolParsed
+	return nil
+}
+
+func SetRegistrationContactType(co *config.ConfigOption) error {
+	regAccountTypeStr := viper.GetString(co.Name)
+	regAccountType := data.RegistrationContactType{}
+
+	err := regAccountType.ParseFromString(regAccountTypeStr)
+	if err != nil {
+		return fmt.Errorf("couldn't parse registration contact type in %s: %w", co.Name, err)
+	}
+
+	*(co.ConfigKey.(*data.RegistrationContactType)) = regAccountType
 	return nil
 }

--- a/cmd/utils/custom_set_value_test.go
+++ b/cmd/utils/custom_set_value_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
@@ -712,6 +713,57 @@ func Test_SetConfigOptionEventBrokerType(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts.eventBrokerType = ""
 			customSetterTester[events.EventBrokerType](t, tc, co)
+		})
+	}
+}
+
+func Test_SetRegistrationContactType(t *testing.T) {
+	opts := struct{ RegistrationContactType data.RegistrationContactType }{}
+
+	co := config.ConfigOption{
+		Name:           "registration-contact-type",
+		OptType:        types.String,
+		CustomSetValue: SetRegistrationContactType,
+		ConfigKey:      &opts.RegistrationContactType,
+	}
+
+	testCases := []customSetterTestCase[data.RegistrationContactType]{
+		{
+			name:            "returns an error if the value is empty",
+			args:            []string{},
+			wantErrContains: `couldn't parse registration contact type in registration-contact-type: unknown ReceiverContactType ""`,
+		},
+		{
+			name:            "returns an error if the value is not supported",
+			args:            []string{"--registration-contact-type", "test"},
+			wantErrContains: `couldn't parse registration contact type in registration-contact-type: unknown ReceiverContactType "TEST"`,
+		},
+		{
+			name:       "🎉 handles registration contact type (through CLI args): EMAIL",
+			args:       []string{"--registration-contact-type", "EmAiL"},
+			wantResult: data.RegistrationContactTypeEmail,
+		},
+		{
+			name:       "🎉 handles registration contact type (through CLI args): EMAIL_AND_WALLET_ADDRESS",
+			args:       []string{"--registration-contact-type", "EMAIL_AND_WALLET_ADDRESS"},
+			wantResult: data.RegistrationContactTypeEmailAndWalletAddress,
+		},
+		{
+			name:       "🎉 handles registration contact type (through CLI args): PHONE_NUMBER",
+			args:       []string{"--registration-contact-type", "PHONE_NUMBER"},
+			wantResult: data.RegistrationContactTypePhone,
+		},
+		{
+			name:       "🎉 handles registration contact type (through CLI args): PHONE_NUMBER_AND_WALLET_ADDRESS",
+			args:       []string{"--registration-contact-type", "PHONE_NUMBER_AND_WALLET_ADDRESS"},
+			wantResult: data.RegistrationContactTypePhoneAndWalletAddress,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts.RegistrationContactType = data.RegistrationContactType{}
+			customSetterTester[data.RegistrationContactType](t, tc, co)
 		})
 	}
 }

--- a/db/migrations/admin-migrations/2024-07-15.0-migrate-data-v1-to-v2-function.sql
+++ b/db/migrations/admin-migrations/2024-07-15.0-migrate-data-v1-to-v2-function.sql
@@ -44,6 +44,7 @@ BEGIN
                 USING verification_field::text::%I.verification_type;
         INSERT INTO %I.receiver_verifications SELECT * FROM public.receiver_verifications;
 
+        -- TODO: create without the NOT NULL constraint, update the existing data, then add the NOT NULL constraint
         ALTER TABLE public.disbursements
             ALTER COLUMN status DROP DEFAULT,
             ALTER COLUMN status TYPE %I.disbursement_status

--- a/db/migrations/admin-migrations/2024-07-15.0-migrate-data-v1-to-v2-function.sql
+++ b/db/migrations/admin-migrations/2024-07-15.0-migrate-data-v1-to-v2-function.sql
@@ -44,14 +44,14 @@ BEGIN
                 USING verification_field::text::%I.verification_type;
         INSERT INTO %I.receiver_verifications SELECT * FROM public.receiver_verifications;
 
-        -- TODO: create without the NOT NULL constraint, update the existing data, then add the NOT NULL constraint
         ALTER TABLE public.disbursements
             ALTER COLUMN status DROP DEFAULT,
             ALTER COLUMN status TYPE %I.disbursement_status
                 USING status::text::%I.disbursement_status,
             ALTER COLUMN verification_field DROP DEFAULT,
             ALTER COLUMN verification_field TYPE %I.verification_type
-                USING verification_field::text::%I.verification_type;
+                USING verification_field::text::%I.verification_type,
+            ADD COLUMN IF NOT EXISTS registration_contact_type %I.registration_contact_types NOT NULL DEFAULT ''PHONE_NUMBER'';
         INSERT INTO %I.disbursements SELECT * FROM public.disbursements;
 
         ALTER TABLE public.payments
@@ -71,7 +71,7 @@ BEGIN
                    schema_name, schema_name, schema_name, schema_name, schema_name, schema_name,
                    schema_name, schema_name, schema_name, schema_name, schema_name, schema_name,
                    schema_name, schema_name, schema_name, schema_name, schema_name, schema_name,
-                   schema_name);
+                   schema_name, schema_name);
 
 
     -- Step 3: Import TSS data

--- a/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
+++ b/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
@@ -8,9 +8,15 @@ CREATE TYPE registration_contact_types AS ENUM (
     'PHONE_NUMBER_AND_WALLET_ADDRESS'
 );
 
--- TODO: create without the NOT NULL constraint, update the existing data, then add the NOT NULL constraint
 ALTER TABLE disbursements
-    ADD COLUMN registration_contact_type registration_contact_types NOT NULL DEFAULT 'PHONE_NUMBER';
+    ADD COLUMN registration_contact_type registration_contact_types;
+
+UPDATE disbursements
+    SET registration_contact_type = 'PHONE_NUMBER'
+    WHERE registration_contact_type IS NULL;
+
+ALTER TABLE disbursements
+    ALTER COLUMN registration_contact_type SET NOT NULL;
 
 -- +migrate Down
 ALTER TABLE disbursements

--- a/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
+++ b/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
@@ -9,14 +9,7 @@ CREATE TYPE registration_contact_types AS ENUM (
 );
 
 ALTER TABLE disbursements
-    ADD COLUMN registration_contact_type registration_contact_types;
-
-UPDATE disbursements
-    SET registration_contact_type = 'PHONE_NUMBER'
-    WHERE registration_contact_type IS NULL;
-
-ALTER TABLE disbursements
-    ALTER COLUMN registration_contact_type SET NOT NULL;
+    ADD COLUMN registration_contact_type registration_contact_types NOT NULL DEFAULT 'PHONE_NUMBER';
 
 -- +migrate Down
 ALTER TABLE disbursements

--- a/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
+++ b/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
@@ -1,0 +1,19 @@
+-- This migration adds the receiver_contact_type enum type and the receiver_contact_type column to the disbursements table.
+
+-- +migrate Up
+CREATE TYPE registration_contact_types AS ENUM (
+    'EMAIL',
+    'EMAIL_AND_WALLET_ADDRESS',
+    'PHONE_NUMBER',
+    'PHONE_NUMBER_AND_WALLET_ADDRESS'
+);
+
+-- TODO: create without the NOT NULL constraint, update the existing data, then add the NOT NULL constraint
+ALTER TABLE disbursements
+    ADD COLUMN registration_contact_type registration_contact_types NOT NULL DEFAULT 'PHONE_NUMBER';
+
+-- +migrate Down
+ALTER TABLE disbursements
+    DROP COLUMN registration_contact_type;
+
+DROP TYPE IF EXISTS registration_contact_types;

--- a/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
+++ b/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
@@ -8,6 +8,7 @@ CREATE TYPE registration_contact_types AS ENUM (
     'PHONE_NUMBER_AND_WALLET_ADDRESS'
 );
 
+-- TODO: create without the NOT NULL constraint, update the existing data, then add the NOT NULL constraint
 ALTER TABLE disbursements
     ADD COLUMN registration_contact_type registration_contact_types NOT NULL DEFAULT 'PHONE_NUMBER';
 

--- a/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
+++ b/db/migrations/sdp-migrations/2024-10-31.0-disbursement-add-registration-contact-type.sql
@@ -8,9 +8,16 @@ CREATE TYPE registration_contact_types AS ENUM (
     'PHONE_NUMBER_AND_WALLET_ADDRESS'
 );
 
--- TODO: create without the NOT NULL constraint, update the existing data, then add the NOT NULL constraint
 ALTER TABLE disbursements
-    ADD COLUMN registration_contact_type registration_contact_types NOT NULL DEFAULT 'PHONE_NUMBER';
+    ADD COLUMN registration_contact_type registration_contact_types;
+
+UPDATE disbursements
+    SET registration_contact_type = 'PHONE_NUMBER'
+    WHERE registration_contact_type IS NULL;
+
+ALTER TABLE disbursements
+    ALTER COLUMN registration_contact_type SET NOT NULL;
+
 
 -- +migrate Down
 ALTER TABLE disbursements

--- a/dev/migrate_1.1.6_to_2.0.0.sh
+++ b/dev/migrate_1.1.6_to_2.0.0.sh
@@ -114,7 +114,6 @@ ALTER TABLE public.receiver_verifications
 		USING verification_field::text::sdp_${tenant}.verification_type;
 INSERT INTO sdp_${tenant}.receiver_verifications SELECT * FROM public.receiver_verifications;
 
--- TODO: create without the NOT NULL constraint, update the existing data, then add the NOT NULL constraint
 ALTER TABLE public.disbursements
 	ALTER COLUMN status DROP DEFAULT,
 	ALTER COLUMN status TYPE sdp_${tenant}.disbursement_status

--- a/dev/migrate_1.1.6_to_2.0.0.sh
+++ b/dev/migrate_1.1.6_to_2.0.0.sh
@@ -114,6 +114,7 @@ ALTER TABLE public.receiver_verifications
 		USING verification_field::text::sdp_${tenant}.verification_type;
 INSERT INTO sdp_${tenant}.receiver_verifications SELECT * FROM public.receiver_verifications;
 
+-- TODO: create without the NOT NULL constraint, update the existing data, then add the NOT NULL constraint
 ALTER TABLE public.disbursements
 	ALTER COLUMN status DROP DEFAULT,
 	ALTER COLUMN status TYPE sdp_${tenant}.disbursement_status

--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -34,28 +34,6 @@ type Disbursement struct {
 	*DisbursementStats
 }
 
-type RegistrationContactType string
-
-const (
-	// RegistrationContactTypeEmail is "EMAIL"
-	RegistrationContactTypeEmail RegistrationContactType = RegistrationContactType(ReceiverContactTypeEmail)
-	// RegistrationContactTypePhone is "PHONE_NUMBER"
-	RegistrationContactTypePhone RegistrationContactType = RegistrationContactType(ReceiverContactTypeSMS)
-	// RegistrationContactTypeEmailAndWalletAddress is "EMAIL_AND_WALLET_ADDRESS"
-	RegistrationContactTypeEmailAndWalletAddress RegistrationContactType = RegistrationContactType(string(ReceiverContactTypeEmail) + "_AND_WALLET_ADDRESS")
-	// RegistrationContactTypePhoneAndWalletAddress is "PHONE_NUMBER_AND_WALLET_ADDRESS"
-	RegistrationContactTypePhoneAndWalletAddress RegistrationContactType = RegistrationContactType(string(ReceiverContactTypeSMS) + "_AND_WALLET_ADDRESS")
-)
-
-func AllRegistrationContactTypes() []RegistrationContactType {
-	return []RegistrationContactType{
-		RegistrationContactTypeEmail,
-		RegistrationContactTypeEmailAndWalletAddress,
-		RegistrationContactTypePhone,
-		RegistrationContactTypePhoneAndWalletAddress,
-	}
-}
-
 type DisbursementStatusHistory []DisbursementStatusHistoryEntry
 
 type DisbursementStats struct {

--- a/internal/data/disbursements_test.go
+++ b/internal/data/disbursements_test.go
@@ -45,6 +45,7 @@ func Test_DisbursementModelInsert(t *testing.T) {
 		Wallet:                              wallet,
 		VerificationField:                   VerificationTypeDateOfBirth,
 		ReceiverRegistrationMessageTemplate: smsTemplate,
+		RegistrationContactType:             RegistrationContactTypePhone,
 	}
 
 	t.Run("returns error when disbursement already exists", func(t *testing.T) {

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -576,6 +576,9 @@ func CreateDisbursementFixture(t *testing.T, ctx context.Context, sqlExec db.SQL
 	if d.VerificationField == "" {
 		d.VerificationField = VerificationTypeDateOfBirth
 	}
+	if d.RegistrationContactType == "" {
+		d.RegistrationContactType = RegistrationContactTypePhone
+	}
 
 	// insert disbursement
 	if d.StatusHistory == nil {
@@ -648,6 +651,10 @@ func CreateDraftDisbursementFixture(t *testing.T, ctx context.Context, sqlExec d
 
 	if insert.VerificationField == "" {
 		insert.VerificationField = VerificationTypeDateOfBirth
+	}
+
+	if insert.RegistrationContactType == "" {
+		insert.RegistrationContactType = RegistrationContactTypePhone
 	}
 
 	id, err := model.Insert(ctx, &insert)

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -576,7 +576,7 @@ func CreateDisbursementFixture(t *testing.T, ctx context.Context, sqlExec db.SQL
 	if d.VerificationField == "" {
 		d.VerificationField = VerificationTypeDateOfBirth
 	}
-	if d.RegistrationContactType == "" {
+	if utils.IsEmpty(d.RegistrationContactType) {
 		d.RegistrationContactType = RegistrationContactTypePhone
 	}
 
@@ -653,7 +653,7 @@ func CreateDraftDisbursementFixture(t *testing.T, ctx context.Context, sqlExec d
 		insert.VerificationField = VerificationTypeDateOfBirth
 	}
 
-	if insert.RegistrationContactType == "" {
+	if utils.IsEmpty(insert.RegistrationContactType) {
 		insert.RegistrationContactType = RegistrationContactTypePhone
 	}
 

--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -156,6 +156,7 @@ SELECT
 	d.status as "disbursement.status",
 	d.created_at as "disbursement.created_at",
 	d.updated_at as "disbursement.updated_at",
+	d.registration_contact_type as "disbursement.registration_contact_type",
 	a.id as "asset.id",
 	a.code as "asset.code",
 	a.issuer as "asset.issuer",

--- a/internal/data/registration_contact_type.go
+++ b/internal/data/registration_contact_type.go
@@ -56,12 +56,15 @@ func (rct RegistrationContactType) MarshalJSON() ([]byte, error) {
 }
 
 func (rct *RegistrationContactType) UnmarshalJSON(data []byte) error {
-	var typeStr string
-	if err := json.Unmarshal(data, &typeStr); err != nil {
+	var strValue string
+	if err := json.Unmarshal(data, &strValue); err != nil {
 		return err
 	}
 
-	return rct.ParseFromString(typeStr)
+	if strValue == "" {
+		return nil
+	}
+	return rct.ParseFromString(strValue)
 }
 
 func (rct RegistrationContactType) Value() (driver.Value, error) {
@@ -78,7 +81,12 @@ func (rct *RegistrationContactType) Scan(value interface{}) error {
 		return fmt.Errorf("unexpected type for RegistrationContactType %T", value)
 	}
 
-	return rct.ParseFromString(string(byteValue))
+	strValue := string(byteValue)
+	if strValue == "" {
+		return nil
+	}
+
+	return rct.ParseFromString(strValue)
 }
 
 var (

--- a/internal/data/registration_contact_type.go
+++ b/internal/data/registration_contact_type.go
@@ -63,9 +63,6 @@ func (rct *RegistrationContactType) UnmarshalJSON(data []byte) error {
 	return rct.parseFromString(typeStr)
 }
 
-var _ json.Marshaler = (*RegistrationContactType)(nil)
-var _ json.Unmarshaler = (*RegistrationContactType)(nil)
-
 func (rct RegistrationContactType) Value() (driver.Value, error) {
 	return rct.String(), nil
 }
@@ -83,5 +80,9 @@ func (rct *RegistrationContactType) Scan(value interface{}) error {
 	return rct.parseFromString(string(byteValue))
 }
 
-var _ driver.Valuer = (*RegistrationContactType)(nil)
-var _ sql.Scanner = (*RegistrationContactType)(nil)
+var (
+	_ json.Marshaler   = (*RegistrationContactType)(nil)
+	_ json.Unmarshaler = (*RegistrationContactType)(nil)
+	_ driver.Valuer    = (*RegistrationContactType)(nil)
+	_ sql.Scanner      = (*RegistrationContactType)(nil)
+)

--- a/internal/data/registration_contact_type.go
+++ b/internal/data/registration_contact_type.go
@@ -29,13 +29,14 @@ func (rct RegistrationContactType) String() string {
 	return string(rct.ReceiverContactType)
 }
 
-// parseFromString parses the string, setting ReceiverContactType and IncludesWalletAddress based on suffix.
-func (rct *RegistrationContactType) parseFromString(input string) error {
+// ParseFromString parses the string, setting ReceiverContactType and IncludesWalletAddress based on suffix.
+func (rct *RegistrationContactType) ParseFromString(input string) error {
+	input = strings.ToUpper(strings.TrimSpace(input))
 	rct.IncludesWalletAddress = strings.HasSuffix(input, "_AND_WALLET_ADDRESS")
 	rct.ReceiverContactType = ReceiverContactType(strings.TrimSuffix(input, "_AND_WALLET_ADDRESS"))
 
 	if !slices.Contains(GetAllReceiverContactTypes(), rct.ReceiverContactType) {
-		return fmt.Errorf("unknown ReceiverContactType = %s", rct.ReceiverContactType)
+		return fmt.Errorf("unknown ReceiverContactType %q", rct.ReceiverContactType)
 	}
 
 	return nil
@@ -60,7 +61,7 @@ func (rct *RegistrationContactType) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return rct.parseFromString(typeStr)
+	return rct.ParseFromString(typeStr)
 }
 
 func (rct RegistrationContactType) Value() (driver.Value, error) {
@@ -77,7 +78,7 @@ func (rct *RegistrationContactType) Scan(value interface{}) error {
 		return fmt.Errorf("unexpected type for RegistrationContactType %T", value)
 	}
 
-	return rct.parseFromString(string(byteValue))
+	return rct.ParseFromString(string(byteValue))
 }
 
 var (

--- a/internal/data/registration_contact_type.go
+++ b/internal/data/registration_contact_type.go
@@ -1,0 +1,87 @@
+package data
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// RegistrationContactType represents the type of contact information to be used when creating and validating a disbursement.
+type RegistrationContactType struct {
+	ReceiverContactType   ReceiverContactType `json:"registration_contact_type"`
+	IncludesWalletAddress bool                `json:"includes_wallet_address"`
+}
+
+var (
+	RegistrationContactTypeEmail                 = RegistrationContactType{ReceiverContactTypeEmail, false}
+	RegistrationContactTypePhone                 = RegistrationContactType{ReceiverContactTypeSMS, false}
+	RegistrationContactTypeEmailAndWalletAddress = RegistrationContactType{ReceiverContactTypeEmail, true}
+	RegistrationContactTypePhoneAndWalletAddress = RegistrationContactType{ReceiverContactTypeSMS, true}
+)
+
+func (rct RegistrationContactType) String() string {
+	if rct.IncludesWalletAddress {
+		return fmt.Sprintf("%s_AND_WALLET_ADDRESS", rct.ReceiverContactType)
+	}
+	return string(rct.ReceiverContactType)
+}
+
+// parseFromString parses the string, setting ReceiverContactType and IncludesWalletAddress based on suffix.
+func (rct *RegistrationContactType) parseFromString(input string) error {
+	rct.IncludesWalletAddress = strings.HasSuffix(input, "_AND_WALLET_ADDRESS")
+	rct.ReceiverContactType = ReceiverContactType(strings.TrimSuffix(input, "_AND_WALLET_ADDRESS"))
+
+	if !slices.Contains(GetAllReceiverContactTypes(), rct.ReceiverContactType) {
+		return fmt.Errorf("unknown ReceiverContactType = %s", rct.ReceiverContactType)
+	}
+
+	return nil
+}
+
+func AllRegistrationContactTypes() []RegistrationContactType {
+	return []RegistrationContactType{
+		RegistrationContactTypeEmail,
+		RegistrationContactTypeEmailAndWalletAddress,
+		RegistrationContactTypePhone,
+		RegistrationContactTypePhoneAndWalletAddress,
+	}
+}
+
+func (rct RegistrationContactType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rct.String())
+}
+
+func (rct *RegistrationContactType) UnmarshalJSON(data []byte) error {
+	var typeStr string
+	if err := json.Unmarshal(data, &typeStr); err != nil {
+		return err
+	}
+
+	return rct.parseFromString(typeStr)
+}
+
+var _ json.Marshaler = (*RegistrationContactType)(nil)
+var _ json.Unmarshaler = (*RegistrationContactType)(nil)
+
+func (rct RegistrationContactType) Value() (driver.Value, error) {
+	return rct.String(), nil
+}
+
+func (rct *RegistrationContactType) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+
+	byteValue, ok := value.([]byte)
+	if !ok {
+		return fmt.Errorf("unexpected type for RegistrationContactType %T", value)
+	}
+
+	return rct.parseFromString(string(byteValue))
+}
+
+var _ driver.Valuer = (*RegistrationContactType)(nil)
+var _ sql.Scanner = (*RegistrationContactType)(nil)

--- a/internal/integrationtests/integration_tests.go
+++ b/internal/integrationtests/integration_tests.go
@@ -19,9 +19,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
-const (
-	paymentProcessTimeSeconds = 30
-)
+const paymentProcessTimeSeconds = 30
 
 type IntegrationTestsInterface interface {
 	StartIntegrationTests(ctx context.Context, opts IntegrationTestsOpts) error
@@ -33,6 +31,7 @@ type IntegrationTestsOpts struct {
 	TenantName                 string
 	UserEmail                  string
 	UserPassword               string
+	RegistrationContactType    data.RegistrationContactType
 	DistributionAccountType    string
 	DisbursedAssetCode         string
 	DisbursetAssetIssuer       string
@@ -176,11 +175,12 @@ func (it *IntegrationTestsService) StartIntegrationTests(ctx context.Context, op
 
 	log.Ctx(ctx).Info("Creating disbursement using server API")
 	disbursement, err := it.serverAPI.CreateDisbursement(ctx, authToken, &httphandler.PostDisbursementRequest{
-		Name:              opts.DisbursementName,
-		CountryCode:       "USA",
-		WalletID:          wallet.ID,
-		AssetID:           asset.ID,
-		VerificationField: data.VerificationTypeDateOfBirth,
+		Name:                    opts.DisbursementName,
+		CountryCode:             "USA",
+		WalletID:                wallet.ID,
+		AssetID:                 asset.ID,
+		VerificationField:       data.VerificationTypeDateOfBirth,
+		RegistrationContactType: opts.RegistrationContactType,
 	})
 	if err != nil {
 		return fmt.Errorf("creating disbursement: %w", err)

--- a/internal/integrationtests/scripts/e2e_integration_test.sh
+++ b/internal/integrationtests/scripts/e2e_integration_test.sh
@@ -22,6 +22,9 @@ wait_for_server() {
 }
 
 accountTypes=("DISTRIBUTION_ACCOUNT.STELLAR.ENV" "DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT")
+if [ -z "${REGISTRATION_CONTACT_TYPE+x}" ]; then
+  export REGISTRATION_CONTACT_TYPE="PHONE_NUMBER"
+fi
 for accountType in "${accountTypes[@]}"; do
   export DISTRIBUTION_ACCOUNT_TYPE=$accountType
   if [ $accountType="DISTRIBUTION_ACCOUNT.STELLAR.ENV" ]

--- a/internal/integrationtests/server_api.go
+++ b/internal/integrationtests/server_api.go
@@ -118,7 +118,7 @@ func (sa *ServerApiIntegrationTests) CreateDisbursement(ctx context.Context, aut
 
 	if resp.StatusCode/100 != 2 {
 		logErrorResponses(ctx, resp.Body)
-		return nil, fmt.Errorf("error trying to create a new disbursement on the server API")
+		return nil, fmt.Errorf("trying to create a new disbursement on the server API")
 	}
 
 	disbursement := &data.Disbursement{}

--- a/internal/integrationtests/server_api_test.go
+++ b/internal/integrationtests/server_api_test.go
@@ -127,7 +127,7 @@ func Test_CreateDisbursement(t *testing.T) {
 		httpClientMock.On("Do", mock.AnythingOfType("*http.Request")).Return(response, nil).Once()
 
 		d, err := sa.CreateDisbursement(ctx, authToken, reqBody)
-		require.EqualError(t, err, "error trying to create a new disbursement on the server API")
+		require.EqualError(t, err, "trying to create a new disbursement on the server API")
 		assert.Empty(t, d)
 
 		httpClientMock.AssertExpectations(t)

--- a/internal/integrationtests/utils.go
+++ b/internal/integrationtests/utils.go
@@ -19,6 +19,7 @@ import (
 // logErrorResponses logs the response body for requests with error status.
 func logErrorResponses(ctx context.Context, body io.ReadCloser) {
 	respBody, err := io.ReadAll(body)
+	defer body.Close()
 	if err == nil {
 		log.Ctx(ctx).Infof("error message response: %s", string(respBody))
 	}

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -99,6 +99,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 		  "wallet_id": "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
 		  "asset_id": "61dbfa89-943a-413c-b862-a2177384d321",
 		  "country_code": "UKR",
+		  "registration_contact_type": "PHONE_NUMBER",
 		  "verification_field": "date_of_birth"
 		}`
 
@@ -119,6 +120,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 		   "name": "My New Disbursement name 5",
 		   "asset_id": "61dbfa89-943a-413c-b862-a2177384d321",
 		   "country_code": "UKR",
+		   "registration_contact_type": "PHONE_NUMBER",
 		   "verification_field": "date_of_birth"
 		}`
 
@@ -133,6 +135,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 		   "name": "My New Disbursement name 5",
 		   "wallet_id": "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
 		   "country_code": "UKR",
+		   "registration_contact_type": "PHONE_NUMBER",
 		   "verification_field": "date_of_birth"
 		}`
 
@@ -147,6 +150,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 		   "name": "My New Disbursement name 5",
 		   "wallet_id": "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
 		   "asset_id": "61dbfa89-943a-413c-b862-a2177384d321",
+		   "registration_contact_type": "PHONE_NUMBER",
 		   "verification_field": "date_of_birth"
 		}`
 
@@ -157,10 +161,11 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 
 	t.Run("returns error when no verification field is provided", func(t *testing.T) {
 		requestBody, err := json.Marshal(PostDisbursementRequest{
-			Name:        "disbursement 1",
-			CountryCode: country.Code,
-			AssetID:     asset.ID,
-			WalletID:    enabledWallet.ID,
+			Name:                    "disbursement 1",
+			CountryCode:             country.Code,
+			AssetID:                 asset.ID,
+			WalletID:                enabledWallet.ID,
+			RegistrationContactType: data.RegistrationContactTypePhone,
 		})
 		require.NoError(t, err)
 
@@ -171,11 +176,12 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 
 	t.Run("returns error when wallet_id is not valid", func(t *testing.T) {
 		requestBody, err := json.Marshal(PostDisbursementRequest{
-			Name:              "disbursement 1",
-			CountryCode:       country.Code,
-			AssetID:           asset.ID,
-			WalletID:          "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
-			VerificationField: data.VerificationTypeDateOfBirth,
+			Name:                    "disbursement 1",
+			CountryCode:             country.Code,
+			AssetID:                 asset.ID,
+			WalletID:                "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
+			RegistrationContactType: data.RegistrationContactTypePhone,
+			VerificationField:       data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
 
@@ -187,11 +193,12 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 	t.Run("returns error when wallet is not enabled", func(t *testing.T) {
 		data.EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, false, disabledWallet.ID)
 		requestBody, err := json.Marshal(PostDisbursementRequest{
-			Name:              "disbursement 1",
-			CountryCode:       country.Code,
-			AssetID:           asset.ID,
-			WalletID:          disabledWallet.ID,
-			VerificationField: data.VerificationTypeDateOfBirth,
+			Name:                    "disbursement 1",
+			CountryCode:             country.Code,
+			AssetID:                 asset.ID,
+			WalletID:                disabledWallet.ID,
+			RegistrationContactType: data.RegistrationContactTypePhone,
+			VerificationField:       data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
 
@@ -202,11 +209,12 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 
 	t.Run("returns error when asset_id is not valid", func(t *testing.T) {
 		requestBody, err := json.Marshal(PostDisbursementRequest{
-			Name:              "disbursement 1",
-			CountryCode:       country.Code,
-			AssetID:           "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
-			WalletID:          enabledWallet.ID,
-			VerificationField: data.VerificationTypeDateOfBirth,
+			Name:                    "disbursement 1",
+			CountryCode:             country.Code,
+			AssetID:                 "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
+			WalletID:                enabledWallet.ID,
+			RegistrationContactType: data.RegistrationContactTypePhone,
+			VerificationField:       data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
 
@@ -217,11 +225,12 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 
 	t.Run("returns error when country_code is not valid", func(t *testing.T) {
 		requestBody, err := json.Marshal(PostDisbursementRequest{
-			Name:              "disbursement 1",
-			CountryCode:       "AAA",
-			AssetID:           asset.ID,
-			WalletID:          enabledWallet.ID,
-			VerificationField: data.VerificationTypeDateOfBirth,
+			Name:                    "disbursement 1",
+			CountryCode:             "AAA",
+			AssetID:                 asset.ID,
+			WalletID:                enabledWallet.ID,
+			RegistrationContactType: data.RegistrationContactTypePhone,
+			VerificationField:       data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
 
@@ -240,19 +249,19 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 		mMonitorService.On("MonitorCounters", monitor.DisbursementsCounterTag, labels.ToMap()).Return(nil).Once()
 
 		requestBody, err := json.Marshal(PostDisbursementRequest{
-			Name:              "disbursement 1",
-			CountryCode:       country.Code,
-			AssetID:           asset.ID,
-			WalletID:          enabledWallet.ID,
-			VerificationField: data.VerificationTypeDateOfBirth,
+			Name:                    "disbursement 1",
+			CountryCode:             country.Code,
+			AssetID:                 asset.ID,
+			WalletID:                enabledWallet.ID,
+			RegistrationContactType: data.RegistrationContactTypePhone,
+			VerificationField:       data.VerificationTypeDateOfBirth,
 		})
 		require.NoError(t, err)
-
-		want := `{"error":"disbursement already exists"}`
 
 		// create disbursement
 		assertPOSTResponse(t, ctx, handler, method, url, string(requestBody), "", http.StatusCreated)
 		// try creating again
+		want := `{"error":"disbursement already exists"}`
 		assertPOSTResponse(t, ctx, handler, method, url, string(requestBody), want, http.StatusConflict)
 	})
 
@@ -266,6 +275,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 			AssetID:                             asset.ID,
 			WalletID:                            enabledWallet.ID,
 			VerificationField:                   data.VerificationTypeDateOfBirth,
+			RegistrationContactType:             data.RegistrationContactTypePhone,
 			ReceiverRegistrationMessageTemplate: smsTemplate,
 		})
 		require.NoError(t, err)
@@ -288,6 +298,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 		assert.Equal(t, &enabledWallet, actualDisbursement.Wallet)
 		assert.Equal(t, country, actualDisbursement.Country)
 		assert.Equal(t, 1, len(actualDisbursement.StatusHistory))
+		assert.Equal(t, data.RegistrationContactTypePhone, actualDisbursement.RegistrationContactType)
 		assert.Equal(t, data.DraftDisbursementStatus, actualDisbursement.StatusHistory[0].Status)
 		assert.Equal(t, user.ID, actualDisbursement.StatusHistory[0].UserID)
 		assert.Equal(t, smsTemplate, actualDisbursement.ReceiverRegistrationMessageTemplate)

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -85,24 +85,24 @@ func (p PaymentsHandler) decorateWithCircleTransactionInfo(ctx context.Context, 
 
 func (p PaymentsHandler) GetPayment(w http.ResponseWriter, r *http.Request) {
 	paymentID := chi.URLParam(r, "id")
+	ctx := r.Context()
 
-	payment, err := p.Models.Payment.Get(r.Context(), paymentID, p.DBConnectionPool)
+	payment, err := p.Models.Payment.Get(ctx, paymentID, p.DBConnectionPool)
 	if err != nil {
 		if errors.Is(err, data.ErrRecordNotFound) {
 			errorResponse := fmt.Sprintf("Cannot retrieve payment with ID: %s", paymentID)
 			httperror.NotFound(errorResponse, err, nil).Render(w)
 			return
 		} else {
-			ctx := r.Context()
 			msg := fmt.Sprintf("Cannot retrieve payment with id %s", paymentID)
 			httperror.InternalError(ctx, msg, err, nil).Render(w)
 			return
 		}
 	}
 
-	payments, err := p.decorateWithCircleTransactionInfo(r.Context(), *payment)
+	payments, err := p.decorateWithCircleTransactionInfo(ctx, *payment)
 	if err != nil {
-		httperror.InternalError(r.Context(), "Cannot retrieve payment with circle info", err, nil).Render(w)
+		httperror.InternalError(ctx, "Cannot retrieve payment with circle info", err, nil).Render(w)
 		return
 	}
 

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -132,6 +132,7 @@ func Test_PaymentsHandlerGet(t *testing.T) {
 				"status": "DRAFT",
 				"created_at": %q,
 				"updated_at": %q,
+				"registration_contact_type": %q,
 				"receiver_registration_message_template":""
 			},
 			"asset": {
@@ -159,7 +160,7 @@ func Test_PaymentsHandlerGet(t *testing.T) {
 			"updated_at": %q,
 			"external_payment_id": %q
 		}`, payment.ID, payment.StellarTransactionID, payment.StellarOperationID, payment.StatusHistory[0].Timestamp.Format(time.RFC3339Nano),
-			disbursement.ID, disbursement.CreatedAt.Format(time.RFC3339Nano), disbursement.UpdatedAt.Format(time.RFC3339Nano),
+			disbursement.ID, disbursement.CreatedAt.Format(time.RFC3339Nano), disbursement.UpdatedAt.Format(time.RFC3339Nano), disbursement.RegistrationContactType,
 			asset.ID, receiverWallet.ID, receiver.ID, wallet.ID, receiverWallet.CreatedAt.Format(time.RFC3339Nano), receiverWallet.UpdatedAt.Format(time.RFC3339Nano),
 			payment.CreatedAt.Format(time.RFC3339Nano), payment.UpdatedAt.Format(time.RFC3339Nano),
 			payment.ExternalPaymentID)

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -160,7 +160,7 @@ func Test_PaymentsHandlerGet(t *testing.T) {
 			"updated_at": %q,
 			"external_payment_id": %q
 		}`, payment.ID, payment.StellarTransactionID, payment.StellarOperationID, payment.StatusHistory[0].Timestamp.Format(time.RFC3339Nano),
-			disbursement.ID, disbursement.CreatedAt.Format(time.RFC3339Nano), disbursement.UpdatedAt.Format(time.RFC3339Nano), disbursement.RegistrationContactType,
+			disbursement.ID, disbursement.CreatedAt.Format(time.RFC3339Nano), disbursement.UpdatedAt.Format(time.RFC3339Nano), disbursement.RegistrationContactType.String(),
 			asset.ID, receiverWallet.ID, receiver.ID, wallet.ID, receiverWallet.CreatedAt.Format(time.RFC3339Nano), receiverWallet.UpdatedAt.Format(time.RFC3339Nano),
 			payment.CreatedAt.Format(time.RFC3339Nano), payment.UpdatedAt.Format(time.RFC3339Nano),
 			payment.ExternalPaymentID)

--- a/internal/serve/httphandler/registration_contact_types.go
+++ b/internal/serve/httphandler/registration_contact_types.go
@@ -2,10 +2,8 @@ package httphandler
 
 import (
 	"net/http"
-	"slices"
 
 	"github.com/stellar/go/support/render/httpjson"
-	"golang.org/x/exp/maps"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 )
@@ -13,15 +11,5 @@ import (
 type RegistrationContactTypesHandler struct{}
 
 func (c RegistrationContactTypesHandler) Get(w http.ResponseWriter, r *http.Request) {
-	allTypes := data.GetAllReceiverContactTypes()
-	allTypesWithWalletAddress := make(map[string]bool, 2*len(allTypes))
-	for _, t := range allTypes {
-		allTypesWithWalletAddress[string(t)] = true
-		allTypesWithWalletAddress[string(t)+"_AND_WALLET_ADDRESS"] = true
-	}
-
-	sortedKeys := maps.Keys(allTypesWithWalletAddress)
-	slices.Sort(sortedKeys)
-
-	httpjson.Render(w, sortedKeys, httpjson.JSON)
+	httpjson.Render(w, data.AllRegistrationContactTypes(), httpjson.JSON)
 }


### PR DESCRIPTION
### What

Update `POST /disbursements` and `GET /disbursements` APIs to persist and return the Registration Contact Type

### Why

Address https://stellarorg.atlassian.net/browse/SDP-1370

### Pending

Under the common interest of merging this PR quickly, I'll address the following tasks in a future PR:
- [ ] Add more unit tests to the `POST /disbursements` endpoint to ensure all types of registration contact type are persisted
- [ ] Slightly refactor `data/disbursements.go` to make the Selector query string into a common constant
- [ ] Update the custom validator of `POST /disburements` so it actually does something. Right now it's barely useful and only increases complexity for no reason.
- [x] Remove the unused file `migrate_1.1.6_to_2.0.0.sh`.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
