### PR TITLE
[DEV-1534] Make create disbursement atomic

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -248,7 +248,7 @@ func CloseConnectionPoolIfNeeded(ctx context.Context, dbConnectionPool DBConnect
 }
 
 // TransactionExecutionError represents an error that occurred during the execution of transaction,
-// as opposed to errors from transaction handling itself
+// as opposed to errors from transaction handling itself.
 type TransactionExecutionError struct {
 	err error
 }
@@ -265,7 +265,7 @@ func (t *TransactionExecutionError) Unwrap() error {
 	return t.err
 }
 
-// IsTransactionExecutionError checks if the given error originated from the atomic function execution
+// IsTransactionExecutionError checks if the given error originated from the atomic function execution.
 func IsTransactionExecutionError(err error) bool {
 	var eErr *TransactionExecutionError
 	return errors.As(err, &eErr)

--- a/db/db.go
+++ b/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -87,7 +88,7 @@ func RunInTransactionWithResult[T any](ctx context.Context, dbConnectionPool DBC
 
 	result, err = atomicFunction(dbTx)
 	if err != nil {
-		return *new(T), fmt.Errorf("running atomic function in RunInTransactionWithResult: %w", err)
+		return *new(T), NewTransactionExecutionError(err)
 	}
 
 	err = dbTx.Commit()
@@ -116,7 +117,7 @@ func RunInTransactionWithPostCommit(ctx context.Context, opts *TransactionOption
 
 	postCommit, err := atomicFunction(dbTx)
 	if err != nil {
-		return fmt.Errorf("running atomic function in RunInTransactionWithPostCommit: %w", err)
+		return NewTransactionExecutionError(err)
 	}
 
 	err = dbTx.Commit()
@@ -185,7 +186,11 @@ var _ SQLExecuter = (DBTransaction)(nil)
 // DBTxRollback rolls back the transaction if there is an error.
 func DBTxRollback(ctx context.Context, dbTx DBTransaction, err error, logMessage string) {
 	if err != nil {
-		log.Ctx(ctx).Errorf("%s: %s", logMessage, err.Error())
+		if IsTransactionExecutionError(err) {
+			log.Ctx(ctx).Debugf("%s: %s", logMessage, err.Error())
+		} else {
+			log.Ctx(ctx).Errorf("%s: %s", logMessage, err.Error())
+		}
 		errRollBack := dbTx.Rollback()
 		if errRollBack != nil {
 			log.Ctx(ctx).Errorf("error in database transaction rollback: %s", errRollBack.Error())
@@ -240,4 +245,28 @@ func CloseConnectionPoolIfNeeded(ctx context.Context, dbConnectionPool DBConnect
 	}
 
 	return dbConnectionPool.Close()
+}
+
+// TransactionExecutionError represents an error that occurred during the execution of transaction,
+// as opposed to errors from transaction handling itself
+type TransactionExecutionError struct {
+	err error
+}
+
+func NewTransactionExecutionError(err error) *TransactionExecutionError {
+	return &TransactionExecutionError{err: err}
+}
+
+func (t *TransactionExecutionError) Error() string {
+	return t.err.Error()
+}
+
+func (t *TransactionExecutionError) Unwrap() error {
+	return t.err
+}
+
+// IsTransactionExecutionError checks if the given error originated from the atomic function execution
+func IsTransactionExecutionError(err error) bool {
+	var eErr *TransactionExecutionError
+	return errors.As(err, &eErr)
 }

--- a/db/db.go
+++ b/db/db.go
@@ -258,7 +258,7 @@ func NewTransactionExecutionError(err error) *TransactionExecutionError {
 }
 
 func (t *TransactionExecutionError) Error() string {
-	return t.err.Error()
+	return fmt.Sprintf("transaction execution error: %s", t.err.Error())
 }
 
 func (t *TransactionExecutionError) Unwrap() error {

--- a/internal/data/disbursement_instructions.go
+++ b/internal/data/disbursement_instructions.go
@@ -91,60 +91,57 @@ type DisbursementInstructionsOpts struct {
 //	|    |    |--- [ReceiverContactType.IncludesWalletAddress] Register the supplied wallet address
 //	|    |    |--- Delete all previously existing payments tied to this disbursement.
 //	|    |    |--- Create all payments passed in the instructions.
-func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, opts DisbursementInstructionsOpts) error {
+func (di DisbursementInstructionModel) ProcessAll(ctx context.Context, dbTx db.DBTransaction, opts DisbursementInstructionsOpts) error {
 	if len(opts.Instructions) > opts.MaxNumberOfInstructions {
 		return ErrMaxInstructionsExceeded
 	}
 
-	// We need all the following logic to be executed in one transaction.
-	return db.RunInTransaction(ctx, di.dbConnectionPool, nil, func(dbTx db.DBTransaction) error {
-		// Step 1: Fetch all receivers by contact information (phone, email, etc.) and create missing ones
-		registrationContactType := opts.Disbursement.RegistrationContactType
-		receiversByIDMap, err := di.reconcileExistingReceiversWithInstructions(ctx, dbTx, opts.Instructions, registrationContactType.ReceiverContactType)
+	// Step 1: Fetch all receivers by contact information (phone, email, etc.) and create missing ones
+	registrationContactType := opts.Disbursement.RegistrationContactType
+	receiversByIDMap, err := di.reconcileExistingReceiversWithInstructions(ctx, dbTx, opts.Instructions, registrationContactType.ReceiverContactType)
+	if err != nil {
+		return fmt.Errorf("processing receivers: %w", err)
+	}
+
+	// Step 2: Fetch all receiver wallets and create missing ones
+	receiverIDToReceiverWalletIDMap, err := di.processReceiverWallets(ctx, dbTx, receiversByIDMap, opts.Disbursement)
+	if err != nil {
+		return fmt.Errorf("processing receiver wallets: %w", err)
+	}
+
+	// Step 3: Register supplied wallets or process receiver verifications based on the registration contact type
+	if registrationContactType.IncludesWalletAddress {
+		if err = di.registerSuppliedWallets(ctx, dbTx, opts.Instructions, receiversByIDMap, receiverIDToReceiverWalletIDMap); err != nil {
+			return fmt.Errorf("registering supplied wallets: %w", err)
+		}
+	} else {
+		err = di.processReceiverVerifications(ctx, dbTx, receiversByIDMap, opts.Instructions, opts.Disbursement, registrationContactType.ReceiverContactType)
 		if err != nil {
-			return fmt.Errorf("processing receivers: %w", err)
+			return fmt.Errorf("processing receiver verifications: %w", err)
 		}
+	}
 
-		// Step 2: Fetch all receiver wallets and create missing ones
-		receiverIDToReceiverWalletIDMap, err := di.processReceiverWallets(ctx, dbTx, receiversByIDMap, opts.Disbursement)
-		if err != nil {
-			return fmt.Errorf("processing receiver wallets: %w", err)
-		}
+	// Step 4: Delete all pre-existing draft payments tied to this disbursement for each receiver in one call
+	if err = di.paymentModel.DeleteAllDraftForDisbursement(ctx, dbTx, opts.Disbursement.ID); err != nil {
+		return fmt.Errorf("deleting draft payments: %w", err)
+	}
 
-		// Step 3: Register supplied wallets or process receiver verifications based on the registration contact type
-		if registrationContactType.IncludesWalletAddress {
-			if err = di.registerSuppliedWallets(ctx, dbTx, opts.Instructions, receiversByIDMap, receiverIDToReceiverWalletIDMap); err != nil {
-				return fmt.Errorf("registering supplied wallets: %w", err)
-			}
-		} else {
-			err = di.processReceiverVerifications(ctx, dbTx, receiversByIDMap, opts.Instructions, opts.Disbursement, registrationContactType.ReceiverContactType)
-			if err != nil {
-				return fmt.Errorf("processing receiver verifications: %w", err)
-			}
-		}
+	// Step 5: Create payments for all receivers
+	if err = di.createPayments(ctx, dbTx, receiversByIDMap, receiverIDToReceiverWalletIDMap, opts.Instructions, opts.Disbursement); err != nil {
+		return fmt.Errorf("creating payments: %w", err)
+	}
 
-		// Step 4: Delete all pre-existing draft payments tied to this disbursement for each receiver in one call
-		if err = di.paymentModel.DeleteAllDraftForDisbursement(ctx, dbTx, opts.Disbursement.ID); err != nil {
-			return fmt.Errorf("deleting draft payments: %w", err)
-		}
+	// Step 6: Persist Payment file to Disbursement
+	if err = di.disbursementModel.Update(ctx, dbTx, opts.DisbursementUpdate); err != nil {
+		return fmt.Errorf("persisting payment file: %w", err)
+	}
 
-		// Step 5: Create payments for all receivers
-		if err = di.createPayments(ctx, dbTx, receiversByIDMap, receiverIDToReceiverWalletIDMap, opts.Instructions, opts.Disbursement); err != nil {
-			return fmt.Errorf("creating payments: %w", err)
-		}
+	// Step 7: Update Disbursement Status
+	if err = di.disbursementModel.UpdateStatus(ctx, dbTx, opts.UserID, opts.Disbursement.ID, ReadyDisbursementStatus); err != nil {
+		return fmt.Errorf("updating status: %w", err)
+	}
 
-		// Step 6: Persist Payment file to Disbursement
-		if err = di.disbursementModel.Update(ctx, opts.DisbursementUpdate); err != nil {
-			return fmt.Errorf("persisting payment file: %w", err)
-		}
-
-		// Step 7: Update Disbursement Status
-		if err = di.disbursementModel.UpdateStatus(ctx, dbTx, opts.UserID, opts.Disbursement.ID, ReadyDisbursementStatus); err != nil {
-			return fmt.Errorf("updating status: %w", err)
-		}
-
-		return nil
-	})
+	return nil
 }
 
 func (di DisbursementInstructionModel) registerSuppliedWallets(ctx context.Context, dbTx db.DBTransaction, instructions []*DisbursementInstruction, receiversByIDMap map[string]*Receiver, receiverIDToReceiverWalletIDMap map[string]string) error {

--- a/internal/data/disbursement_instructions_test.go
+++ b/internal/data/disbursement_instructions_test.go
@@ -11,17 +11,17 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 )
 
 func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 
+	ctx := context.Background()
 	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
 	require.NoError(t, outerErr)
 	defer dbConnectionPool.Close()
-
-	ctx := context.Background()
 
 	asset := CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
 	wallet := CreateWalletFixture(t, ctx, dbConnectionPool, "wallet1", "https://www.wallet.com", "www.wallet.com", "wallet1://")
@@ -122,6 +122,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("failure - invalid wallet address for known wallet address instructions", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
 		instructions := []*DisbursementInstruction{
 			{
@@ -132,7 +133,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 			},
 		}
 
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            instructions,
 			Disbursement:            knownWalletDisbursement,
@@ -144,6 +145,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("failure - receiver wallet address mismatch for known wallet address instructions", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
 		firstInstruction := []*DisbursementInstruction{
 			{
@@ -154,7 +156,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 			},
 		}
 		update := knownWalletDisbursementUpdate(firstInstruction)
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            firstInstruction,
 			Disbursement:            knownWalletDisbursement,
@@ -172,7 +174,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 			},
 		}
 		mismatchUpdate := knownWalletDisbursementUpdate(mismatchAddressInstruction)
-		err = di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err = di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            mismatchAddressInstruction,
 			Disbursement:            knownWalletDisbursement,
@@ -184,6 +186,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("success - known wallet address instructions", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
 		instructions := []*DisbursementInstruction{
 			{
@@ -201,7 +204,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		}
 
 		update := knownWalletDisbursementUpdate(instructions)
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            instructions,
 			Disbursement:            knownWalletDisbursement,
@@ -211,7 +214,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify Receivers
-		receivers, err := di.receiverModel.GetByContacts(ctx, dbConnectionPool, instructions[0].Phone, instructions[1].Phone)
+		receivers, err := di.receiverModel.GetByContacts(ctx, dbTx, instructions[0].Phone, instructions[1].Phone)
 		require.NoError(t, err)
 		assertEqualReceivers(t, []string{instructions[0].Phone, instructions[1].Phone}, []string{"1", "2"}, receivers)
 
@@ -224,7 +227,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		assert.Len(t, receiver2Verifications, 0)
 
 		// Verify Receiver Wallets
-		receiverWallets, err := di.receiverWalletModel.GetWithReceiverIDs(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID})
+		receiverWallets, err := di.receiverWalletModel.GetWithReceiverIDs(ctx, dbTx, []string{receivers[0].ID, receivers[1].ID})
 		require.NoError(t, err)
 		assert.Len(t, receiverWallets, 2)
 		for _, receiverWallet := range receiverWallets {
@@ -234,16 +237,16 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		}
 
 		// Verify Payments
-		actualPayments := GetPaymentsByDisbursementID(t, ctx, dbConnectionPool, knownWalletDisbursement.ID)
+		actualPayments := GetPaymentsByDisbursementID(t, ctx, dbTx, knownWalletDisbursement.ID)
 		assert.Len(t, actualPayments, 2)
 		assert.Contains(t, actualPayments, instructions[0].Amount)
 		assert.Contains(t, actualPayments, instructions[1].Amount)
 
-		actualExternalPaymentIDs := GetExternalPaymentIDsByDisbursementID(t, ctx, dbConnectionPool, knownWalletDisbursement.ID)
+		actualExternalPaymentIDs := GetExternalPaymentIDsByDisbursementID(t, ctx, dbTx, knownWalletDisbursement.ID)
 		assert.Len(t, actualExternalPaymentIDs, 0)
 
 		// Verify Disbursement
-		actualDisbursement, err := di.disbursementModel.Get(ctx, dbConnectionPool, knownWalletDisbursement.ID)
+		actualDisbursement, err := di.disbursementModel.Get(ctx, dbTx, knownWalletDisbursement.ID)
 		require.NoError(t, err)
 		assert.Equal(t, ReadyDisbursementStatus, actualDisbursement.Status)
 		assert.Equal(t, update.FileContent, actualDisbursement.FileContent)
@@ -252,8 +255,9 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("success - sms instructions", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            smsInstructions,
 			Disbursement:            disbursement,
@@ -263,17 +267,17 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify Receivers
-		receivers, err := di.receiverModel.GetByContacts(ctx, dbConnectionPool, smsInstruction1.Phone, smsInstruction2.Phone, smsInstruction3.Phone)
+		receivers, err := di.receiverModel.GetByContacts(ctx, dbTx, smsInstruction1.Phone, smsInstruction2.Phone, smsInstruction3.Phone)
 		require.NoError(t, err)
 		assertEqualReceivers(t, expectedPhoneNumbers, expectedExternalIDs, receivers)
 
 		// Verify ReceiverVerifications
-		receiverVerifications, err := di.receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, VerificationTypeDateOfBirth)
+		receiverVerifications, err := di.receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, VerificationTypeDateOfBirth)
 		require.NoError(t, err)
 		assertEqualVerifications(t, smsInstructions, receiverVerifications, receivers)
 
 		// Verify ReceiverWallets
-		receiverWallets, err := di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, wallet.ID)
+		receiverWallets, err := di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbTx, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, wallet.ID)
 		require.NoError(t, err)
 		assert.Len(t, receiverWallets, len(receivers))
 
@@ -283,14 +287,14 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		}
 
 		// Verify Payments
-		actualPayments := GetPaymentsByDisbursementID(t, ctx, dbConnectionPool, disbursement.ID)
+		actualPayments := GetPaymentsByDisbursementID(t, ctx, dbTx, disbursement.ID)
 		assert.Equal(t, expectedPayments, actualPayments)
 
-		actualExternalPaymentIDs := GetExternalPaymentIDsByDisbursementID(t, ctx, dbConnectionPool, disbursement.ID)
+		actualExternalPaymentIDs := GetExternalPaymentIDsByDisbursementID(t, ctx, dbTx, disbursement.ID)
 		assert.Equal(t, expectedExternalPaymentIDs, actualExternalPaymentIDs)
 
 		// Verify Disbursement
-		actualDisbursement, err := di.disbursementModel.Get(ctx, dbConnectionPool, disbursement.ID)
+		actualDisbursement, err := di.disbursementModel.Get(ctx, dbTx, disbursement.ID)
 		require.NoError(t, err)
 		require.Equal(t, ReadyDisbursementStatus, actualDisbursement.Status)
 		require.Equal(t, disbursementUpdate.FileContent, actualDisbursement.FileContent)
@@ -299,8 +303,9 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("success - email instructions", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            emailInstructions,
 			Disbursement:            emailDisbursement,
@@ -310,7 +315,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify Receivers
-		receivers, err := di.receiverModel.GetByContacts(ctx, dbConnectionPool, emailInstruction1.Email, emailInstruction2.Email, emailInstruction3.Email)
+		receivers, err := di.receiverModel.GetByContacts(ctx, dbTx, emailInstruction1.Email, emailInstruction2.Email, emailInstruction3.Email)
 		require.NoError(t, err)
 		assert.Len(t, receivers, len(expectedEmails))
 		for _, actual := range receivers {
@@ -322,8 +327,9 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("failure - email instructions without email fields", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            smsInstructions,
 			Disbursement:            emailDisbursement,
@@ -335,6 +341,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("failure - email instructions with email and phone fields", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
 		emailAndSMSInstructions := []*DisbursementInstruction{
 			{
@@ -346,7 +353,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 			},
 		}
 
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            emailAndSMSInstructions,
 			Disbursement:            disbursement,
@@ -359,9 +366,10 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("success - Not confirmed Verification Value updated", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
 		// process instructions for the first time
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            smsInstructions,
 			Disbursement:            disbursement,
@@ -371,7 +379,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		require.NoError(t, err)
 
 		smsInstruction1.VerificationValue = "1990-01-04"
-		err = di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err = di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            smsInstructions,
 			Disbursement:            disbursement,
@@ -381,17 +389,17 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify Receivers
-		receivers, err := di.receiverModel.GetByContacts(ctx, dbConnectionPool, smsInstruction1.Phone, smsInstruction2.Phone, smsInstruction3.Phone)
+		receivers, err := di.receiverModel.GetByContacts(ctx, dbTx, smsInstruction1.Phone, smsInstruction2.Phone, smsInstruction3.Phone)
 		require.NoError(t, err)
 		assertEqualReceivers(t, expectedPhoneNumbers, expectedExternalIDs, receivers)
 
 		// Verify ReceiverVerifications
-		receiverVerifications, err := di.receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, VerificationTypeDateOfBirth)
+		receiverVerifications, err := di.receiverVerificationModel.GetByReceiverIDsAndVerificationField(ctx, dbTx, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, VerificationTypeDateOfBirth)
 		require.NoError(t, err)
 		assertEqualVerifications(t, smsInstructions, receiverVerifications, receivers)
 
 		// Verify Disbursement
-		actualDisbursement, err := di.disbursementModel.Get(ctx, dbConnectionPool, disbursement.ID)
+		actualDisbursement, err := di.disbursementModel.Get(ctx, dbTx, disbursement.ID)
 		require.NoError(t, err)
 		require.Equal(t, ReadyDisbursementStatus, actualDisbursement.Status)
 		require.Equal(t, disbursementUpdate.FileContent, actualDisbursement.FileContent)
@@ -400,9 +408,10 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("success - existing receiver wallet", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
 		// New instructions
-		readyDisbursement := CreateDisbursementFixture(t, ctx, dbConnectionPool, &DisbursementModel{dbConnectionPool: dbConnectionPool}, &Disbursement{
+		readyDisbursement := CreateDisbursementFixture(t, ctx, dbTx, &DisbursementModel{dbConnectionPool: dbConnectionPool}, &Disbursement{
 			Name:   "readyDisbursement",
 			Wallet: wallet,
 			Asset:  asset,
@@ -439,7 +448,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 			FileContent: CreateInstructionsFixture(t, newInstructions),
 		}
 
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            newInstructions,
 			Disbursement:            readyDisbursement,
@@ -448,16 +457,16 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		receivers, err := di.receiverModel.GetByContacts(ctx, dbConnectionPool, newInstruction1.Phone, newInstruction2.Phone, newInstruction3.Phone)
+		receivers, err := di.receiverModel.GetByContacts(ctx, dbTx, newInstruction1.Phone, newInstruction2.Phone, newInstruction3.Phone)
 		require.NoError(t, err)
 		assertEqualReceivers(t, newExpectedPhoneNumbers, newExpectedExternalIDs, receivers)
 
-		receiverWallets, err := di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, wallet.ID)
+		receiverWallets, err := di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbTx, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, wallet.ID)
 		require.NoError(t, err)
 
 		// Set invitation_sent_at = NOW()
 		for _, receiverWallet := range receiverWallets {
-			result, updateErr := dbConnectionPool.ExecContext(ctx, "UPDATE receiver_wallets SET invitation_sent_at = NOW() WHERE id = $1", receiverWallet.ID)
+			result, updateErr := dbTx.ExecContext(ctx, "UPDATE receiver_wallets SET invitation_sent_at = NOW() WHERE id = $1", receiverWallet.ID)
 			require.NoError(t, updateErr)
 			updatedRowsAffected, rowsErr := result.RowsAffected()
 			require.NoError(t, rowsErr)
@@ -465,24 +474,24 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		}
 
 		// Update Receiver Waller Status to Ready
-		err = di.receiverWalletModel.UpdateStatusByDisbursementID(ctx, dbConnectionPool, readyDisbursement.ID, DraftReceiversWalletStatus, ReadyReceiversWalletStatus)
+		err = di.receiverWalletModel.UpdateStatusByDisbursementID(ctx, dbTx, readyDisbursement.ID, DraftReceiversWalletStatus, ReadyReceiversWalletStatus)
 		require.NoError(t, err)
 
 		// receivers[2] - Update Receiver Waller Status to Registered
-		result, err := dbConnectionPool.ExecContext(ctx, "UPDATE receiver_wallets SET status = $1 WHERE receiver_id = $2", RegisteredReceiversWalletStatus, receivers[2].ID)
+		result, err := dbTx.ExecContext(ctx, "UPDATE receiver_wallets SET status = $1 WHERE receiver_id = $2", RegisteredReceiversWalletStatus, receivers[2].ID)
 		require.NoError(t, err)
 		updatedRowsAffected, err := result.RowsAffected()
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), updatedRowsAffected)
 
-		receiverWallets, err = di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, wallet.ID)
+		receiverWallets, err = di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbTx, []string{receivers[0].ID, receivers[1].ID, receivers[2].ID}, wallet.ID)
 		require.NoError(t, err)
 		for _, receiverWallet := range receiverWallets {
 			assert.Equal(t, wallet.ID, receiverWallet.Wallet.ID)
 			assert.NotNil(t, receiverWallet.InvitationSentAt)
 		}
 
-		err = di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err = di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            newInstructions,
 			Disbursement:            readyDisbursement,
@@ -492,7 +501,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify ReceiverWallets
-		receiverWallets, err = di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbConnectionPool, []string{receivers[0].ID, receivers[1].ID}, wallet.ID)
+		receiverWallets, err = di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbTx, []string{receivers[0].ID, receivers[1].ID}, wallet.ID)
 		require.NoError(t, err)
 		assert.Len(t, receiverWallets, 2)
 		for _, receiverWallet := range receiverWallets {
@@ -500,7 +509,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 			assert.Nil(t, receiverWallet.InvitationSentAt)
 		}
 
-		receiverWallets, err = di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbConnectionPool, []string{receivers[2].ID}, wallet.ID)
+		receiverWallets, err = di.receiverWalletModel.GetByReceiverIDsAndWalletID(ctx, dbTx, []string{receivers[2].ID}, wallet.ID)
 		require.NoError(t, err)
 		assert.Len(t, receiverWallets, 1)
 		assert.Equal(t, RegisteredReceiversWalletStatus, receiverWallets[0].Status)
@@ -508,7 +517,9 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 	})
 
 	t.Run("failure - Too many instructions", func(t *testing.T) {
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
+
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            smsInstructions,
 			Disbursement:            disbursement,
@@ -520,9 +531,10 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 
 	t.Run("failure - Confirmed Verification Value not matching", func(t *testing.T) {
 		defer cleanup()
+		dbTx := testutils.BeginTxWithRollback(t, ctx, dbConnectionPool)
 
 		// process instructions for the first time
-		err := di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err := di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            smsInstructions,
 			Disbursement:            disbursement,
@@ -531,7 +543,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		receivers, err := di.receiverModel.GetByContacts(ctx, dbConnectionPool, smsInstruction1.Phone, smsInstruction2.Phone, smsInstruction3.Phone)
+		receivers, err := di.receiverModel.GetByContacts(ctx, dbTx, smsInstruction1.Phone, smsInstruction2.Phone, smsInstruction3.Phone)
 		require.Len(t, receivers, 3)
 		require.NoError(t, err)
 		receiversMap := make(map[string]*Receiver)
@@ -540,11 +552,11 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 		}
 
 		// confirm a verification
-		ConfirmVerificationForRecipient(t, ctx, dbConnectionPool, receiversMap[smsInstruction3.Phone].ID)
+		ConfirmVerificationForRecipient(t, ctx, dbTx, receiversMap[smsInstruction3.Phone].ID)
 
 		// process instructions with mismatched verification values
 		smsInstruction3.VerificationValue = "1990-01-07"
-		err = di.ProcessAll(ctx, DisbursementInstructionsOpts{
+		err = di.ProcessAll(ctx, dbTx, DisbursementInstructionsOpts{
 			UserID:                  "user-id",
 			Instructions:            smsInstructions,
 			Disbursement:            disbursement,
@@ -552,7 +564,7 @@ func Test_DisbursementInstructionModel_ProcessAll(t *testing.T) {
 			MaxNumberOfInstructions: MaxInstructionsPerDisbursement,
 		})
 		require.Error(t, err)
-		assert.EqualError(t, err, "running atomic function in RunInTransactionWithResult: processing receiver verifications: receiver verification mismatch: receiver verification for +380-12-345-673 doesn't match. Check instruction with ID 123456783")
+		assert.EqualError(t, err, "processing receiver verifications: receiver verification mismatch: receiver verification for +380-12-345-673 doesn't match. Check instruction with ID 123456783")
 	})
 }
 
@@ -585,7 +597,7 @@ func assertEqualVerifications(t *testing.T, expectedInstructions []*Disbursement
 	}
 }
 
-func ConfirmVerificationForRecipient(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, receiverID string) {
+func ConfirmVerificationForRecipient(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, receiverID string) {
 	query := `
 		UPDATE
 			receiver_verifications
@@ -596,11 +608,11 @@ func ConfirmVerificationForRecipient(t *testing.T, ctx context.Context, dbConnec
 		WHERE
 			receiver_id = $1
 		`
-	_, err := dbConnectionPool.ExecContext(ctx, query, receiverID)
+	_, err := sqlExec.ExecContext(ctx, query, receiverID)
 	require.NoError(t, err)
 }
 
-func GetPaymentsByDisbursementID(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, disbursementID string) []string {
+func GetPaymentsByDisbursementID(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, disbursementID string) []string {
 	query := `
 		SELECT
 			ROUND(p.amount, 2)
@@ -609,12 +621,12 @@ func GetPaymentsByDisbursementID(t *testing.T, ctx context.Context, dbConnection
 			WHERE p.disbursement_id = $1
 		`
 	var payments []string
-	err := dbConnectionPool.SelectContext(ctx, &payments, query, disbursementID)
+	err := sqlExec.SelectContext(ctx, &payments, query, disbursementID)
 	require.NoError(t, err)
 	return payments
 }
 
-func GetExternalPaymentIDsByDisbursementID(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, disbursementID string) []string {
+func GetExternalPaymentIDsByDisbursementID(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, disbursementID string) []string {
 	query := `
 	SELECT
 		p.external_payment_id
@@ -623,7 +635,7 @@ func GetExternalPaymentIDsByDisbursementID(t *testing.T, ctx context.Context, db
 		WHERE p.disbursement_id = $1
 	`
 	var externalPaymentIDRefs []sql.NullString
-	err := dbConnectionPool.SelectContext(ctx, &externalPaymentIDRefs, query, disbursementID)
+	err := sqlExec.SelectContext(ctx, &externalPaymentIDRefs, query, disbursementID)
 	require.NoError(t, err)
 
 	var externalPaymentIDs []string

--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -69,7 +69,7 @@ var (
 	AllowedDisbursementSorts     = []SortField{SortFieldName, SortFieldCreatedAt}
 )
 
-func (d *DisbursementModel) Insert(ctx context.Context, disbursement *Disbursement) (string, error) {
+func (d *DisbursementModel) Insert(ctx context.Context, sqlExec db.SQLExecuter, disbursement *Disbursement) (string, error) {
 	const q = `
 		INSERT INTO 
 		    disbursements (name, status, status_history, wallet_id, asset_id, verification_field, receiver_registration_message_template, registration_contact_type)
@@ -78,7 +78,7 @@ func (d *DisbursementModel) Insert(ctx context.Context, disbursement *Disburseme
 		RETURNING id
 	`
 	var newID string
-	err := d.dbConnectionPool.GetContext(ctx, &newID, q,
+	err := sqlExec.GetContext(ctx, &newID, q,
 		disbursement.Name,
 		disbursement.Status,
 		disbursement.StatusHistory,

--- a/internal/data/disbursements.go
+++ b/internal/data/disbursements.go
@@ -367,7 +367,7 @@ func (du *DisbursementUpdate) Validate() error {
 	return nil
 }
 
-func (d *DisbursementModel) Update(ctx context.Context, du *DisbursementUpdate) error {
+func (d *DisbursementModel) Update(ctx context.Context, sqlExec db.SQLExecuter, du *DisbursementUpdate) error {
 	if err := du.Validate(); err != nil {
 		return fmt.Errorf("error validating disbursement update: %w", err)
 	}
@@ -381,7 +381,7 @@ func (d *DisbursementModel) Update(ctx context.Context, du *DisbursementUpdate) 
 		WHERE
 			id = $3
 		`
-	result, err := d.dbConnectionPool.ExecContext(ctx, query, du.FileName, du.FileContent, du.ID)
+	result, err := sqlExec.ExecContext(ctx, query, du.FileName, du.FileContent, du.ID)
 	if err != nil {
 		return fmt.Errorf("error updating disbursement: %w", err)
 	}

--- a/internal/data/disbursements_test.go
+++ b/internal/data/disbursements_test.go
@@ -472,7 +472,7 @@ func Test_DisbursementModel_Update(t *testing.T) {
 	})
 
 	t.Run("update instructions", func(t *testing.T) {
-		err := disbursementModel.Update(ctx, &DisbursementUpdate{
+		err := disbursementModel.Update(ctx, dbConnectionPool, &DisbursementUpdate{
 			ID:          disbursement.ID,
 			FileContent: disbursementFileContent,
 			FileName:    "instructions.csv",
@@ -486,7 +486,7 @@ func Test_DisbursementModel_Update(t *testing.T) {
 	})
 
 	t.Run("no disbursement ID in update", func(t *testing.T) {
-		err := disbursementModel.Update(ctx, &DisbursementUpdate{
+		err := disbursementModel.Update(ctx, dbConnectionPool, &DisbursementUpdate{
 			FileContent: disbursementFileContent,
 			FileName:    "instructions.csv",
 		})
@@ -494,7 +494,7 @@ func Test_DisbursementModel_Update(t *testing.T) {
 	})
 
 	t.Run("no file name in update", func(t *testing.T) {
-		err := disbursementModel.Update(ctx, &DisbursementUpdate{
+		err := disbursementModel.Update(ctx, dbConnectionPool, &DisbursementUpdate{
 			FileContent: disbursementFileContent,
 			ID:          disbursement.ID,
 		})
@@ -502,7 +502,7 @@ func Test_DisbursementModel_Update(t *testing.T) {
 	})
 
 	t.Run("no file content in update", func(t *testing.T) {
-		err := disbursementModel.Update(ctx, &DisbursementUpdate{
+		err := disbursementModel.Update(ctx, dbConnectionPool, &DisbursementUpdate{
 			FileName: "instructions.csv",
 			ID:       disbursement.ID,
 		})
@@ -510,7 +510,7 @@ func Test_DisbursementModel_Update(t *testing.T) {
 	})
 
 	t.Run("empty file content in update", func(t *testing.T) {
-		err := disbursementModel.Update(ctx, &DisbursementUpdate{
+		err := disbursementModel.Update(ctx, dbConnectionPool, &DisbursementUpdate{
 			FileName:    "instructions.csv",
 			ID:          disbursement.ID,
 			FileContent: []byte{},
@@ -519,7 +519,7 @@ func Test_DisbursementModel_Update(t *testing.T) {
 	})
 
 	t.Run("wrong disbursement ID", func(t *testing.T) {
-		err := disbursementModel.Update(ctx, &DisbursementUpdate{
+		err := disbursementModel.Update(ctx, dbConnectionPool, &DisbursementUpdate{
 			FileName:    "instructions.csv",
 			ID:          "9e0ff65f-f6e9-46e9-bf03-dc46723e3bfb",
 			FileContent: disbursementFileContent,

--- a/internal/data/disbursements_test.go
+++ b/internal/data/disbursements_test.go
@@ -51,9 +51,9 @@ func Test_DisbursementModelInsert(t *testing.T) {
 	t.Run("🔴 fails to insert disbursements with non-unique name", func(t *testing.T) {
 		defer DeleteAllDisbursementFixtures(t, ctx, dbConnectionPool)
 
-		_, err := disbursementModel.Insert(ctx, &disbursement)
+		_, err := disbursementModel.Insert(ctx, dbConnectionPool, &disbursement)
 		require.NoError(t, err)
-		_, err = disbursementModel.Insert(ctx, &disbursement)
+		_, err = disbursementModel.Insert(ctx, dbConnectionPool, &disbursement)
 		require.Error(t, err)
 		require.Equal(t, ErrRecordAlreadyExists, err)
 	})
@@ -61,7 +61,7 @@ func Test_DisbursementModelInsert(t *testing.T) {
 	t.Run("🟢 successfully insert disbursement", func(t *testing.T) {
 		defer DeleteAllDisbursementFixtures(t, ctx, dbConnectionPool)
 
-		id, err := disbursementModel.Insert(ctx, &disbursement)
+		id, err := disbursementModel.Insert(ctx, dbConnectionPool, &disbursement)
 		require.NoError(t, err)
 		require.NotNil(t, id)
 
@@ -86,7 +86,7 @@ func Test_DisbursementModelInsert(t *testing.T) {
 		d.ReceiverRegistrationMessageTemplate = ""
 		d.VerificationField = ""
 
-		id, err := disbursementModel.Insert(ctx, &d)
+		id, err := disbursementModel.Insert(ctx, dbConnectionPool, &d)
 		require.NoError(t, err)
 		require.NotNil(t, id)
 

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -641,7 +641,7 @@ func CreateDraftDisbursementFixture(t *testing.T, ctx context.Context, sqlExec d
 		insert.RegistrationContactType = RegistrationContactTypePhone
 	}
 
-	id, err := model.Insert(ctx, &insert)
+	id, err := model.Insert(ctx, sqlExec, &insert)
 	require.NoError(t, err)
 
 	// get disbursement

--- a/internal/serve/httperror/httperror.go
+++ b/internal/serve/httperror/httperror.go
@@ -19,7 +19,7 @@ type HTTPError struct {
 	Err error `json:"-"`
 }
 
-// ReportFunc is a function type used to report unexpected errors.
+// ReportErrorFunc is a function type used to report unexpected errors.
 type ReportErrorFunc func(ctx context.Context, err error, msg string)
 
 // ReportError is a struct type used to report unexpected errors.

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -737,7 +737,7 @@ func Test_AssetHandler_DeleteAsset(t *testing.T) {
 		assert.Nil(t, assetDB.DeletedAt)
 
 		entries := getEntries()
-		assert.Len(t, entries, 2)
+		assert.Len(t, entries, 1)
 		assert.Equal(t, "not removing trustline for the asset ABC:GBHC5ADV2XYITXCYC5F6X6BM2OYTYHV4ZU2JF6QWJORJQE2O7RKH2LAQ because the distribution account still has balance: 100.0000000 ABC", entries[0].Message)
 	})
 

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -1896,7 +1896,7 @@ func Test_DisbursementHandler_GetDisbursementInstructions(t *testing.T) {
 		{
 			name: "200-disbursement has instructions",
 			updateDisbursementFn: func(d *data.Disbursement) error {
-				return models.Disbursements.Update(ctx, &data.DisbursementUpdate{
+				return models.Disbursements.Update(ctx, dbConnectionPool, &data.DisbursementUpdate{
 					ID:          d.ID,
 					FileContent: disbursementFileContent,
 					FileName:    "instructions.csv",
@@ -1909,7 +1909,7 @@ func Test_DisbursementHandler_GetDisbursementInstructions(t *testing.T) {
 		{
 			name: "200-disbursement has instructions but filename is missing .csv",
 			updateDisbursementFn: func(d *data.Disbursement) error {
-				return models.Disbursements.Update(ctx, &data.DisbursementUpdate{
+				return models.Disbursements.Update(ctx, dbConnectionPool, &data.DisbursementUpdate{
 					ID:          d.ID,
 					FileContent: disbursementFileContent,
 					FileName:    "instructions.bat",

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -115,7 +115,7 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		} else if errors.Is(err, auth.ErrUserHasValidToken) {
 			log.Ctx(ctx).Errorf("in forgot password handler, user has a valid token")
 		} else {
-			httperror.InternalError(ctx, err.Error(), err, nil).Render(w)
+			httperror.InternalError(ctx, "Failed to reset password", err, nil).Render(w)
 			return
 		}
 	}

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -227,7 +227,7 @@ func Test_ForgotPasswordHandler_ServeHTTP(t *testing.T) {
 					Once()
 			},
 			wantStatusCode:   http.StatusInternalServerError,
-			wantResponseBody: `{"error": "sending forgot password message: sending forgot password email for foo...com: unexpected error"}`,
+			wantResponseBody: `{"error": "Failed to reset password"}`,
 		},
 		{
 			name:              "🟢[200](ReCAPTCHADisabled=false) successfully handle forgot password",

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -227,7 +227,7 @@ func Test_ForgotPasswordHandler_ServeHTTP(t *testing.T) {
 					Once()
 			},
 			wantStatusCode:   http.StatusInternalServerError,
-			wantResponseBody: `{"error": "running atomic function in RunInTransactionWithResult: sending forgot password message: sending forgot password email for foo...com: unexpected error"}`,
+			wantResponseBody: `{"error": "sending forgot password message: sending forgot password email for foo...com: unexpected error"}`,
 		},
 		{
 			name:              "🟢[200](ReCAPTCHADisabled=false) successfully handle forgot password",

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -1566,7 +1566,7 @@ func Test_PaymentsHandler_getPaymentsWithCount(t *testing.T) {
 				data.FilterKeyStatus: "INVALID",
 			},
 		})
-		require.EqualError(t, err, `running atomic function in RunInTransactionWithResult: error counting payments: error counting payments: pq: invalid input value for enum payment_status: "INVALID"`)
+		require.EqualError(t, err, `error counting payments: error counting payments: pq: invalid input value for enum payment_status: "INVALID"`)
 	})
 
 	asset := data.CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -1566,7 +1566,7 @@ func Test_PaymentsHandler_getPaymentsWithCount(t *testing.T) {
 				data.FilterKeyStatus: "INVALID",
 			},
 		})
-		require.EqualError(t, err, `error counting payments: error counting payments: pq: invalid input value for enum payment_status: "INVALID"`)
+		require.ErrorContains(t, err, `error counting payments: error counting payments: pq: invalid input value for enum payment_status: "INVALID"`)
 	})
 
 	asset := data.CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -692,7 +692,7 @@ func Test_DisbursementManagementService_StartDisbursement_failure(t *testing.T) 
 			TotalPendingAmount:  1100.0,
 		}
 
-		require.EqualError(t, err, fmt.Sprintf("validating balance for disbursement: %v", expectedErr))
+		require.ErrorContains(t, err, fmt.Sprintf("validating balance for disbursement: %v", expectedErr))
 
 		// PendingTotal includes payments associated with 'readyDisbursement' that were moved from the draft to ready status
 		expectedErrStr := fmt.Sprintf("the disbursement %s failed due to an account balance (11111.00) that was insufficient to fulfill new amount (22222.00) along with the pending amount (1100.00). To complete this action, your distribution account (stellar:GAAHIL6ZW4QFNLCKALZ3YOIWPP4TXQ7B7J5IU7RLNVGQAV6GFDZHLDTA) needs to be recharged with at least 12211.00 USDT", disbursementInsufficientBalance.ID)

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -692,7 +692,7 @@ func Test_DisbursementManagementService_StartDisbursement_failure(t *testing.T) 
 			TotalPendingAmount:  1100.0,
 		}
 
-		require.EqualError(t, err, fmt.Sprintf("running atomic function in RunInTransactionWithPostCommit: validating balance for disbursement: %v", expectedErr))
+		require.EqualError(t, err, fmt.Sprintf("validating balance for disbursement: %v", expectedErr))
 
 		// PendingTotal includes payments associated with 'readyDisbursement' that were moved from the draft to ready status
 		expectedErrStr := fmt.Sprintf("the disbursement %s failed due to an account balance (11111.00) that was insufficient to fulfill new amount (22222.00) along with the pending amount (1100.00). To complete this action, your distribution account (stellar:GAAHIL6ZW4QFNLCKALZ3YOIWPP4TXQ7B7J5IU7RLNVGQAV6GFDZHLDTA) needs to be recharged with at least 12211.00 USDT", disbursementInsufficientBalance.ID)

--- a/internal/services/setup_wallets_for_network_service_test.go
+++ b/internal/services/setup_wallets_for_network_service_test.go
@@ -292,7 +292,7 @@ func Test_SetupWalletsForProperNetwork(t *testing.T) {
 		// The problem was that in the DefaultWalletsNetworkMap, in the `testnet` key, we used the name `Boss Money` and not `BOSS Money`
 		// to refer to the BOSS Money wallet. So the query tried to insert the `Boss Money` wallet, but since the `homepage` and `deep_link_schema`
 		// were the same as the already inserted then, the insert statement resulted in a duplicated constraint error.
-		assert.EqualError(t, err, `upserting wallets for the proper network: running atomic function in RunInTransactionWithResult: error upserting wallets: pq: duplicate key value violates unique constraint "wallets_homepage_key"`)
+		assert.EqualError(t, err, `upserting wallets for the proper network: error upserting wallets: pq: duplicate key value violates unique constraint "wallets_homepage_key"`)
 
 		// DefaultNetworkMap test - should NOT error
 		data.ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)

--- a/internal/services/setup_wallets_for_network_service_test.go
+++ b/internal/services/setup_wallets_for_network_service_test.go
@@ -292,7 +292,7 @@ func Test_SetupWalletsForProperNetwork(t *testing.T) {
 		// The problem was that in the DefaultWalletsNetworkMap, in the `testnet` key, we used the name `Boss Money` and not `BOSS Money`
 		// to refer to the BOSS Money wallet. So the query tried to insert the `Boss Money` wallet, but since the `homepage` and `deep_link_schema`
 		// were the same as the already inserted then, the insert statement resulted in a duplicated constraint error.
-		assert.EqualError(t, err, `upserting wallets for the proper network: error upserting wallets: pq: duplicate key value violates unique constraint "wallets_homepage_key"`)
+		assert.ErrorContains(t, err, `error upserting wallets: pq: duplicate key value violates unique constraint "wallets_homepage_key"`)
 
 		// DefaultNetworkMap test - should NOT error
 		data.ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)

--- a/internal/transactionsubmission/store/channel_transaction_bundle_test.go
+++ b/internal/transactionsubmission/store/channel_transaction_bundle_test.go
@@ -112,7 +112,7 @@ func Test_ChannelTransactionBundleModel_LoadAndLockTuples(t *testing.T) {
 			limit:                        100,
 			lockToLedgerNumber:           currentLedgerNumber + 1,
 			numberOfTransactionsUnlocked: 10,
-			expectedError:                fmt.Errorf("running atomic function in RunInTransactionWithResult: %w", ErrInsuficientChannelAccounts),
+			expectedError:                db.NewTransactionExecutionError(ErrInsuficientChannelAccounts),
 		},
 		{
 			name:                            "🎉 successfully returns chTxBundles if limit == len(unlockedTransactions) == len(unlockedChannelAccounts) > 0",

--- a/stellar-auth/pkg/auth/authenticator_test.go
+++ b/stellar-auth/pkg/auth/authenticator_test.go
@@ -483,12 +483,12 @@ func Test_DefaultAuthenticator_ResetPassword(t *testing.T) {
 		token := CreateResetPasswordTokenFixture(t, ctx, dbConnectionPool, randUser, true, time.Now())
 
 		err := authenticator.ResetPassword(ctx, token, newPassword)
-		assert.EqualError(t, err, "running atomic function in RunInTransactionWithResult: error trying to encrypt user password: unexpected error")
+		assert.EqualError(t, err, "error trying to encrypt user password: unexpected error")
 	})
 
 	t.Run("Should treat a not found token error", func(t *testing.T) {
 		err := authenticator.ResetPassword(ctx, "notfoundtoken", "newpassword")
-		assert.EqualError(t, err, "running atomic function in RunInTransactionWithResult: "+ErrInvalidResetPasswordToken.Error())
+		assert.ErrorIs(t, err, ErrInvalidResetPasswordToken)
 	})
 
 	t.Run("Should reset the password with a valid token, and make the token invalid after", func(t *testing.T) {
@@ -538,7 +538,7 @@ func Test_DefaultAuthenticator_ResetPassword(t *testing.T) {
 		token := CreateResetPasswordTokenFixture(t, ctx, dbConnectionPool, randUser, true, time.Now().Add(-time.Hour*25))
 
 		err := authenticator.ResetPassword(ctx, token, newPassword)
-		require.EqualError(t, err, "running atomic function in RunInTransactionWithResult: "+ErrInvalidResetPasswordToken.Error())
+		require.ErrorIs(t, err, ErrInvalidResetPasswordToken)
 	})
 
 	passwordEncrypterMock.AssertExpectations(t)

--- a/stellar-auth/pkg/auth/authenticator_test.go
+++ b/stellar-auth/pkg/auth/authenticator_test.go
@@ -483,7 +483,7 @@ func Test_DefaultAuthenticator_ResetPassword(t *testing.T) {
 		token := CreateResetPasswordTokenFixture(t, ctx, dbConnectionPool, randUser, true, time.Now())
 
 		err := authenticator.ResetPassword(ctx, token, newPassword)
-		assert.EqualError(t, err, "error trying to encrypt user password: unexpected error")
+		assert.ErrorContains(t, err, "error trying to encrypt user password: unexpected error")
 	})
 
 	t.Run("Should treat a not found token error", func(t *testing.T) {


### PR DESCRIPTION
### 👋  Note for Review
I separated the refactors into their own commits to make review easier. 
<img width="1268" alt="Screenshot 2025-02-14 at 8 23 49 PM" src="https://github.com/user-attachments/assets/6d61a131-0c86-4ed0-ab6f-969f1f100e25" />

### What
Change `POST /disbursements` 
* if only fields are sent, works the same as nowadays
* 👋 (new*) if fields + file are sent, then process the request as `ATOMIC{POST payload + POST instructions}`

### Why
* Improve user experience when creating disbursements. 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
