### PR TITLE
[SDP-1523] allow patching already confirmed verification fields

### DIFF
--- a/db/migrations/sdp-migrations/2025-01-24.0-track-who-confirmed-receiver-verification-info.sql
+++ b/db/migrations/sdp-migrations/2025-01-24.0-track-who-confirmed-receiver-verification-info.sql
@@ -15,14 +15,9 @@ SET
 WHERE
     confirmed_at IS NOT NULL;
 
--- Add constraint where confirmed_by_id cannot be empty if confirmed_at is populated
-ALTER TABLE receiver_verifications
-    ADD CONSTRAINT confirmed_by_id_not_empty_when_completed CHECK (confirmed_by_id IS NOT NULL OR confirmed_at IS NULL);
-
 
 -- +migrate Down
 ALTER TABLE receiver_verifications
-    DROP CONSTRAINT confirmed_by_id_not_empty_when_completed,
     DROP COLUMN confirmed_by_type,
     DROP COLUMN confirmed_by_id;
 

--- a/db/migrations/sdp-migrations/2025-01-24.0-track-who-confirmed-receiver-verification-info.sql
+++ b/db/migrations/sdp-migrations/2025-01-24.0-track-who-confirmed-receiver-verification-info.sql
@@ -4,10 +4,16 @@
 CREATE TYPE confirmed_by_type AS ENUM ('RECEIVER', 'USER');
 
 ALTER TABLE receiver_verifications
-    ADD COLUMN confirmed_by_type confirmed_by_type NOT NULL DEFAULT 'RECEIVER',
+    ADD COLUMN confirmed_by_type confirmed_by_type,
     ADD COLUMN confirmed_by_id VARCHAR(36);
 
-UPDATE receiver_verifications SET confirmed_by_id = receiver_id WHERE confirmed_at IS NOT NULL;
+UPDATE
+    receiver_verifications
+SET
+    confirmed_by_id = receiver_id,
+    confirmed_by_type = 'RECEIVER'
+WHERE
+    confirmed_at IS NOT NULL;
 
 -- Add constraint where confirmed_by_id cannot be empty if confirmed_at is populated
 ALTER TABLE receiver_verifications
@@ -17,7 +23,7 @@ ALTER TABLE receiver_verifications
 -- +migrate Down
 ALTER TABLE receiver_verifications
     DROP CONSTRAINT confirmed_by_id_not_empty_when_completed,
-    DROP COLUMN confirmed_by,
+    DROP COLUMN confirmed_by_type,
     DROP COLUMN confirmed_by_id;
 
 DROP TYPE confirmed_by_type;

--- a/db/migrations/sdp-migrations/2025-01-24.0-track-who-confirmed-receiver-verification-info.sql
+++ b/db/migrations/sdp-migrations/2025-01-24.0-track-who-confirmed-receiver-verification-info.sql
@@ -1,0 +1,23 @@
+-- Purpose: Add columns to track who confirmed receiver verification info
+
+-- +migrate Up
+CREATE TYPE confirmed_by_type AS ENUM ('RECEIVER', 'USER');
+
+ALTER TABLE receiver_verifications
+    ADD COLUMN confirmed_by_type confirmed_by_type NOT NULL DEFAULT 'RECEIVER',
+    ADD COLUMN confirmed_by_id VARCHAR(36);
+
+UPDATE receiver_verifications SET confirmed_by_id = receiver_id WHERE confirmed_at IS NOT NULL;
+
+-- Add constraint where confirmed_by_id cannot be empty if confirmed_at is populated
+ALTER TABLE receiver_verifications
+    ADD CONSTRAINT confirmed_by_id_not_empty_when_completed CHECK (confirmed_by_id IS NOT NULL OR confirmed_at IS NULL);
+
+
+-- +migrate Down
+ALTER TABLE receiver_verifications
+    DROP CONSTRAINT confirmed_by_id_not_empty_when_completed,
+    DROP COLUMN confirmed_by,
+    DROP COLUMN confirmed_by_id;
+
+DROP TYPE confirmed_by_type;

