### PR TITLE
[SDP-1364] Prevent user from setting a custom invite template with JS or HTML

### DIFF
--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -60,6 +60,7 @@ func (d DisbursementHandler) validateRequest(req PostDisbursementRequest) *valid
 		"registration_contact_type",
 		fmt.Sprintf("registration_contact_type must be one of %v", data.AllRegistrationContactTypes()),
 	)
+	v.CheckError(utils.ValidateNoHTMLNorJSNorCSS(req.ReceiverRegistrationMessageTemplate), "receiver_registration_message_template", "receiver_registration_message_template cannot contain HTML, JS or CSS")
 	if !req.RegistrationContactType.IncludesWalletAddress {
 		v.Check(
 			slices.Contains(data.GetAllVerificationTypes(), req.VerificationField),

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -73,6 +73,34 @@ func Test_DisbursementHandler_validateRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "🔴 receiver_registration_message_template contains HTML",
+			request: PostDisbursementRequest{
+				Name:                                "disbursement 1",
+				AssetID:                             "61dbfa89-943a-413c-b862-a2177384d321",
+				WalletID:                            "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
+				RegistrationContactType:             data.RegistrationContactTypePhone,
+				VerificationField:                   data.VerificationTypeDateOfBirth,
+				ReceiverRegistrationMessageTemplate: "<a href='evil.com'>Redeem money</a>",
+			},
+			expectedErrors: map[string]interface{}{
+				"receiver_registration_message_template": "receiver_registration_message_template cannot contain HTML, JS or CSS",
+			},
+		},
+		{
+			name: "🔴 receiver_registration_message_template contains JS",
+			request: PostDisbursementRequest{
+				Name:                                "disbursement 1",
+				AssetID:                             "61dbfa89-943a-413c-b862-a2177384d321",
+				WalletID:                            "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
+				RegistrationContactType:             data.RegistrationContactTypePhone,
+				VerificationField:                   data.VerificationTypeDateOfBirth,
+				ReceiverRegistrationMessageTemplate: "javascript:alert(localStorage.getItem('sdp_session'))",
+			},
+			expectedErrors: map[string]interface{}{
+				"receiver_registration_message_template": "receiver_registration_message_template cannot contain HTML, JS or CSS",
+			},
+		},
+		{
 			name: "🟢 all fields are valid",
 			request: PostDisbursementRequest{
 				Name:                    "disbursement 1",
@@ -80,6 +108,17 @@ func Test_DisbursementHandler_validateRequest(t *testing.T) {
 				WalletID:                "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
 				RegistrationContactType: data.RegistrationContactTypePhone,
 				VerificationField:       data.VerificationTypeDateOfBirth,
+			},
+		},
+		{
+			name: "🟢 all fields are valid w/ receiver_registration_message_template",
+			request: PostDisbursementRequest{
+				Name:                                "disbursement 1",
+				AssetID:                             "61dbfa89-943a-413c-b862-a2177384d321",
+				WalletID:                            "aab4a4a9-2493-4f37-9741-01d5bd31d68b",
+				RegistrationContactType:             data.RegistrationContactTypePhone,
+				VerificationField:                   data.VerificationTypeDateOfBirth,
+				ReceiverRegistrationMessageTemplate: "My custom invitation message",
 			},
 		},
 	}

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -1,19 +1,19 @@
 package httphandler
 
 import (
-	// Don't remove the `image/jpeg` and `image/png` packages import unless
-	// the `image` package is no longer necessary.
-	// It registers the `Decoders` to handle the image decoding - `image.Decode`.
-	// See https://pkg.go.dev/image#pkg-overview
-	_ "image/jpeg"
-	_ "image/png"
-
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"image"
+
+	// Don't remove the `image/jpeg` and `image/png` packages import unless
+	// the `image` package is no longer necessary.
+	// It registers the `Decoders` to handle the image decoding - `image.Decode`.
+	// See https://pkg.go.dev/image#pkg-overview
+	_ "image/jpeg"
+	_ "image/png"
 	"io"
 	"io/fs"
 	"net/http"

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -202,7 +202,7 @@ func ValidateURLScheme(link string, scheme ...string) error {
 // ValidateNoHTMLNorJSNorCSS detects HTML, <script> tags, inline JavaScript, and CSS styles in a string
 func ValidateNoHTMLNorJSNorCSS(input string) error {
 	// Regular expressions to catch HTML tags, <script> tags, javascript: URIs, <style> tags, and inline style attributes
-	htmlPattern := regexp.MustCompile(`</?[a-z][\s\S]*>`)
+	htmlPattern := regexp.MustCompile(`</(?i)[a-z][\s\S]*>`)
 	scriptTagPattern := regexp.MustCompile(`(?i)<script[\s\S]*?>[\s\S]*?</script>`)
 	inlineJSURIPattern := regexp.MustCompile(`(?i)javascript:[\s\S]*`)
 	styleTagPattern := regexp.MustCompile(`(?i)<style[\s\S]*?>[\s\S]*?</style>`)

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -203,15 +203,12 @@ func ValidateURLScheme(link string, scheme ...string) error {
 func ValidateNoHTMLNorJSNorCSS(input string) error {
 	// Regular expressions to catch HTML tags, <script> tags, javascript: URIs, <style> tags, and inline style attributes
 	htmlPattern := regexp.MustCompile(`</(?i)[a-z][\s\S]*>`)
-	scriptTagPattern := regexp.MustCompile(`(?i)<script[\s\S]*?>[\s\S]*?</script>`)
 	inlineJSURIPattern := regexp.MustCompile(`(?i)javascript:[\s\S]*`)
-	styleTagPattern := regexp.MustCompile(`(?i)<style[\s\S]*?>[\s\S]*?</style>`)
 	inlineStyleAttrPattern := regexp.MustCompile(`(?i)style=['"][\s\S]*?['"]`)
 	cssExpressionPattern := regexp.MustCompile(`(?i)expression\(`)
 
 	// Check if any pattern matches the input
-	if htmlPattern.MatchString(input) || scriptTagPattern.MatchString(input) ||
-		inlineJSURIPattern.MatchString(input) || styleTagPattern.MatchString(input) ||
+	if htmlPattern.MatchString(input) || inlineJSURIPattern.MatchString(input) ||
 		inlineStyleAttrPattern.MatchString(input) || cssExpressionPattern.MatchString(input) {
 		return errors.New("input contains HTML, JavaScript, or CSS content")
 	}

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -198,3 +198,23 @@ func ValidateURLScheme(link string, scheme ...string) error {
 
 	return nil
 }
+
+// ValidateNoHTMLNorJSNorCSS detects HTML, <script> tags, inline JavaScript, and CSS styles in a string
+func ValidateNoHTMLNorJSNorCSS(input string) error {
+	// Regular expressions to catch HTML tags, <script> tags, javascript: URIs, <style> tags, and inline style attributes
+	htmlPattern := regexp.MustCompile(`</?[a-z][\s\S]*>`)
+	scriptTagPattern := regexp.MustCompile(`(?i)<script[\s\S]*?>[\s\S]*?</script>`)
+	inlineJSURIPattern := regexp.MustCompile(`(?i)javascript:[\s\S]*`)
+	styleTagPattern := regexp.MustCompile(`(?i)<style[\s\S]*?>[\s\S]*?</style>`)
+	inlineStyleAttrPattern := regexp.MustCompile(`(?i)style=['"][\s\S]*?['"]`)
+	cssExpressionPattern := regexp.MustCompile(`(?i)expression\(`)
+
+	// Check if any pattern matches the input
+	if htmlPattern.MatchString(input) || scriptTagPattern.MatchString(input) ||
+		inlineJSURIPattern.MatchString(input) || styleTagPattern.MatchString(input) ||
+		inlineStyleAttrPattern.MatchString(input) || cssExpressionPattern.MatchString(input) {
+		return errors.New("input contains HTML, JavaScript, or CSS content")
+	}
+
+	return nil
+}

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -295,11 +295,17 @@ func Test_ValidateURLScheme(t *testing.T) {
 func Test_ValidateNoHTMLNorJSNorCSS(t *testing.T) {
 	testCases := []string{
 		"<a href='evil.com'>Click here</a>",
+		"<A HREF='evil.com'>Click here</A>",
 		"<style>body { background: red; }</style>",
+		"<STYLE>body { background: red; }</STYLE>",
 		"<div style='color: red;'>Test</div>",
+		"<DIV STYLE='color: red;'>Test</DIV>",
 		"expression(alert('XSS'))",
+		"EXPRESSION(ALERT('XSS'))",
 		"javascript:alert(localStorage.getItem('sdp_session'))",
+		"JAVASCRIPT:ALERT(localStorage.getItem('sdp_session'))",
 		"javascript:alert('XSS')",
+		"JAVASCRIPT:ALERT('XSS')",
 	}
 
 	for _, tc := range testCases {

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ValidatePhoneNumber(t *testing.T) {
@@ -287,6 +288,24 @@ func Test_ValidateURLScheme(t *testing.T) {
 			} else {
 				assert.ErrorContains(t, err, tc.wantErrContains)
 			}
+		})
+	}
+}
+
+func Test_ValidateNoHTMLNorJSNorCSS(t *testing.T) {
+	testCases := []string{
+		"<a href='evil.com'>Click here</a>",
+		"<style>body { background: red; }</style>",
+		"<div style='color: red;'>Test</div>",
+		"expression(alert('XSS'))",
+		"javascript:alert(localStorage.getItem('sdp_session'))",
+		"javascript:alert('XSS')",
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			err := ValidateNoHTMLNorJSNorCSS(tc)
+			require.Error(t, err, "ValidateNoHTMLNorJSNorCSS(%q) didn't catch the error", tc)
 		})
 	}
 }


### PR DESCRIPTION
### What

Prevent user from setting a custom invite template with JS or HTML

### Why

Address https://stellarorg.atlassian.net/browse/SDP-1364

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
