### PR TITLE
[SDP-1561] Add `organization_logo` and `is_recaptcha_disabled` to `/init` call

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -496,17 +496,20 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				Models:              o.Models,
 				ReceiverWalletModel: o.Models.ReceiverWallet,
 				ReCAPTCHASiteKey:    o.ReCAPTCHASiteKey,
+				ReCAPTCHADisabled:   o.DisableReCAPTCHA,
 			}.ServeHTTP)
 
 			r.Post("/otp", httphandler.ReceiverSendOTPHandler{
 				Models:             o.Models,
 				MessageDispatcher:  o.MessageDispatcher,
 				ReCAPTCHAValidator: reCAPTCHAValidator,
+				ReCAPTCHADisabled:  o.DisableReCAPTCHA,
 			}.ServeHTTP)
 			r.Post("/verification", httphandler.VerifyReceiverRegistrationHandler{
 				AnchorPlatformAPIService:    o.AnchorPlatformAPIService,
 				Models:                      o.Models,
 				ReCAPTCHAValidator:          reCAPTCHAValidator,
+				ReCAPTCHADisabled:           o.DisableReCAPTCHA,
 				NetworkPassphrase:           o.NetworkPassphrase,
 				EventProducer:               o.EventProducer,
 				CrashTrackerClient:          o.CrashTrackerClient,


### PR DESCRIPTION
### What
Added two fields to `/sep24-interactive-deposit/init` API: 
* `is_recaptcha_disabled` 
* `organization_logo` 

Added enforcement for `is_recaptcha_disabled` to `sep24-interactive-deposit` endpoints. 

### Why
Improve UX for SEP24 registration

### Checklist

#### PR Structure

* [x] This PR has a reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR title and description are clear enough for anyone to review it.
* [x] This PR does not mix refactoring changes with feature changes (split into two PRs otherwise).

#### Thoroughness

* [x] This PR adds tests for the new functionality or fixes.
* [x] This PR contains the link to the Jira ticket it addresses.

#### Configs and Secrets

* [x] No new CONFIG variables are required -OR- the new required ones were added to the helmchart's [`values.yaml`] file.
* [x] No new CONFIG variables are required -OR- the new required ones were added to the deployments ([`pr-preview`], [`dev`], [`demo`], `prd`).
* [x] No new SECRETS variables are required -OR- the new required ones were mentioned in the helmchart's [`values.yaml`] file.
* [x] No new SECRETS variables are required -OR- the new required ones were added to the deployments ([`pr-preview secrets`], [`dev secrets`], [`demo secrets`], `prd secrets`).

#### Release

* [x] This is not a breaking change.
* [x] **This is ready for production.**. If your PR is not ready for production, please consider opening additional complementary PRs using this one as the base. Only merge this into `develop` or `main` after it's ready for production!

#### Deployment

* [ ] Does the deployment work after merging?

[`values.yaml`]: ../helmchart/sdp/values.yaml
[`pr-preview`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/stellar-disbursement-platform/backend-helm-values
[`dev`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/backend-helm-values
[`demo`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-backend-helm-values
[`pr-preview secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/common-previews/externalsecrets-common-previews.yaml#L241-L346
[`dev secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/stellar-disbursement-platform-externalsecrets.yaml
[`demo secrets`]: https://github.com/stellar/kube/blob/d3e4f5dd8aa4c13b45a31a5a937f3e98841171a7/kube001-dev/namespaces/stellar-disbursement-platform/demo/demo-sdp-externalsecrets.yaml
