### PR TITLE
[SDP-1459] workaround for Circle's bug where retries are not handled correctly when a trustline is missing

### DIFF
--- a/db/migrations/sdp-migrations/2025-01-15.0-circle-recipient-new-status.sql
+++ b/db/migrations/sdp-migrations/2025-01-15.0-circle-recipient-new-status.sql
@@ -1,0 +1,22 @@
+-- Add a new status 'failed' to the circle_recipient_status enum type
+
+-- +migrate Up
+ALTER TYPE circle_recipient_status ADD VALUE 'failed';
+
+
+-- +migrate Down
+-- Update any existing records with 'failed' status to 'denied'
+UPDATE circle_recipients SET status = 'denied' WHERE status = 'failed';
+
+-- Rename the existing enum type to a temporary name
+ALTER TYPE circle_recipient_status RENAME TO circle_recipient_status_old;
+
+-- Create a new enum type without the 'failed' value
+CREATE TYPE circle_recipient_status AS ENUM ('pending', 'active', 'inactive', 'denied');
+
+-- Update all references of the old type to the new type
+ALTER TABLE circle_recipients
+    ALTER COLUMN status TYPE circle_recipient_status USING status::text::circle_recipient_status;
+
+-- Drop the old enum type
+DROP TYPE circle_recipient_status_old;

--- a/internal/circle/client.go
+++ b/internal/circle/client.go
@@ -270,6 +270,12 @@ func (client *Client) PostPayout(ctx context.Context, payoutRequest PayoutReques
 	return parsePayoutResponse(resp)
 }
 
+// DestinationAddressErrorCodes are the error codes that indicate an issue with the destination address. If they show up
+// when sending a payout, the Circle recipient will likely become unusable and will need to be recreated.
+//
+// Circle API documentation: https://developers.circle.com/circle-mint/circle-apis-api-errors.
+var DestinationAddressErrorCodes = []int{5003, 5004, 5011}
+
 // GetPayoutByID retrieves a payout by its ID.
 //
 // Circle API documentation: https://developers.circle.com/api-reference/circle-mint/payouts/get-payout.

