### PR TITLE
[SDP-1304] Add audit receivers and unit tests

### DIFF
--- a/db/migrations/sdp-migrations/2025-01-28.0-add-audit-to-receivers-table.sql
+++ b/db/migrations/sdp-migrations/2025-01-28.0-add-audit-to-receivers-table.sql
@@ -1,0 +1,7 @@
+-- Add auditing to receiver_verifications
+
+-- +migrate Up
+SELECT 1 FROM create_audit_table('receivers');
+
+-- +migrate Down
+SELECT 1 FROM drop_audit_table('receivers');

--- a/internal/data/receiver_verification_audit_test.go
+++ b/internal/data/receiver_verification_audit_test.go
@@ -1,0 +1,144 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+)
+
+type receiverVerificationAuditEntry struct {
+	ReceiverVerification
+	Operation string    `db:"operation"`
+	ChangedAt time.Time `db:"changed_at"`
+}
+
+func Test_ReceiverVerificationsAudit(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+	model := ReceiverVerificationModel{}
+
+	testCases := []struct {
+		name      string
+		operation string
+		setup     func(*testing.T, context.Context, db.DBConnectionPool) *ReceiverVerification
+	}{
+		{
+			name:      "🎉 insert operation is logged",
+			operation: "INSERT",
+			setup: func(t *testing.T, ctx context.Context, db db.DBConnectionPool) *ReceiverVerification {
+				receiver := CreateReceiverFixture(t, ctx, db, &Receiver{})
+				return CreateReceiverVerificationFixture(t, ctx, db, ReceiverVerificationInsert{
+					ReceiverID:        receiver.ID,
+					VerificationField: VerificationTypeDateOfBirth,
+					VerificationValue: "1990-01-01",
+				})
+			},
+		},
+		{
+			name:      "🎉 update operation is logged",
+			operation: "UPDATE",
+			setup: func(t *testing.T, ctx context.Context, db db.DBConnectionPool) *ReceiverVerification {
+				receiver := CreateReceiverFixture(t, ctx, db, &Receiver{})
+				receiverVerification := CreateReceiverVerificationFixture(t, ctx, db, ReceiverVerificationInsert{
+					ReceiverID:        receiver.ID,
+					VerificationField: VerificationTypeYearMonth,
+					VerificationValue: "1990-01-01",
+				})
+
+				err := model.UpdateReceiverVerification(ctx, ReceiverVerificationUpdate{
+					ReceiverID:          receiver.ID,
+					VerificationField:   VerificationTypeYearMonth,
+					Attempts:            utils.IntPtr(3),
+					VerificationChannel: message.MessageChannelSMS,
+					ConfirmedByType:     ConfirmedByTypeUser,
+					ConfirmedByID:       "user-123",
+				}, db)
+				require.NoError(t, err)
+
+				return receiverVerification
+			},
+		},
+		{
+			name:      "🎉 delete operation is logged",
+			operation: "DELETE",
+			setup: func(t *testing.T, ctx context.Context, db db.DBConnectionPool) *ReceiverVerification {
+				receiver := CreateReceiverFixture(t, ctx, db, &Receiver{})
+				verification := CreateReceiverVerificationFixture(t, ctx, db, ReceiverVerificationInsert{
+					ReceiverID:        receiver.ID,
+					VerificationField: VerificationTypeDateOfBirth,
+					VerificationValue: "1990-01-01",
+				})
+
+				_, err := db.ExecContext(ctx,
+					"DELETE FROM receiver_verifications WHERE receiver_id = $1 AND verification_field = $2",
+					verification.ReceiverID,
+					verification.VerificationField,
+				)
+				require.NoError(t, err)
+
+				return verification
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			verification := tc.setup(t, ctx, dbConnectionPool)
+			latestEntry := getLastReceiverVerificationsAuditEntry(t, ctx, dbConnectionPool,
+				verification.ReceiverID,
+				verification.VerificationField,
+			)
+
+			// ☑️ check audit metadata fields
+			assert.Equal(t, tc.operation, latestEntry.Operation)
+			assert.WithinDuration(t, time.Now(), latestEntry.ChangedAt, 5*time.Second)
+
+			// ☑️ check receiver verification fields
+			assert.Equal(t, verification.ReceiverID, latestEntry.ReceiverID)
+			assert.Equal(t, verification.VerificationField, latestEntry.VerificationField)
+			assert.Equal(t, verification.Attempts, latestEntry.Attempts)
+			assert.Equal(t, verification.ConfirmedAt, latestEntry.ConfirmedAt)
+			assert.Equal(t, verification.FailedAt, latestEntry.FailedAt)
+			assert.Equal(t, verification.VerificationChannel, latestEntry.VerificationChannel)
+			assert.Equal(t, verification.ConfirmedByType, latestEntry.ConfirmedByType)
+			assert.Equal(t, verification.ConfirmedByID, latestEntry.ConfirmedByID)
+		})
+	}
+}
+
+// getLastReceiverVerificationsAuditEntry retrieves the last audit entry for a verification
+func getLastReceiverVerificationsAuditEntry(
+	t *testing.T,
+	ctx context.Context,
+	db db.DBConnectionPool,
+	receiverID string,
+	verificationField VerificationType,
+) receiverVerificationAuditEntry {
+	const query = `
+		SELECT *, operation, changed_at 
+		FROM receiver_verifications_audit 
+		WHERE receiver_id = $1 AND verification_field = $2 
+		ORDER BY changed_at DESC
+		LIMIT 1
+	`
+
+	var lastEntry receiverVerificationAuditEntry
+	err := db.GetContext(ctx, &lastEntry, query, receiverID, verificationField)
+	require.NoError(t, err)
+
+	return lastEntry
+}

