### PR TITLE
[SDP-1247] Prepare code for API-only usage by reorganizing the reCaptcha and MFA sections in the handlers they're being used

### DIFF
--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -101,9 +101,9 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		// if we don't find the user by email, we just return an ok response
 		// to prevent malicious client from searching accounts in the system
 		if errors.Is(err, auth.ErrUserNotFound) {
-			log.Ctx(ctx).Errorf("error in forgot password handler, email not found: %s", forgotPasswordRequest.Email)
+			log.Ctx(ctx).Errorf("in forgot password handler, email not found: %s", forgotPasswordRequest.Email)
 		} else if errors.Is(err, auth.ErrUserHasValidToken) {
-			log.Ctx(ctx).Errorf("error in forgot password handler, user has a valid token")
+			log.Ctx(ctx).Errorf("in forgot password handler, user has a valid token")
 		} else {
 			httperror.InternalError(ctx, "", err, nil).Render(w)
 			return

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -39,14 +39,23 @@ type ForgotPasswordRequest struct {
 	ReCAPTCHAToken string `json:"recaptcha_token"`
 }
 
-type ForgotPasswordResponseBody struct {
-	Message string `json:"message"`
+func (h ForgotPasswordHandler) validateRequest(req ForgotPasswordRequest) *httperror.HTTPError {
+	v := validators.NewValidator()
+	v.Check(req.Email != "", "email", "email is required")
+	v.Check(h.ReCAPTCHADisabled || req.ReCAPTCHAToken != "", "recaptcha_token", "reCAPTCHA token is required")
+
+	if v.HasErrors() {
+		return httperror.BadRequest("", nil, v.Errors)
+	}
+
+	return nil
 }
 
 // ServeHTTP implements the http.Handler interface.
 func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	// Step 1: Get tenant from context
 	tnt, err := tenant.GetTenantFromContext(ctx)
 	if err != nil {
 		err = fmt.Errorf("getting tenant from context: %w", err)
@@ -54,13 +63,21 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Step 2: Decode and validate the incoming request
 	var forgotPasswordRequest ForgotPasswordRequest
 	err = json.NewDecoder(r.Body).Decode(&forgotPasswordRequest)
 	if err != nil {
 		httperror.BadRequest("invalid request body", err, nil).Render(w)
 		return
 	}
+	if httpErr := h.validateRequest(forgotPasswordRequest); httpErr != nil {
+		httpErr.Render(w)
+		return
+	}
 
+	truncatedEmail := utils.TruncateString(forgotPasswordRequest.Email, 3)
+
+	// Step 3: Run the reCAPTCHA validation if it is enabled
 	if !h.ReCAPTCHADisabled {
 		// validating reCAPTCHA Token
 		isValid, recaptchaErr := h.ReCAPTCHAValidator.IsTokenValid(ctx, forgotPasswordRequest.ReCAPTCHAToken)
@@ -70,20 +87,13 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 
 		if !isValid {
-			log.Ctx(ctx).Errorf("reCAPTCHA token is invalid for request with email %s", utils.TruncateString(forgotPasswordRequest.Email, 3))
+			log.Ctx(ctx).Errorf("reCAPTCHA token is invalid for request with email %s", truncatedEmail)
 			httperror.BadRequest("reCAPTCHA token invalid", nil, nil).Render(w)
 			return
 		}
 	}
 
-	// validate request
-	v := validators.NewValidator()
-	v.Check(forgotPasswordRequest.Email != "", "email", "email is required")
-	if v.HasErrors() {
-		httperror.BadRequest("request invalid", err, v.Errors).Render(w)
-		return
-	}
-
+	// Step 4: Find the user by email and send the forgot password message
 	err = db.RunInTransaction(ctx, h.Models.DBConnectionPool, nil, func(tx db.DBTransaction) error {
 		resetToken, txErr := h.AuthManager.ForgotPassword(ctx, tx, forgotPasswordRequest.Email)
 		if txErr != nil {
@@ -101,19 +111,18 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		// if we don't find the user by email, we just return an ok response
 		// to prevent malicious client from searching accounts in the system
 		if errors.Is(err, auth.ErrUserNotFound) {
-			log.Ctx(ctx).Errorf("in forgot password handler, email not found: %s", forgotPasswordRequest.Email)
+			log.Ctx(ctx).Errorf("in forgot password handler, email not found: %s", truncatedEmail)
 		} else if errors.Is(err, auth.ErrUserHasValidToken) {
 			log.Ctx(ctx).Errorf("in forgot password handler, user has a valid token")
 		} else {
-			httperror.InternalError(ctx, "", err, nil).Render(w)
+			httperror.InternalError(ctx, err.Error(), err, nil).Render(w)
 			return
 		}
 	}
 
-	responseBody := ForgotPasswordResponseBody{
-		Message: "Password reset requested. If the email is registered, you'll receive a reset link shortly. Check your inbox and spam folders.",
+	responseBody := map[string]string{
+		"message": "Password reset requested. If the email is registered, you'll receive a reset link shortly. Check your inbox and spam folders.",
 	}
-
 	httpjson.RenderStatus(w, http.StatusOK, responseBody, httpjson.JSON)
 }
 
@@ -145,7 +154,7 @@ func (h ForgotPasswordHandler) SendForgotPasswordMessage(ctx context.Context, ui
 	}
 	err = h.MessengerClient.SendMessage(msg)
 	if err != nil {
-		return fmt.Errorf("sending forgot password email for email %s: %w", utils.TruncateString(email, 3), err)
+		return fmt.Errorf("sending forgot password email for %s: %w", utils.TruncateString(email, 3), err)
 	}
 
 	return nil

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -67,7 +67,7 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	var forgotPasswordRequest ForgotPasswordRequest
 	err = json.NewDecoder(r.Body).Decode(&forgotPasswordRequest)
 	if err != nil {
-		httperror.BadRequest("invalid request body", err, nil).Render(w)
+		httperror.BadRequest("", err, nil).Render(w)
 		return
 	}
 	if httpErr := h.validateRequest(forgotPasswordRequest); httpErr != nil {

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -3,10 +3,8 @@ package httphandler
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	urllib "net/url"
 	"strings"
 	"testing"
 
@@ -17,7 +15,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
@@ -87,11 +84,9 @@ func Test_ForgotPasswordHandler_validateRequest(t *testing.T) {
 	}
 }
 
-// TODO: tests with reCaptcha enabled and disabled
 func Test_ForgotPasswordHandler_ServeHTTP(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
-
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
@@ -99,405 +94,212 @@ func Test_ForgotPasswordHandler_ServeHTTP(t *testing.T) {
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 
-	const url = "/forgot-password"
-
-	authenticatorMock := &auth.AuthenticatorMock{}
-	reCAPTCHAValidatorMock := &validators.ReCAPTCHAValidatorMock{}
-	authManager := auth.NewAuthManager(
-		auth.WithCustomAuthenticatorOption(authenticatorMock),
-	)
-
-	messengerClientMock := message.NewMessengerClientMock(t)
-	handler := &ForgotPasswordHandler{
-		AuthManager:        authManager,
-		MessengerClient:    messengerClientMock,
-		Models:             models,
-		ReCAPTCHAValidator: reCAPTCHAValidatorMock,
-		ReCAPTCHADisabled:  false,
-	}
-
 	uiBaseURL := "https://sdp.com"
-	tnt := tenant.Tenant{
-		SDPUIBaseURL: &uiBaseURL,
-	}
-	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
+	tnt := tenant.Tenant{SDPUIBaseURL: &uiBaseURL}
+	defaultSuccessishBody := `{"message": "Password reset requested. If the email is registered, you'll receive a reset link shortly. Check your inbox and spam folders."}`
+	// ctxWithTenant := tenant.SaveTenantInContext(ctxWithoutTenant, &tnt)
 
-	t.Run("Should not create a token when email provider fails", func(t *testing.T) {
-		requestBody := `
-		{ 
-			"email": "valid@email.com" ,
-			"recaptcha_token": "validToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-
-		authenticatorMock.
-			On("ForgotPassword", req.Context(), mock.Anything, "valid@email.com").
-			Return("resetToken", nil).
-			Once()
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "validToken").
-			Return(true, nil).
-			Once()
-
-		messengerClientMock.
-			On("SendMessage", mock.Anything).
-			Return(errors.New("unexpected error")).
-			Once()
-
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-
-		// check that there are no tokens created in the database for this user
-		sql := `SELECT * FROM auth_user_password_reset JOIN auth_users ON auth_user_password_reset.auth_user_id = auth_users.id WHERE auth_users.email = $1`
-		rows, queryErr := dbConnectionPool.QueryContext(context.Background(), sql, "valid@email.com")
-		require.NoError(t, queryErr)
-		assert.False(t, rows.Next())
-	})
-
-	t.Run("Should return http status 200 on a valid request", func(t *testing.T) {
-		requestBody := `
-		{ 
-			"email": "valid@email.com" ,
-			"recaptcha_token": "validToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-
-		authenticatorMock.
-			On("ForgotPassword", req.Context(), mock.Anything, "valid@email.com").
-			Return("resetToken", nil).
-			Once()
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "validToken").
-			Return(true, nil).
-			Once()
-
-		resetPasswordLink, err := urllib.JoinPath(uiBaseURL, "reset-password")
-		require.NoError(t, err)
-
-		content, err := htmltemplate.ExecuteHTMLTemplateForStaffForgotPasswordEmailMessage(htmltemplate.StaffForgotPasswordEmailMessageTemplate{
-			ResetToken:        "resetToken",
-			ResetPasswordLink: resetPasswordLink,
-			OrganizationName:  "MyCustomAid",
-		})
-		require.NoError(t, err)
-
-		msg := message.Message{
-			ToEmail: "valid@email.com",
-			Title:   forgotPasswordMessageTitle,
-			Body:    content,
-		}
-		messengerClientMock.
-			On("SendMessage", msg).
-			Return(nil).
-			Once()
-
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-	})
-
-	t.Run("Should return http status 500 when the reset password link is invalid", func(t *testing.T) {
-		tntInvalidUIBaseURL := tenant.Tenant{
-			SDPUIBaseURL: &[]string{"%invalid%"}[0],
-		}
-		ctxTenantWithInvalidUIBaseURL := tenant.SaveTenantInContext(context.Background(), &tntInvalidUIBaseURL)
-
-		requestBody := `
-		{ 
-			"email": "valid@email.com" ,
-			"recaptcha_token": "validToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctxTenantWithInvalidUIBaseURL, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-
-		authenticatorMock.
-			On("ForgotPassword", req.Context(), mock.Anything, "valid@email.com").
-			Return("resetToken", nil).
-			Once()
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "validToken").
-			Return(true, nil).
-			Once()
-
-		http.HandlerFunc(ForgotPasswordHandler{
-			AuthManager:        authManager,
-			MessengerClient:    messengerClientMock,
-			Models:             models,
-			ReCAPTCHAValidator: reCAPTCHAValidatorMock,
-			ReCAPTCHADisabled:  false,
-		}.ServeHTTP).ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-	})
-
-	t.Run("Should return an http status ok even if the email is not found", func(t *testing.T) {
-		requestBody := `
-		{ 
-			"email": "not_found@email.com" ,
-			"recaptcha_token": "validToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-
-		authenticatorMock.
-			On("ForgotPassword", req.Context(), mock.Anything, "not_found@email.com").
-			Return("", auth.ErrUserNotFound).
-			Once()
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "validToken").
-			Return(true, nil).
-			Once()
-
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		resp := rr.Result()
-
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-	})
-
-	t.Run("Should return an http status ok even if the user has a valid token", func(t *testing.T) {
-		requestBody := `
-		{ 
-			"email": "valid@email.com" ,
-			"recaptcha_token": "validToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-
-		authenticatorMock.
-			On("ForgotPassword", req.Context(), mock.Anything, "valid@email.com").
-			Return("", auth.ErrUserHasValidToken).
-			Once()
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "validToken").
-			Return(true, nil).
-			Once()
-
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-	})
-
-	t.Run("Should require email param", func(t *testing.T) {
-		requestBody := `
-		{ 
-			"email": "",
-			"recaptcha_token": "validToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		expectedBody := `
-			{
+	testCases := []struct {
+		name              string
+		hasTenant         bool
+		ReCAPTCHADisabled bool
+		prepareMocks      func(t *testing.T, reCAPTCHAValidatorMock *validators.ReCAPTCHAValidatorMock, authManagerMock *auth.AuthManagerMock, messengerClientMock *message.MessengerClientMock)
+		reqBody           string
+		wantStatusCode    int
+		wantResponseBody  string
+	}{
+		{
+			name:             "🔴[401] no tenant in the context",
+			hasTenant:        false,
+			wantStatusCode:   http.StatusUnauthorized,
+			wantResponseBody: `{"error":"Not authorized."}`,
+		},
+		{
+			name:             "🔴[400] invalid body",
+			hasTenant:        true,
+			reqBody:          "invalid json",
+			wantStatusCode:   http.StatusBadRequest,
+			wantResponseBody: `{"error":"The request was invalid in some way."}`,
+		},
+		{
+			name:              "🔴[400](ReCAPTCHADisabled=false) missing [email, recaptcha_token]",
+			hasTenant:         true,
+			ReCAPTCHADisabled: false,
+			reqBody:           "{}",
+			wantStatusCode:    http.StatusBadRequest,
+			wantResponseBody: `{
 				"error":"The request was invalid in some way.",
 				"extras": {
-					"email":"email is required"
+					"email": "email is required",
+					"recaptcha_token": "reCAPTCHA token is required"
 				}
+			}`,
+		},
+		{
+			name:              "🔴[400](ReCAPTCHADisabled=true) missing [email]",
+			hasTenant:         true,
+			ReCAPTCHADisabled: true,
+			reqBody:           "{}",
+			wantStatusCode:    http.StatusBadRequest,
+			wantResponseBody: `{
+				"error":"The request was invalid in some way.",
+				"extras": {
+					"email": "email is required"
+				}
+			}`,
+		},
+		{
+			name:      "🔴[500] when reCAPTCHA validator throws an unexpected error",
+			hasTenant: true,
+			reqBody:   `{"email": "foobar@test.com","recaptcha_token":"token"}`,
+			prepareMocks: func(t *testing.T, reCAPTCHAValidatorMock *validators.ReCAPTCHAValidatorMock, authManagerMock *auth.AuthManagerMock, messengerClientMock *message.MessengerClientMock) {
+				reCAPTCHAValidatorMock.
+					On("IsTokenValid", mock.Anything, "token").
+					Return(false, errors.New("unexpected error")).
+					Once()
+			},
+			wantStatusCode:   http.StatusInternalServerError,
+			wantResponseBody: `{"error": "Cannot validate reCAPTCHA token"}`,
+		},
+		{
+			name:      "🔴[400] when mfa_code is invalid",
+			hasTenant: true,
+			reqBody:   `{"email": "foobar@test.com","recaptcha_token":"token"}`,
+			prepareMocks: func(t *testing.T, reCAPTCHAValidatorMock *validators.ReCAPTCHAValidatorMock, authManagerMock *auth.AuthManagerMock, messengerClientMock *message.MessengerClientMock) {
+				reCAPTCHAValidatorMock.
+					On("IsTokenValid", mock.Anything, "token").
+					Return(false, nil).
+					Once()
+			},
+			wantStatusCode:   http.StatusBadRequest,
+			wantResponseBody: `{"error": "reCAPTCHA token invalid"}`,
+		},
+		{
+			name:      "🟡[200] return Ok-ish even when user was not found",
+			hasTenant: true,
+			reqBody:   `{"email": "foobar@test.com","recaptcha_token":"token"}`,
+			prepareMocks: func(t *testing.T, reCAPTCHAValidatorMock *validators.ReCAPTCHAValidatorMock, authManagerMock *auth.AuthManagerMock, messengerClientMock *message.MessengerClientMock) {
+				reCAPTCHAValidatorMock.
+					On("IsTokenValid", mock.Anything, "token").
+					Return(true, nil).
+					Once()
+				authManagerMock.
+					On("ForgotPassword", mock.Anything, mock.Anything, "foobar@test.com").
+					Return("", auth.ErrUserNotFound).
+					Once()
+			},
+			wantStatusCode:   http.StatusOK,
+			wantResponseBody: defaultSuccessishBody,
+		},
+		{
+			name:      "🟡[200] return Ok-ish if user already has a valid token",
+			hasTenant: true,
+			reqBody:   `{"email": "foobar@test.com","recaptcha_token":"token"}`,
+			prepareMocks: func(t *testing.T, reCAPTCHAValidatorMock *validators.ReCAPTCHAValidatorMock, authManagerMock *auth.AuthManagerMock, messengerClientMock *message.MessengerClientMock) {
+				reCAPTCHAValidatorMock.
+					On("IsTokenValid", mock.Anything, "token").
+					Return(true, nil).
+					Once()
+				authManagerMock.
+					On("ForgotPassword", mock.Anything, mock.Anything, "foobar@test.com").
+					Return("", auth.ErrUserHasValidToken).
+					Once()
+			},
+			wantStatusCode:   http.StatusOK,
+			wantResponseBody: defaultSuccessishBody,
+		},
+		{
+			name:      "🔴[500] when the SendMessage method fails",
+			hasTenant: true,
+			reqBody:   `{"email": "foobar@test.com","recaptcha_token":"token"}`,
+			prepareMocks: func(t *testing.T, reCAPTCHAValidatorMock *validators.ReCAPTCHAValidatorMock, authManagerMock *auth.AuthManagerMock, messengerClientMock *message.MessengerClientMock) {
+				reCAPTCHAValidatorMock.
+					On("IsTokenValid", mock.Anything, "token").
+					Return(true, nil).
+					Once()
+				authManagerMock.
+					On("ForgotPassword", mock.Anything, mock.Anything, "foobar@test.com").
+					Return("resetToken", nil).
+					Once()
+				messengerClientMock.
+					On("SendMessage", mock.Anything).
+					Return(errors.New("unexpected error")).
+					Once()
+			},
+			wantStatusCode:   http.StatusInternalServerError,
+			wantResponseBody: `{"error": "running atomic function in RunInTransactionWithResult: sending forgot password message: sending forgot password email for foo...com: unexpected error"}`,
+		},
+		{
+			name:              "🟢[200](ReCAPTCHADisabled=false) successfully handle forgot password",
+			ReCAPTCHADisabled: false,
+			hasTenant:         true,
+			reqBody:           `{"email": "foobar@test.com","recaptcha_token":"token"}`,
+			prepareMocks: func(t *testing.T, reCAPTCHAValidatorMock *validators.ReCAPTCHAValidatorMock, authManagerMock *auth.AuthManagerMock, messengerClientMock *message.MessengerClientMock) {
+				reCAPTCHAValidatorMock.
+					On("IsTokenValid", mock.Anything, "token").
+					Return(true, nil).
+					Once()
+				authManagerMock.
+					On("ForgotPassword", mock.Anything, mock.Anything, "foobar@test.com").
+					Return("resetToken", nil).
+					Once()
+				messengerClientMock.
+					On("SendMessage", mock.Anything).
+					Return(nil).
+					Once()
+			},
+			wantStatusCode:   http.StatusOK,
+			wantResponseBody: defaultSuccessishBody,
+		},
+		{
+			name:              "🟢[200](ReCAPTCHADisabled=true) successfully handle forgot password",
+			ReCAPTCHADisabled: true,
+			hasTenant:         true,
+			reqBody:           `{"email": "foobar@test.com","recaptcha_token":"token"}`,
+			prepareMocks: func(t *testing.T, reCAPTCHAValidatorMock *validators.ReCAPTCHAValidatorMock, authManagerMock *auth.AuthManagerMock, messengerClientMock *message.MessengerClientMock) {
+				authManagerMock.
+					On("ForgotPassword", mock.Anything, mock.Anything, "foobar@test.com").
+					Return("resetToken", nil).
+					Once()
+				messengerClientMock.
+					On("SendMessage", mock.Anything).
+					Return(nil).
+					Once()
+			},
+			wantStatusCode:   http.StatusOK,
+			wantResponseBody: defaultSuccessishBody,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reCAPTCHAValidatorMock := validators.NewReCAPTCHAValidatorMock(t)
+			authManagerMock := auth.NewAuthManagerMock(t)
+			messengerClientMock := message.NewMessengerClientMock(t)
+			if tc.prepareMocks != nil {
+				tc.prepareMocks(t, reCAPTCHAValidatorMock, authManagerMock, messengerClientMock)
 			}
-		`
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.JSONEq(t, expectedBody, string(respBody))
-	})
 
-	t.Run("Should return http status 500 when error sending email", func(t *testing.T) {
-		requestBody := `
-		{ 
-			"email": "valid@email.com",
-			"recaptcha_token": "validToken"
-		}`
+			h := ForgotPasswordHandler{
+				Models:             models,
+				ReCAPTCHADisabled:  tc.ReCAPTCHADisabled,
+				ReCAPTCHAValidator: reCAPTCHAValidatorMock,
+				AuthManager:        authManagerMock,
+				MessengerClient:    messengerClientMock,
+			}
 
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
+			ctx := context.Background()
+			if tc.hasTenant {
+				ctx = tenant.SaveTenantInContext(ctx, &tnt)
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/forgot-password", strings.NewReader(tc.reqBody))
+			require.NoError(t, err)
+			rw := httptest.NewRecorder()
 
-		authenticatorMock.
-			On("ForgotPassword", req.Context(), mock.Anything, "valid@email.com").
-			Return("resetToken", nil).
-			Once()
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "validToken").
-			Return(true, nil).
-			Once()
+			h.ServeHTTP(rw, req)
 
-		resetPasswordLink, err := urllib.JoinPath(uiBaseURL, "reset-password")
-		require.NoError(t, err)
-
-		content, err := htmltemplate.ExecuteHTMLTemplateForStaffForgotPasswordEmailMessage(htmltemplate.StaffForgotPasswordEmailMessageTemplate{
-			ResetToken:        "resetToken",
-			ResetPasswordLink: resetPasswordLink,
-			OrganizationName:  "MyCustomAid",
+			assert.Equal(t, tc.wantStatusCode, rw.Code)
+			assert.JSONEq(t, tc.wantResponseBody, rw.Body.String())
 		})
-		require.NoError(t, err)
-
-		msg := message.Message{
-			ToEmail: "valid@email.com",
-			Title:   forgotPasswordMessageTitle,
-			Body:    content,
-		}
-		messengerClientMock.
-			On("SendMessage", msg).
-			Return(errors.New("unexpected error")).
-			Once()
-
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		expectedBody := `
-			{
-				"error": "running atomic function in RunInTransactionWithResult: sending forgot password message: sending forgot password email for val...com: unexpected error"
-			}
-		`
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.JSONEq(t, expectedBody, string(respBody))
-	})
-
-	t.Run("Should return http status 500 when authenticator fails", func(t *testing.T) {
-		requestBody := `
-		{
-			"email": "valid@email.com",
-			"recaptcha_token": "validToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-
-		authenticatorMock.
-			On("ForgotPassword", req.Context(), mock.Anything, "valid@email.com").
-			Return("", errors.New("unexpected error")).
-			Once()
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "validToken").
-			Return(true, nil).
-			Once()
-
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		expectedBody := `
-			{
-				"error": "running atomic function in RunInTransactionWithResult: resetting password: calling authenticator's ForgotPassword: unexpected error"
-			}
-		`
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.JSONEq(t, expectedBody, string(respBody))
-	})
-
-	t.Run("Should return http status 500 when reCAPTCHA validator returns an error", func(t *testing.T) {
-		requestBody := `
-		{
-			"email": "valid@email.com" ,
-			"recaptcha_token": "validToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", req.Context(), "validToken").
-			Return(false, errors.New("error requesting verify reCAPTCHA token")).
-			Once()
-
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		wantsBody := `
-			{
-				"error": "Cannot validate reCAPTCHA token"
-			}
-		`
-		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.JSONEq(t, wantsBody, string(respBody))
-	})
-
-	t.Run("Should return http status 400 when reCAPTCHA token is invalid", func(t *testing.T) {
-		requestBody := `
-		{
-			"email": "valid@email.com" ,
-			"recaptcha_token": "invalidToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-
-		reCAPTCHAValidatorMock.
-			On("IsTokenValid", mock.Anything, "invalidToken").
-			Return(false, nil).
-			Once()
-
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		wantsBody := `
-			{
-				"error": "reCAPTCHA token invalid"
-			}
-		`
-		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.JSONEq(t, wantsBody, string(respBody))
-	})
-
-	t.Run("returns Unauthorized when tenant is not in the context", func(t *testing.T) {
-		ctxWithoutTenant := context.Background()
-
-		requestBody := `
-		{
-			"email": "valid@email.com" ,
-			"recaptcha_token": "invalidToken"
-		}`
-
-		rr := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(ctxWithoutTenant, http.MethodPost, url, strings.NewReader(requestBody))
-		require.NoError(t, err)
-
-		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-		assert.JSONEq(t, `{"error": "Not authorized."}`, string(respBody))
-	})
-
-	authenticatorMock.AssertExpectations(t)
-	reCAPTCHAValidatorMock.AssertExpectations(t)
+	}
 }

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -87,6 +87,7 @@ func Test_ForgotPasswordHandler_validateRequest(t *testing.T) {
 	}
 }
 
+// TODO: tests with reCaptcha enabled and disabled
 func Test_ForgotPasswordHandler_ServeHTTP(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -89,14 +89,14 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if err != nil {
-		log.Ctx(ctx).Errorf("error authenticating user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err)
+		log.Ctx(ctx).Errorf("authenticating user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err)
 		httperror.InternalError(ctx, "Cannot authenticate user credentials", err, nil).Render(rw)
 		return
 	}
 
 	user, err := h.AuthManager.GetUser(ctx, token)
 	if err != nil {
-		log.Ctx(ctx).Errorf("error getting user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err)
+		log.Ctx(ctx).Errorf("getting user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err)
 		httperror.InternalError(ctx, "", err, nil).Render(rw)
 		return
 	}
@@ -116,7 +116,7 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	isRemembered, err := h.AuthManager.MFADeviceRemembered(ctx, deviceID, user.ID)
 	if err != nil {
-		log.Ctx(ctx).Errorf("error checking if device is remembered for user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err.Error())
+		log.Ctx(ctx).Errorf("checking if device is remembered for user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err.Error())
 		httperror.InternalError(ctx, "", err, nil).Render(rw)
 		return
 	}
@@ -130,7 +130,7 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// Get the MFA code for the user
 	code, err := h.AuthManager.GetMFACode(ctx, deviceID, user.ID)
 	if err != nil {
-		log.Ctx(ctx).Errorf("error getting MFA code for user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err.Error())
+		log.Ctx(ctx).Errorf("getting MFA code for user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err.Error())
 		httperror.InternalError(ctx, "Cannot get MFA code", err, nil).Render(rw)
 		return
 	}
@@ -164,7 +164,7 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 	err = h.MessengerClient.SendMessage(msg)
 	if err != nil {
-		err = fmt.Errorf("error sending mfa code for email %s: %w", user.Email, err)
+		err = fmt.Errorf("sending mfa code for email %s: %w", user.Email, err)
 		log.Ctx(ctx).Error(err)
 		httperror.InternalError(ctx, "", err, nil).Render(rw)
 		return

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -142,7 +142,10 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	httpjson.RenderStatus(rw, http.StatusOK, map[string]string{"message": "MFA code sent to email. Check your inbox and spam folders."}, httpjson.JSON)
+	responseBody := map[string]string{
+		"message": "MFA code sent to email. Check your inbox and spam folders.",
+	}
+	httpjson.RenderStatus(rw, http.StatusOK, responseBody, httpjson.JSON)
 }
 
 func (h LoginHandler) sendMFAEmail(ctx context.Context, user *auth.User, code string) *httperror.HTTPError {

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -26,19 +27,6 @@ type LoginRequest struct {
 	ReCAPTCHAToken string `json:"recaptcha_token"`
 }
 
-func (r LoginRequest) validate() *httperror.HTTPError {
-	validator := validators.NewValidator()
-
-	validator.Check(r.Email != "", "email", "email is required")
-	validator.Check(r.Password != "", "password", "password is required")
-
-	if validator.HasErrors() {
-		return httperror.BadRequest("Request invalid", nil, validator.Errors)
-	}
-
-	return nil
-}
-
 type LoginResponse struct {
 	Token string `json:"token"`
 }
@@ -52,9 +40,27 @@ type LoginHandler struct {
 	MFADisabled        bool
 }
 
+func (h LoginHandler) validateRequest(req LoginRequest, headers http.Header) *httperror.HTTPError {
+	lv := validators.NewValidator()
+
+	lv.Check(req.Email != "", "email", "email is required")
+	lv.Check(req.Password != "", "password", "password is required")
+	lv.Check(h.ReCAPTCHADisabled || req.ReCAPTCHAToken != "", "recaptcha_token", "reCAPTCHA token is required")
+
+	deviceID := headers.Get(DeviceIDHeader)
+	lv.Check(h.MFADisabled || deviceID != "", DeviceIDHeader, "Device-ID header is required")
+
+	if lv.HasErrors() {
+		return httperror.BadRequest("", nil, lv.Errors)
+	}
+
+	return nil
+}
+
 func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
+	// Step 1: Decode and validate the incoming request
 	var reqBody LoginRequest
 	if err := httpdecode.DecodeJSON(req, &reqBody); err != nil {
 		err = fmt.Errorf("decoding the request body: %w", err)
@@ -62,12 +68,14 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		httperror.BadRequest("", err, nil).Render(rw)
 		return
 	}
-
-	if err := reqBody.validate(); err != nil {
-		err.Render(rw)
+	if httpErr := h.validateRequest(reqBody, req.Header); httpErr != nil {
+		httpErr.Render(rw)
 		return
 	}
 
+	truncatedEmail := utils.TruncateString(reqBody.Email, 3)
+
+	// Step 2: Run the reCAPTCHA validation if it is enabled
 	if !h.ReCAPTCHADisabled {
 		// validating reCAPTCHA Token
 		isValid, err := h.ReCAPTCHAValidator.IsTokenValid(ctx, reqBody.ReCAPTCHAToken)
@@ -77,74 +85,70 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		if !isValid {
-			log.Ctx(ctx).Errorf("reCAPTCHA token is invalid for request with email %s", utils.TruncateString(reqBody.Email, 3))
+			log.Ctx(ctx).Errorf("reCAPTCHA token is invalid for request with email %s", truncatedEmail)
 			httperror.BadRequest("reCAPTCHA token invalid", nil, nil).Render(rw)
 			return
 		}
 	}
 
+	// Step 3: Authenticate the user
 	token, err := h.AuthManager.Authenticate(ctx, reqBody.Email, reqBody.Password)
 	if errors.Is(err, auth.ErrInvalidCredentials) {
 		httperror.Unauthorized("", err, map[string]interface{}{"details": "Incorrect email or password"}).Render(rw)
 		return
 	}
 	if err != nil {
-		log.Ctx(ctx).Errorf("authenticating user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err)
+		log.Ctx(ctx).Errorf("authenticating user with email %s: %s", truncatedEmail, err)
 		httperror.InternalError(ctx, "Cannot authenticate user credentials", err, nil).Render(rw)
 		return
 	}
 
 	user, err := h.AuthManager.GetUser(ctx, token)
 	if err != nil {
-		log.Ctx(ctx).Errorf("getting user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err)
+		log.Ctx(ctx).Errorf("getting user with email %s: %s", truncatedEmail, err)
 		httperror.InternalError(ctx, "", err, nil).Render(rw)
 		return
 	}
 
+	// Step 4.A: If MFA is disabled, return the token
 	if h.MFADisabled {
 		log.Ctx(ctx).Infof("[UserLogin] - Logged in user with account ID %s", user.ID)
 		httpjson.RenderStatus(rw, http.StatusOK, LoginResponse{Token: token}, httpjson.JSON)
 		return
 	}
 
-	// 🔒 Handling MFA
+	// Step 4.B: If MFA is enabled, check if the device is remembered
 	deviceID := req.Header.Get(DeviceIDHeader)
-	if deviceID == "" {
-		httperror.BadRequest("Device-ID header is required", nil, nil).Render(rw)
-		return
-	}
-
-	isRemembered, err := h.AuthManager.MFADeviceRemembered(ctx, deviceID, user.ID)
-	if err != nil {
-		log.Ctx(ctx).Errorf("checking if device is remembered for user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err.Error())
+	var isRemembered bool
+	if isRemembered, err = h.AuthManager.MFADeviceRemembered(ctx, deviceID, user.ID); err != nil {
+		err = fmt.Errorf("checking if device is remembered for user with email %s: %w", truncatedEmail, err)
 		httperror.InternalError(ctx, "", err, nil).Render(rw)
 		return
-	}
-
-	if isRemembered {
+	} else if isRemembered {
 		log.Ctx(ctx).Infof("[UserLogin] - Logged in user with account ID %s", user.ID)
 		httpjson.RenderStatus(rw, http.StatusOK, LoginResponse{Token: token}, httpjson.JSON)
 		return
 	}
 
-	// Get the MFA code for the user
+	// Step 4.C: If MFA is enabled and the device is not remembered, send the MFA code
 	code, err := h.AuthManager.GetMFACode(ctx, deviceID, user.ID)
 	if err != nil {
-		log.Ctx(ctx).Errorf("getting MFA code for user with email %s: %s", utils.TruncateString(reqBody.Email, 3), err.Error())
+		log.Ctx(ctx).Errorf("getting MFA code for user with email %s: %s", truncatedEmail, err.Error())
 		httperror.InternalError(ctx, "Cannot get MFA code", err, nil).Render(rw)
 		return
 	}
-
-	if code == "" {
-		log.Ctx(ctx).Errorf("MFA code for user with email %s is empty", utils.TruncateString(reqBody.Email, 3))
-		httperror.InternalError(ctx, "Cannot get MFA code", err, nil).Render(rw)
+	if httpErr := h.sendMFAEmail(ctx, user, code); httpErr != nil {
+		httpErr.Render(rw)
 		return
 	}
 
+	httpjson.RenderStatus(rw, http.StatusOK, map[string]string{"message": "MFA code sent to email. Check your inbox and spam folders."}, httpjson.JSON)
+}
+
+func (h LoginHandler) sendMFAEmail(ctx context.Context, user *auth.User, code string) *httperror.HTTPError {
 	organization, err := h.Models.Organizations.Get(ctx)
 	if err != nil {
-		httperror.InternalError(ctx, "Cannot fetch organization", err, nil).Render(rw)
-		return
+		return httperror.InternalError(ctx, "Cannot fetch organization", err, nil)
 	}
 
 	msgTemplate := htmltemplate.StaffMFAEmailMessageTemplate{
@@ -153,8 +157,7 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 	msgContent, err := htmltemplate.ExecuteHTMLTemplateForStaffMFAEmailMessage(msgTemplate)
 	if err != nil {
-		httperror.InternalError(ctx, "Cannot execute mfa message template", err, nil).Render(rw)
-		return
+		return httperror.InternalError(ctx, "Cannot execute mfa message template", err, nil)
 	}
 
 	msg := message.Message{
@@ -162,13 +165,10 @@ func (h LoginHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		Title:   mfaMessageTitle,
 		Body:    msgContent,
 	}
-	err = h.MessengerClient.SendMessage(msg)
-	if err != nil {
+	if err = h.MessengerClient.SendMessage(msg); err != nil {
 		err = fmt.Errorf("sending mfa code for email %s: %w", user.Email, err)
-		log.Ctx(ctx).Error(err)
-		httperror.InternalError(ctx, "", err, nil).Render(rw)
-		return
+		return httperror.InternalError(ctx, "", err, nil)
 	}
 
-	httpjson.RenderStatus(rw, http.StatusOK, map[string]string{"message": "MFA code sent to email. Check your inbox and spam folders."}, httpjson.JSON)
+	return nil
 }

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -1,6 +1,8 @@
 package httphandler
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -98,6 +100,12 @@ func Test_LoginHandler_validateRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func requestToJSON(t *testing.T, req interface{}) io.Reader {
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	return bytes.NewReader(body)
 }
 
 // TODO: tests with reCaptcha enabled and disabled

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -100,7 +100,7 @@ func Test_LoginHandler_validateRequest(t *testing.T) {
 	}
 }
 
-func Test_LoginHandler(t *testing.T) {
+func Test_LoginHandler_ServeHTTP(t *testing.T) {
 	r := chi.NewRouter()
 
 	authenticatorMock := &auth.AuthenticatorMock{}

--- a/internal/serve/httphandler/login_handler_test.go
+++ b/internal/serve/httphandler/login_handler_test.go
@@ -100,6 +100,7 @@ func Test_LoginHandler_validateRequest(t *testing.T) {
 	}
 }
 
+// TODO: tests with reCaptcha enabled and disabled
 func Test_LoginHandler_ServeHTTP(t *testing.T) {
 	r := chi.NewRouter()
 

--- a/internal/serve/httphandler/mfa_handler.go
+++ b/internal/serve/httphandler/mfa_handler.go
@@ -76,7 +76,7 @@ func (h MFAHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			httperror.Unauthorized("", err, nil).Render(rw)
 			return
 		}
-		log.Ctx(ctx).Errorf("error authenticating user: %s", err.Error())
+		log.Ctx(ctx).Errorf("authenticating user: %s", err.Error())
 		httperror.InternalError(ctx, "Cannot authenticate user", err, nil).Render(rw)
 		return
 	}

--- a/internal/serve/httphandler/mfa_handler.go
+++ b/internal/serve/httphandler/mfa_handler.go
@@ -33,51 +33,61 @@ type MFAHandler struct {
 
 const DeviceIDHeader = "Device-ID"
 
+func (h MFAHandler) validateRequest(req MFARequest, deviceID string) *httperror.HTTPError {
+	lv := validators.NewValidator()
+
+	lv.Check(req.MFACode != "", "mfa_code", "MFA Code is required")
+	lv.Check(h.ReCAPTCHADisabled || req.ReCAPTCHAToken != "", "recaptcha_token", "reCAPTCHA token is required")
+
+	lv.Check(deviceID != "", DeviceIDHeader, DeviceIDHeader+" header is required")
+
+	if lv.HasErrors() {
+		return httperror.BadRequest("", nil, lv.Errors)
+	}
+
+	return nil
+}
+
 func (h MFAHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
+	// Step 1: Decode and validate the incoming request
 	var reqBody MFARequest
 	if err := httpdecode.DecodeJSON(req, &reqBody); err != nil {
 		log.Ctx(ctx).Errorf("decoding the request body: %s", err.Error())
 		httperror.BadRequest("", err, nil).Render(rw)
 		return
 	}
+	deviceID := req.Header.Get(DeviceIDHeader)
+	if httpErr := h.validateRequest(reqBody, deviceID); httpErr != nil {
+		httpErr.Render(rw)
+		return
+	}
 
-	// validating reCAPTCHA Token
+	// Step 2: Run the reCAPTCHA validation if it is enabled
 	if !h.ReCAPTCHADisabled {
-		isValid, recaptchaErr := h.ReCAPTCHAValidator.IsTokenValid(ctx, reqBody.ReCAPTCHAToken)
-		if recaptchaErr != nil {
-			httperror.InternalError(ctx, "Cannot validate reCAPTCHA token", recaptchaErr, nil).Render(rw)
+		isValid, err := h.ReCAPTCHAValidator.IsTokenValid(ctx, reqBody.ReCAPTCHAToken)
+		if err != nil {
+			httperror.InternalError(ctx, "Cannot validate reCAPTCHA token", err, nil).Render(rw)
 			return
 		}
 
 		if !isValid {
-			log.Ctx(ctx).Errorf("reCAPTCHA token is invalid for request with email")
+			log.Ctx(ctx).Errorf("reCAPTCHA token is invalid for request with device ID %s", deviceID)
 			httperror.BadRequest("reCAPTCHA token invalid", nil, nil).Render(rw)
 			return
 		}
 	}
 
-	if reqBody.MFACode == "" {
-		extras := map[string]interface{}{"mfa_code": "MFA Code is required"}
-		httperror.BadRequest("Request invalid", nil, extras).Render(rw)
-		return
-	}
-
-	deviceID := req.Header.Get(DeviceIDHeader)
-	if deviceID == "" {
-		httperror.BadRequest("Device-ID header is required", nil, nil).Render(rw)
-		return
-	}
-
+	// Step 3: Authenticate the user with the MFA code
 	token, err := h.AuthManager.AuthenticateMFA(ctx, deviceID, reqBody.MFACode, reqBody.RememberMe)
 	if err != nil {
 		if errors.Is(err, auth.ErrMFACodeInvalid) {
 			httperror.Unauthorized("", err, nil).Render(rw)
-			return
+		} else {
+			log.Ctx(ctx).Errorf("authenticating user: %s", err.Error())
+			httperror.InternalError(ctx, "Cannot authenticate user", err, nil).Render(rw)
 		}
-		log.Ctx(ctx).Errorf("authenticating user: %s", err.Error())
-		httperror.InternalError(ctx, "Cannot authenticate user", err, nil).Render(rw)
 		return
 	}
 

--- a/internal/serve/httphandler/mfa_handler_test.go
+++ b/internal/serve/httphandler/mfa_handler_test.go
@@ -267,7 +267,7 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			reCAPTCHAValidatorMock := &validators.ReCAPTCHAValidatorMock{}
+			reCAPTCHAValidatorMock := validators.NewReCAPTCHAValidatorMock(t)
 			authManager := auth.NewAuthManagerMock(t)
 			if tc.prepareMocks != nil {
 				tc.prepareMocks(t, reCAPTCHAValidatorMock, authManager)

--- a/internal/serve/httphandler/reset_password_handler.go
+++ b/internal/serve/httphandler/reset_password_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stellar/go/support/render/httpjson"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 	authUtils "github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
@@ -26,54 +27,51 @@ type ResetPasswordRequest struct {
 	ResetToken string `json:"reset_token"`
 }
 
+func (h ResetPasswordHandler) validateRequest(req ResetPasswordRequest) *httperror.HTTPError {
+	v := validators.NewValidator()
+	if validatePasswordError := h.PasswordValidator.ValidatePassword(req.Password); validatePasswordError != nil {
+		for k, msg := range validatePasswordError.FailedValidations() {
+			v.AddError(k, msg)
+		}
+	}
+
+	v.Check(req.ResetToken != "", "reset_token", "reset token is required")
+
+	if v.HasErrors() {
+		return httperror.BadRequest("", nil, v.Errors)
+	}
+
+	return nil
+}
+
 // ServeHTTP implements the http.Handler interface.
 func (h ResetPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	var resetPasswordRequest ResetPasswordRequest
 
+	// Step 1: Decode and validate the incoming request
+	var resetPasswordRequest ResetPasswordRequest
 	err := json.NewDecoder(r.Body).Decode(&resetPasswordRequest)
 	if err != nil {
 		httperror.BadRequest("invalid request body", err, nil).Render(w)
 		return
 	}
-
-	// validate password
-	badRequestExtras := map[string]interface{}{}
-	err = h.PasswordValidator.ValidatePassword(resetPasswordRequest.Password)
-	if err != nil {
-		var validatePasswordError *authUtils.ValidatePasswordError
-		if errors.As(err, &validatePasswordError) {
-			for k, v := range validatePasswordError.FailedValidations() {
-				badRequestExtras[k] = v
-			}
-			log.Ctx(ctx).Errorf("validating password in ResetPasswordHandler.ServeHTTP: %v", err)
-		} else {
-			httperror.InternalError(ctx, "Cannot update user password", err, nil).Render(w)
-			return
-		}
-	}
-	// validate reset token
-	if resetPasswordRequest.ResetToken == "" {
-		badRequestExtras["reset_token"] = "reset token is required"
-	}
-	// return 400 if there are any errors
-	if len(badRequestExtras) > 0 {
-		httperror.BadRequest("request invalid", err, badRequestExtras).Render(w)
+	if httpErr := h.validateRequest(resetPasswordRequest); httpErr != nil {
+		httpErr.Render(w)
 		return
 	}
 
-	// Reset password with a valid token
+	// Step 2: Reset password with a valid token
 	err = h.AuthManager.ResetPassword(ctx, resetPasswordRequest.ResetToken, resetPasswordRequest.Password)
 	if err != nil {
 		if errors.Is(err, auth.ErrInvalidResetPasswordToken) {
 			httperror.BadRequest("invalid reset password token", err, nil).Render(w)
-			return
+		} else {
+			httperror.InternalError(ctx, "Cannot reset password", err, nil).Render(w)
 		}
-		httperror.InternalError(ctx, "Cannot reset password", err, nil).Render(w)
 		return
 	}
 
-	log.Ctx(ctx).Infof("[ResetUserPassword] - Reset password for user with token %s",
-		utils.TruncateString(resetPasswordRequest.ResetToken, len(resetPasswordRequest.ResetToken)/4))
+	truncatedToken := utils.TruncateString(resetPasswordRequest.ResetToken, len(resetPasswordRequest.ResetToken)/4)
+	log.Ctx(ctx).Infof("[ResetUserPassword] - Successfully reset password for user with token %s", truncatedToken)
 	httpjson.RenderStatus(w, http.StatusOK, nil, httpjson.JSON)
 }

--- a/internal/serve/httphandler/verify_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verify_receiver_registration_handler_test.go
@@ -153,13 +153,12 @@ func Test_VerifyReceiverRegistrationHandler_validate(t *testing.T) {
 			}
 
 			if tc.isRecaptchaValidFnResponse != nil {
-				reCAPTCHAValidatorMock := &validators.ReCAPTCHAValidatorMock{}
+				reCAPTCHAValidatorMock := validators.NewReCAPTCHAValidatorMock(t)
 				handler.ReCAPTCHAValidator = reCAPTCHAValidatorMock
 				reCAPTCHAValidatorMock.
 					On("IsTokenValid", mock.Anything, "token").
 					Return(tc.isRecaptchaValidFnResponse...).
 					Once()
-				defer reCAPTCHAValidatorMock.AssertExpectations(t)
 			}
 
 			gotReceiverRegistrationRequest, gotSep24Claims, httpErr := handler.validate(req)

--- a/internal/serve/validators/query_validator.go
+++ b/internal/serve/validators/query_validator.go
@@ -28,14 +28,14 @@ func (qv *QueryValidator) ParseParametersFromRequest(r *http.Request) *data.Quer
 	if sortBy == "" {
 		sortBy = qv.DefaultSortField
 	} else if !slices.Contains(qv.AllowedSortFields, sortBy) {
-		qv.addError("sort", "invalid sort field name")
+		qv.AddError("sort", "invalid sort field name")
 	}
 
 	sortOrder := data.SortOrder(strings.ToUpper(query.Get("direction")))
 	if sortOrder == "" {
 		sortOrder = qv.DefaultSortOrder
 	} else if sortOrder != data.SortOrderASC && sortOrder != data.SortOrderDESC {
-		qv.addError("direction", "invalid sort order. valid values are 'asc' and 'desc'")
+		qv.AddError("direction", "invalid sort order. valid values are 'asc' and 'desc'")
 	}
 
 	filters := make(map[data.FilterKey]interface{})

--- a/internal/serve/validators/validator.go
+++ b/internal/serve/validators/validator.go
@@ -14,7 +14,7 @@ func (v *Validator) HasErrors() bool {
 
 func (v *Validator) Check(ok bool, key, message string) {
 	if !ok {
-		v.addError(key, message)
+		v.AddError(key, message)
 	}
 }
 
@@ -26,6 +26,6 @@ func (v *Validator) CheckError(err error, key, message string) {
 	v.Check(err == nil, key, message)
 }
 
-func (v *Validator) addError(key, message string) {
+func (v *Validator) AddError(key, message string) {
 	v.Errors[key] = message
 }

--- a/internal/serve/validators/validator_test.go
+++ b/internal/serve/validators/validator_test.go
@@ -34,8 +34,8 @@ func Test_HasErrors(t *testing.T) {
 
 func Test_addError(t *testing.T) {
 	validator := NewValidator()
-	validator.addError("key", "error message")
-	validator.addError("key2", "error message 2")
+	validator.AddError("key", "error message")
+	validator.AddError("key2", "error message 2")
 	assert.Equal(t, len(validator.Errors), 2)
 	assert.Equal(t, validator.Errors["key"], "error message")
 	assert.Equal(t, validator.Errors["key2"], "error message 2")

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -183,7 +183,7 @@ func (am *defaultAuthManager) ForgotPassword(ctx context.Context, sqlExec db.SQL
 		if errors.Is(err, ErrUserNotFound) {
 			return "", fmt.Errorf("user not found in auth forgot password: %w", err)
 		}
-		return "", fmt.Errorf("error on forgot password: %w", err)
+		return "", fmt.Errorf("calling authenticator's ForgotPassword: %w", err)
 	}
 
 	return resetToken, nil

--- a/stellar-auth/pkg/auth/auth_test.go
+++ b/stellar-auth/pkg/auth/auth_test.go
@@ -937,7 +937,7 @@ func Test_AuthManager_ForgotPassword(t *testing.T) {
 			Once()
 
 		resetToken, err := authManager.ForgotPassword(ctx, mockDBConnectionPool, "wrongemail@email.com")
-		assert.EqualError(t, err, "error on forgot password: unexpected error")
+		assert.EqualError(t, err, "calling authenticator's ForgotPassword: unexpected error")
 		assert.Empty(t, resetToken)
 	})
 

--- a/stellar-auth/pkg/auth/manager.go
+++ b/stellar-auth/pkg/auth/manager.go
@@ -132,9 +132,3 @@ func WithDefaultMFAManagerOption(dbConnectionPool db.DBConnectionPool) AuthManag
 		am.mfaManager = newDefaultMFAManager(withMFADatabaseConnectionPool(dbConnectionPool))
 	}
 }
-
-func WithCustomMFAManagerOption(mfaManager MFAManager) AuthManagerOption {
-	return func(am *defaultAuthManager) {
-		am.mfaManager = mfaManager
-	}
-}

--- a/stellar-auth/pkg/auth/mocks.go
+++ b/stellar-auth/pkg/auth/mocks.go
@@ -172,33 +172,6 @@ func (rm *RoleManagerMock) UpdateRoles(ctx context.Context, user *User, roleName
 
 var _ RoleManager = (*RoleManagerMock)(nil)
 
-// MFAManager
-type MFAManagerMock struct {
-	mock.Mock
-}
-
-func (m *MFAManagerMock) MFADeviceRemembered(ctx context.Context, deviceID, userID string) (bool, error) {
-	args := m.Called(ctx, deviceID, userID)
-	return args.Get(0).(bool), args.Error(1)
-}
-
-func (m *MFAManagerMock) GenerateMFACode(ctx context.Context, deviceID, userID string) (string, error) {
-	args := m.Called(ctx, deviceID, userID)
-	return args.Get(0).(string), args.Error(1)
-}
-
-func (m *MFAManagerMock) ValidateMFACode(ctx context.Context, deviceID, code string) (string, error) {
-	args := m.Called(ctx, deviceID, code)
-	return args.Get(0).(string), args.Error(1)
-}
-
-func (m *MFAManagerMock) RememberDevice(ctx context.Context, deviceID, code string) error {
-	args := m.Called(ctx, deviceID, code)
-	return args.Error(0)
-}
-
-var _ MFAManager = (*MFAManagerMock)(nil)
-
 // AuthManager
 type AuthManagerMock struct {
 	mock.Mock

--- a/stellar-auth/pkg/cli/add_user.go
+++ b/stellar-auth/pkg/cli/add_user.go
@@ -123,9 +123,8 @@ func AddUserCmd(databaseURLFlagName string, passwordPrompt PasswordPromptInterfa
 				if err != nil {
 					log.Ctx(ctx).Fatalf("cannot initialize password validator: %s", err)
 				}
-				err = pwValidator.ValidatePassword(result)
-				if err != nil {
-					log.Ctx(ctx).Fatalf("password is not valid: %v", err)
+				if validatePassErr := pwValidator.ValidatePassword(result); validatePassErr != nil {
+					log.Ctx(ctx).Fatalf("password is not valid: %v", validatePassErr)
 				}
 				password = result
 			}

--- a/stellar-auth/pkg/utils/password_validation.go
+++ b/stellar-auth/pkg/utils/password_validation.go
@@ -84,7 +84,7 @@ func GetPasswordValidatorInstance() (*PasswordValidator, error) {
 }
 
 // ValidatePassword returns an error if the password does not meet the requirements.
-func (pv *PasswordValidator) ValidatePassword(input string) error {
+func (pv *PasswordValidator) ValidatePassword(input string) *ValidatePasswordError {
 	var (
 		hasLength          bool
 		hasLower           bool

--- a/stellar-auth/pkg/utils/password_validation_test.go
+++ b/stellar-auth/pkg/utils/password_validation_test.go
@@ -146,7 +146,7 @@ func Test_ValidatePassword(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := pwValidator.ValidatePassword(tc.input)
 			if tc.errContains == nil {
-				require.NoError(t, err)
+				require.Nil(t, err)
 			} else {
 				var e *ValidatePasswordError
 				require.ErrorAs(t, err, &e)


### PR DESCRIPTION
### What

Prepare code for API-only usage by reorganizing the reCaptcha and MFA sections in the handlers they're being used.

### Why

Since the MFA and reCAPTCHA enforcers were being used in different places for different handlers, it wasn't easy to modularize their usage. By streamlining their usage, the code becomes easier to adapt and make it optional.

### Further work

Add a way to bypass them through IP filering.

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
