### PR TITLE
[SDP-1537] Complete Circle Disbursements during Reconciliation

### DIFF
--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -486,3 +486,27 @@ func (d *DisbursementModel) Delete(ctx context.Context, sqlExec db.SQLExecuter, 
 
 	return nil
 }
+
+// CompleteIfNecessary completes the disbursement if all payments are in the final state.
+func (d *DisbursementModel) CompleteIfNecessary(ctx context.Context, sqlExec db.SQLExecuter) ([]string, error) {
+	query := `
+		UPDATE
+			disbursements d
+		SET status         = $1,
+			status_history = array_append(status_history, create_disbursement_status_history(NOW(), $1, ''))
+		WHERE d.status = $2
+		-- disbursement has no payments that are not in a final state. 
+		  AND NOT EXISTS (SELECT 1
+						  FROM payments p
+						  WHERE p.disbursement_id = d.id
+							AND NOT p.status = ANY ($3))
+		RETURNING d.id
+	`
+	var disbursementIDs []string
+	err := sqlExec.SelectContext(ctx, &disbursementIDs, query, CompletedDisbursementStatus, StartedDisbursementStatus, pq.Array(PaymentCompletedStatuses()))
+	if err != nil {
+		return nil, fmt.Errorf("completing disbursements: %w", err)
+	}
+
+	return disbursementIDs, nil
+}

--- a/internal/data/payments_state_machine.go
+++ b/internal/data/payments_state_machine.go
@@ -68,7 +68,7 @@ func PaymentInProgressStatuses() []PaymentStatus {
 	return []PaymentStatus{ReadyPaymentStatus, PendingPaymentStatus, PausedPaymentStatus}
 }
 
-// PaymentCompletedStatuses returns a list of payment statuses that reached a terminal state
+// PaymentCompletedStatuses returns a list of payment statuses that reached a terminal state.
 func PaymentCompletedStatuses() []PaymentStatus {
 	return []PaymentStatus{SuccessPaymentStatus, CanceledPaymentStatus}
 }

--- a/internal/data/payments_state_machine.go
+++ b/internal/data/payments_state_machine.go
@@ -68,6 +68,11 @@ func PaymentInProgressStatuses() []PaymentStatus {
 	return []PaymentStatus{ReadyPaymentStatus, PendingPaymentStatus, PausedPaymentStatus}
 }
 
+// PaymentCompletedStatuses returns a list of payment statuses that reached a terminal state
+func PaymentCompletedStatuses() []PaymentStatus {
+	return []PaymentStatus{SuccessPaymentStatus, CanceledPaymentStatus}
+}
+
 func PaymentActiveStatuses() []PaymentStatus {
 	return []PaymentStatus{ReadyPaymentStatus, PendingPaymentStatus}
 }

--- a/internal/data/receivers_test.go
+++ b/internal/data/receivers_test.go
@@ -673,8 +673,7 @@ func Test_ReceiversModel_GetAll(t *testing.T) {
 		}, QueryTypeSelectAll)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(actualReceivers))
-		assert.Equal(t, receiver1.ID, actualReceivers[0].ID)
-		assert.Equal(t, receiver2.ID, actualReceivers[1].ID)
+		assert.ElementsMatch(t, []string{receiver1.ID, receiver2.ID}, []string{actualReceivers[0].ID, actualReceivers[1].ID})
 	})
 
 	t.Run("returns receivers successfully with query filter email", func(t *testing.T) {


### PR DESCRIPTION
### What
- Complete Circle Disbursements when all payments reach a terminal state. 
- Payment Terminal State = `SUCCESS` or `CANCELED` . 

Note: `FAILED` isn't considered terminal because it's retriable. 

### Why

- Bugfix: Circle Disbursements weren't getting terminated. 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