--- a/internal/data/circle_recipient.go
+++ b/internal/data/circle_recipient.go
@@ -51,10 +51,11 @@ const (
 	CircleRecipientStatusActive   CircleRecipientStatus = "active" // means success
 	CircleRecipientStatusInactive CircleRecipientStatus = "inactive"
 	CircleRecipientStatusDenied   CircleRecipientStatus = "denied"
+	CircleRecipientStatusFailed   CircleRecipientStatus = "failed"
 )
 
 func CompletedCircleRecipientStatuses() []CircleRecipientStatus {
-	return []CircleRecipientStatus{CircleRecipientStatusActive, CircleRecipientStatusDenied, CircleRecipientStatusInactive}
+	return []CircleRecipientStatus{CircleRecipientStatusActive, CircleRecipientStatusDenied, CircleRecipientStatusFailed, CircleRecipientStatusInactive}
 }
 
 func (s CircleRecipientStatus) IsCompleted() bool {
@@ -73,6 +74,8 @@ func ParseRecipientStatus(statusStr string) (CircleRecipientStatus, error) {
 		return CircleRecipientStatusInactive, nil
 	case string(CircleRecipientStatusDenied):
 		return CircleRecipientStatusDenied, nil
+	case string(CircleRecipientStatusFailed):
+		return CircleRecipientStatusFailed, nil
 	default:
 		return "", fmt.Errorf("unknown recipient status %q", statusStr)
 	}

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher.go
@@ -101,7 +101,7 @@ func (c *CirclePaymentDispatcher) sendPaymentsToCircle(ctx context.Context, sdpD
 			var cAPIErr *circle.APIError
 			// 5.1. If the destination address is invalid, mark the recipient as failed
 			if errors.As(err, &cAPIErr) && slices.Contains(circle.DestinationAddressErrorCodes, cAPIErr.Code) {
-				log.Ctx(ctx).Error("the destination address is deemed invalid by Circle, marking the recipient as pending...")
+				log.Ctx(ctx).Error("the destination address is deemed invalid by Circle, marking the recipient as denied...")
 				_, cRecipientUpdateErr := c.sdpModels.CircleRecipient.Update(ctx, recipient.ReceiverWalletID, data.CircleRecipientUpdate{Status: data.CircleRecipientStatusDenied})
 				if cRecipientUpdateErr != nil {
 					return fmt.Errorf("updating Circle recipient status: %w", cRecipientUpdateErr)

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -97,7 +98,17 @@ func (c *CirclePaymentDispatcher) sendPaymentsToCircle(ctx context.Context, sdpD
 			IdempotencyKey:   transferRequest.IdempotencyKey,
 		})
 		if err != nil {
-			// 5. If the transfer fails, set the payment status to failed
+			var cAPIErr *circle.APIError
+			if errors.As(err, &cAPIErr) && slices.Contains(circle.DestinationAddressErrorCodes, cAPIErr.Code) {
+				// 5.1. If the destination address is invalid, mark the recipient as failed
+				log.Ctx(ctx).Error("the destination address is deemed invalid by Circle, marking the recipient as pending...")
+				_, cRecipientUpdateErr := c.sdpModels.CircleRecipient.Update(ctx, recipient.ReceiverWalletID, data.CircleRecipientUpdate{Status: data.CircleRecipientStatusDenied})
+				if cRecipientUpdateErr != nil {
+					return fmt.Errorf("updating Circle recipient status: %w", cRecipientUpdateErr)
+				}
+			}
+
+			// 5.2 If the payout fails, set the payment status to failed
 			err = fmt.Errorf("failed to submit payment ID %s to Circle: %w", payment.ID, err)
 			log.Ctx(ctx).Error(err)
 			err = c.sdpModels.Payment.UpdateStatus(ctx, sdpDBTx, payment.ID, data.FailedPaymentStatus, utils.Ptr(err.Error()), "")
@@ -198,19 +209,20 @@ func (c *CirclePaymentDispatcher) getOrCreateRecipient(ctx context.Context, rece
 	return dataRecipient, nil
 }
 
-// handleFailedOrInactiveRecipientIfNeeded handles the case when the recipient is in a FAILED or INACTIVE state.
-func (c *CirclePaymentDispatcher) handleFailedOrInactiveRecipientIfNeeded(ctx context.Context, dataRecipient *data.CircleRecipient) (*data.CircleRecipient, error) {
-	var err error
+// handleFailedRecipientIfNeeded handles the case when the recipient is in a FAILED or INACTIVE state.
+func (c *CirclePaymentDispatcher) handleFailedRecipientIfNeeded(ctx context.Context, dataRecipient *data.CircleRecipient) (*data.CircleRecipient, error) {
+	if !dataRecipient.Status.IsCompleted() {
+		return dataRecipient, nil
+	}
 
-	// FAILED or INACTIVE -> refresh the idempotency key
-	if dataRecipient.Status.IsCompleted() {
-		log.Ctx(ctx).Infof("Renovating idempotency_key for circle_recipient with receiver_wallet_id %q and status %s", dataRecipient.ReceiverWalletID, dataRecipient.Status)
-		dataRecipient, err = c.sdpModels.CircleRecipient.Update(ctx, dataRecipient.ReceiverWalletID, data.CircleRecipientUpdate{
-			IdempotencyKey: uuid.NewString(),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("updating Circle recipient's idempotency key: %w", err)
-		}
+	// FAILED, DENIED or INACTIVE -> renovate the idempotency key
+	var err error
+	log.Ctx(ctx).Infof("Renovating idempotency_key for circle_recipient with receiver_wallet_id %q and status %s", dataRecipient.ReceiverWalletID, dataRecipient.Status)
+	dataRecipient, err = c.sdpModels.CircleRecipient.Update(ctx, dataRecipient.ReceiverWalletID, data.CircleRecipientUpdate{
+		IdempotencyKey: uuid.NewString(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("updating Circle recipient's idempotency key: %w", err)
 	}
 
 	return dataRecipient, nil
@@ -285,7 +297,7 @@ func (c *CirclePaymentDispatcher) ensureRecipientIsReady(ctx context.Context, re
 	}
 
 	// FAILED or INACTIVE
-	dataRecipient, err = c.handleFailedOrInactiveRecipientIfNeeded(ctx, dataRecipient)
+	dataRecipient, err = c.handleFailedRecipientIfNeeded(ctx, dataRecipient)
 	if err != nil {
 		return nil, fmt.Errorf("handling failed or inactive recipient: %w", err)
 	}

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher.go
@@ -99,8 +99,8 @@ func (c *CirclePaymentDispatcher) sendPaymentsToCircle(ctx context.Context, sdpD
 		})
 		if err != nil {
 			var cAPIErr *circle.APIError
+			// 5.1. If the destination address is invalid, mark the recipient as failed
 			if errors.As(err, &cAPIErr) && slices.Contains(circle.DestinationAddressErrorCodes, cAPIErr.Code) {
-				// 5.1. If the destination address is invalid, mark the recipient as failed
 				log.Ctx(ctx).Error("the destination address is deemed invalid by Circle, marking the recipient as pending...")
 				_, cRecipientUpdateErr := c.sdpModels.CircleRecipient.Update(ctx, recipient.ReceiverWalletID, data.CircleRecipientUpdate{Status: data.CircleRecipientStatusDenied})
 				if cRecipientUpdateErr != nil {

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
@@ -131,7 +131,7 @@ func Test_CirclePaymentDispatcher_ensureRecipientIsReady_success(t *testing.T) {
 		},
 	}
 
-	for _, failedStatus := range []data.CircleRecipientStatus{data.CircleRecipientStatusInactive, data.CircleRecipientStatusDenied} {
+	for _, failedStatus := range []data.CircleRecipientStatus{data.CircleRecipientStatusInactive, data.CircleRecipientStatusDenied, data.CircleRecipientStatusFailed} {
 		testCases = append(testCases, TestCase{
 			name: fmt.Sprintf("recipient already exists [status=%s]", failedStatus),
 			populateInitialRecipientFn: func(t *testing.T) *data.CircleRecipient {
@@ -257,6 +257,7 @@ func Test_CirclePaymentDispatcher_ensureRecipientIsReady_failure(t *testing.T) {
 	for _, failedStatus := range []data.CircleRecipientStatus{
 		data.CircleRecipientStatusInactive,
 		data.CircleRecipientStatusDenied,
+		data.CircleRecipientStatusFailed,
 		"",
 	} {
 		testCases = append(testCases, TestCase{
@@ -428,7 +429,7 @@ func Test_CirclePaymentDispatcher_ensureRecipientIsReadyWithRetry(t *testing.T) 
 		},
 	}
 
-	for _, nonSuccessfulState := range []data.CircleRecipientStatus{data.CircleRecipientStatusInactive, data.CircleRecipientStatusDenied, data.CircleRecipientStatusPending} {
+	for _, nonSuccessfulState := range []data.CircleRecipientStatus{data.CircleRecipientStatusInactive, data.CircleRecipientStatusDenied, data.CircleRecipientStatusFailed, data.CircleRecipientStatusPending} {
 		testCases = append(testCases, TestCase{
 			name: fmt.Sprintf("tries 5 times [status=%s]", nonSuccessfulState),
 			populateInitialRecipientFn: func(t *testing.T) *data.CircleRecipient {

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
@@ -279,6 +279,7 @@ func Test_CirclePaymentDispatcher_ensureRecipientIsReady_failure(t *testing.T) {
 	for _, failedStatus := range []data.CircleRecipientStatus{
 		data.CircleRecipientStatusInactive,
 		data.CircleRecipientStatusDenied,
+		data.CircleRecipientStatusFailed,
 		"",
 	} {
 		testCases = append(testCases, TestCase{

--- a/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/circle_payment_dispatcher_test.go
@@ -508,123 +508,97 @@ func Test_CirclePaymentDispatcher_DispatchPayments(t *testing.T) {
 	disbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{})
 
 	// Receivers
-	receiver1 := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+	receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
 
-	// Receiver Wallets
-	rw1Registered := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver1.ID, disbursement.Wallet.ID, data.RegisteredReceiversWalletStatus)
-
-	// Circle Recipient
-	circleRecipient := data.CreateCircleRecipientFixture(t, ctx, dbConnectionPool, data.CircleRecipient{
-		ReceiverWalletID:  rw1Registered.ID,
-		Status:            data.CircleRecipientStatusActive,
-		CircleRecipientID: uuid.NewString(),
-	})
-
-	// Payments
-	payment1 := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
-		ReceiverWallet: rw1Registered,
-		Disbursement:   disbursement,
-		Asset:          *disbursement.Asset,
-		Amount:         "100",
-		Status:         data.ReadyPaymentStatus,
-	})
-
-	tests := []struct {
-		name               string
-		paymentsToDispatch []*data.Payment
-		wantErr            error
-		fnSetup            func(*testing.T, *circle.MockService)
-		fnAsserts          func(*testing.T, db.SQLExecuter)
-	}{
+	type TestCase struct {
+		name            string
+		wantErrContains []string
+		fnSetup         func(*testing.T, *circle.MockService, *data.Payment, *data.CircleRecipient)
+		fnAsserts       func(*testing.T, db.SQLExecuter, *data.Payment)
+	}
+	tests := []TestCase{
 		{
-			name: "failure validating payment ready for sending",
-			paymentsToDispatch: []*data.Payment{
-				{
-					ID:             "123",
-					ReceiverWallet: rw1Registered,
-				},
+			name: "🔴 if payment does not exist return error",
+			fnSetup: func(*testing.T, *circle.MockService, *data.Payment, *data.CircleRecipient) {
+				// By deleting all payments, the function will return an error
+				data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
 			},
-			wantErr: fmt.Errorf("payment with ID 123 does not exist"),
+			wantErrContains: []string{"payment with ID", "does not exist"},
 		},
 		{
-			name:               "payment marked as failed when posting circle transfer fails",
-			paymentsToDispatch: []*data.Payment{payment1},
-			wantErr:            nil,
-			fnSetup: func(t *testing.T, m *circle.MockService) {
-				transferRequest, setupErr := models.CircleTransferRequests.Insert(ctx, payment1.ID)
+			name: "🔴 if SendPayment fails return error",
+			fnSetup: func(t *testing.T, m *circle.MockService, payment *data.Payment, circleRecipient *data.CircleRecipient) {
+				transferRequest, setupErr := models.CircleTransferRequests.Insert(ctx, payment.ID)
 				require.NoError(t, setupErr)
 
 				m.On("SendPayment", ctx, circle.PaymentRequest{
 					SourceWalletID:   circleWalletID,
 					RecipientID:      circleRecipient.CircleRecipientID,
-					Amount:           payment1.Amount,
-					StellarAssetCode: payment1.Asset.Code,
+					Amount:           payment.Amount,
+					StellarAssetCode: payment.Asset.Code,
 					IdempotencyKey:   transferRequest.IdempotencyKey,
 				}).
 					Return(nil, fmt.Errorf("error posting transfer to Circle")).
 					Once()
 			},
-			fnAsserts: func(t *testing.T, sqlExecuter db.SQLExecuter) {
+			fnAsserts: func(t *testing.T, sqlExecuter db.SQLExecuter, payment *data.Payment) {
 				// Payment should be marked as failed
-				payment, assertErr := models.Payment.Get(ctx, payment1.ID, sqlExecuter)
+				payment, assertErr := models.Payment.Get(ctx, payment.ID, sqlExecuter)
 				require.NoError(t, assertErr)
 				assert.Equal(t, data.FailedPaymentStatus, payment.Status)
 			},
 		},
 		{
-			name:               "error updating circle transfer request",
-			paymentsToDispatch: []*data.Payment{payment1},
-			wantErr:            fmt.Errorf("updating circle transfer request: payout cannot be nil"),
-			fnSetup: func(t *testing.T, m *circle.MockService) {
-				m.On("SendPayment", ctx, mock.AnythingOfType("circle.PaymentRequest")).
+			name: "🔴 if the payout is unexpectedly nil return an error",
+			fnSetup: func(t *testing.T, m *circle.MockService, payment *data.Payment, circleRecipient *data.CircleRecipient) {
+				m.
+					On("SendPayment", ctx, mock.AnythingOfType("circle.PaymentRequest")).
 					Return(nil, nil).
 					Once()
 			},
+			wantErrContains: []string{"updating circle transfer request: payout cannot be nil"},
 		},
 		{
-			name:               "error updating payment status for completed request",
-			paymentsToDispatch: []*data.Payment{payment1},
-			wantErr:            fmt.Errorf("invalid input value for enum circle_transfer_status"),
-			fnSetup: func(t *testing.T, m *circle.MockService) {
-				m.On("SendPayment", ctx, mock.AnythingOfType("circle.PaymentRequest")).
-					Return(&circle.Payout{
-						ID:     "payout_id",
-						Status: "wrong-status",
-					}, nil).
+			name: "🔴 if the payout status is unsupported return an error",
+			fnSetup: func(t *testing.T, m *circle.MockService, payment *data.Payment, circleRecipient *data.CircleRecipient) {
+				m.
+					On("SendPayment", ctx, mock.AnythingOfType("circle.PaymentRequest")).
+					Return(&circle.Payout{ID: "payout_id", Status: "unsupported-status"}, nil).
 					Once()
 			},
+			wantErrContains: []string{"invalid input value for enum circle_transfer_status"},
 		},
 		{
-			name:               "success posting transfer to Circle",
-			paymentsToDispatch: []*data.Payment{payment1},
-			wantErr:            nil,
-			fnSetup: func(t *testing.T, m *circle.MockService) {
-				m.On("SendPayment", ctx, mock.AnythingOfType("circle.PaymentRequest")).
+			name: "🟢 successful SendPayment",
+			fnSetup: func(t *testing.T, m *circle.MockService, payment *data.Payment, circleRecipient *data.CircleRecipient) {
+				m.
+					On("SendPayment", ctx, mock.AnythingOfType("circle.PaymentRequest")).
 					Return(&circle.Payout{
 						ID:     circlePayoutID,
 						Status: circle.TransferStatusPending,
 						Amount: circle.Balance{
-							Amount:   payment1.Amount,
+							Amount:   payment.Amount,
 							Currency: "USD",
 						},
 					}, nil).
 					Once()
 			},
-			fnAsserts: func(t *testing.T, sqlExecuter db.SQLExecuter) {
+			fnAsserts: func(t *testing.T, sqlExecuter db.SQLExecuter, payment *data.Payment) {
 				// Payment should be marked as pending
-				payment, assertErr := models.Payment.Get(ctx, payment1.ID, sqlExecuter)
+				var assertErr error
+				payment, assertErr = models.Payment.Get(ctx, payment.ID, sqlExecuter)
 				require.NoError(t, assertErr)
 				assert.Equal(t, data.PendingPaymentStatus, payment.Status)
 
 				// Transfer request is still not updated for the main connection pool
 				var transferRequest data.CircleTransferRequest
-				assertErr = dbConnectionPool.GetContext(ctx, &transferRequest, "SELECT * FROM circle_transfer_requests WHERE payment_id = $1", payment1.ID)
+				assertErr = dbConnectionPool.GetContext(ctx, &transferRequest, "SELECT * FROM circle_transfer_requests WHERE payment_id = $1", payment.ID)
 				require.NoError(t, assertErr)
 				assert.Nil(t, transferRequest.CirclePayoutID)
 				assert.Nil(t, transferRequest.SourceWalletID)
 
 				// Transfer request is updated for the transaction
-				assertErr = sqlExecuter.GetContext(ctx, &transferRequest, "SELECT * FROM circle_transfer_requests WHERE payment_id = $1", payment1.ID)
+				assertErr = sqlExecuter.GetContext(ctx, &transferRequest, "SELECT * FROM circle_transfer_requests WHERE payment_id = $1", payment.ID)
 				require.NoError(t, assertErr)
 				assert.Equal(t, circlePayoutID, *transferRequest.CirclePayoutID)
 				assert.Equal(t, circleWalletID, *transferRequest.SourceWalletID)
@@ -633,18 +607,68 @@ func Test_CirclePaymentDispatcher_DispatchPayments(t *testing.T) {
 		},
 	}
 
+	// Errors that invalidate the Circle recipient:
+	for _, circleErrCode := range circle.DestinationAddressErrorCodes {
+		tests = append(tests, TestCase{
+			name: fmt.Sprintf("🟠[CircleAPI.error.code=%d] should move the CircleRecipient to status=denied", circleErrCode),
+			fnSetup: func(t *testing.T, m *circle.MockService, payment *data.Payment, circleRecipient *data.CircleRecipient) {
+				transferRequest, setupErr := models.CircleTransferRequests.Insert(ctx, payment.ID)
+				require.NoError(t, setupErr)
+
+				m.On("SendPayment", ctx, circle.PaymentRequest{
+					SourceWalletID:   circleWalletID,
+					RecipientID:      circleRecipient.CircleRecipientID,
+					Amount:           payment.Amount,
+					StellarAssetCode: payment.Asset.Code,
+					IdempotencyKey:   transferRequest.IdempotencyKey,
+				}).
+					Return(nil, &circle.APIError{Code: circleErrCode}).
+					Once()
+			},
+			fnAsserts: func(t *testing.T, sqlExecuter db.SQLExecuter, payment *data.Payment) {
+				// Payment should be marked as failed
+				var assertErr error
+				payment, assertErr = models.Payment.Get(ctx, payment.ID, sqlExecuter)
+				require.NoError(t, assertErr)
+				assert.Equal(t, data.FailedPaymentStatus, payment.Status)
+
+				// Circle recipient should be marked as Denied
+				circleRecipient, assertErr := models.CircleRecipient.GetByReceiverWalletID(ctx, payment.ReceiverWallet.ID)
+				require.NoError(t, assertErr)
+				assert.Equal(t, data.CircleRecipientStatusDenied, circleRecipient.Status)
+			},
+		})
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dbtx, runErr := dbConnectionPool.BeginTxx(ctx, nil)
+			// Receiver Wallets
+			rwRegistered := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, disbursement.Wallet.ID, data.RegisteredReceiversWalletStatus)
+			circleRecipient := data.CreateCircleRecipientFixture(t, ctx, dbConnectionPool, data.CircleRecipient{
+				ReceiverWalletID:  rwRegistered.ID,
+				Status:            data.CircleRecipientStatusActive,
+				CircleRecipientID: uuid.NewString(),
+			})
+			payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+				ReceiverWallet: rwRegistered,
+				Disbursement:   disbursement,
+				Asset:          *disbursement.Asset,
+				Amount:         "100",
+				Status:         data.ReadyPaymentStatus,
+			})
+
+			dbTx, runErr := dbConnectionPool.BeginTxx(ctx, nil)
 			require.NoError(t, runErr)
 
 			// Teardown
 			defer func() {
-				err = dbtx.Rollback()
+				err = dbTx.Rollback()
 				require.NoError(t, err)
 
-				_, err = dbConnectionPool.ExecContext(ctx, "DELETE FROM circle_transfer_requests")
-				require.NoError(t, err)
+				data.DeleteAllCircleTransferRequests(t, ctx, dbConnectionPool)
+				data.DeleteAllCircleRecipientsFixtures(t, ctx, dbConnectionPool)
+				data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
+				data.DeleteAllReceiverWalletsFixtures(t, ctx, dbConnectionPool)
 			}()
 
 			mCircleService := circle.NewMockService(t)
@@ -661,17 +685,19 @@ func Test_CirclePaymentDispatcher_DispatchPayments(t *testing.T) {
 			dispatcher := NewCirclePaymentDispatcher(models, mCircleService, mDistAccountResolver)
 
 			if tt.fnSetup != nil {
-				tt.fnSetup(t, mCircleService)
+				tt.fnSetup(t, mCircleService, payment, circleRecipient)
 			}
-			runErr = dispatcher.DispatchPayments(ctx, dbtx, tenantID, tt.paymentsToDispatch)
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, runErr, tt.wantErr.Error())
+			runErr = dispatcher.DispatchPayments(ctx, dbTx, tenantID, []*data.Payment{payment})
+			if tt.wantErrContains != nil {
+				for _, wantErr := range tt.wantErrContains {
+					assert.ErrorContains(t, runErr, wantErr)
+				}
 			} else {
 				assert.NoError(t, runErr)
 			}
 
 			if tt.fnAsserts != nil {
-				tt.fnAsserts(t, dbtx)
+				tt.fnAsserts(t, dbTx, payment)
 			}
 		})
 	}


### PR DESCRIPTION
### What

Workaround for Circle's bug where retries are not handled correctly when a trustline is missing.

### Why

A new error was detected in the Circle API that was not there in December: after the Circle payment to a recipient fails, that Recipient seems to be put in a burned/unusable state. This needs further investigation

#### How to reproduce?

1. Get a Stellar account that exists in the network but doesn't have the USDC trustline
2. Create a Stellar recipient on Circle (`POST /v1/addressBook/recipients`) using that address
3. Wait until the recipient status is updated to `active` in the Circle API
4. Send a payout to that receiver
5. The payout gets updated from `pending` to `failed`
6. If I submit the same payload again (with same `idempotency_key`) I get an API error `{code=5003, message=Inactive destination address, StatusCode=400}`
7. When I look at the recipient payload, its status is now `failed`.
    - 🚨 The [documentation](https://developers.circle.com/api-reference/circle-mint/payouts/get-address-book-recipient) shows that the recipient status should be one of the following though `[pending, inactive, active, denied]`. ~`failed`~ is not on the list
9. After that, add the USDC trustline to that address
10. Send a new payout to that recipient.
11. The error persists, although it should succeed.
    - 🚨 The [documentation](https://developers.circle.com/circle-mint/circle-apis-api-errors) describes the `5003` as _"Cannot send payout to an inactive destination address. If you have just added the address, you may have to wait for 24 hours before use"_.
    - The phrase _"If you have just added the address, you may have to wait for 24 hours before use"_ implies that even if I receive such an error code, the payout should eventually succeed if I retry after the address is active, which is not happening.

<img width="1164" alt="Screenshot 2025-01-14 at 6 27 04 PM" src="https://github.com/user-attachments/assets/2dd118dc-b87d-4c3f-a2ad-12bcffd86288" />


#### What was expected?

- The recipient should be handled consistently across these errors. Using a status that is not listed in the documentation makes it hard to handle this issue
- Retrying the payout once the recipient's Stellar address is correctly configured should succeed.
- Between steps 5 and 6, the response payload changes from `{payout_body... status:failed}` to an API error. The response should be consistent and return the same payload after repeating the request with the same `idempotency_key`.

### Known limitations

[TODO or N/A]

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