--- a/internal/data/disbursement_instructions_test.go
+++ b/internal/data/disbursement_instructions_test.go
@@ -590,7 +590,9 @@ func ConfirmVerificationForRecipient(t *testing.T, ctx context.Context, dbConnec
 		UPDATE
 			receiver_verifications
 		SET
-			confirmed_at = now()
+			confirmed_at = NOW(),
+			confirmed_by_id = $1,
+			confirmed_by_type = 'RECEIVER'
 		WHERE
 			receiver_id = $1
 		`

--- a/internal/data/receiver_verification.go
+++ b/internal/data/receiver_verification.go
@@ -23,6 +23,8 @@ type ReceiverVerification struct {
 	HashedValue         string                  `json:"hashed_value" db:"hashed_value"`
 	Attempts            int                     `json:"attempts" db:"attempts"`
 	CreatedAt           time.Time               `json:"created_at" db:"created_at"`
+	ConfirmedByType     *ConfirmedByType        `json:"confirmed_by_type" db:"confirmed_by_type"`
+	ConfirmedByID       *string                 `json:"confirmed_by_id" db:"confirmed_by_id"`
 	UpdatedAt           time.Time               `json:"updated_at" db:"updated_at"`
 	ConfirmedAt         *time.Time              `json:"confirmed_at" db:"confirmed_at"`
 	FailedAt            *time.Time              `json:"failed_at" db:"failed_at"`
@@ -184,7 +186,7 @@ func (m *ReceiverVerificationModel) UpdateVerificationValue(ctx context.Context,
 
 // UpsertVerificationValue creates or updates the receiver's verification. Even if the verification exists and is
 // already confirmed by the receiver, it will be updated.
-func (m *ReceiverVerificationModel) UpsertVerificationValue(ctx context.Context, sqlExec db.SQLExecuter, receiverID string, verificationField VerificationType, verificationValue string) error {
+func (m *ReceiverVerificationModel) UpsertVerificationValue(ctx context.Context, sqlExec db.SQLExecuter, userID, receiverID string, verificationField VerificationType, verificationValue string) error {
 	log.Ctx(ctx).Infof("Calling UpsertVerificationValue for receiver %s and verification field %s", receiverID, verificationField)
 	hashedValue, err := HashVerificationValue(verificationValue)
 	if err != nil {
@@ -216,8 +218,17 @@ type ReceiverVerificationUpdate struct {
 	VerificationChannel message.MessageChannel `db:"verification_channel"`
 	Attempts            *int                   `db:"attempts"`
 	ConfirmedAt         *time.Time             `db:"confirmed_at"`
+	ConfirmedByType     ConfirmedByType        `db:"confirmed_by_type"`
+	ConfirmedByID       string                 `db:"confirmed_by_id"`
 	FailedAt            *time.Time             `db:"failed_at"`
 }
+
+type ConfirmedByType string
+
+const (
+	ConfirmedByTypeReceiver ConfirmedByType = "RECEIVER"
+	ConfirmedByTypeUser     ConfirmedByType = "USER"
+)
 
 func (rvu ReceiverVerificationUpdate) Validate() error {
 	if strings.TrimSpace(rvu.ReceiverID) == "" {
@@ -249,6 +260,16 @@ func (m *ReceiverVerificationModel) UpdateReceiverVerification(ctx context.Conte
 	if update.ConfirmedAt != nil {
 		fields = append(fields, "confirmed_at = ?")
 		args = append(args, update.ConfirmedAt)
+	}
+
+	if update.ConfirmedByID != "" {
+		fields = append(fields, "confirmed_by_id = ?")
+		args = append(args, update.ConfirmedByID)
+	}
+
+	if update.ConfirmedByType != "" {
+		fields = append(fields, "confirmed_by_type = ?")
+		args = append(args, update.ConfirmedByType)
 	}
 
 	if update.FailedAt != nil {

--- a/internal/data/receiver_verification.go
+++ b/internal/data/receiver_verification.go
@@ -182,8 +182,8 @@ func (m *ReceiverVerificationModel) UpdateVerificationValue(ctx context.Context,
 	return nil
 }
 
-// UpsertVerificationValue creates or updates the receiver's verification. In case the verification exists and it's already confirmed by the receiver
-// it's not updated.
+// UpsertVerificationValue creates or updates the receiver's verification. Even if the verification exists and is
+// already confirmed by the receiver, it will be updated.
 func (m *ReceiverVerificationModel) UpsertVerificationValue(ctx context.Context, sqlExec db.SQLExecuter, receiverID string, verificationField VerificationType, verificationValue string) error {
 	log.Ctx(ctx).Infof("Calling UpsertVerificationValue for receiver %s and verification field %s", receiverID, verificationField)
 	hashedValue, err := HashVerificationValue(verificationValue)
@@ -200,8 +200,6 @@ func (m *ReceiverVerificationModel) UpsertVerificationValue(ctx context.Context,
 		DO UPDATE SET
 			hashed_value = EXCLUDED.hashed_value,
 			updated_at = NOW()
-		WHERE
-			receiver_verifications.confirmed_at IS NULL
 	`
 
 	_, err = sqlExec.ExecContext(ctx, query, receiverID, verificationField, hashedValue)

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -108,7 +108,7 @@ func Test_ReceiverVerificationModel_GetAllByReceiverId(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, actualVerifications, 4)
 
-		assert.Equal(t, []ReceiverVerification{
+		assert.ElementsMatch(t, []ReceiverVerification{
 			{
 				ReceiverID:        receiver.ID,
 				VerificationField: VerificationTypeDateOfBirth,

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -281,55 +281,56 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 	ctx := context.Background()
 	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{})
 	receiverVerificationModel := ReceiverVerificationModel{}
-	getReceiverVerificationHashedValue := func(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, receiverID string, verificationField VerificationType) string {
-		const q = "SELECT hashed_value FROM receiver_verifications WHERE receiver_id = $1 AND verification_field = $2"
-		var hashedValue string
-		qErr := dbConnectionPool.GetContext(ctx, &hashedValue, q, receiverID, verificationField)
+	getReceiverVerification := func(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, receiverID string, verificationField VerificationType) ReceiverVerification {
+		tvSlice, qErr := receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receiverID}, verificationField)
 		require.NoError(t, qErr)
-		return hashedValue
+		require.Lenf(t, tvSlice, 1, "expected to have one verification value but had %d", len(tvSlice))
+		return *tvSlice[0]
 	}
 
 	t.Run("upserts the verification value successfully", func(t *testing.T) {
 		// Inserts the verification value
 		firstVerificationValue := "123456"
-		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypePin, firstVerificationValue)
+		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, "my-user-id", receiver.ID, VerificationTypePin, firstVerificationValue)
 		require.NoError(t, err)
 
-		currentHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationTypePin)
-		assert.NotEmpty(t, currentHashedValue)
-		verified := CompareVerificationValue(currentHashedValue, firstVerificationValue)
+		initialRV := getReceiverVerification(t, ctx, dbConnectionPool, receiver.ID, VerificationTypePin)
+		assert.NotEmpty(t, initialRV.HashedValue)
+		verified := CompareVerificationValue(initialRV.HashedValue, firstVerificationValue)
 		assert.True(t, verified)
 
 		// Updates the verification value
 		newVerificationValue := "654321"
-		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypePin, newVerificationValue)
+		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, "my-user-id", receiver.ID, VerificationTypePin, newVerificationValue)
 		require.NoError(t, err)
 
-		afterUpdateHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationTypePin)
-		assert.NotEmpty(t, afterUpdateHashedValue)
+		finalRV := getReceiverVerification(t, ctx, dbConnectionPool, receiver.ID, VerificationTypePin)
+		assert.NotEmpty(t, finalRV.HashedValue)
 
 		// Checking if the hashed value is NOT the first one.
