### PR TITLE
[SDP-1545] Get Disbursements fails when user deactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- GET `/disbursements` breaks when one of the users is deactivated. [#546](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/546)
+- GET `/disbursements` breaks when one of the users is deactivated. [#550](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/550)
 
 ## [3.5.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/3.5.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/3.4.0...3.5.0))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [3.5.1](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/3.5.1) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/3.5.0...3.5.1))
+
+### Fixed
+
+- GET `/disbursements` breaks when one of the users is deactivated. [#546](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/546)
+
 ## [3.5.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/3.5.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/3.4.0...3.5.0))
 
 > [!WARNING]

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -571,13 +571,13 @@ func Test_DisbursementHandler_GetDisbursements_Success(t *testing.T) {
 	}
 
 	authManagerMock.
-		On("GetUsersByID", mock.Anything, []string{createdByUser.ID, startedByUser.ID}).
+		On("GetUsersByID", mock.Anything, []string{createdByUser.ID, startedByUser.ID}, false).
 		Return(allUsers, nil)
 	authManagerMock.
-		On("GetUsersByID", mock.Anything, []string{startedByUser.ID, createdByUser.ID}).
+		On("GetUsersByID", mock.Anything, []string{startedByUser.ID, createdByUser.ID}, false).
 		Return(allUsers, nil)
 	authManagerMock.
-		On("GetUsersByID", mock.Anything, []string{createdByUser.ID}).
+		On("GetUsersByID", mock.Anything, []string{createdByUser.ID}, false).
 		Return([]*auth.User{&createdByUser}, nil)
 
 	createdByUserRef := services.UserReference{
@@ -1227,10 +1227,10 @@ func Test_DisbursementHandler_GetDisbursement(t *testing.T) {
 	}
 
 	authManagerMock.
-		On("GetUsersByID", mock.Anything, []string{createdByUser.ID, startedByUser.ID}).
+		On("GetUsersByID", mock.Anything, []string{createdByUser.ID, startedByUser.ID}, false).
 		Return(allUsers, nil)
 	authManagerMock.
-		On("GetUsersByID", mock.Anything, []string{startedByUser.ID, createdByUser.ID}).
+		On("GetUsersByID", mock.Anything, []string{startedByUser.ID, createdByUser.ID}, false).
 		Return(allUsers, nil)
 
 	handler := &DisbursementHandler{

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -92,7 +92,7 @@ func (s *DisbursementManagementService) AppendUserMetadata(ctx context.Context, 
 		}
 	}
 
-	usersList, err := s.AuthManager.GetUsersByID(ctx, maps.Keys(users))
+	usersList, err := s.AuthManager.GetUsersByID(ctx, maps.Keys(users), false)
 	if err != nil {
 		return nil, fmt.Errorf("error getting user for IDs: %w", err)
 	}

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -72,10 +72,10 @@ func Test_DisbursementManagementService_GetDisbursementsWithCount(t *testing.T) 
 
 	authManagerMock := &auth.AuthManagerMock{}
 	authManagerMock.
-		On("GetUsersByID", mock.Anything, []string{users[0].ID, users[1].ID}).
+		On("GetUsersByID", mock.Anything, []string{users[0].ID, users[1].ID}, false).
 		Return(users, nil)
 	authManagerMock.
-		On("GetUsersByID", mock.Anything, []string{users[1].ID, users[0].ID}).
+		On("GetUsersByID", mock.Anything, []string{users[1].ID, users[0].ID}, false).
 		Return(users, nil)
 
 	service := &DisbursementManagementService{

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -25,7 +25,7 @@ type AuthManager interface {
 	ResetPassword(ctx context.Context, tokenString, password string) error
 	UpdatePassword(ctx context.Context, token, currentPassword, newPassword string) error
 	GetUser(ctx context.Context, tokenString string) (*User, error)
-	GetUsersByID(ctx context.Context, userIDs []string) ([]*User, error)
+	GetUsersByID(ctx context.Context, userIDs []string, activeOnly bool) ([]*User, error)
 	GetUserID(ctx context.Context, tokenString string) (string, error)
 	GetTenantID(ctx context.Context, tokenString string) (string, error)
 	GetAllUsers(ctx context.Context, tokenString string) ([]User, error)
@@ -316,8 +316,8 @@ func (am *defaultAuthManager) getUserFromToken(ctx context.Context, tokenString 
 	return user, nil
 }
 
-func (am *defaultAuthManager) GetUsersByID(ctx context.Context, userIDs []string) ([]*User, error) {
-	users, err := am.authenticator.GetUsers(ctx, userIDs)
+func (am *defaultAuthManager) GetUsersByID(ctx context.Context, userIDs []string, activeOnly bool) ([]*User, error) {
+	users, err := am.authenticator.GetUsers(ctx, userIDs, activeOnly)
 	if err != nil {
 		return nil, fmt.Errorf("getting user with IDs: %w", err)
 	}

--- a/stellar-auth/pkg/auth/auth_test.go
+++ b/stellar-auth/pkg/auth/auth_test.go
@@ -1379,11 +1379,11 @@ func Test_AuthManager_GetUsersByID(t *testing.T) {
 	t.Run("returns error when aunthenticator fails", func(t *testing.T) {
 		userIDs := []string{"invalid-id"}
 		authenticatorMock.
-			On("GetUsers", ctx, userIDs).
+			On("GetUsers", ctx, userIDs, true).
 			Return(nil, errUnexpectedError).
 			Once()
 
-		_, err := authManager.GetUsersByID(ctx, userIDs)
+		_, err := authManager.GetUsersByID(ctx, userIDs, true)
 		require.Error(t, err)
 	})
 
@@ -1403,11 +1403,11 @@ func Test_AuthManager_GetUsersByID(t *testing.T) {
 
 		userIDs := []string{expectedUsers[0].ID, expectedUsers[1].ID}
 		authenticatorMock.
-			On("GetUsers", ctx, userIDs).
+			On("GetUsers", ctx, userIDs, true).
 			Return(expectedUsers, nil).
 			Once()
 
-		users, err := authManager.GetUsersByID(ctx, userIDs)
+		users, err := authManager.GetUsersByID(ctx, userIDs, true)
 		require.NoError(t, err)
 		assert.Equal(t, expectedUsers, users)
 	})

--- a/stellar-auth/pkg/auth/mocks.go
+++ b/stellar-auth/pkg/auth/mocks.go
@@ -128,8 +128,8 @@ func (am *AuthenticatorMock) GetUser(ctx context.Context, userID string) (*User,
 	return args.Get(0).(*User), args.Error(1)
 }
 
-func (am *AuthenticatorMock) GetUsers(ctx context.Context, userIDs []string) ([]*User, error) {
-	args := am.Called(ctx, userIDs)
+func (am *AuthenticatorMock) GetUsers(ctx context.Context, userIDs []string, activeOnly bool) ([]*User, error) {
+	args := am.Called(ctx, userIDs, activeOnly)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -238,8 +238,8 @@ func (am *AuthManagerMock) GetUser(ctx context.Context, tokenString string) (*Us
 	return args.Get(0).(*User), args.Error(1)
 }
 
-func (am *AuthManagerMock) GetUsersByID(ctx context.Context, tokenString []string) ([]*User, error) {
-	args := am.Called(ctx, tokenString)
+func (am *AuthManagerMock) GetUsersByID(ctx context.Context, userIDs []string, activeOnly bool) ([]*User, error) {
+	args := am.Called(ctx, userIDs, activeOnly)
 	return args.Get(0).([]*User), args.Error(1)
 }
 


### PR DESCRIPTION
### What
Resolve all users (active and inactive) when decorating GET /disbursements data.

### Why
Get Disbursements fails when user deactivated

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
