### PR TITLE
[SDP-1234] DELETE disbursement in draft or ready status

### DIFF
--- a/internal/data/dibursements_state_machine.go
+++ b/internal/data/dibursements_state_machine.go
@@ -15,6 +15,8 @@ const (
 	CompletedDisbursementStatus DisbursementStatus = "COMPLETED"
 )
 
+var NotStartedDisbursementStatuses = []DisbursementStatus{DraftDisbursementStatus, ReadyDisbursementStatus}
+
 // TransitionTo transitions the disbursement status to the target state
 func (status DisbursementStatus) TransitionTo(targetState DisbursementStatus) error {
 	return DisbursementStateMachineWithInitialState(status).TransitionTo(targetState.State())

--- a/internal/data/disbursement_instructions.go
+++ b/internal/data/disbursement_instructions.go
@@ -123,9 +123,9 @@ func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, opts Disb
 			}
 		}
 
-		// Step 4: Delete all pre-existing payments tied to this disbursement for each receiver in one call
-		if err = di.paymentModel.DeleteAllForDisbursement(ctx, dbTx, opts.Disbursement.ID); err != nil {
-			return fmt.Errorf("deleting payments: %w", err)
+		// Step 4: Delete all pre-existing draft payments tied to this disbursement for each receiver in one call
+		if err = di.paymentModel.DeleteAllDraftForDisbursement(ctx, dbTx, opts.Disbursement.ID); err != nil {
+			return fmt.Errorf("deleting draft payments: %w", err)
 		}
 
 		// Step 5: Create payments for all receivers

--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -302,14 +302,15 @@ func (p *PaymentModel) GetAll(ctx context.Context, queryParams *QueryParams, sql
 	return payments, nil
 }
 
-// DeleteAllForDisbursement deletes all payments for a given disbursement.
-func (p *PaymentModel) DeleteAllForDisbursement(ctx context.Context, sqlExec db.SQLExecuter, disbursementID string) error {
+// DeleteAllDraftForDisbursement deletes all payments for a given disbursement.
+func (p *PaymentModel) DeleteAllDraftForDisbursement(ctx context.Context, sqlExec db.SQLExecuter, disbursementID string) error {
 	query := `
 		DELETE FROM payments
 		WHERE disbursement_id = $1
+			AND status = $2
 		`
 
-	result, err := sqlExec.ExecContext(ctx, query, disbursementID)
+	result, err := sqlExec.ExecContext(ctx, query, disbursementID, DraftPaymentStatus)
 	if err != nil {
 		return fmt.Errorf("error deleting payments for disbursement: %w", err)
 	}

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/httpjson"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
@@ -184,6 +185,53 @@ func (d DisbursementHandler) PostDisbursement(w http.ResponseWriter, r *http.Req
 	}
 
 	httpjson.RenderStatus(w, http.StatusCreated, newDisbursement, httpjson.JSON)
+}
+
+// DeleteDisbursement deletes a draft or ready disbursement and its associated payments
+func (d DisbursementHandler) DeleteDisbursement(w http.ResponseWriter, r *http.Request) {
+	disbursementID := chi.URLParam(r, "id")
+	ctx := r.Context()
+
+	ErrDisbursementStarted := errors.New("can't delete disbursement that has started")
+
+	disbursement, err := db.RunInTransactionWithResult(ctx, d.Models.DBConnectionPool, nil, func(tx db.DBTransaction) (*data.Disbursement, error) {
+		// Check if disbursement exists and is in draft or ready status
+		disbursement, err := d.Models.Disbursements.Get(ctx, tx, disbursementID)
+		if err != nil {
+			return nil, fmt.Errorf("getting disbursement: %w", err)
+		}
+
+		if !slices.Contains(data.NotStartedDisbursementStatuses, disbursement.Status) {
+			return nil, ErrDisbursementStarted
+		}
+
+		// Delete associated payments
+		err = d.Models.Payment.DeleteAllDraftForDisbursement(ctx, tx, disbursementID)
+		if err != nil {
+			return nil, fmt.Errorf("deleting payments: %w", err)
+		}
+
+		// Delete disbursement
+		err = d.Models.Disbursements.Delete(ctx, tx, disbursementID)
+		if err != nil {
+			return nil, fmt.Errorf("deleting draft or ready disbursement: %w", err)
+		}
+
+		return disbursement, nil
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, data.ErrRecordNotFound):
+			httperror.NotFound("Disbursement not found", err, nil).Render(w)
+		case errors.Is(err, ErrDisbursementStarted):
+			httperror.BadRequest("Cannot delete a disbursement that has started", err, nil).Render(w)
+		default:
+			httperror.InternalError(ctx, "Cannot delete disbursement", err, nil).Render(w)
+		}
+		return
+	}
+
+	httpjson.RenderStatus(w, http.StatusOK, disbursement, httpjson.JSON)
 }
 
 // GetDisbursements returns a paginated list of disbursements

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -267,6 +267,9 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				Post("/", handler.PostDisbursement)
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+				Delete("/{id}", handler.DeleteDisbursement)
+
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Post("/{id}/instructions", handler.PostDisbursementInstructions)
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -443,6 +443,7 @@ func Test_handleHTTP_authenticatedEndpoints(t *testing.T) {
 		{http.MethodGet, "/disbursements/1234"},
 		{http.MethodGet, "/disbursements/1234/receivers"},
 		{http.MethodPatch, "/disbursements/1234/status"},
+		{http.MethodDelete, "/disbursements/1234"},
 		// Payments
 		{http.MethodGet, "/payments"},
 		{http.MethodGet, "/payments/1234"},


### PR DESCRIPTION
### What

Add `DELETE /disbursements/:id` endpoint.

### Why

Ability to delete disbursements in `Ready` and `Draft` state.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
