### PR TITLE
[SDP-1430] Run e2e tests workflow only prior to publishing Docker images

### DIFF
--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -79,7 +79,7 @@ jobs:
           docker restart e2e-anchor-platform
         shell: bash
 
-      - name: Wait for Anchor Platform at both localhost:8080/health and localhost:8085/health
+      - name: Wait for Anchor Platform and SDP to be up
         run: |
           wait_for_server() {
             local endpoint=$1
@@ -97,6 +97,7 @@ jobs:
             echo "Server at $endpoint is up."
           }
 
+          wait_for_server http://localhost:8000/health 120
           wait_for_server http://localhost:8080/health 120
           wait_for_server http://localhost:8085/health 120
         shell: bash

--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -1,11 +1,7 @@
 name: Integration Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_call: # allows this workflow to be called from another workflow
+  workflow_call: # allows this workflow to be called from another workflow, like `docker_image_public_release`
 
 env:
   USER_EMAIL: "sdp_user@stellar.org"

--- a/.github/workflows/singletenant_to_multitenant_db_migration_test.yml
+++ b/.github/workflows/singletenant_to_multitenant_db_migration_test.yml
@@ -48,6 +48,27 @@ jobs:
           docker cp internal/integrationtests/resources/single_tenant_dump.sql e2e-sdp-v2-database:/tmp/single_tenant_dump.sql
           docker exec e2e-sdp-v2-database bash -c "psql -d $DATABASE_URL -f /tmp/single_tenant_dump.sql"
 
+      - name: Wait for SDP to be up at localhost:8000/health
+        run: |
+          wait_for_server() {
+            local endpoint=$1
+            local max_wait_time=$2
+
+            SECONDS=0
+            while ! curl -s $endpoint > /dev/null; do
+              echo "Waiting for server at $endpoint to be up... $SECONDS seconds elapsed"
+              sleep 4
+              if [ $SECONDS -ge $max_wait_time ]; then
+                echo "Server at $endpoint is not up after $max_wait_time seconds."
+                exit 1
+              fi
+            done
+            echo "Server at $endpoint is up."
+          }
+
+          wait_for_server http://localhost:8000/health 120
+        shell: bash
+
       - name: Provision New Tenant
         run: |
           adminAccount="SDP-admin"


### PR DESCRIPTION
### What

Run e2e tests workflow only prior to publishing Docker images.

### Why

The PRs are taking too long to have their e2e tests approved, and we don't really need this being executed on every PR.

Also, due to the sequence number this cannot be parallelized, which leads to this workflow failing when running in parallel PRs.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