-		verified = CompareVerificationValue(afterUpdateHashedValue, firstVerificationValue)
+		verified = CompareVerificationValue(finalRV.HashedValue, firstVerificationValue)
 		assert.False(t, verified)
 		// Checking if the hashed value is equal the updated verification value
-		verified = CompareVerificationValue(afterUpdateHashedValue, newVerificationValue)
+		verified = CompareVerificationValue(finalRV.HashedValue, newVerificationValue)
 		assert.True(t, verified)
 	})
 
 	t.Run("update the verification value even when it was already confirmed by the receiver", func(t *testing.T) {
 		// Inserts the verification value
 		firstVerificationValue := "0301016957187"
-		err := receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID, firstVerificationValue)
+		err := receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, "my-user-id", receiver.ID, VerificationTypeNationalID, firstVerificationValue)
 		require.NoError(t, err)
 
-		currentHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID)
-		assert.NotEmpty(t, currentHashedValue)
-		verified := CompareVerificationValue(currentHashedValue, firstVerificationValue)
+		initialRV := getReceiverVerification(t, ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID)
+		assert.NotEmpty(t, initialRV.HashedValue)
+		verified := CompareVerificationValue(initialRV.HashedValue, firstVerificationValue)
 		assert.True(t, verified)
 
 		// Receiver confirmed the verification value
 		now := time.Now()
 		err = receiverVerificationModel.UpdateReceiverVerification(ctx, ReceiverVerificationUpdate{
+			ConfirmedByType:     ConfirmedByTypeUser,
+			ConfirmedByID:       "my-user-id",
 			ReceiverID:          receiver.ID,
 			VerificationField:   VerificationTypeNationalID,
 			ConfirmedAt:         &now,
@@ -338,17 +339,17 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 		require.NoError(t, err)
 
 		newVerificationValue := "0301017821085"
-		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID, newVerificationValue)
+		err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, "my-user-id", receiver.ID, VerificationTypeNationalID, newVerificationValue)
 		require.NoError(t, err)
 
-		afterUpdateHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID)
-		assert.NotEmpty(t, currentHashedValue)
+		finalRV := getReceiverVerification(t, ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID)
+		assert.NotEmpty(t, finalRV.HashedValue)
 
 		// Checking if the hashed value is NOT the first one.
