### PR TITLE
[SDP-1311] Make Dashboard User E-mails case insensitive 

### DIFF
--- a/db/migrations/auth-migrations/2024-11-29.0-sanitize-email-auth_users-table.sql
+++ b/db/migrations/auth-migrations/2024-11-29.0-sanitize-email-auth_users-table.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+UPDATE auth_users
+SET
+    email = LOWER(TRIM(email));
+
+-- +migrate Down
+-- No down migration needed as email sanitization cannot be reversed

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -147,7 +147,7 @@ func (am *defaultAuthManager) AnyRolesInTokenUser(ctx context.Context, tokenStri
 func (am *defaultAuthManager) CreateUser(ctx context.Context, user *User, password string) (*User, error) {
 	user, err := am.authenticator.CreateUser(ctx, user, password)
 	if err != nil {
-		return nil, fmt.Errorf("error creating user: %w", err)
+		return nil, fmt.Errorf("creating user: %w", err)
 	}
 
 	return user, nil

--- a/stellar-auth/pkg/auth/auth_test.go
+++ b/stellar-auth/pkg/auth/auth_test.go
@@ -560,7 +560,7 @@ func Test_AuthManager_CreateUser(t *testing.T) {
 
 		u, err := authManager.CreateUser(ctx, user, password)
 
-		assert.EqualError(t, err, "error creating user: unexpected error")
+		assert.EqualError(t, err, "creating user: unexpected error")
 		assert.Nil(t, u)
 	})
 

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -71,7 +71,7 @@ func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, p
 		FROM
 			auth_users u
 		WHERE
-			LOWER(email) = LOWER($1) AND is_active = true
+			email = $1 AND is_active = true
 	`
 
 	au := authUser{}
@@ -274,7 +274,7 @@ func (a *defaultAuthenticator) ForgotPassword(ctx context.Context, sqlExec db.SQ
 			SELECT 1
 			FROM auth_user_password_reset ar
 			INNER JOIN auth_users au ON ar.auth_user_id = au.id
-			WHERE LOWER(au.email) = LOWER($1)
+			WHERE au.email = $1
 			AND ar.is_valid = true
 			AND (ar.created_at + INTERVAL '20 minutes') > now()
 		)
@@ -291,7 +291,7 @@ func (a *defaultAuthenticator) ForgotPassword(ctx context.Context, sqlExec db.SQ
 
 	q := `
 		WITH auth_user_reset_token_info AS (
-			SELECT id, $2 as reset_token FROM auth_users WHERE LOWER(email) = LOWER($1)
+			SELECT id, $2 as reset_token FROM auth_users WHERE email = $1
 		)
 		INSERT INTO
 			auth_user_password_reset (auth_user_id, token)

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -59,16 +59,19 @@ type authUser struct {
 }
 
 func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, password string) (*User, error) {
+	email = strings.TrimSpace(strings.ToLower(email))
+
 	const query = `
 		SELECT
 			u.id,
+			u.email,
 			u.first_name,
 			u.last_name,
 			u.encrypted_password
 		FROM
 			auth_users u
 		WHERE
-			email = $1 AND is_active = true
+			LOWER(email) = LOWER($1) AND is_active = true
 	`
 
 	au := authUser{}
@@ -91,7 +94,7 @@ func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, p
 
 	return &User{
 		ID:        au.ID,
-		Email:     email,
+		Email:     au.Email,
 		FirstName: au.FirstName,
 		LastName:  au.LastName,
 	}, nil
@@ -100,8 +103,8 @@ func (a *defaultAuthenticator) ValidateCredentials(ctx context.Context, email, p
 // CreateUser creates a user in the database. If a empty password is passed by parameter, a random password is generated,
 // so the user can go through the ForgotPassword flow.
 func (a *defaultAuthenticator) CreateUser(ctx context.Context, user *User, password string) (*User, error) {
-	if err := user.Validate(); err != nil {
-		return nil, fmt.Errorf("error validating user fields: %w", err)
+	if err := user.SanitizeAndValidate(); err != nil {
+		return nil, fmt.Errorf("validating user fields: %w", err)
 	}
 
 	// In case no password is passed we generate a random OTP (One Time Password)
@@ -109,19 +112,19 @@ func (a *defaultAuthenticator) CreateUser(ctx context.Context, user *User, passw
 		// Random length pasword
 		randomNumber, err := rand.Int(rand.Reader, big.NewInt(MaxPasswordLength-MinPasswordLength+1))
 		if err != nil {
-			return nil, fmt.Errorf("error generating random number in create user: %w", err)
+			return nil, fmt.Errorf("generating random number in create user: %w", err)
 		}
 
 		passwordLength := int(randomNumber.Int64() + MinPasswordLength)
 		password, err = utils.StringWithCharset(passwordLength, utils.PasswordCharset)
 		if err != nil {
-			return nil, fmt.Errorf("error generating random password string in create user: %w", err)
+			return nil, fmt.Errorf("generating random password string in create user: %w", err)
 		}
 	}
 
 	encryptedPassword, err := a.passwordEncrypter.Encrypt(ctx, password)
 	if err != nil {
-		return nil, fmt.Errorf("error encrypting password: %w", err)
+		return nil, fmt.Errorf("encrypting password: %w", err)
 	}
 
 	const query = `
@@ -138,7 +141,7 @@ func (a *defaultAuthenticator) CreateUser(ctx context.Context, user *User, passw
 		if pqError, ok := err.(*pq.Error); ok && pqError.Constraint == "auth_users_email_key" {
 			return nil, ErrUserEmailAlreadyExists
 		}
-		return nil, fmt.Errorf("error inserting user: %w", err)
+		return nil, fmt.Errorf("inserting user: %w", err)
 	}
 
 	user.ID = userID
@@ -148,6 +151,10 @@ func (a *defaultAuthenticator) CreateUser(ctx context.Context, user *User, passw
 }
 
 func (a *defaultAuthenticator) UpdateUser(ctx context.Context, ID, firstName, lastName, email, password string) error {
+	firstName = strings.TrimSpace(firstName)
+	lastName = strings.TrimSpace(lastName)
+	email = strings.TrimSpace(strings.ToLower(email))
+
 	if firstName == "" && lastName == "" && email == "" && password == "" {
 		return fmt.Errorf("provide at least one of these values: firstName, lastName, email or password")
 	}
@@ -174,7 +181,7 @@ func (a *defaultAuthenticator) UpdateUser(ctx context.Context, ID, firstName, la
 
 	if email != "" {
 		if err := utils.ValidateEmail(email); err != nil {
-			return fmt.Errorf("error validating email: %w", err)
+			return fmt.Errorf("validating email: %w", err)
 		}
 
 		fields = append(fields, "email = ?")
@@ -185,7 +192,7 @@ func (a *defaultAuthenticator) UpdateUser(ctx context.Context, ID, firstName, la
 		encryptedPassword, err := a.passwordEncrypter.Encrypt(ctx, password)
 		if err != nil {
 			if !errors.Is(err, ErrPasswordTooShort) {
-				return fmt.Errorf("error encrypting password: %w", err)
+				return fmt.Errorf("encrypting password: %w", err)
 			}
 			return err
 		}
@@ -199,12 +206,12 @@ func (a *defaultAuthenticator) UpdateUser(ctx context.Context, ID, firstName, la
 
 	res, err := a.dbConnectionPool.ExecContext(ctx, query, args...)
 	if err != nil {
-		return fmt.Errorf("error updating user in the database: %w", err)
+		return fmt.Errorf("updating user in the database: %w", err)
 	}
 
 	numRowsAffected, err := res.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("error getting the number of rows affected: %w", err)
+		return fmt.Errorf("getting the number of rows affected: %w", err)
 	}
 	if numRowsAffected == 0 {
 		return ErrNoRowsAffected
@@ -252,13 +259,14 @@ func (a *defaultAuthenticator) DeactivateUser(ctx context.Context, userID string
 }
 
 func (a *defaultAuthenticator) ForgotPassword(ctx context.Context, sqlExec db.SQLExecuter, email string) (string, error) {
+	email = strings.TrimSpace(strings.ToLower(email))
 	if email == "" {
-		return "", fmt.Errorf("error generating user reset password token: email cannot be empty")
+		return "", fmt.Errorf("generating user reset password token: email cannot be empty")
 	}
 
 	resetToken, err := utils.StringWithCharset(resetTokenLength, utils.DefaultCharset)
 	if err != nil {
-		return "", fmt.Errorf("error generating random reset token in forgot password: %w", err)
+		return "", fmt.Errorf("generating random reset token in forgot password: %w", err)
 	}
 
 	checkValidTokenQuery := `
@@ -266,7 +274,7 @@ func (a *defaultAuthenticator) ForgotPassword(ctx context.Context, sqlExec db.SQ
 			SELECT 1
 			FROM auth_user_password_reset ar
 			INNER JOIN auth_users au ON ar.auth_user_id = au.id
-			WHERE au.email = $1
+			WHERE LOWER(au.email) = LOWER($1)
 			AND ar.is_valid = true
 			AND (ar.created_at + INTERVAL '20 minutes') > now()
 		)
@@ -274,7 +282,7 @@ func (a *defaultAuthenticator) ForgotPassword(ctx context.Context, sqlExec db.SQ
 	var hasValidToken bool
 	err = sqlExec.GetContext(ctx, &hasValidToken, checkValidTokenQuery, email)
 	if err != nil {
-		return "", fmt.Errorf("error checking if user has valid token: %w", err)
+		return "", fmt.Errorf("checking if user has valid token: %w", err)
 	}
 
 	if hasValidToken {
@@ -283,7 +291,7 @@ func (a *defaultAuthenticator) ForgotPassword(ctx context.Context, sqlExec db.SQ
 
 	q := `
 		WITH auth_user_reset_token_info AS (
-			SELECT id, $2 as reset_token FROM auth_users WHERE email = $1
+			SELECT id, $2 as reset_token FROM auth_users WHERE LOWER(email) = LOWER($1)
 		)
 		INSERT INTO
 			auth_user_password_reset (auth_user_id, token)
@@ -291,11 +299,11 @@ func (a *defaultAuthenticator) ForgotPassword(ctx context.Context, sqlExec db.SQ
 	`
 	result, err := sqlExec.ExecContext(ctx, q, email, resetToken)
 	if err != nil {
-		return "", fmt.Errorf("error inserting user reset password token in the database: %w", err)
+		return "", fmt.Errorf("inserting user reset password token in the database: %w", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return "", fmt.Errorf("error getting rows affected inserting user reset password token in the database: %w", err)
+		return "", fmt.Errorf("getting rows affected inserting user reset password token in the database: %w", err)
 	}
 	if rowsAffected == 0 {
 		return "", ErrUserNotFound

--- a/stellar-auth/pkg/auth/fixtures.go
+++ b/stellar-auth/pkg/auth/fixtures.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -55,6 +56,7 @@ func randStringRunes(t *testing.T, n int) string {
 
 func CreateRandomAuthUserFixture(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, passwordEncrypter PasswordEncrypter, isAdmin bool, roles ...string) *RandomAuthUser {
 	randomSuffix := randStringRunes(t, 5)
+	randomSuffix = strings.TrimSpace(strings.ToLower(randomSuffix))
 	email := fmt.Sprintf("email%s@randomemail.com", randomSuffix)
 	password := "password" + randomSuffix
 	firstName := "firstName" + randomSuffix

--- a/stellar-auth/pkg/auth/manager.go
+++ b/stellar-auth/pkg/auth/manager.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
@@ -20,7 +21,11 @@ type User struct {
 	Roles     []string `json:"roles"`
 }
 
-func (u *User) Validate() error {
+func (u *User) SanitizeAndValidate() error {
+	u.Email = strings.TrimSpace(strings.ToLower(u.Email))
+	u.FirstName = strings.TrimSpace(u.FirstName)
+	u.LastName = strings.TrimSpace(u.LastName)
+
 	if u.Email == "" {
 		return fmt.Errorf("email is required")
 	} else if err := utils.ValidateEmail(u.Email); err != nil {

--- a/stellar-auth/pkg/auth/manager_test.go
+++ b/stellar-auth/pkg/auth/manager_test.go
@@ -7,26 +7,100 @@ import (
 )
 
 func Test_User_Validate(t *testing.T) {
-	user := &User{
-		ID:        "",
-		FirstName: "",
-		LastName:  "",
-		Email:     "",
-		IsOwner:   false,
-		Roles:     []string{},
+	testCases := []struct {
+		name      string
+		user      *User
+		wantEmail string
+		wantFirst string
+		wantLast  string
+	}{
+		{
+			name: "trims whitespace and lowercases email",
+			user: &User{
+				Email:     "  Test@Email.com  ",
+				FirstName: "First",
+				LastName:  "Last",
+			},
+			wantEmail: "test@email.com",
+			wantFirst: "First",
+			wantLast:  "Last",
+		},
+		{
+			name: "trims whitespace from names",
+			user: &User{
+				Email:     "test@email.com",
+				FirstName: "  First  ",
+				LastName:  "  Last  ",
+			},
+			wantEmail: "test@email.com",
+			wantFirst: "First",
+			wantLast:  "Last",
+		},
 	}
 
-	assert.EqualError(t, user.Validate(), "email is required")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.user.SanitizeAndValidate()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantEmail, tc.user.Email)
+			assert.Equal(t, tc.wantFirst, tc.user.FirstName)
+			assert.Equal(t, tc.wantLast, tc.user.LastName)
+		})
+	}
+}
 
-	user.Email = "invalid"
-	assert.EqualError(t, user.Validate(), `email is invalid: the provided email "invalid" is not valid`)
+func Test_User_SanitizeAndValidate_Validation(t *testing.T) {
+	testCases := []struct {
+		name    string
+		user    *User
+		wantErr string
+	}{
+		{
+			name:    "empty email returns error",
+			user:    &User{},
+			wantErr: "email is required",
+		},
+		{
+			name: "invalid email returns error",
+			user: &User{
+				Email: "invalid",
+			},
+			wantErr: `email is invalid: the provided email "invalid" is not valid`,
+		},
+		{
+			name: "empty first name returns error",
+			user: &User{
+				Email: "test@email.com",
+			},
+			wantErr: "first name is required",
+		},
+		{
+			name: "empty last name returns error",
+			user: &User{
+				Email:     "test@email.com",
+				FirstName: "First",
+			},
+			wantErr: "last name is required",
+		},
+		{
+			name: "valid user returns no error",
+			user: &User{
+				Email:     "test@email.com",
+				FirstName: "First",
+				LastName:  "Last",
+			},
+			wantErr: "",
+		},
+	}
 
-	user.Email = "email@email.com"
-	assert.EqualError(t, user.Validate(), "first name is required")
-
-	user.FirstName = "First"
-	assert.EqualError(t, user.Validate(), "last name is required")
-
-	user.LastName = "Last"
-	assert.NoError(t, user.Validate())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.user.SanitizeAndValidate()
+			if tc.wantErr != "" {
+				assert.EqualError(t, err, tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/stellar-auth/pkg/cli/add_user.go
+++ b/stellar-auth/pkg/cli/add_user.go
@@ -197,7 +197,7 @@ func execAddUser(ctx context.Context, dbUrl string, email, firstName, lastName, 
 
 	u, err := authManager.CreateUser(ctx, newUser, password)
 	if err != nil {
-		return fmt.Errorf("error creating user: %w", err)
+		return fmt.Errorf("creating user: %w", err)
 	}
 
 	log.Ctx(ctx).Infof("[CLI - CreateUserAccount] - Created user with account ID %s through CLI with roles %v", u.ID, roles)

--- a/stellar-auth/pkg/cli/add_user_test.go
+++ b/stellar-auth/pkg/cli/add_user_test.go
@@ -237,22 +237,22 @@ func Test_execAddUserFunc(t *testing.T) {
 
 		// Invalid invalid
 		err := execAddUser(ctx, dbt.DSN, "", firstName, lastName, password, false, []string{}, tenantID)
-		assert.EqualError(t, err, "error creating user: error creating user: error validating user fields: email is required")
+		assert.EqualError(t, err, "creating user: creating user: validating user fields: email is required")
 
 		err = execAddUser(ctx, dbt.DSN, "wrongemail", firstName, lastName, password, false, []string{}, tenantID)
-		assert.EqualError(t, err, `error creating user: error creating user: error validating user fields: email is invalid: the provided email "wrongemail" is not valid`)
+		assert.EqualError(t, err, `creating user: creating user: validating user fields: email is invalid: the provided email "wrongemail" is not valid`)
 
 		// Invalid password
 		err = execAddUser(ctx, dbt.DSN, email, firstName, lastName, "pass", false, []string{}, tenantID)
-		assert.EqualError(t, err, fmt.Sprintf("error creating user: error creating user: error encrypting password: password should have at least %d characters", auth.MinPasswordLength))
+		assert.EqualError(t, err, fmt.Sprintf("creating user: creating user: encrypting password: password should have at least %d characters", auth.MinPasswordLength))
 
 		// Invalid first name
 		err = execAddUser(ctx, dbt.DSN, email, "", lastName, "pass", false, []string{}, tenantID)
-		assert.EqualError(t, err, "error creating user: error creating user: error validating user fields: first name is required")
+		assert.EqualError(t, err, "creating user: creating user: validating user fields: first name is required")
 
 		// Invalid last name
 		err = execAddUser(ctx, dbt.DSN, email, firstName, "", "pass", false, []string{}, tenantID)
-		assert.EqualError(t, err, "error creating user: error creating user: error validating user fields: last name is required")
+		assert.EqualError(t, err, "creating user: creating user: validating user fields: last name is required")
 
 		// Valid user
 		err = execAddUser(ctx, dbt.DSN, email, firstName, lastName, password, false, []string{}, tenantID)
@@ -284,7 +284,7 @@ func Test_execAddUserFunc(t *testing.T) {
 		require.NoError(t, err)
 
 		err = execAddUser(ctx, dbt.DSN, email, firstName, lastName, password, false, []string{}, tenantID)
-		assert.EqualError(t, err, `error creating user: error creating user: a user with this email already exists`)
+		assert.EqualError(t, err, `creating user: creating user: a user with this email already exists`)
 	})
 
 	t.Run("set the user roles", func(t *testing.T) {


### PR DESCRIPTION
### What
- Change persistence and Validation for emails to be case-insensitive for dashboard users

### Why
- Avoid login / forgot password validation errors due to case-sensitivity. 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
