### PR TITLE
[SDP-1535] Update the `GET /payments` endpoint to accept `q={term}` query searches

### DIFF
--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -248,7 +248,7 @@ func (p *PaymentModel) Count(ctx context.Context, queryParams *QueryParams, sqlE
 			payments p
 		JOIN disbursements d on p.disbursement_id = d.id
 		JOIN assets a on p.asset_id = a.id
-		JOIN wallets w on d.wallet_id = w.id			
+		JOIN wallets w on d.wallet_id = w.id
 		JOIN receiver_wallets rw on rw.receiver_id = p.receiver_id AND rw.wallet_id = w.id
 		`
 
@@ -622,6 +622,11 @@ func (p *PaymentModel) GetByIDs(ctx context.Context, sqlExec db.SQLExecuter, pay
 // newPaymentQuery generates the full query and parameters for a payment search query
 func newPaymentQuery(baseQuery string, queryParams *QueryParams, sqlExec db.SQLExecuter, queryType QueryType) (string, []interface{}) {
 	qb := NewQueryBuilder(baseQuery)
+	if queryParams.Query != "" {
+		q := "%" + queryParams.Query + "%"
+		qb.AddCondition("(p.id ILIKE ? OR p.external_payment_id ILIKE ? OR rw.stellar_address ILIKE ? OR d.name ILIKE ?)", q, q, q, q)
+	}
+
 	if queryParams.Filters[FilterKeyStatus] != nil {
 		if statusSlice, ok := queryParams.Filters[FilterKeyStatus].([]PaymentStatus); ok {
 			if len(statusSlice) > 0 {

--- a/internal/data/payments_test.go
+++ b/internal/data/payments_test.go
@@ -621,6 +621,16 @@ func Test_PaymentNewPaymentQuery(t *testing.T) {
 			expectedParams: []interface{}{},
 		},
 		{
+			name:      "build payment query with a query search",
+			baseQuery: "SELECT * FROM payments p",
+			queryParams: QueryParams{
+				Query: "foo-bar",
+			},
+			queryType:      QueryTypeSelectAll,
+			expectedQuery:  "SELECT * FROM payments p WHERE 1=1 AND (p.id ILIKE $1 OR p.external_payment_id ILIKE $2 OR rw.stellar_address ILIKE $3 OR d.name ILIKE $4)",
+			expectedParams: []interface{}{"%foo-bar%", "%foo-bar%", "%foo-bar%", "%foo-bar%"},
+		},
+		{
 			name:      "build payment query with status filter",
 			baseQuery: "SELECT * FROM payments p",
 			queryParams: QueryParams{

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -11,7 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"net/url"
 	"testing"
 	"time"
 
@@ -2114,13 +2114,15 @@ func createInstructionsMultipartRequest(t *testing.T, ctx context.Context, multi
 }
 
 func buildURLWithQueryParams(baseURL, endpoint string, queryParams map[string]string) string {
-	url := baseURL + endpoint
-	if len(queryParams) > 0 {
-		url += "?"
-		for k, v := range queryParams {
-			url += fmt.Sprintf("%s=%s&", k, v)
-		}
-		url = strings.TrimSuffix(url, "&")
+	u, err := url.Parse(baseURL + endpoint)
+	if err != nil {
+		panic(fmt.Sprintf("invalid URL: %v", err))
 	}
-	return url
+
+	q := u.Query()
+	for k, v := range queryParams {
+		q.Set(k, v)
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -588,6 +588,8 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 			paymentFailed = payment
 		case data.CanceledPaymentStatus:
 			paymentCanceled = payment
+		default:
+			panic(fmt.Sprintf("invalid payment status: %s", paymentStatus))
 		}
 	}
 

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -495,11 +495,11 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	// create payments
-	payment1 := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+	paymentDraft := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
 		Amount:               "50",
 		StellarTransactionID: stellarTransactionID,
 		StellarOperationID:   stellarOperationID,
-		Status:               data.PendingPaymentStatus,
+		Status:               data.DraftPaymentStatus,
 		Disbursement:         disbursement1,
 		Asset:                *asset,
 		ReceiverWallet:       receiverWallet1,
@@ -512,11 +512,11 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 	stellarOperationID, err = utils.RandomString(32)
 	require.NoError(t, err)
 
-	payment2 := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+	paymentReady := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
 		Amount:               "150",
 		StellarTransactionID: stellarTransactionID,
 		StellarOperationID:   stellarOperationID,
-		Status:               data.DraftPaymentStatus,
+		Status:               data.ReadyPaymentStatus,
 		Disbursement:         disbursement1,
 		Asset:                *asset,
 		ReceiverWallet:       receiverWallet2,
@@ -529,11 +529,11 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 	stellarOperationID, err = utils.RandomString(32)
 	require.NoError(t, err)
 
-	payment3 := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+	paymentPending := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
 		Amount:               "200.50",
 		StellarTransactionID: stellarTransactionID,
 		StellarOperationID:   stellarOperationID,
-		Status:               data.DraftPaymentStatus,
+		Status:               data.PendingPaymentStatus,
 		Disbursement:         disbursement2,
 		Asset:                *asset,
 		ReceiverWallet:       receiverWallet1,
@@ -546,11 +546,11 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 	stellarOperationID, err = utils.RandomString(32)
 	require.NoError(t, err)
 
-	payment4 := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+	paymentPaused := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
 		Amount:               "20",
 		StellarTransactionID: stellarTransactionID,
 		StellarOperationID:   stellarOperationID,
-		Status:               data.PendingPaymentStatus,
+		Status:               data.PausedPaymentStatus,
 		Disbursement:         disbursement2,
 		Asset:                *asset,
 		ReceiverWallet:       receiverWallet2,
@@ -558,24 +558,53 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 		UpdatedAt:            time.Date(2023, 4, 10, 23, 40, 20, 1431, time.UTC),
 	})
 
-	tests := []struct {
+	var paymentSuccess *data.Payment
+	var paymentFailed *data.Payment
+	var paymentCanceled *data.Payment
+
+	for i, paymentStatus := range []data.PaymentStatus{data.SuccessPaymentStatus, data.FailedPaymentStatus, data.CanceledPaymentStatus} {
+		payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+			Amount:               "50",
+			StellarTransactionID: stellarTransactionID,
+			StellarOperationID:   stellarOperationID,
+			Status:               paymentStatus,
+			Disbursement:         disbursement1,
+			Asset:                *asset,
+			ReceiverWallet:       receiverWallet1,
+			CreatedAt:            time.Date(2024, time.Month(i+1), 10, 23, 40, 20, 1431, time.UTC),
+			UpdatedAt:            time.Date(2024, time.Month(i+1), 10, 23, 40, 20, 1431, time.UTC),
+		})
+
+		switch paymentStatus {
+		case data.SuccessPaymentStatus:
+			paymentSuccess = payment
+		case data.FailedPaymentStatus:
+			paymentFailed = payment
+		case data.CanceledPaymentStatus:
+			paymentCanceled = payment
+		}
+	}
+
+	type TestCase struct {
 		name               string
 		queryParams        map[string]string
 		expectedStatusCode int
 		expectedPagination httpresponse.PaginationInfo
 		expectedPayments   []data.Payment
-	}{
+	}
+
+	tests := []TestCase{
 		{
-			name:               "fetch all payments without filters",
+			name:               "fetch all payments without filters will use the default sorter (updated_at DESC)",
 			queryParams:        map[string]string{},
 			expectedStatusCode: http.StatusOK,
 			expectedPagination: httpresponse.PaginationInfo{
 				Next:  "",
 				Prev:  "",
 				Pages: 1,
-				Total: 4,
+				Total: 7,
 			},
-			expectedPayments: []data.Payment{*payment4, *payment1, *payment3, *payment2},
+			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentPaused, *paymentDraft, *paymentPending, *paymentReady},
 		},
 		{
 			name: "fetch first page of payments with limit 1 and sort by created_at",
@@ -589,10 +618,10 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 			expectedPagination: httpresponse.PaginationInfo{
 				Next:  "/payments?direction=asc&page=2&page_limit=1&sort=created_at",
 				Prev:  "",
-				Pages: 4,
-				Total: 4,
+				Pages: 7,
+				Total: 7,
 			},
-			expectedPayments: []data.Payment{*payment1},
+			expectedPayments: []data.Payment{*paymentDraft},
 		},
 		{
 			name: "fetch second page of payments with limit 1 and sort by created_at",
@@ -606,15 +635,15 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 			expectedPagination: httpresponse.PaginationInfo{
 				Next:  "/payments?direction=asc&page=3&page_limit=1&sort=created_at",
 				Prev:  "/payments?direction=asc&page=1&page_limit=1&sort=created_at",
-				Pages: 4,
-				Total: 4,
+				Pages: 7,
+				Total: 7,
 			},
-			expectedPayments: []data.Payment{*payment2},
+			expectedPayments: []data.Payment{*paymentReady},
 		},
 		{
 			name: "fetch last page of payments with limit 1 and sort by created_at",
 			queryParams: map[string]string{
-				"page":       "4",
+				"page":       "7",
 				"page_limit": "1",
 				"sort":       "created_at",
 				"direction":  "asc",
@@ -622,28 +651,14 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedPagination: httpresponse.PaginationInfo{
 				Next:  "",
-				Prev:  "/payments?direction=asc&page=3&page_limit=1&sort=created_at",
-				Pages: 4,
-				Total: 4,
+				Prev:  "/payments?direction=asc&page=6&page_limit=1&sort=created_at",
+				Pages: 7,
+				Total: 7,
 			},
-			expectedPayments: []data.Payment{*payment4},
+			expectedPayments: []data.Payment{*paymentCanceled},
 		},
 		{
-			name: "fetch payments with status draft",
-			queryParams: map[string]string{
-				"status": "dRaFt",
-			},
-			expectedStatusCode: http.StatusOK,
-			expectedPagination: httpresponse.PaginationInfo{
-				Next:  "",
-				Prev:  "",
-				Pages: 1,
-				Total: 2,
-			},
-			expectedPayments: []data.Payment{*payment3, *payment2},
-		},
-		{
-			name: "fetch payments for receiver1",
+			name: "fetch payments for receiver1 with default sorter (updated_at DESC)",
 			queryParams: map[string]string{
 				"receiver_id": receiver1.ID,
 			},
@@ -652,12 +667,12 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Next:  "",
 				Prev:  "",
 				Pages: 1,
-				Total: 2,
+				Total: 5,
 			},
-			expectedPayments: []data.Payment{*payment1, *payment3},
+			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentDraft, *paymentPending},
 		},
 		{
-			name: "fetch payments for receiver2",
+			name: "fetch payments for receiver2 with default sorter (updated_at DESC)",
 			queryParams: map[string]string{
 				"receiver_id": receiver2.ID,
 			},
@@ -668,12 +683,12 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Pages: 1,
 				Total: 2,
 			},
-			expectedPayments: []data.Payment{*payment4, *payment2},
+			expectedPayments: []data.Payment{*paymentPaused, *paymentReady},
 		},
 		{
 			name: "returns empty list when receiver_id is not found",
 			queryParams: map[string]string{
-				"receiver_id": "invalid_id",
+				"receiver_id": "non_existing_id",
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedPagination: httpresponse.PaginationInfo{
@@ -696,7 +711,7 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Pages: 1,
 				Total: 1,
 			},
-			expectedPayments: []data.Payment{*payment1},
+			expectedPayments: []data.Payment{*paymentDraft},
 		},
 		{
 			name: "fetch payments after 2023-03-01",
@@ -708,9 +723,9 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Next:  "",
 				Prev:  "",
 				Pages: 1,
-				Total: 1,
+				Total: 4,
 			},
-			expectedPayments: []data.Payment{*payment4},
+			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentPaused},
 		},
 		{
 			name: "fetch payment created at after 2023-01-01 and before 2023-03-01",
@@ -725,8 +740,25 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Pages: 1,
 				Total: 2,
 			},
-			expectedPayments: []data.Payment{*payment3, *payment2},
+			expectedPayments: []data.Payment{*paymentPending, *paymentReady},
 		},
+	}
+
+	for _, payment := range []data.Payment{*paymentDraft, *paymentPending, *paymentReady, *paymentPaused, *paymentSuccess, *paymentFailed, *paymentCanceled} {
+		tests = append(tests, TestCase{
+			name: "fetch payments with status=" + string(payment.Status),
+			queryParams: map[string]string{
+				"status": string(payment.Status),
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedPagination: httpresponse.PaginationInfo{
+				Next:  "",
+				Prev:  "",
+				Pages: 1,
+				Total: 1,
+			},
+			expectedPayments: []data.Payment{payment},
+		})
 	}
 
 	for _, tc := range tests {

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -610,7 +610,7 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Pages: 1,
 				Total: 7,
 			},
-			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentPaused, *paymentDraft, *paymentPending, *paymentReady},
+			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentPaused, *paymentDraft, *paymentPending, *paymentReady}, // default sorter: (updated_at DESC)
 		},
 		{
 			name: "fetch first page of payments with limit 1 and sort by created_at",
@@ -675,7 +675,7 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Pages: 1,
 				Total: 5,
 			},
-			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentDraft, *paymentPending},
+			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentDraft, *paymentPending}, // default sorter: (updated_at DESC)
 		},
 		{
 			name: "fetch payments for receiver2 with default sorter (updated_at DESC)",
@@ -689,7 +689,7 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Pages: 1,
 				Total: 2,
 			},
-			expectedPayments: []data.Payment{*paymentPaused, *paymentReady},
+			expectedPayments: []data.Payment{*paymentPaused, *paymentReady}, // default sorter: (updated_at DESC)
 		},
 		{
 			name: "returns empty list when receiver_id is not found",
@@ -731,7 +731,7 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Pages: 1,
 				Total: 4,
 			},
-			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentPaused},
+			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentPaused}, // default sorter: (updated_at DESC)
 		},
 		{
 			name: "fetch payment created at after 2023-01-01 and before 2023-03-01",
@@ -746,7 +746,7 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Pages: 1,
 				Total: 2,
 			},
-			expectedPayments: []data.Payment{*paymentPending, *paymentReady},
+			expectedPayments: []data.Payment{*paymentPending, *paymentReady}, // default sorter: (updated_at DESC)
 		},
 		{
 			name: "query[p.id]",
@@ -782,7 +782,7 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Next: "", Prev: "",
 				Pages: 1, Total: 5,
 			},
-			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentDraft, *paymentPending},
+			expectedPayments: []data.Payment{*paymentCanceled, *paymentFailed, *paymentSuccess, *paymentDraft, *paymentPending}, // default sorter: (updated_at DESC)
 		},
 		{
 			name: "query[d.name]",
@@ -794,7 +794,7 @@ func Test_PaymentHandler_GetPayments_Success(t *testing.T) {
 				Next: "", Prev: "",
 				Pages: 1, Total: 2,
 			},
-			expectedPayments: []data.Payment{*paymentPaused, *paymentPending},
+			expectedPayments: []data.Payment{*paymentPaused, *paymentPending}, // default sorter: (updated_at DESC)
 		},
 	}
 


### PR DESCRIPTION
### What

Implement `q={term}` in the `GET /payments` endpoint. It queries for the fields `p.id`, `p.external_payment_id`, `rw.stellar_address`, `d.name`.

### Why

Address the BE part of https://stellarorg.atlassian.net/browse/SDP-1535

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [x] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
