### PR TITLE
SDP-1569: Change `{CIRCLE_API}/ping` method to validate only the response status code

### DIFF
--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -1,7 +1,6 @@
 name: Integration Tests
 
 on:
-  pull_request:
   workflow_call: # allows this workflow to be called from another workflow, like `docker_image_public_release`
 
 env:
@@ -22,10 +21,10 @@ jobs:
       max-parallel: 1
       matrix:
         platform:
-          # - "Stellar-phone" # Stellar distribution account where receivers are registered with their phone number
-          # - "Stellar-phone-FUTURENET" # Stellar distribution account where receivers are registered with their phone number
-          # - "Stellar-phone-wallet" # Stellar distribution account where receivers are registered with their phone number and wallet address
-          # - "Stellar-email" # Stellar distribution account where receivers are registered with their email
+          - "Stellar-phone" # Stellar distribution account where receivers are registered with their phone number
+          - "Stellar-phone-FUTURENET" # Stellar distribution account where receivers are registered with their phone number
+          - "Stellar-phone-wallet" # Stellar distribution account where receivers are registered with their phone number and wallet address
+          - "Stellar-email" # Stellar distribution account where receivers are registered with their email
           - "Circle-phone" # Circle distribution account where receivers are registered with their email
         include:
           - platform: "Stellar-phone"

--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -1,6 +1,7 @@
 name: Integration Tests
 
 on:
+  pull_request:
   workflow_call: # allows this workflow to be called from another workflow, like `docker_image_public_release`
 
 env:
@@ -21,10 +22,10 @@ jobs:
       max-parallel: 1
       matrix:
         platform:
-          - "Stellar-phone" # Stellar distribution account where receivers are registered with their phone number
-          - "Stellar-phone-FUTURENET" # Stellar distribution account where receivers are registered with their phone number
-          - "Stellar-phone-wallet" # Stellar distribution account where receivers are registered with their phone number and wallet address
-          - "Stellar-email" # Stellar distribution account where receivers are registered with their email
+          # - "Stellar-phone" # Stellar distribution account where receivers are registered with their phone number
+          # - "Stellar-phone-FUTURENET" # Stellar distribution account where receivers are registered with their phone number
+          # - "Stellar-phone-wallet" # Stellar distribution account where receivers are registered with their phone number and wallet address
+          # - "Stellar-email" # Stellar distribution account where receivers are registered with their email
           - "Circle-phone" # Circle distribution account where receivers are registered with their email
         include:
           - platform: "Stellar-phone"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Improve UX on the reset-password flow by embedding the reset token in the URL so it can be parsed by the FE without human intervention. [#557](https://github.com/stellar/stellar-disbursement-platform-backend/pull/557)
 - Make create disbursement atomic. [#554](https://github.com/stellar/stellar-disbursement-platform-backend/pull/554)
 - Refactor the PR checklist to be more user-friendly and easier to follow. [#568](https://github.com/stellar/stellar-disbursement-platform-backend/pull/568)
+- Change `{CIRCLE_API}/ping` method to validate only the response status code and not the body. [#580](https://github.com/stellar/stellar-disbursement-platform-backend/pull/580)
 
 ### Fixed
 

--- a/internal/circle/client.go
+++ b/internal/circle/client.go
@@ -103,18 +103,7 @@ func (client *Client) Ping(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	var pingResp struct {
-		Message string `json:"message"`
-	}
-	if err = json.NewDecoder(resp.Body).Decode(&pingResp); err != nil {
-		return false, fmt.Errorf("decoding Ping response: %w", err)
-	}
-
-	if pingResp.Message == "pong" {
-		return true, nil
-	}
-
-	return false, fmt.Errorf("unexpected response message: %s", pingResp.Message)
+	return true, nil
 }
 
 // PostTransfer creates a new transfer.


### PR DESCRIPTION
### What

Change `{CIRCLE_API}/ping` method to validate only the response status code

### Why

It was validating the response body as well, but Circle inadvertently changed it and the API is not compliant with the documentation anymore. Since this is just a /ping endpoint, we don't need to enforce any specific body content.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [x] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [x] Preview deployment works as expected
- [x] Ready for production