-		verified = CompareVerificationValue(afterUpdateHashedValue, firstVerificationValue)
+		verified = CompareVerificationValue(finalRV.HashedValue, firstVerificationValue)
 		assert.False(t, verified)
 		// Checking if the hashed value is equal the updated verification value
-		verified = CompareVerificationValue(afterUpdateHashedValue, newVerificationValue)
+		verified = CompareVerificationValue(finalRV.HashedValue, newVerificationValue)
 		assert.True(t, verified)
 	})
 }
@@ -356,7 +357,6 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 func Test_ReceiverVerificationModel_UpdateReceiverVerification(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
-
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
@@ -382,10 +382,11 @@ func Test_ReceiverVerificationModel_UpdateReceiverVerification(t *testing.T) {
 		VerificationField:   VerificationTypeDateOfBirth,
 		Attempts:            utils.IntPtr(5),
 		ConfirmedAt:         &date,
+		ConfirmedByType:     ConfirmedByTypeUser,
+		ConfirmedByID:       "my-user-id",
 		FailedAt:            &date,
 		VerificationChannel: message.MessageChannelSMS,
 	}
-
 	err = receiverVerificationModel.UpdateReceiverVerification(ctx, verificationUpdate, dbConnectionPool)
 	require.NoError(t, err)
 
@@ -528,9 +529,9 @@ func Test_ReceiverVerificationModel_GetLatestByContactInfo(t *testing.T) {
 
 				receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, receiverInsert)
 
-				err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, oldVerificationType, oldVerificationValue)
+				err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, "new-user-id", receiver.ID, oldVerificationType, oldVerificationValue)
 				require.NoError(t, err)
-				err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, latestVerificationType, latestVerificationValue)
+				err = receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, "new-user-id", receiver.ID, latestVerificationType, latestVerificationValue)
 				require.NoError(t, err)
 
 				contactInfo := tc.contactInfo(*receiver, contactType)

--- a/internal/data/receiver_verification_test.go
+++ b/internal/data/receiver_verification_test.go
@@ -274,7 +274,6 @@ func Test_ReceiverVerificationModel_UpdateVerificationValue(t *testing.T) {
 func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
-
 	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
@@ -317,7 +316,7 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 		assert.True(t, verified)
 	})
 
-	t.Run("doesn't update the verification value when it was confirmed by the receiver", func(t *testing.T) {
+	t.Run("update the verification value even when it was already confirmed by the receiver", func(t *testing.T) {
 		// Inserts the verification value
 		firstVerificationValue := "0301016957187"
 		err := receiverVerificationModel.UpsertVerificationValue(ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID, firstVerificationValue)
@@ -345,14 +344,12 @@ func Test_ReceiverVerificationModel_UpsertVerificationValue(t *testing.T) {
 		afterUpdateHashedValue := getReceiverVerificationHashedValue(t, ctx, dbConnectionPool, receiver.ID, VerificationTypeNationalID)
 		assert.NotEmpty(t, currentHashedValue)
 
-		// Checking if the hashed value is NOT the new one.
-		verified = CompareVerificationValue(afterUpdateHashedValue, newVerificationValue)
-		assert.False(t, verified)
-		// Checking if the hashed value is equal the first verification value
+		// Checking if the hashed value is NOT the first one.
 		verified = CompareVerificationValue(afterUpdateHashedValue, firstVerificationValue)
+		assert.False(t, verified)
+		// Checking if the hashed value is equal the updated verification value
+		verified = CompareVerificationValue(afterUpdateHashedValue, newVerificationValue)
 		assert.True(t, verified)
-
-		assert.Equal(t, currentHashedValue, afterUpdateHashedValue)
 	})
 }
 

--- a/internal/serve/httphandler/verify_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verify_receiver_registration_handler.go
@@ -173,6 +173,8 @@ func (v VerifyReceiverRegistrationHandler) processReceiverVerificationPII(
 	// STEP 4: update the receiver verification row with the confirmation that the value was successfully validated
 	if receiverVerification.ConfirmedAt == nil {
 		rvu.ConfirmedAt = &now
+		rvu.ConfirmedByID = receiver.ID
+		rvu.ConfirmedByType = data.ConfirmedByTypeReceiver
 
 		err = v.Models.ReceiverVerification.UpdateReceiverVerification(ctx, rvu, dbTx)
 		if err != nil {


### PR DESCRIPTION
### What

Allow patching already confirmed verification fields

### Why

Some receivers got locked out from a partner's system and this seems to be the most reliable fix.

### Pending work

@marwen-abid added an audit table in #513 that will be used to keep track of such changes.

