### PR TITLE
[SDP-1391] Export Payments with Filtering

### DIFF
--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -1456,7 +1456,7 @@ func Test_AssetHandler_submitChangeTrustTransaction_makeSurePreconditionsAreSetA
 			timeSinceCreation := time.Since(creationTime)
 
 			expectedAdjustedMaxTime := expectedMaxTime.Add(timeSinceCreation)
-			require.WithinDuration(t, expectedAdjustedMaxTime, actualMaxTime, 5*time.Second)
+			require.WithinDuration(t, expectedAdjustedMaxTime, actualMaxTime, 10*time.Second)
 		}
 	}
 

--- a/internal/serve/httphandler/export_handler_test.go
+++ b/internal/serve/httphandler/export_handler_test.go
@@ -132,3 +132,146 @@ func Test_ExportHandler_ExportDisbursements(t *testing.T) {
 		})
 	}
 }
+
+func Test_ExportHandler_ExportPayments(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	ctx := context.Background()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+
+	handler := &ExportHandler{
+		Models: models,
+	}
+
+	r := chi.NewRouter()
+	r.Get("/exports/payments", handler.ExportPayments)
+
+	wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "Wallet", "https://www.wallet.com", "www.wallet.com", "wallet://")
+	asset := data.CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+	receiverReady := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+	rwReady := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiverReady.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+
+	disbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, handler.Models.Disbursements, &data.Disbursement{
+		Name:   "disbursement 1",
+		Status: data.StartedDisbursementStatus,
+		Wallet: wallet,
+		Asset:  asset,
+	})
+
+	pendingPayment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+		ReceiverWallet:    rwReady,
+		Disbursement:      disbursement,
+		Asset:             *asset,
+		Amount:            "100",
+		Status:            data.PendingPaymentStatus,
+		CreatedAt:         time.Date(2024, 3, 21, 23, 40, 20, 1431, time.UTC),
+		ExternalPaymentID: "PAY01",
+	})
+	successfulPayment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+		ReceiverWallet:    rwReady,
+		Disbursement:      disbursement,
+		Asset:             *asset,
+		Amount:            "200",
+		Status:            data.SuccessPaymentStatus,
+		CreatedAt:         time.Date(2023, 3, 21, 23, 40, 20, 1431, time.UTC),
+		ExternalPaymentID: "PAY02",
+	})
+	failedPayment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+		ReceiverWallet:    rwReady,
+		Disbursement:      disbursement,
+		Asset:             *asset,
+		Amount:            "300",
+		Status:            data.FailedPaymentStatus,
+		CreatedAt:         time.Date(2022, 3, 21, 23, 40, 20, 1431, time.UTC),
+		ExternalPaymentID: "PAY03",
+	})
+
+	tests := []struct {
+		name               string
+		queryParams        string
+		expectedStatusCode int
+		expectedPayments   []*data.Payment
+	}{
+		{
+			name:               "success - returns CSV with no payments",
+			queryParams:        "status=draft",
+			expectedStatusCode: http.StatusOK,
+			expectedPayments:   []*data.Payment{},
+		},
+		{
+			name:               "success - returns CSV with all payments",
+			expectedStatusCode: http.StatusOK,
+			queryParams:        "sort=created_at",
+			expectedPayments:   []*data.Payment{pendingPayment, successfulPayment, failedPayment},
+		},
+		{
+			name:               "success - return CSV with reverse order of payments",
+			expectedStatusCode: http.StatusOK,
+			queryParams:        "sort=created_at&direction=asc",
+			expectedPayments:   []*data.Payment{failedPayment, successfulPayment, pendingPayment},
+		},
+		{
+			name:               "success - return CSV with only successful payments",
+			expectedStatusCode: http.StatusOK,
+			queryParams:        "status=success",
+			expectedPayments:   []*data.Payment{successfulPayment},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			url := "/exports/payments"
+			if tc.queryParams != "" {
+				url += "?" + tc.queryParams
+			}
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			require.NoError(t, err)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			assert.Equal(t, tc.expectedStatusCode, rr.Code)
+			csvReader := csv.NewReader(strings.NewReader(rr.Body.String()))
+
+			header, err := csvReader.Read()
+			require.NoError(t, err)
+
+			expectedHeaders := []string{
+				"ID", "Amount", "StellarTransactionID", "Status",
+				"Disbursement.ID", "Asset.Code", "Asset.Issuer", "Wallet.Name", "Receiver.ID",
+				"ReceiverWallet.Address", "ReceiverWallet.Status", "CreatedAt", "UpdatedAt",
+				"ExternalPaymentID", "CircleTransferRequestID",
+			}
+			assert.Equal(t, expectedHeaders, header)
+
+			assert.Equal(t, "text/csv", rr.Header().Get("Content-Type"))
+			today := time.Now().Format("2006-01-02")
+			assert.Contains(t, rr.Header().Get("Content-Disposition"), fmt.Sprintf("attachment; filename=payments_%s", today))
+
+			rows, err := csvReader.ReadAll()
+			require.NoError(t, err)
+			assert.Len(t, rows, len(tc.expectedPayments))
+
+			for i, row := range rows {
+				assert.Equal(t, tc.expectedPayments[i].ID, row[0])
+				assert.Equal(t, tc.expectedPayments[i].Amount, row[1])
+				assert.Equal(t, tc.expectedPayments[i].StellarTransactionID, row[2])
+				assert.Equal(t, string(tc.expectedPayments[i].Status), row[3])
+				assert.Equal(t, tc.expectedPayments[i].Disbursement.ID, row[4])
+				assert.Equal(t, tc.expectedPayments[i].Asset.Code, row[5])
+				assert.Equal(t, tc.expectedPayments[i].Asset.Issuer, row[6])
+				assert.Equal(t, tc.expectedPayments[i].ReceiverWallet.Wallet.Name, row[7])
+				assert.Equal(t, tc.expectedPayments[i].ReceiverWallet.Receiver.ID, row[8])
+				assert.Equal(t, tc.expectedPayments[i].ReceiverWallet.StellarAddress, row[9])
+				assert.Equal(t, string(tc.expectedPayments[i].ReceiverWallet.Status), row[10])
+				assert.Equal(t, tc.expectedPayments[i].ExternalPaymentID, row[13])
+			}
+		})
+	}
+}

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -258,7 +258,7 @@ func (p PaymentsHandler) getPaymentsWithCount(ctx context.Context, queryParams *
 
 		var payments []data.Payment
 		if totalPayments != 0 {
-			payments, innerErr = p.Models.Payment.GetAll(ctx, queryParams, dbTx)
+			payments, innerErr = p.Models.Payment.GetAll(ctx, queryParams, dbTx, data.QueryTypeSelectPaginated)
 			if innerErr != nil {
 				return nil, fmt.Errorf("error querying payments: %w", innerErr)
 			}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -419,6 +419,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 			Route("/exports", func(r chi.Router) {
 				r.Get("/disbursements", exportHandler.ExportDisbursements)
+				r.Get("/payments", exportHandler.ExportPayments)
 			})
 	})
 

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -480,6 +480,7 @@ func Test_handleHTTP_authenticatedEndpoints(t *testing.T) {
 		{http.MethodGet, "/balances"},
 		// Exports
 		{http.MethodGet, "/exports/disbursements"},
+		{http.MethodGet, "/exports/payments"},
 	}
 
 	// Expect 401 as a response:

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -346,7 +346,7 @@ func (s *DisbursementManagementService) validateBalanceForDisbursement(
 		Filters: map[data.FilterKey]interface{}{
 			data.FilterKeyStatus: data.PaymentInProgressStatuses(),
 		},
-	}, dbTx)
+	}, dbTx, data.QueryTypeSelectAll)
 	if err != nil {
 		return fmt.Errorf("cannot retrieve incomplete payments: %w", err)
 	}


