### PR TITLE
[Chore] Change order of the registration types

### DIFF
--- a/internal/data/registration_contact_type.go
+++ b/internal/data/registration_contact_type.go
@@ -45,8 +45,8 @@ func (rct *RegistrationContactType) ParseFromString(input string) error {
 func AllRegistrationContactTypes() []RegistrationContactType {
 	return []RegistrationContactType{
 		RegistrationContactTypeEmail,
-		RegistrationContactTypeEmailAndWalletAddress,
 		RegistrationContactTypePhone,
+		RegistrationContactTypeEmailAndWalletAddress,
 		RegistrationContactTypePhoneAndWalletAddress,
 	}
 }

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -232,7 +232,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 						"name": "name is required",
 						"wallet_id": "wallet_id is required",
 						"asset_id": "asset_id is required",
-						"registration_contact_type": "registration_contact_type must be one of [EMAIL EMAIL_AND_WALLET_ADDRESS PHONE_NUMBER PHONE_NUMBER_AND_WALLET_ADDRESS]",
+						"registration_contact_type": "registration_contact_type must be one of [EMAIL PHONE_NUMBER EMAIL_AND_WALLET_ADDRESS PHONE_NUMBER_AND_WALLET_ADDRESS]",
 						"verification_field": "verification_field must be one of [DATE_OF_BIRTH YEAR_MONTH PIN NATIONAL_ID_NUMBER]"
 					}
 				}`

--- a/internal/serve/httphandler/registration_contact_types_test.go
+++ b/internal/serve/httphandler/registration_contact_types_test.go
@@ -24,8 +24,8 @@ func Test_RegistrationContactTypesHandler_Get(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	expectedJSON := `[
 		"EMAIL",
-		"EMAIL_AND_WALLET_ADDRESS",
 		"PHONE_NUMBER",
+		"EMAIL_AND_WALLET_ADDRESS",
 		"PHONE_NUMBER_AND_WALLET_ADDRESS"
 	]`
 	assert.JSONEq(t, expectedJSON, string(respBody))


### PR DESCRIPTION
### What

Change order of the registration types

### Why

To have non-wallets options at the top and wallets options at the bottom, according with product feedback.

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
