### PR TITLE
Remove nginx.ingress.kubernetes.io/server-snippet annotation

### DIFF
--- a/helmchart/sdp/templates/04.1-ingress-sdp.yaml
+++ b/helmchart/sdp/templates/04.1-ingress-sdp.yaml
@@ -8,11 +8,6 @@ metadata:
     {{- include "sdp.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.sdp.ingress.annotations | nindent 4 }}
-    # This is a way to block the stellar.toml file from being served on the "sdp.domain":
-    nginx.ingress.kubernetes.io/server-snippet: |
-      location ~ /.well-known/stellar.toml {
-        return 404;
-      }
 spec:
   {{- if .Values.sdp.ingress.className }}
   ingressClassName: {{ .Values.sdp.ingress.className }}

--- a/helmchart/sdp/templates/04.2-ingress-ap.yaml
+++ b/helmchart/sdp/templates/04.2-ingress-ap.yaml
@@ -8,11 +8,6 @@ metadata:
     {{- include "sdp.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.anchorPlatform.ingress.annotations | nindent 4 }}
-    # This is a way to block the stellar.toml file from being served on the "sdp.domain":
-    nginx.ingress.kubernetes.io/server-snippet: |
-      location ~ /.well-known/stellar.toml {
-        proxy_pass {{ include "sdp.ap.sepServiceAddress" . }};
-      }
 spec:
   {{- if .Values.anchorPlatform.ingress.className }}
   ingressClassName: {{ .Values.anchorPlatform.ingress.className }}


### PR DESCRIPTION
### What

Remove `nginx.ingress.kubernetes.io/server-snippet` annotation

### Why

[This snippet](https://github.com/stellar/stellar-disbursement-platform-backend/pull/5/files#diff-ee6d3e08fc06195d14f677988de28e706e50231a869f86bbd8aa3110edc3d816) was a way to expose only one toml file (the AP one) through the same ingress, since we were using only one ingress for both SDP and AP.

It doesn't make sense anymore and should be removed

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