--- a/internal/data/receivers_audit_test.go
+++ b/internal/data/receivers_audit_test.go
@@ -1,0 +1,119 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+)
+
+type receiverAuditEntry struct {
+	Receiver
+	Operation string    `db:"operation"`
+	ChangedAt time.Time `db:"changed_at"`
+}
+
+func Test_ReceiversAudit(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+
+	receiverModel := ReceiverModel{}
+
+	testCases := []struct {
+		name      string
+		operation string
+		setup     func(*testing.T, context.Context, db.DBConnectionPool) *Receiver
+	}{
+		{
+			name:      "🎉 insert operation is logged",
+			operation: "INSERT",
+			setup: func(t *testing.T, ctx context.Context, db db.DBConnectionPool) *Receiver {
+				return CreateReceiverFixture(t, ctx, db, &Receiver{
+					Email:       "insert@stellar.org",
+					PhoneNumber: "+1111111111",
+					ExternalID:  "audit-test-insert",
+				})
+			},
+		},
+		{
+			name:      "🎉 update operation is logged",
+			operation: "UPDATE",
+			setup: func(t *testing.T, ctx context.Context, db db.DBConnectionPool) *Receiver {
+				receiver := CreateReceiverFixture(t, ctx, db, &Receiver{
+					Email:       "update@stellar.org",
+					PhoneNumber: "+2222222222",
+					ExternalID:  "audit-test-update",
+				})
+
+				err := receiverModel.Update(ctx, db, receiver.ID, ReceiverUpdate{
+					Email: utils.StringPtr("updated@stellar.org"),
+				})
+				require.NoError(t, err)
+
+				return receiver
+			},
+		},
+		{
+			name:      "🎉 delete operation is logged",
+			operation: "DELETE",
+			setup: func(t *testing.T, ctx context.Context, db db.DBConnectionPool) *Receiver {
+				receiver := CreateReceiverFixture(t, ctx, db, &Receiver{
+					Email:       "delete@stellar.org",
+					PhoneNumber: "+3333333333",
+					ExternalID:  "audit-test-delete",
+				})
+
+				_, err := db.ExecContext(ctx, "DELETE FROM receivers WHERE id = $1", receiver.ID)
+				require.NoError(t, err)
+
+				return receiver
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			receiver := tc.setup(t, ctx, dbConnectionPool)
+			latestEntry := getLastReceiversAuditEntries(t, ctx, dbConnectionPool, receiver.ID)
+
+			// ☑️ check audit metadata fields
+			assert.Equal(t, tc.operation, latestEntry.Operation)
+			assert.WithinDuration(t, time.Now(), latestEntry.ChangedAt, 5*time.Second)
+
+			// ☑️ check receiver fields
+			assert.Equal(t, receiver.ID, latestEntry.ID)
+			assert.Equal(t, receiver.Email, latestEntry.Email)
+			assert.Equal(t, receiver.PhoneNumber, latestEntry.PhoneNumber)
+			assert.Equal(t, receiver.ExternalID, latestEntry.ExternalID)
+		})
+	}
+}
+
+// getLastReceiversAuditEntries retrieves audit entries for a receiver ordered by most recent first
+func getLastReceiversAuditEntries(t *testing.T, ctx context.Context, db db.DBConnectionPool, receiverID string) receiverAuditEntry {
+	const query = `
+		SELECT *, operation, changed_at 
+		FROM receivers_audit 
+		WHERE id = $1 
+		ORDER BY changed_at DESC
+		LIMIT 1
+	`
+
+	var lastEntry receiverAuditEntry
+	err := db.GetContext(ctx, &lastEntry, query, receiverID)
+	require.NoError(t, err)
+
+	return lastEntry
+}

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -357,6 +357,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 			"receiver_verifications_audit",
 			"receiver_wallets",
 			"receivers",
+			"receivers_audit",
 			"sdp_migrations",
 			"wallets",
 			"wallets_assets",

--- a/stellar-multitenant/internal/provisioning/manager_test.go
+++ b/stellar-multitenant/internal/provisioning/manager_test.go
@@ -464,6 +464,7 @@ func getExpectedTablesAfterMigrationsApplied() []string {
 		"receiver_verifications_audit",
 		"receiver_wallets",
 		"receivers",
+		"receivers_audit",
 		"sdp_migrations",
 		"wallets",
 		"wallets_assets",


### PR DESCRIPTION
### What

- add auditing for `receivers` table
- add unit tests for `receivers_audit` and `receiver_verification_audit` 

### Why

- track changes in critical tables. 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
