### PR TITLE
[SDP-1259] Export Disbursements with Filters

### DIFF
--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -16,12 +16,12 @@ import (
 )
 
 type Asset struct {
-	ID        string     `json:"id" db:"id"`
+	ID        string     `json:"id" csv:"-" db:"id"`
 	Code      string     `json:"code" db:"code"`
 	Issuer    string     `json:"issuer" db:"issuer"`
-	CreatedAt *time.Time `json:"created_at,omitempty" db:"created_at"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty" db:"updated_at"`
-	DeletedAt *time.Time `json:"deleted_at" db:"deleted_at"`
+	CreatedAt *time.Time `json:"created_at,omitempty" csv:"-" db:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty" csv:"-" db:"updated_at"`
+	DeletedAt *time.Time `json:"deleted_at" csv:"-" db:"deleted_at"`
 }
 
 // IsNative returns true if the asset is the native asset (XLM).

--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -336,11 +336,11 @@ func (d *DisbursementModel) newDisbursementQuery(baseQuery string, queryParams *
 		qb.AddCondition("d.created_at <= ?", queryParams.Filters[FilterKeyCreatedAtBefore])
 	}
 
-	switch queryType {
-	case QueryTypeSelectPaginated:
+	if queryType == QueryTypeSelectPaginated {
 		qb.AddPagination(queryParams.Page, queryParams.PageLimit)
-		qb.AddSorting(queryParams.SortBy, queryParams.SortOrder, "d")
-	case QueryTypeSelectAll:
+	}
+
+	if queryType == QueryTypeSelectAll || queryType == QueryTypeSelectPaginated {
 		qb.AddSorting(queryParams.SortBy, queryParams.SortOrder, "d")
 	}
 

--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -24,10 +24,10 @@ type Disbursement struct {
 	Asset                               *Asset                    `json:"asset,omitempty" db:"asset"`
 	Status                              DisbursementStatus        `json:"status" db:"status"`
 	VerificationField                   VerificationType          `json:"verification_field,omitempty" db:"verification_field"`
-	StatusHistory                       DisbursementStatusHistory `json:"status_history,omitempty" db:"status_history"`
-	ReceiverRegistrationMessageTemplate string                    `json:"receiver_registration_message_template" db:"receiver_registration_message_template"`
-	FileName                            string                    `json:"file_name,omitempty" db:"file_name"`
-	FileContent                         []byte                    `json:"-" db:"file_content"`
+	StatusHistory                       DisbursementStatusHistory `json:"status_history,omitempty" csv:"-" db:"status_history"`
+	ReceiverRegistrationMessageTemplate string                    `json:"receiver_registration_message_template" csv:"-" db:"receiver_registration_message_template"`
+	FileName                            string                    `json:"file_name,omitempty" csv:"-" db:"file_name"`
+	FileContent                         []byte                    `json:"-" csv:"-" db:"file_content"`
 	CreatedAt                           time.Time                 `json:"created_at" db:"created_at"`
 	UpdatedAt                           time.Time                 `json:"updated_at" db:"updated_at"`
 	RegistrationContactType             RegistrationContactType   `json:"registration_contact_type,omitempty" db:"registration_contact_type"`
@@ -255,7 +255,7 @@ func (d *DisbursementModel) Count(ctx context.Context, sqlExec db.SQLExecuter, q
 		JOIN assets a on d.asset_id = a.id
 		`
 
-	query, params := d.newDisbursementQuery(baseQuery, queryParams, false)
+	query, params := d.newDisbursementQuery(baseQuery, queryParams, QueryTypeCount)
 
 	err := sqlExec.GetContext(ctx, &count, query, params...)
 	if err != nil {
@@ -265,10 +265,10 @@ func (d *DisbursementModel) Count(ctx context.Context, sqlExec db.SQLExecuter, q
 }
 
 // GetAll returns all disbursements matching the given query parameters.
-func (d *DisbursementModel) GetAll(ctx context.Context, sqlExec db.SQLExecuter, queryParams *QueryParams) ([]*Disbursement, error) {
+func (d *DisbursementModel) GetAll(ctx context.Context, sqlExec db.SQLExecuter, queryParams *QueryParams, queryType QueryType) ([]*Disbursement, error) {
 	disbursements := []*Disbursement{}
 
-	query, params := d.newDisbursementQuery(selectDisbursementQuery, queryParams, true)
+	query, params := d.newDisbursementQuery(selectDisbursementQuery, queryParams, queryType)
 	err := sqlExec.SelectContext(ctx, &disbursements, query, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error querying disbursements: %w", err)
@@ -319,7 +319,7 @@ func (d *DisbursementModel) UpdateStatus(ctx context.Context, sqlExec db.SQLExec
 }
 
 // newDisbursementQuery generates the full query and parameters for a disbursement search query
-func (d *DisbursementModel) newDisbursementQuery(baseQuery string, queryParams *QueryParams, paginated bool) (string, []interface{}) {
+func (d *DisbursementModel) newDisbursementQuery(baseQuery string, queryParams *QueryParams, queryType QueryType) (string, []interface{}) {
 	qb := NewQueryBuilder(baseQuery)
 
 	if queryParams.Query != "" {
@@ -335,10 +335,15 @@ func (d *DisbursementModel) newDisbursementQuery(baseQuery string, queryParams *
 	if queryParams.Filters[FilterKeyCreatedAtBefore] != nil {
 		qb.AddCondition("d.created_at <= ?", queryParams.Filters[FilterKeyCreatedAtBefore])
 	}
-	if paginated {
-		qb.AddSorting(queryParams.SortBy, queryParams.SortOrder, "d")
+
+	switch queryType {
+	case QueryTypeSelectPaginated:
 		qb.AddPagination(queryParams.Page, queryParams.PageLimit)
+		qb.AddSorting(queryParams.SortBy, queryParams.SortOrder, "d")
+	case QueryTypeSelectAll:
+		qb.AddSorting(queryParams.SortBy, queryParams.SortOrder, "d")
 	}
+
 	query, params := qb.Build()
 	return d.dbConnectionPool.Rebind(query), params
 }

--- a/internal/data/disbursements_test.go
+++ b/internal/data/disbursements_test.go
@@ -282,7 +282,7 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 
 	t.Run("returns empty list when no disbursements exist", func(t *testing.T) {
 		DeleteAllDisbursementFixtures(t, ctx, dbConnectionPool)
-		disbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{})
+		disbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{}, QueryTypeSelectPaginated)
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(disbursements))
 	})
@@ -296,7 +296,7 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 		disbursement.Name = "disbursement2"
 		expected2 := CreateDisbursementFixture(t, ctx, dbConnectionPool, &disbursementModel, &disbursement)
 
-		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{})
+		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{}, QueryTypeSelectPaginated)
 		require.NoError(t, err)
 		assert.Len(t, actualDisbursements, 2)
 		assert.Equal(t, []*Disbursement{expected2, expected1}, actualDisbursements)
@@ -311,7 +311,7 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 		disbursement.Name = "disbursement2"
 		CreateDisbursementFixture(t, ctx, dbConnectionPool, &disbursementModel, &disbursement)
 
-		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{Page: 1, PageLimit: 1})
+		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{Page: 1, PageLimit: 1}, QueryTypeSelectPaginated)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(actualDisbursements))
 		assert.Equal(t, []*Disbursement{expected1}, actualDisbursements)
@@ -326,7 +326,7 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 		disbursement.Name = "disbursement2"
 		expected2 := CreateDisbursementFixture(t, ctx, dbConnectionPool, &disbursementModel, &disbursement)
 
-		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{Page: 2, PageLimit: 1})
+		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{Page: 2, PageLimit: 1}, QueryTypeSelectPaginated)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(actualDisbursements))
 		assert.Equal(t, []*Disbursement{expected2}, actualDisbursements)
@@ -341,7 +341,9 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 		disbursement.Name = "disbursement2"
 		expected2 := CreateDisbursementFixture(t, ctx, dbConnectionPool, &disbursementModel, &disbursement)
 
-		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{SortBy: SortFieldName, SortOrder: SortOrderDESC})
+		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool,
+			&QueryParams{SortBy: SortFieldName, SortOrder: SortOrderDESC},
+			QueryTypeSelectPaginated)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(actualDisbursements))
 		assert.Equal(t, []*Disbursement{expected2, expected1}, actualDisbursements)
@@ -361,7 +363,7 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 		filters := map[FilterKey]interface{}{
 			FilterKeyStatus: []DisbursementStatus{DraftDisbursementStatus},
 		}
-		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{Filters: filters})
+		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{Filters: filters}, QueryTypeSelectPaginated)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(actualDisbursements))
 		assert.Equal(t, []*Disbursement{expected1}, actualDisbursements)
@@ -383,7 +385,9 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 		filters := map[FilterKey]interface{}{
 			FilterKeyStatus: []DisbursementStatus{DraftDisbursementStatus, CompletedDisbursementStatus},
 		}
-		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{Filters: filters, SortBy: SortFieldCreatedAt, SortOrder: SortOrderDESC})
+		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool,
+			&QueryParams{Filters: filters, SortBy: SortFieldCreatedAt, SortOrder: SortOrderDESC},
+			QueryTypeSelectPaginated)
 
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(actualDisbursements))
@@ -437,7 +441,7 @@ func Test_DisbursementModelGetAll(t *testing.T) {
 
 		expectedDisbursement.DisbursementStats = expectedStats
 
-		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{})
+		actualDisbursements, err := disbursementModel.GetAll(ctx, dbConnectionPool, &QueryParams{}, QueryTypeSelectPaginated)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(actualDisbursements))
 		assert.Equal(t, []*Disbursement{expectedDisbursement}, actualDisbursements)

--- a/internal/data/query_params.go
+++ b/internal/data/query_params.go
@@ -2,6 +2,14 @@ package data
 
 import "fmt"
 
+type QueryType string
+
+const (
+	QueryTypeSelectPaginated QueryType = "SELECT_PAGINATED"
+	QueryTypeSelectAll       QueryType = "SELECT_ALL"
+	QueryTypeCount           QueryType = "COUNT"
+)
+
 type QueryParams struct {
 	Query               string
 	Page                int

--- a/internal/data/registration_contact_type.go
+++ b/internal/data/registration_contact_type.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/gocarina/gocsv"
 )
 
 // RegistrationContactType represents the type of contact information to be used when creating and validating a disbursement.
@@ -89,9 +91,14 @@ func (rct *RegistrationContactType) Scan(value interface{}) error {
 	return rct.ParseFromString(strValue)
 }
 
+func (rct RegistrationContactType) MarshalCSV() (string, error) {
+	return rct.String(), nil
+}
+
 var (
-	_ json.Marshaler   = (*RegistrationContactType)(nil)
-	_ json.Unmarshaler = (*RegistrationContactType)(nil)
-	_ driver.Valuer    = (*RegistrationContactType)(nil)
-	_ sql.Scanner      = (*RegistrationContactType)(nil)
+	_ gocsv.TypeMarshaller = (*RegistrationContactType)(nil)
+	_ json.Marshaler       = (*RegistrationContactType)(nil)
+	_ json.Unmarshaler     = (*RegistrationContactType)(nil)
+	_ driver.Valuer        = (*RegistrationContactType)(nil)
+	_ sql.Scanner          = (*RegistrationContactType)(nil)
 )

--- a/internal/data/wallets.go
+++ b/internal/data/wallets.go
@@ -21,17 +21,17 @@ var (
 )
 
 type Wallet struct {
-	ID                string       `json:"id" db:"id"`
+	ID                string       `json:"id" csv:"-" db:"id"`
 	Name              string       `json:"name" db:"name"`
-	Homepage          string       `json:"homepage,omitempty" db:"homepage"`
-	SEP10ClientDomain string       `json:"sep_10_client_domain,omitempty" db:"sep_10_client_domain"`
-	DeepLinkSchema    string       `json:"deep_link_schema,omitempty" db:"deep_link_schema"`
-	Enabled           bool         `json:"enabled" db:"enabled"`
-	UserManaged       bool         `json:"user_managed,omitempty" db:"user_managed"`
-	Assets            WalletAssets `json:"assets,omitempty" db:"assets"`
-	CreatedAt         *time.Time   `json:"created_at,omitempty" db:"created_at"`
-	UpdatedAt         *time.Time   `json:"updated_at,omitempty" db:"updated_at"`
-	DeletedAt         *time.Time   `json:"-" db:"deleted_at"`
+	Homepage          string       `json:"homepage,omitempty" csv:"-" db:"homepage"`
+	SEP10ClientDomain string       `json:"sep_10_client_domain,omitempty" csv:"-" db:"sep_10_client_domain"`
+	DeepLinkSchema    string       `json:"deep_link_schema,omitempty" csv:"-" db:"deep_link_schema"`
+	Enabled           bool         `json:"enabled" csv:"-" db:"enabled"`
+	UserManaged       bool         `json:"user_managed,omitempty" csv:"-" db:"user_managed"`
+	Assets            WalletAssets `json:"assets,omitempty" csv:"-" db:"assets"`
+	CreatedAt         *time.Time   `json:"created_at,omitempty" csv:"-" db:"created_at"`
+	UpdatedAt         *time.Time   `json:"updated_at,omitempty" csv:"-" db:"updated_at"`
+	DeletedAt         *time.Time   `json:"-" csv:"-" db:"deleted_at"`
 }
 
 type WalletInsert struct {

--- a/internal/serve/httphandler/export_handler.go
+++ b/internal/serve/httphandler/export_handler.go
@@ -1,0 +1,50 @@
+package httphandler
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gocarina/gocsv"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
+)
+
+type ExportHandler struct {
+	Models *data.Models
+}
+
+func (e ExportHandler) ExportDisbursements(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	validator := validators.NewDisbursementQueryValidator()
+	queryParams := validator.ParseParametersFromRequest(r)
+
+	if validator.HasErrors() {
+		httperror.BadRequest("Request invalid", nil, validator.Errors).Render(rw)
+		return
+	}
+
+	queryParams.Filters = validator.ValidateAndGetDisbursementFilters(queryParams.Filters)
+	if validator.HasErrors() {
+		httperror.BadRequest("Request invalid", nil, validator.Errors).Render(rw)
+		return
+	}
+
+	disbursements, err := e.Models.Disbursements.GetAll(ctx, e.Models.DBConnectionPool, queryParams, data.QueryTypeSelectAll)
+	if err != nil {
+		httperror.InternalError(ctx, "Failed to get disbursements", err, nil).Render(rw)
+		return
+	}
+
+	fileName := fmt.Sprintf("disbursements_%s.csv", time.Now().Format("2006-01-02-15-04-05"))
+	rw.Header().Set("Content-Type", "text/csv")
+	rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
+
+	if err := gocsv.Marshal(disbursements, rw); err != nil {
+		httperror.InternalError(ctx, "Failed to write CSV", err, nil).Render(rw)
+		return
+	}
+}

--- a/internal/serve/httphandler/export_handler_test.go
+++ b/internal/serve/httphandler/export_handler_test.go
@@ -1,0 +1,134 @@
+package httphandler
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+)
+
+func Test_ExportHandler_ExportDisbursements(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	ctx := context.Background()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+
+	handler := &ExportHandler{
+		Models: models,
+	}
+
+	r := chi.NewRouter()
+	r.Get("/exports/disbursements", handler.ExportDisbursements)
+
+	wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "Wallet", "https://www.wallet.com", "www.wallet.com", "wallet://")
+	asset := data.CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+
+	disbursement1 := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, handler.Models.Disbursements, &data.Disbursement{
+		Name:      "disbursement 1",
+		Status:    data.StartedDisbursementStatus,
+		Wallet:    wallet,
+		Asset:     asset,
+		CreatedAt: time.Date(2023, 3, 21, 23, 40, 20, 1431, time.UTC),
+	})
+
+	disbursement2 := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, handler.Models.Disbursements, &data.Disbursement{
+		Name:      "disbursement 2",
+		Status:    data.DraftDisbursementStatus,
+		Wallet:    wallet,
+		Asset:     asset,
+		CreatedAt: time.Date(2022, 3, 21, 23, 40, 20, 1431, time.UTC),
+	})
+
+	disbursement3 := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, handler.Models.Disbursements, &data.Disbursement{
+		Name:      "disbursement 3",
+		Status:    data.ReadyDisbursementStatus,
+		Wallet:    wallet,
+		Asset:     asset,
+		CreatedAt: time.Date(2021, 3, 21, 23, 40, 20, 1431, time.UTC),
+	})
+
+	tests := []struct {
+		name                  string
+		queryParams           string
+		expectedStatusCode    int
+		expectedDisbursements []*data.Disbursement
+	}{
+		{
+			name:                  "success - returns CSV with no disbursements",
+			queryParams:           "status=completed",
+			expectedStatusCode:    http.StatusOK,
+			expectedDisbursements: []*data.Disbursement{},
+		},
+		{
+			name:                  "success - returns CSV with all disbursements",
+			expectedStatusCode:    http.StatusOK,
+			expectedDisbursements: []*data.Disbursement{disbursement1, disbursement2, disbursement3},
+		},
+		{
+			name:                  "success - return CSV with reverse order of disbursements",
+			expectedStatusCode:    http.StatusOK,
+			queryParams:           "sort=created_at&direction=asc",
+			expectedDisbursements: []*data.Disbursement{disbursement3, disbursement2, disbursement1},
+		},
+		{
+			name:                  "success - return CSV with only started disbursements",
+			expectedStatusCode:    http.StatusOK,
+			queryParams:           "status=started",
+			expectedDisbursements: []*data.Disbursement{disbursement1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			url := "/exports/disbursements"
+			if tc.queryParams != "" {
+				url += "?" + tc.queryParams
+			}
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			require.NoError(t, err)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			assert.Equal(t, tc.expectedStatusCode, rr.Code)
+			csvReader := csv.NewReader(strings.NewReader(rr.Body.String()))
+
+			header, err := csvReader.Read()
+			require.NoError(t, err)
+			assert.Contains(t, header, "Name")
+			assert.Contains(t, header, "Status")
+			assert.Contains(t, header, "CreatedAt")
+
+			assert.Equal(t, "text/csv", rr.Header().Get("Content-Type"))
+			today := time.Now().Format("2006-01-02")
+			assert.Contains(t, rr.Header().Get("Content-Disposition"), fmt.Sprintf("attachment; filename=disbursements_%s", today))
+
+			rows, err := csvReader.ReadAll()
+			require.NoError(t, err)
+			assert.Len(t, rows, len(tc.expectedDisbursements))
+
+			for i, row := range rows {
+				assert.Equal(t, tc.expectedDisbursements[i].Name, row[1])
+				assert.Equal(t, string(tc.expectedDisbursements[i].Status), row[5])
+			}
+		})
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -412,6 +412,14 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			NetworkType:                 o.NetworkType,
 		}
 		r.Get("/balances", balancesHandler.Get)
+
+		exportHandler := httphandler.ExportHandler{
+			Models: o.Models,
+		}
+		r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+			Route("/exports", func(r chi.Router) {
+				r.Get("/disbursements", exportHandler.ExportDisbursements)
+			})
 	})
 
 	reCAPTCHAValidator := validators.NewGoogleReCAPTCHAValidator(o.ReCAPTCHASiteSecretKey, httpclient.DefaultClient())

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -478,6 +478,8 @@ func Test_handleHTTP_authenticatedEndpoints(t *testing.T) {
 		{http.MethodPatch, "/organization/circle-config"},
 		// Balances
 		{http.MethodGet, "/balances"},
+		// Exports
+		{http.MethodGet, "/exports/disbursements"},
 	}
 
 	// Expect 401 as a response:

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -146,7 +146,7 @@ func (s *DisbursementManagementService) GetDisbursementsWithCount(ctx context.Co
 
 			var disbursements []*data.Disbursement
 			if totalDisbursements != 0 {
-				disbursements, err = s.Models.Disbursements.GetAll(ctx, dbTx, queryParams)
+				disbursements, err = s.Models.Disbursements.GetAll(ctx, dbTx, queryParams, data.QueryTypeSelectPaginated)
 				if err != nil {
 					return nil, fmt.Errorf("error retrieving disbursements: %w", err)
 				}


### PR DESCRIPTION
### What
- Add a new endpoint `GET /exports/disbursements` 

Returned CSV : 
```csv
ID,Name,Wallet.Name,Asset.Code,Asset.Issuer,Status,VerificationField,CreatedAt,UpdatedAt,RegistrationContactType,TotalPayments,SuccessfulPayments,FailedPayments,CanceledPayments,RemainingPayments,AmountDisbursed,TotalAmount,AverageAmount
68494ca8-4f49-4d56-af81-42589963293c,WA_XLM,User Managed Wallet,XLM,,COMPLETED,,2024-11-28T22:31:24.722812Z,2024-11-28T22:31:36.441927Z,EMAIL_AND_WALLET_ADDRESS,1,1,0,0,0,0.12,0.12,0.12
9427421d-9540-4942-85c0-a2de2a45de31,WA_XLM_@,User Managed Wallet,XLM,,COMPLETED,,2024-11-28T22:34:44.172295Z,2024-11-28T22:34:52.497641Z,EMAIL_AND_WALLET_ADDRESS,1,1,0,0,0,0.12,0.12,0.12
```

### Why
- Add ability to export disbursements in CSV

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