### PR DESCRIPTION
### What

Add a new endpoint to export payments with filtering 
`GET /exports/payments?sort=created_at&direction=asc&status=success`

**File name:** `payments_2024-12-12-14-51-41.csv`
```csv
ID,Amount,StellarTransactionID,Status,Disbursement.ID,Asset.Code,Asset.Issuer,Wallet.Name,Receiver.ID,ReceiverWallet.Address,ReceiverWallet.Status,CreatedAt,UpdatedAt,ExternalPaymentID,CircleTransferRequestID
3e01fae9-a6b7-41c2-b713-d8894603dfc3,0.1200000,be5760ce9b6ac91421ee896675e453daff0deced3aa852d48521ccced59f28f4,SUCCESS,68494ca8-4f49-4d56-af81-42589963293c,XLM,,User Managed Wallet,d37031d2-8bf4-41bb-8ce5-bf59075cdf8e,GDAKY4LJVM4TJDZWUCX4TAABRRPD5A53DAJ4VULG3QSAHQLWL2YNSZQJ,REGISTERED,2024-11-28T22:31:24.733382Z,2024-11-28T22:31:36.441927Z,PAY_01,
6e68ad2a-3400-4cd2-90bd-c1657e40ebcd,0.1200000,564abaccc208dea99e97897d87e360c375740e799a8418820727a31b038790ca,SUCCESS,9427421d-9540-4942-85c0-a2de2a45de31,XLM,,User Managed Wallet,d37031d2-8bf4-41bb-8ce5-bf59075cdf8e,GDAKY4LJVM4TJDZWUCX4TAABRRPD5A53DAJ4VULG3QSAHQLWL2YNSZQJ,REGISTERED,2024-11-28T22:34:44.190991Z,2024-11-28T22:34:52.497641Z,PAY_01,
```

### Why

- Allow users to export their data. 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
