### PR TITLE
[SDP-1561] Make `GET /organization/logo` unauthenticated 

### DIFF
--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -339,7 +339,7 @@ func (h ProfileHandler) GetOrganizationInfo(rw http.ResponseWriter, req *http.Re
 		return
 	}
 
-	lu, err := getLogoURL(currentTenant.BaseURL)
+	logoURL, err := getLogoURL(currentTenant.BaseURL)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot get logo URL", err, nil).Render(rw)
 		return
@@ -353,7 +353,7 @@ func (h ProfileHandler) GetOrganizationInfo(rw http.ResponseWriter, req *http.Re
 
 	resp := map[string]interface{}{
 		"name":                                     org.Name,
-		"logo_url":                                 lu.String(),
+		"logo_url":                                 logoURL,
 		"base_url":                                 currentTenant.BaseURL,
 		"distribution_account":                     distributionAccount,
 		"distribution_account_public_key":          distributionAccount.Address, // TODO: deprecate `distribution_account_public_key`
@@ -390,22 +390,22 @@ func (h ProfileHandler) GetOrganizationInfo(rw http.ResponseWriter, req *http.Re
 	httpjson.RenderStatus(rw, http.StatusOK, resp, httpjson.JSON)
 }
 
-func getLogoURL(baseURL *string) (*url.URL, error) {
+func getLogoURL(baseURL *string) (string, error) {
 	if baseURL == nil {
-		return nil, fmt.Errorf("baseURL is nil")
+		return "", fmt.Errorf("baseURL is nil")
 	}
 
 	logoURL, err := url.JoinPath(*baseURL, "organization", "logo")
 	if err != nil {
-		return nil, fmt.Errorf("constructing logo URL from base URL: %w", err)
+		return "", fmt.Errorf("constructing logo URL from base URL: %w", err)
 	}
 
 	lu, err := url.Parse(logoURL)
 	if err != nil {
-		return nil, fmt.Errorf("parsing logo URL: %w", err)
+		return "", fmt.Errorf("parsing logo URL: %w", err)
 	}
 
-	return lu, nil
+	return lu.String(), nil
 }
 
 type OrganizationLogoHandler struct {

--- a/internal/serve/httphandler/receiver_registration_handler.go
+++ b/internal/serve/httphandler/receiver_registration_handler.go
@@ -67,7 +67,7 @@ func (h ReceiverRegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	lu, err := getLogoURL(currentTenant.BaseURL)
+	logoURL, err := getLogoURL(currentTenant.BaseURL)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot get logo URL", err, nil).Render(w)
 		return
@@ -76,7 +76,7 @@ func (h ReceiverRegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 	response := ReceiverRegistrationResponse{
 		PrivacyPolicyLink:   privacyPolicyLink,
 		OrganizationName:    organization.Name,
-		OrganizationLogo:    lu.String(),
+		OrganizationLogo:    logoURL,
 		IsRecaptchaDisabled: h.ReCAPTCHADisabled,
 	}
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -496,17 +496,20 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				Models:              o.Models,
 				ReceiverWalletModel: o.Models.ReceiverWallet,
 				ReCAPTCHASiteKey:    o.ReCAPTCHASiteKey,
+				ReCAPTCHADisabled:   o.DisableReCAPTCHA,
 			}.ServeHTTP)
 
 			r.Post("/otp", httphandler.ReceiverSendOTPHandler{
 				Models:             o.Models,
 				MessageDispatcher:  o.MessageDispatcher,
 				ReCAPTCHAValidator: reCAPTCHAValidator,
+				ReCAPTCHADisabled:  o.DisableReCAPTCHA,
 			}.ServeHTTP)
 			r.Post("/verification", httphandler.VerifyReceiverRegistrationHandler{
 				AnchorPlatformAPIService:    o.AnchorPlatformAPIService,
 				Models:                      o.Models,
 				ReCAPTCHAValidator:          reCAPTCHAValidator,
+				ReCAPTCHADisabled:           o.DisableReCAPTCHA,
 				NetworkPassphrase:           o.NetworkPassphrase,
 				EventProducer:               o.EventProducer,
 				CrashTrackerClient:          o.CrashTrackerClient,

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -371,10 +371,8 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			Models:                      o.Models,
 			AuthManager:                 authManager,
 			MaxMemoryAllocation:         httphandler.DefaultMaxMemoryAllocation,
-			BaseURL:                     o.BaseURL,
 			DistributionAccountResolver: o.SubmitterEngine.DistributionAccountResolver,
 			PasswordValidator:           o.PasswordValidator,
-			PublicFilesFS:               publicfiles.PublicFiles,
 			NetworkType:                 o.NetworkType,
 		}
 		r.Route("/profile", func(r chi.Router) {
@@ -394,9 +392,6 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
 				Get("/", profileHandler.GetOrganizationInfo)
-
-			r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).
-				Get("/logo", profileHandler.GetOrganizationLogo)
 
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole)).
 				Patch("/circle-config", httphandler.CircleConfigHandler{
@@ -434,6 +429,11 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	// Public routes that are tenant aware (they need to know the tenant ID)
 	mux.Group(func(r chi.Router) {
 		r.Use(middleware.EnsureTenantMiddleware)
+
+		r.Get("/organization/logo", httphandler.OrganizationLogoHandler{
+			Models:        o.Models,
+			PublicFilesFS: publicfiles.PublicFiles,
+		}.GetOrganizationLogo)
 
 		r.Post("/login", httphandler.LoginHandler{
 			AuthManager:        authManager,

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -386,6 +386,7 @@ func Test_handleHTTP_unauthenticatedEndpoints(t *testing.T) {
 		method string
 		path   string
 	}{
+		{http.MethodGet, "/organization/logo"},
 		{http.MethodGet, "/health"},
 		{http.MethodGet, "/.well-known/stellar.toml"},
 		{http.MethodPost, "/login"},
@@ -474,7 +475,6 @@ func Test_handleHTTP_authenticatedEndpoints(t *testing.T) {
 		// Organization
 		{http.MethodGet, "/organization"},
 		{http.MethodPatch, "/organization"},
-		{http.MethodGet, "/organization/logo"},
 		{http.MethodPatch, "/organization/circle-config"},
 		// Balances
 		{http.MethodGet, "/balances"},


### PR DESCRIPTION
### What
Change `GET /organization/logo` to not be authenticated. 

### Why
This call doesn't need to be authenticated. This will also help with displaying logo in SEP-24 flow. 

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml

