### PR TITLE
[SDP-1380] Allow disbursement.verification_field to be empty

### DIFF
--- a/db/migrations/sdp-migrations/2024-11-01.1-disbursement-make-verification-field-nullable.sql
+++ b/db/migrations/sdp-migrations/2024-11-01.1-disbursement-make-verification-field-nullable.sql
@@ -1,0 +1,7 @@
+-- This migration drops the verification_field NOT NULL constraint from the disbursements table.
+
+-- +migrate Up
+ALTER TABLE disbursements
+    ALTER COLUMN verification_field DROP NOT NULL;
+
+-- +migrate Down

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -61,11 +61,13 @@ func (d DisbursementHandler) validateRequest(req PostDisbursementRequest) *valid
 		"registration_contact_type",
 		fmt.Sprintf("registration_contact_type must be one of %v", data.AllRegistrationContactTypes()),
 	)
-	v.Check(
-		slices.Contains(data.GetAllVerificationTypes(), req.VerificationField),
-		"verification_field",
-		fmt.Sprintf("verification_field must be one of %v", data.GetAllVerificationTypes()),
-	)
+	if !req.RegistrationContactType.IncludesWalletAddress {
+		v.Check(
+			slices.Contains(data.GetAllVerificationTypes(), req.VerificationField),
+			"verification_field",
+			fmt.Sprintf("verification_field must be one of %v", data.GetAllVerificationTypes()),
+		)
+	}
 
 	return v
 }

--- a/internal/utils/sql.go
+++ b/internal/utils/sql.go
@@ -1,0 +1,10 @@
+package utils
+
+import "database/sql"
+
+func SQLNullString(s string) sql.NullString {
+	return sql.NullString{
+		String: s,
+		Valid:  s != "",
+	}
+}


### PR DESCRIPTION
### What

Allow disbursement.verification_field to be empty

### Why

Address https://stellarorg.atlassian.net/browse/SDP-1380

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
