### PR TITLE
[SDP-1397] Circle Payouts pt2: error handling & retries

### DIFF
--- a/internal/data/circle_recipient_test.go
+++ b/internal/data/circle_recipient_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -158,4 +159,178 @@ func Test_CircleRecipientModel_GetByReceiverWalletID(t *testing.T) {
 
 		assert.Equal(t, insertedCircleRecipient, fetchedCircleRecipient)
 	})
+}
+
+func Test_CircleRecipientModel_ResetRecipientsForRetryIfNeeded(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+
+	m, err := NewModels(dbConnectionPool)
+	require.NoError(t, err)
+
+	asset := CreateAssetFixture(t, ctx, dbConnectionPool, "FOO1", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{})
+
+	walletA := CreateWalletFixture(t, ctx, dbConnectionPool, "walletA", "https://www.a.com", "www.a.com", "a://")
+	disbursementA := CreateDisbursementFixture(t, ctx, dbConnectionPool, m.Disbursements, &Disbursement{
+		Wallet:                              walletA,
+		Status:                              ReadyDisbursementStatus,
+		Asset:                               asset,
+		ReceiverRegistrationMessageTemplate: "Disbursement SMS Registration Message Template A1",
+	})
+	rwA := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, walletA.ID, RegisteredReceiversWalletStatus)
+	paymentA1 := CreatePaymentFixture(t, ctx, dbConnectionPool, m.Payment, &Payment{
+		ReceiverWallet: rwA,
+		Disbursement:   disbursementA,
+		Asset:          *asset,
+		Status:         ReadyPaymentStatus,
+		Amount:         "100",
+	})
+	paymentA2 := CreatePaymentFixture(t, ctx, dbConnectionPool, m.Payment, &Payment{
+		ReceiverWallet: rwA,
+		Disbursement:   disbursementA,
+		Asset:          *asset,
+		Status:         ReadyPaymentStatus,
+		Amount:         "100",
+	})
+
+	walletB := CreateWalletFixture(t, ctx, dbConnectionPool, "walletB", "https://www.b.com", "www.b.com", "b://")
+	disbursementB := CreateDisbursementFixture(t, ctx, dbConnectionPool, m.Disbursements, &Disbursement{
+		Wallet:                              walletB,
+		Status:                              ReadyDisbursementStatus,
+		Asset:                               asset,
+		ReceiverRegistrationMessageTemplate: "Disbursement SMS Registration Message Template A1",
+	})
+	rwB := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, walletB.ID, RegisteredReceiversWalletStatus)
+	paymentB1 := CreatePaymentFixture(t, ctx, dbConnectionPool, m.Payment, &Payment{
+		ReceiverWallet: rwB,
+		Disbursement:   disbursementB,
+		Asset:          *asset,
+		Status:         ReadyPaymentStatus,
+		Amount:         "100",
+	})
+	paymentB2 := CreatePaymentFixture(t, ctx, dbConnectionPool, m.Payment, &Payment{
+		ReceiverWallet: rwB,
+		Disbursement:   disbursementA,
+		Asset:          *asset,
+		Status:         ReadyPaymentStatus,
+		Amount:         "100",
+	})
+
+	t.Run("🔴 fails if no Payment IDs are provided", func(t *testing.T) {
+		circleRecipients, err := m.CircleRecipient.ResetRecipientsForRetryIfNeeded(ctx, dbConnectionPool)
+		require.ErrorContains(t, err, "at least one payment ID is required")
+		require.Nil(t, circleRecipients)
+	})
+
+	now := time.Now()
+	type TestCases struct {
+		name              string
+		prepareFixturesFn func(t *testing.T, models *Models)
+		paymentIDs        []string
+		wantUpdatedIDs    []string
+	}
+	testCases := []TestCases{
+		{
+			name:           "🟡 nothing happens if no paymentIDs are found",
+			paymentIDs:     []string{"non-existent", "non-existent-2"},
+			wantUpdatedIDs: []string{},
+		},
+		{
+			name:           "🟡 nothing happens if no circle recipients are found for the given payment IDs",
+			paymentIDs:     []string{paymentA1.ID, paymentA2.ID, paymentB1.ID, paymentB2.ID},
+			wantUpdatedIDs: []string{},
+		},
+		{
+			name: "🟢 only 'paymentA*' related recipients were updated",
+			prepareFixturesFn: func(t *testing.T, models *Models) {
+				for _, rwID := range []string{rwA.ID, rwB.ID} {
+					CreateCircleRecipientFixture(t, ctx, dbConnectionPool, CircleRecipient{
+						IdempotencyKey:   uuid.NewString(),
+						ReceiverWalletID: rwID,
+						UpdatedAt:        now,
+						CreatedAt:        now,
+						Status:           CircleRecipientStatusDenied,
+					})
+				}
+			},
+			paymentIDs:     []string{paymentA1.ID, paymentA2.ID},
+			wantUpdatedIDs: []string{rwA.ID},
+		},
+		{
+			name: "🟢 only 'payment*1' related recipients were updated",
+			prepareFixturesFn: func(t *testing.T, models *Models) {
+				for _, rwID := range []string{rwA.ID, rwB.ID} {
+					CreateCircleRecipientFixture(t, ctx, dbConnectionPool, CircleRecipient{
+						IdempotencyKey:   uuid.NewString(),
+						ReceiverWalletID: rwID,
+						UpdatedAt:        now,
+						CreatedAt:        now,
+						Status:           CircleRecipientStatusDenied,
+					})
+				}
+			},
+			paymentIDs:     []string{paymentA1.ID, paymentB1.ID},
+			wantUpdatedIDs: []string{rwA.ID, rwB.ID},
+		},
+	}
+
+	for _, nonActiveStatus := range []CircleRecipientStatus{
+		CircleRecipientStatusDenied,
+		CircleRecipientStatusInactive,
+		CircleRecipientStatusPending,
+		"",
+	} {
+		testCases = append(testCases, TestCases{
+			name: fmt.Sprintf("🟢 all recipients were updated [status=%s]", nonActiveStatus),
+			prepareFixturesFn: func(t *testing.T, models *Models) {
+				for _, rwID := range []string{rwA.ID, rwB.ID} {
+					CreateCircleRecipientFixture(t, ctx, dbConnectionPool, CircleRecipient{
+						IdempotencyKey:   uuid.NewString(),
+						ReceiverWalletID: rwID,
+						UpdatedAt:        now,
+						CreatedAt:        now,
+						Status:           nonActiveStatus,
+					})
+				}
+			},
+			paymentIDs:     []string{paymentA1.ID, paymentA2.ID, paymentB1.ID, paymentB2.ID},
+			wantUpdatedIDs: []string{rwA.ID, rwB.ID},
+		})
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer DeleteAllCircleRecipientsFixtures(t, ctx, m.DBConnectionPool)
+			if tc.prepareFixturesFn != nil {
+				tc.prepareFixturesFn(t, m)
+			}
+
+			circleRecipients, err := m.CircleRecipient.ResetRecipientsForRetryIfNeeded(ctx, dbConnectionPool, tc.paymentIDs...)
+			require.NoError(t, err)
+
+			updatedIDs := make([]string, 0, len(circleRecipients))
+			for _, cr := range circleRecipients {
+				updatedIDs = append(updatedIDs, cr.ReceiverWalletID)
+			}
+			require.ElementsMatch(t, tc.wantUpdatedIDs, updatedIDs)
+
+			if len(updatedIDs) > 0 {
+				for _, rwID := range updatedIDs {
+					circleRecipient, err := m.CircleRecipient.GetByReceiverWalletID(ctx, rwID)
+					require.NoError(t, err)
+					require.NotNil(t, circleRecipient)
+					assert.Empty(t, circleRecipient.Status)
+					assert.Empty(t, circleRecipient.SyncAttempts)
+					assert.Empty(t, circleRecipient.LastSyncAttemptAt)
+					assert.Empty(t, circleRecipient.ResponseBody)
+				}
+			}
+		})
+	}
 }

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type PaymentsHandler struct {
@@ -178,9 +179,14 @@ func (p PaymentsHandler) RetryPayments(rw http.ResponseWriter, req *http.Request
 				return nil, fmt.Errorf("retrying failed payments: %w", err)
 			}
 
-			_, err = p.Models.CircleRecipient.ResetRecipientsForRetryIfNeeded(ctx, dbTx, reqBody.PaymentIDs...)
-			if err != nil {
-				return nil, fmt.Errorf("resetting circle recipients for retry if needed: %w", err)
+			var tnt *tenant.Tenant
+			if tnt, err = tenant.GetTenantFromContext(ctx); err != nil {
+				return nil, fmt.Errorf("getting tenant from context: %w", err)
+			} else if tnt.DistributionAccountType.IsCircle() {
+				_, err = p.Models.CircleRecipient.ResetRecipientsForRetryIfNeeded(ctx, dbTx, reqBody.PaymentIDs...)
+				if err != nil {
+					return nil, fmt.Errorf("resetting circle recipients for retry if needed: %w", err)
+				}
 			}
 
 			// Producing event to send ready payments to TSS

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -178,6 +178,11 @@ func (p PaymentsHandler) RetryPayments(rw http.ResponseWriter, req *http.Request
 				return nil, fmt.Errorf("retrying failed payments: %w", err)
 			}
 
+			_, err = p.Models.CircleRecipient.ResetRecipientsForRetryIfNeeded(ctx, dbTx, reqBody.PaymentIDs...)
+			if err != nil {
+				return nil, fmt.Errorf("resetting circle recipients for retry if needed: %w", err)
+			}
+
 			// Producing event to send ready payments to TSS
 			var payments []*data.Payment
 			payments, err = p.Models.Payment.GetReadyByID(ctx, dbTx, reqBody.PaymentIDs...)

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher.go
@@ -191,9 +191,7 @@ func (c *CirclePaymentDispatcher) ensureRecipientIsReady(ctx context.Context, re
 	}
 
 	// FAILED or INACTIVE -> refresh the idempotency key
-	shouldBumpSyncAttempts := false
 	if dataRecipient.Status.IsCompleted() {
-		shouldBumpSyncAttempts = true // Only bump sync_attempts when trying to re-register the recipient
 		if dataRecipient.SyncAttempts >= maxCircleRecipientCreationAttempts {
 			return nil, ErrCircleRecipientCreationFailedTooManyTimes
 		}
@@ -248,10 +246,8 @@ func (c *CirclePaymentDispatcher) ensureRecipientIsReady(ctx context.Context, re
 		CircleRecipientID: recipient.ID,
 		Status:            dataRecipientStatus,
 		ResponseBody:      recipientJson,
-	}
-	if shouldBumpSyncAttempts {
-		updateDataRecipient.SyncAttempts = dataRecipient.SyncAttempts + 1
-		updateDataRecipient.LastSyncAttemptAt = time.Now()
+		SyncAttempts:      dataRecipient.SyncAttempts + 1,
+		LastSyncAttemptAt: time.Now(),
 	}
 	dataRecipient, err = c.sdpModels.CircleRecipient.Update(ctx, dataRecipient.ReceiverWalletID, updateDataRecipient)
 	if err != nil {

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher.go
@@ -237,6 +237,7 @@ func (c *CirclePaymentDispatcher) submitRecipientToCircle(ctx context.Context, r
 		_, updateErr := c.sdpModels.CircleRecipient.Update(ctx, dataRecipient.ReceiverWalletID, data.CircleRecipientUpdate{
 			SyncAttempts:      dataRecipient.SyncAttempts + 1,
 			LastSyncAttemptAt: time.Now(),
+			ResponseBody:      []byte(fmt.Sprintf(`{"error": "%s"}`, err.Error())),
 		})
 		if updateErr != nil {
 			return nil, fmt.Errorf("updating Circle recipient after postRecipientErr: %w", updateErr)

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher.go
@@ -194,7 +194,7 @@ func (c *CirclePaymentDispatcher) ensureRecipientIsReady(ctx context.Context, re
 	}
 
 	// FAILED or INACTIVE -> refresh the idempotency key
-	if dataRecipient.Status == nil || dataRecipient.Status.IsCompleted() {
+	if dataRecipient.Status.IsCompleted() {
 		log.Ctx(ctx).Infof("Renovating idempotency_key for circle_recipient with receiver_wallet_id %q...", receiverWallet.ID)
 		dataRecipient, err = c.sdpModels.CircleRecipient.Update(ctx, dataRecipient.ReceiverWalletID, data.CircleRecipientUpdate{
 			IdempotencyKey: uuid.NewString(),

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher.go
@@ -70,7 +70,6 @@ var _ PaymentDispatcherInterface = (*CirclePaymentDispatcher)(nil)
 func (c *CirclePaymentDispatcher) sendPaymentsToCircle(ctx context.Context, sdpDBTx db.DBTransaction, circleWalletID string, paymentsToSubmit []*data.Payment) error {
 	for _, payment := range paymentsToSubmit {
 		// 1. Ensure the recipient is ready
-		// TODO: When clicking retries, we should reset the recipient count?
 		recipient, err := c.ensureRecipientIsReadyWithRetry(ctx, *payment.ReceiverWallet, initialBackoffDelay)
 		if err != nil {
 			// 2. If the recipient creation fails, set the payment status to failed

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher.go
@@ -302,7 +302,7 @@ func (c *CirclePaymentDispatcher) ensureRecipientIsReady(ctx context.Context, re
 // calls ensureRecipientIsReadyWithRetry with a retry policy.
 func (c *CirclePaymentDispatcher) ensureRecipientIsReadyWithRetry(ctx context.Context, receiverWallet data.ReceiverWallet, initialDelay time.Duration) (*data.CircleRecipient, error) {
 	if initialDelay <= 0 || initialDelay > time.Second {
-		initialDelay = 100 * time.Millisecond
+		initialDelay = initialBackoffDelay
 	}
 
 	var recipient *data.CircleRecipient

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
@@ -354,6 +354,146 @@ func Test_CirclePaymentDispatcher_ensureRecipientIsReady_failure(t *testing.T) {
 	}
 }
 
+func Test_CirclePaymentDispatcher_ensureRecipientIsReadyWithRetry(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+
+	// Fixtures
+	disbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{})
+	receiver1 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+	receiverWallet := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver1.ID, disbursement.Wallet.ID, data.RegisteredReceiversWalletStatus)
+
+	now := time.Now()
+	initialTime := now.Add(-time.Hour)
+	recipientInsertTemplate := data.CircleRecipient{
+		ReceiverWalletID:  receiverWallet.ID,
+		CircleRecipientID: "circle-recipient-id",
+		IdempotencyKey:    "idepotency-key",
+		CreatedAt:         initialTime,
+		UpdatedAt:         initialTime,
+		SyncAttempts:      0,
+		LastSyncAttemptAt: initialTime,
+	}
+	type TestCase struct {
+		name                       string
+		populateInitialRecipientFn func(t *testing.T) *data.CircleRecipient
+		prepareMocksFn             func(t *testing.T, mCircleService *circle.MockService)
+		assertRecipients           func(t *testing.T, initialRecipient, finalRecipient data.CircleRecipient)
+		wantErrContains            string
+	}
+	testCases := []TestCase{
+		{
+			name: "tries 5 times (error returned)",
+			populateInitialRecipientFn: func(t *testing.T) *data.CircleRecipient {
+				recipientInsert := recipientInsertTemplate
+				recipientInsert.Status = data.CircleRecipientStatusPending
+				recipientInsert.ResponseBody = []byte(`{"foo": "bar"}`)
+				return data.CreateCircleRecipientFixture(t, ctx, dbConnectionPool, recipientInsert)
+			},
+			prepareMocksFn: func(t *testing.T, mCircleService *circle.MockService) {
+				mCircleService.
+					On("PostRecipient", ctx, mock.Anything).
+					Run(func(args mock.Arguments) {
+						recipientRequest, ok := args.Get(1).(circle.RecipientRequest)
+						require.True(t, ok)
+						assert.Equal(t, recipientInsertTemplate.IdempotencyKey, recipientRequest.IdempotencyKey)
+						assert.Equal(t, receiverWallet.StellarAddress, recipientRequest.Address)
+						assert.Equal(t, circle.StellarChainCode, recipientRequest.Chain)
+						assert.Equal(t, receiverWallet.Receiver.PhoneNumber, recipientRequest.Metadata.Nickname)
+						assert.Equal(t, receiverWallet.Receiver.Email, recipientRequest.Metadata.Email)
+					}).
+					Return(nil, errors.New("got 400 from vendor's API")).
+					Times(5)
+			},
+			assertRecipients: func(t *testing.T, initialRecipient, finalRecipient data.CircleRecipient) {
+				assert.Equal(t, initialRecipient.SyncAttempts+maxCircleRecipientCreationAttempts, finalRecipient.SyncAttempts)
+				assert.Greater(t, finalRecipient.LastSyncAttemptAt.Unix(), initialRecipient.LastSyncAttemptAt.Unix())
+			},
+			wantErrContains: "failed to ensure recipient is ready: All attempts fail:\n#1: creating Circle recipient: got 400 from vendor's API",
+		},
+		{
+			name: "gives up if maxCircleRecipientCreationAttempts is reached",
+			populateInitialRecipientFn: func(t *testing.T) *data.CircleRecipient {
+				recipientInsert := recipientInsertTemplate
+				recipientInsert.Status = data.CircleRecipientStatusPending
+				recipientInsert.ResponseBody = []byte(`{"foo": "bar"}`)
+				recipientInsert.SyncAttempts = maxCircleRecipientCreationAttempts
+				return data.CreateCircleRecipientFixture(t, ctx, dbConnectionPool, recipientInsert)
+			},
+			assertRecipients: func(t *testing.T, initialRecipient, finalRecipient data.CircleRecipient) {
+				assert.Equal(t, initialRecipient.SyncAttempts, finalRecipient.SyncAttempts)
+				assert.Equal(t, finalRecipient.LastSyncAttemptAt.Unix(), initialRecipient.LastSyncAttemptAt.Unix())
+			},
+			wantErrContains: ErrCircleRecipientCreationFailedTooManyTimes.Error(),
+		},
+	}
+
+	for _, nonSuccessfulState := range []data.CircleRecipientStatus{data.CircleRecipientStatusInactive, data.CircleRecipientStatusDenied, data.CircleRecipientStatusPending} {
+		testCases = append(testCases, TestCase{
+			name: fmt.Sprintf("tries 5 times [status=%s]", nonSuccessfulState),
+			populateInitialRecipientFn: func(t *testing.T) *data.CircleRecipient {
+				recipientInsert := recipientInsertTemplate
+				recipientInsert.Status = data.CircleRecipientStatusPending
+				recipientInsert.ResponseBody = []byte(`{"foo": "bar"}`)
+				return data.CreateCircleRecipientFixture(t, ctx, dbConnectionPool, recipientInsert)
+			},
+			prepareMocksFn: func(t *testing.T, mCircleService *circle.MockService) {
+				mCircleService.
+					On("PostRecipient", ctx, mock.Anything).
+					Run(func(args mock.Arguments) {
+						recipientRequest, ok := args.Get(1).(circle.RecipientRequest)
+						require.True(t, ok)
+						assert.Equal(t, receiverWallet.StellarAddress, recipientRequest.Address)
+						assert.Equal(t, circle.StellarChainCode, recipientRequest.Chain)
+						assert.Equal(t, receiverWallet.Receiver.PhoneNumber, recipientRequest.Metadata.Nickname)
+						assert.Equal(t, receiverWallet.Receiver.Email, recipientRequest.Metadata.Email)
+					}).
+					Return(&circle.Recipient{ID: "recipient-id", Status: string(nonSuccessfulState)}, nil).
+					Times(5)
+			},
+			assertRecipients: func(t *testing.T, initialRecipient, finalRecipient data.CircleRecipient) {
+				assert.Equal(t, nonSuccessfulState, finalRecipient.Status)
+				assert.Equal(t, initialRecipient.SyncAttempts+maxCircleRecipientCreationAttempts, finalRecipient.SyncAttempts)
+				assert.Greater(t, finalRecipient.LastSyncAttemptAt.Unix(), initialRecipient.LastSyncAttemptAt.Unix())
+			},
+		})
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer data.DeleteAllCircleRecipientsFixtures(t, ctx, dbConnectionPool)
+			initialRecipient := tc.populateInitialRecipientFn(t)
+
+			mDistAccountResolver := mocks.NewMockDistributionAccountResolver(t)
+			mCircleService := circle.NewMockService(t)
+			if tc.prepareMocksFn != nil {
+				tc.prepareMocksFn(t, mCircleService)
+			}
+
+			dispatcher := NewCirclePaymentDispatcher(models, mCircleService, mDistAccountResolver)
+
+			finalRecipient, err := dispatcher.ensureRecipientIsReadyWithRetry(ctx, *receiverWallet, 1*time.Millisecond)
+
+			if tc.wantErrContains != "" {
+				assert.ErrorContains(t, err, tc.wantErrContains)
+				assert.Nil(t, finalRecipient)
+			}
+
+			finalRecipient, err = models.CircleRecipient.GetByReceiverWalletID(ctx, receiverWallet.ID)
+			require.NoError(t, err)
+			tc.assertRecipients(t, *initialRecipient, *finalRecipient)
+		})
+	}
+}
+
 func Test_CirclePaymentDispatcher_DispatchPayments(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
@@ -407,7 +407,7 @@ func Test_CirclePaymentDispatcher_ensureRecipientIsReadyWithRetry(t *testing.T) 
 				assert.Equal(t, initialRecipient.SyncAttempts+maxCircleRecipientCreationAttempts, finalRecipient.SyncAttempts)
 				assert.Greater(t, finalRecipient.LastSyncAttemptAt.Unix(), initialRecipient.LastSyncAttemptAt.Unix())
 			},
-			wantErrContains: "failed to ensure recipient is ready: All attempts fail:\n#1: creating Circle recipient: got 400 from vendor's API",
+			wantErrContains: "failed to ensure recipient is ready: All attempts fail:\n#1: submitting recipient to Circle: creating Circle recipient: got 400 from vendor's API",
 		},
 		{
 			name: "gives up if maxCircleRecipientCreationAttempts is reached",

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
@@ -248,6 +248,7 @@ func Test_CirclePaymentDispatcher_ensureRecipientIsReady_failure(t *testing.T) {
 			assertRecipients: func(t *testing.T, initialRecipient, finalRecipient data.CircleRecipient) {
 				assert.Equal(t, initialRecipient.SyncAttempts+1, finalRecipient.SyncAttempts)
 				assert.Greater(t, finalRecipient.LastSyncAttemptAt.Unix(), initialRecipient.LastSyncAttemptAt.Unix())
+				assert.JSONEq(t, `{"error": "got 400 from vendor's API"}`, string(finalRecipient.ResponseBody))
 			},
 			wantErrContains: "creating Circle recipient: got 400 from vendor's API",
 		},


### PR DESCRIPTION
### What

Errors in the POST /recipient endpoint are not being properly handled. What;s missing?
- When POST /recipient fails with `ErrCircleRecipientCreationFailedTooManyTimes`, we update the payments table with the failed status explaining the reason.
- When a payment that failed due to recipient creation issues is retried, the recipient is reset with `status=NULL` and `sync_attempts=0`.
- The method `ensureRecipientIsReady` was split into different sub-methods for better modularity and clarity, as suggested in https://github.com/stellar/stellar-disbursement-platform-backend/pull/486#discussion_r1878843074.

<img width="1151" alt="Screenshot 2024-12-12 at 4 39 08 PM" src="https://github.com/user-attachments/assets/53ed59d9-bba0-42e2-b149-0fca3bfb5a66" />

- [x] Tested with scheduled jobs
- [x] Tested with Kafka

### Why

To wrap up https://stellarorg.atlassian.net/browse/SDP-1397

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
