### PR TITLE
[SDP-1553] - POST /users fails with 500 during validation errors.

### DIFF
--- a/internal/data/receivers_test.go
+++ b/internal/data/receivers_test.go
@@ -1248,7 +1248,7 @@ func Test_ReceiversModel_Update(t *testing.T) {
 			Email:      utils.StringPtr("invalid"),
 			ExternalId: utils.StringPtr(""),
 		})
-		assert.EqualError(t, err, `validating receiver update: validating email: the provided email is not valid`)
+		assert.EqualError(t, err, `validating receiver update: validating email: the email address provided is not valid`)
 	})
 
 	t.Run("updates email name successfully", func(t *testing.T) {

--- a/internal/message/aws_ses_client_test.go
+++ b/internal/message/aws_ses_client_test.go
@@ -46,7 +46,7 @@ func Test_NewAWSSESClient(t *testing.T) {
 	// [email] type needs a valid email as a sender ID:
 	gotAWSSESClient, err = NewAWSSESClient("accessKeyID", "secretAccessKey", "region", "invalid-email")
 	require.Nil(t, gotAWSSESClient)
-	require.EqualError(t, err, "aws SES (email) senderID is invalid: the provided email is not valid")
+	require.EqualError(t, err, "aws SES (email) senderID is invalid: the email address provided is not valid")
 
 	// [email] all fields are present 🎉
 	gotAWSSESClient, err = NewAWSSESClient("accessKeyID", "secretAccessKey", "region", "foo@test.com")
@@ -57,7 +57,7 @@ func Test_NewAWSSESClient(t *testing.T) {
 func Test_AWSSES_SendMessage_messageIsInvalid(t *testing.T) {
 	var mAWS MessengerClient = &awsSESClient{}
 	err := mAWS.SendMessage(Message{})
-	require.EqualError(t, err, "validating message to send an email through AWS: invalid e-mail: invalid email format: email cannot be empty")
+	require.EqualError(t, err, "validating message to send an email through AWS: invalid e-mail: invalid email format: email field is required")
 }
 
 func Test_AWSSES_SendMessage_errorIsHandledCorrectly(t *testing.T) {

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -50,13 +50,13 @@ func Test_message_Validate(t *testing.T) {
 			name:          "Email types need a non-empty email address",
 			messengerType: MessengerTypeAWSEmail,
 			message:       Message{},
-			wantErr:       fmt.Errorf("invalid e-mail: invalid email format: email cannot be empty"),
+			wantErr:       fmt.Errorf("invalid e-mail: invalid email format: email field is required"),
 		},
 		{
 			name:          "Email types need a valid email address",
 			messengerType: MessengerTypeAWSEmail,
 			message:       Message{ToEmail: "invalid-email"},
-			wantErr:       fmt.Errorf("invalid e-mail: invalid email format: the provided email is not valid"),
+			wantErr:       fmt.Errorf("invalid e-mail: invalid email format: the email address provided is not valid"),
 		},
 		{
 			name:          "Email types need a title",

--- a/internal/message/twilio_sendgrid_client_test.go
+++ b/internal/message/twilio_sendgrid_client_test.go
@@ -34,7 +34,7 @@ func Test_NewTwilioSendGridClient(t *testing.T) {
 			name:          "senderAddress needs to be a valid email",
 			apiKey:        "api-key",
 			senderAddress: "invalid-email",
-			wantErr:       fmt.Errorf("sendGrid senderAddress is invalid: the provided email is not valid"),
+			wantErr:       fmt.Errorf("sendGrid senderAddress is invalid: the email address provided is not valid"),
 		},
 		{
 			name:          "all fields are present",
@@ -58,7 +58,7 @@ func Test_NewTwilioSendGridClient(t *testing.T) {
 func Test_TwilioSendGridClient_SendMessage_messageIsInvalid(t *testing.T) {
 	var mSendGrid MessengerClient = &twilioSendGridClient{}
 	err := mSendGrid.SendMessage(Message{})
-	assert.EqualError(t, err, "validating message to send an email through SendGrid: invalid e-mail: invalid email format: email cannot be empty")
+	assert.EqualError(t, err, "validating message to send an email through SendGrid: invalid e-mail: invalid email format: email field is required")
 }
 
 func Test_TwilioSendGridClient_SendMessage_errorIsHandledCorrectly(t *testing.T) {

--- a/internal/serve/httphandler/receiver_send_otp_handler_test.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler_test.go
@@ -74,7 +74,7 @@ func Test_ReceiverSendOTPRequest_validateContactInfo(t *testing.T) {
 				Email: "invalid",
 			},
 			wantValidationErrors: map[string]interface{}{
-				"email": "the provided email is not valid",
+				"email": "the email address provided is not valid",
 			},
 		},
 		{

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -340,48 +340,141 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 }
 
 func Test_CreateUserRequest_validate(t *testing.T) {
-	cur := CreateUserRequest{
-		FirstName: "",
-		LastName:  "",
-		Email:     "",
-		Roles:     []data.UserRole{},
+	tests := []struct {
+		name        string
+		request     CreateUserRequest
+		expectError bool
+		errorExtras map[string]interface{}
+	}{
+		{
+			name: "🔴error - all fields empty",
+			request: CreateUserRequest{
+				FirstName: "",
+				LastName:  "",
+				Email:     "",
+				Roles:     []data.UserRole{},
+			},
+			expectError: true,
+			errorExtras: map[string]interface{}{
+				"email":     "email field is required",
+				"fist_name": "first_name field is required",
+				"last_name": "last_name field is required",
+				"roles":     "the number of roles required is exactly one",
+			},
+		},
+		{
+			name: "🔴error - all fields empty with spaces",
+			request: CreateUserRequest{
+				FirstName: "  ",
+				LastName:  " ",
+				Email:     "   ",
+				Roles:     []data.UserRole{},
+			},
+			expectError: true,
+			errorExtras: map[string]interface{}{
+				"email":     "email field is required",
+				"fist_name": "first_name field is required",
+				"last_name": "last_name field is required",
+				"roles":     "the number of roles required is exactly one",
+			},
+		},
+		{
+			name: "🔴error - multiple roles",
+			request: CreateUserRequest{
+				FirstName: "First",
+				LastName:  "Last",
+				Email:     "email@email.com",
+				Roles:     []data.UserRole{data.BusinessUserRole, data.DeveloperUserRole},
+			},
+			expectError: true,
+			errorExtras: map[string]interface{}{
+				"roles": "the number of roles required is exactly one",
+			},
+		},
+		{
+			name: "🔴error - invalid email format",
+			request: CreateUserRequest{
+				FirstName: "First",
+				LastName:  "Last",
+				Email:     "invalid-email",
+				Roles:     []data.UserRole{data.DeveloperUserRole},
+			},
+			expectError: true,
+			errorExtras: map[string]interface{}{
+				"email": "the email address provided is not valid",
+			},
+		},
+		{
+			name: "🔴error - first name too long",
+			request: CreateUserRequest{
+				FirstName: strings.Repeat("a", 256),
+				LastName:  "Last",
+				Email:     "email@email.com",
+				Roles:     []data.UserRole{data.DeveloperUserRole},
+			},
+			expectError: true,
+			errorExtras: map[string]interface{}{
+				"fist_name": "first_name cannot exceed 128 characters",
+			},
+		},
+		{
+			name: "🔴error - last name too long",
+			request: CreateUserRequest{
+				FirstName: "First",
+				LastName:  strings.Repeat("a", 256),
+				Email:     "email@email.com",
+				Roles:     []data.UserRole{data.DeveloperUserRole},
+			},
+			expectError: true,
+			errorExtras: map[string]interface{}{
+				"last_name": "last_name cannot exceed 128 characters",
+			},
+		},
+		{
+			name: "🔴error - invalid role",
+			request: CreateUserRequest{
+				FirstName: "First",
+				LastName:  "Last",
+				Email:     "email@email.com",
+				Roles:     []data.UserRole{"invalid_role"},
+			},
+			expectError: true,
+			errorExtras: map[string]interface{}{
+				"roles": "unexpected value for roles[0]=invalid_role. Expect one of these values: [owner financial_controller developer business]",
+			},
+		},
+		{
+			name: "🟢success - valid request",
+			request: CreateUserRequest{
+				FirstName: "First",
+				LastName:  "Last",
+				Email:     "email@email.com",
+				Roles:     []data.UserRole{data.DeveloperUserRole},
+			},
+			expectError: false,
+		},
 	}
 
-	extras := map[string]interface{}{
-		"email":     "email is required",
-		"fist_name": "fist_name is required",
-		"last_name": "last_name is required",
-		"roles":     "the number of roles required is exactly one",
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.request.validate()
+			if tc.expectError {
+				assert.NotNil(t, err)
+				var httpErr *httperror.HTTPError
+				require.True(t, errors.As(err, &httpErr), "expected an HTTPError")
+				assert.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+				assert.Equal(t, "Request invalid", httpErr.Message)
+
+				for key, expectedValue := range tc.errorExtras {
+					actualValue, exists := httpErr.Extras[key]
+					assert.True(t, exists)
+					assert.Equal(t, expectedValue, actualValue)
+				}
+			} else {
+				assert.Nil(t, err)
+			}
+		})
 	}
-	expectedErr := httperror.BadRequest("Request invalid", nil, extras)
-
-	err := cur.validate()
-	assert.Equal(t, expectedErr, err)
-
-	cur = CreateUserRequest{
-		FirstName: "First",
-		LastName:  "Last",
-		Email:     "email@email.com",
-		Roles:     []data.UserRole{data.BusinessUserRole, data.DeveloperUserRole},
-	}
-
-	extras = map[string]interface{}{
-		"roles": "the number of roles required is exactly one",
-	}
-	expectedErr = httperror.BadRequest("Request invalid", nil, extras)
-
-	err = cur.validate()
-	assert.Equal(t, expectedErr, err)
-
-	cur = CreateUserRequest{
-		FirstName: "First",
-		LastName:  "Last",
-		Email:     "email@email.com",
-		Roles:     []data.UserRole{data.DeveloperUserRole},
-	}
-
-	err = cur.validate()
-	assert.Nil(t, err)
 }
 
 func Test_UserHandler_CreateUser(t *testing.T) {
@@ -438,9 +531,9 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 			{
 				"error": "Request invalid",
 				"extras": {
-					"email": "email is required",
-					"fist_name": "fist_name is required",
-					"last_name": "last_name is required",
+					"email": "email field is required",
+					"fist_name": "first_name field is required",
+					"last_name": "last_name field is required",
 					"roles": "the number of roles required is exactly one"
 				}
 			}

--- a/internal/serve/validators/receiver_registration_validator_test.go
+++ b/internal/serve/validators/receiver_registration_validator_test.go
@@ -38,7 +38,7 @@ func Test_ReceiverRegistrationValidator_ValidateReceiver(t *testing.T) {
 				VerificationField: data.VerificationTypeDateOfBirth,
 			},
 			expectedValidationErrors: map[string]interface{}{
-				"email": "the provided email is not valid",
+				"email": "the email address provided is not valid",
 			},
 		},
 		{

--- a/internal/utils/string.go
+++ b/internal/utils/string.go
@@ -45,7 +45,7 @@ func TrimAndLower(str string) string {
 	return strings.TrimSpace(strings.ToLower(str))
 }
 
-// Humanize converts a string to a human readable format.
+// Humanize converts a string to a human-readable format.
 func Humanize(str string) string {
 	return strings.ToLower(strings.ReplaceAll(str, "_", " "))
 }

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/asaskevich/govalidator"
@@ -20,7 +21,7 @@ var (
 	rxOTP                     = regexp.MustCompile(`^\d{6}$`)
 	ErrInvalidE164PhoneNumber = fmt.Errorf("the provided phone number is not a valid E.164 number")
 	ErrEmptyPhoneNumber       = fmt.Errorf("phone number cannot be empty")
-	ErrEmptyEmail             = fmt.Errorf("email cannot be empty")
+	ErrEmptyEmail             = fmt.Errorf("email field is required")
 )
 
 const (
@@ -76,7 +77,20 @@ func ValidateEmail(email string) error {
 	}
 
 	if !rxEmail.MatchString(email) {
-		return fmt.Errorf("the provided email is not valid")
+		return fmt.Errorf("the email address provided is not valid")
+	}
+
+	return nil
+}
+
+// ValidateStringLength will validate the given string to ensure it is not empty and does not exceed the maximum length.
+func ValidateStringLength(field, fieldName string, maxLength int) error {
+	if strings.TrimSpace(field) == "" {
+		return fmt.Errorf("%s field is required", fieldName)
+	}
+
+	if len(field) > maxLength {
+		return fmt.Errorf("%s cannot exceed %d characters", fieldName, maxLength)
 	}
 
 	return nil

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -261,7 +261,7 @@ func (a *defaultAuthenticator) DeactivateUser(ctx context.Context, userID string
 func (a *defaultAuthenticator) ForgotPassword(ctx context.Context, sqlExec db.SQLExecuter, email string) (string, error) {
 	email = strings.TrimSpace(strings.ToLower(email))
 	if email == "" {
-		return "", fmt.Errorf("generating user reset password token: email cannot be empty")
+		return "", fmt.Errorf("generating user reset password token: email field is required")
 	}
 
 	resetToken, err := utils.StringWithCharset(resetTokenLength, utils.DefaultCharset)

--- a/stellar-auth/pkg/auth/authenticator_test.go
+++ b/stellar-auth/pkg/auth/authenticator_test.go
@@ -558,7 +558,7 @@ func Test_DefaultAuthenticator_ForgotPassword(t *testing.T) {
 
 	t.Run("Should return an error if the email is empty", func(t *testing.T) {
 		resetToken, err := authenticator.ForgotPassword(ctx, dbConnectionPool, "")
-		assert.EqualError(t, err, "generating user reset password token: email cannot be empty")
+		assert.EqualError(t, err, "generating user reset password token: email field is required")
 		assert.Empty(t, resetToken)
 	})
 

--- a/stellar-auth/pkg/utils/utils.go
+++ b/stellar-auth/pkg/utils/utils.go
@@ -34,7 +34,7 @@ var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9
 
 func ValidateEmail(email string) error {
 	if email == "" {
-		return fmt.Errorf("email cannot be empty")
+		return fmt.Errorf("email field is required")
 	}
 
 	if !rxEmail.MatchString(email) {

--- a/stellar-auth/pkg/utils/utils_test.go
+++ b/stellar-auth/pkg/utils/utils_test.go
@@ -25,7 +25,7 @@ func Test_ValidateEmail(t *testing.T) {
 		email   string
 		wantErr error
 	}{
-		{"", fmt.Errorf("email cannot be empty")},
+		{"", fmt.Errorf("email field is required")},
 		{"notvalidemail", fmt.Errorf(`the provided email "notvalidemail" is not valid`)},
 		{"valid@test.com", nil},
 		{"valid+email@test.com", nil},


### PR DESCRIPTION
### What
* Improve `POST /users` request validation. 

### Why
* `POST /users` was returning 500 instead of 400 in certain cases 
```
POST /users
{"first_name":"Marwen","last_name":" ","roles":["owner"],"email":"marwen@stellar.org"}
```

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
