### PR TITLE
SDP-1575: fix CLI test assertions and improve DRY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Allow the AWS configuration to be handled by the AWS session if the static credentials and region are not all passed to the SDP function. [#565](https://github.com/stellar/stellar-disbursement-platform-backend/pull/565)
 
+### Fixed
+
+- Fix CLI tests and test assertions. [#587](https://github.com/stellar/stellar-disbursement-platform-backend/pull/587)
+
 ### Security and Dependencies
 
 - Upgrade AWS and stellar/go dependencies. [#581](https://github.com/stellar/stellar-disbursement-platform-backend/pull/581)

--- a/cmd/channel_accounts_test.go
+++ b/cmd/channel_accounts_test.go
@@ -3,15 +3,11 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -19,6 +15,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	di "github.com/stellar/stellar-disbursement-platform-backend/internal/dependencyinjection"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
 func Test_ChannelAccountsCommand_CreateCommand(t *testing.T) {
@@ -44,8 +41,8 @@ func Test_ChannelAccountsCommand_CreateCommand(t *testing.T) {
 	})
 
 	t.Run("exit with status 1 when ChannelAccountsService fails", func(t *testing.T) {
-		if os.Getenv("TEST_FATAL") == "1" {
-			customErr := errors.New("unexpected error")
+		utils.AssertFuncExitsWithFatal(t, func() {
+			customErr := errors.New("unexpected error creating channel accounts")
 			crashTrackerMock.
 				On("LogAndReportErrors", context.Background(), customErr, "Cmd channel-accounts create crash").
 				Once()
@@ -55,23 +52,8 @@ func Test_ChannelAccountsCommand_CreateCommand(t *testing.T) {
 				On("CreateChannelAccounts", context.Background(), mock.Anything, 2).
 				Return(customErr)
 
-			err := rootCmmd.Execute()
-			require.NoError(t, err)
-
-			return
-		}
-
-		// We're using a strategy to setup a cmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-		err := cmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+			_ = rootCmmd.Execute()
+		}, "unexpected error creating channel accounts")
 	})
 
 	t.Run("executes the create command successfully", func(t *testing.T) {
@@ -109,8 +91,8 @@ func Test_ChannelAccountsCommand_VerifyCommand(t *testing.T) {
 	})
 
 	t.Run("exit with status 1 when ChannelAccountsService fails", func(t *testing.T) {
-		if os.Getenv("TEST_FATAL") == "1" {
-			customErr := errors.New("unexpected error")
+		utils.AssertFuncExitsWithFatal(t, func() {
+			customErr := errors.New("unexpected error verifying channel accounts")
 			crashTrackerMock.
 				On("LogAndReportErrors", context.Background(), customErr, "Cmd channel-accounts verify crash").
 				Once()
@@ -121,24 +103,8 @@ func Test_ChannelAccountsCommand_VerifyCommand(t *testing.T) {
 				Return(customErr).
 				Once()
 
-			err := rootCmmd.Execute()
-			require.NoError(t, err)
-
-			return
-		}
-
-		// We're using a strategy to setup a cmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-
-		err := cmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+			_ = rootCmmd.Execute()
+		}, "unexpected error verifying channel accounts")
 	})
 
 	t.Run("executes the verify command successfully", func(t *testing.T) {
@@ -177,8 +143,8 @@ func Test_ChannelAccountsCommand_EnsureCommand(t *testing.T) {
 	})
 
 	t.Run("exit with status 1 when ChannelAccountsService fails", func(t *testing.T) {
-		if os.Getenv("TEST_FATAL") == "1" {
-			customErr := errors.New("unexpected error")
+		utils.AssertFuncExitsWithFatal(t, func() {
+			customErr := errors.New("unexpected error ensuring channel accounts count")
 			crashTrackerMock.
 				On("LogAndReportErrors", context.Background(), customErr, "Cmd channel-accounts create crash").
 				Once()
@@ -188,23 +154,8 @@ func Test_ChannelAccountsCommand_EnsureCommand(t *testing.T) {
 				On("EnsureChannelAccountsCount", context.Background(), mock.Anything, 2).
 				Return(customErr)
 
-			err := rootCmmd.Execute()
-			require.NoError(t, err)
-
-			return
-		}
-
-		// We're using a strategy to setup a cmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-		err := cmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+			_ = rootCmmd.Execute()
+		}, "unexpected error ensuring channel accounts count")
 	})
 
 	t.Run("executes the create command successfully", func(t *testing.T) {
@@ -245,8 +196,8 @@ func Test_ChannelAccountsCommand_DeleteCommand(t *testing.T) {
 
 	t.Run("exit with status 1 when ChannelAccountsService fails", func(t *testing.T) {
 		rootCmmd.SetArgs(args)
-		if os.Getenv("TEST_FATAL") == "1" {
-			customErr := errors.New("unexpected error")
+		utils.AssertFuncExitsWithFatal(t, func() {
+			customErr := errors.New("unexpected error deleting channel account")
 			crashTrackerMock.
 				On("LogAndReportErrors", context.Background(), customErr, "Cmd channel-accounts delete crash").
 				Once()
@@ -257,24 +208,8 @@ func Test_ChannelAccountsCommand_DeleteCommand(t *testing.T) {
 				Return(customErr).
 				Once()
 
-			err := rootCmmd.Execute()
-			require.NoError(t, err)
-
-			return
-		}
-
-		// We're using a strategy to setup a cmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-
-		err := cmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+			_ = rootCmmd.Execute()
+		}, "unexpected error deleting channel account")
 	})
 
 	t.Run("executes the delete command successfully", func(t *testing.T) {
@@ -313,8 +248,8 @@ func Test_ChannelAccountsCommand_ViewCommand(t *testing.T) {
 	parentCmdMock.AddCommand(cmd)
 
 	t.Run("exit with status 1 when ChannelAccountsService fails", func(t *testing.T) {
-		if os.Getenv("TEST_FATAL") == "1" {
-			customErr := errors.New("unexpected error")
+		utils.AssertFuncExitsWithFatal(t, func() {
+			customErr := errors.New("unexpected error viewing channel accounts")
 
 			crashTrackerMock := &crashtracker.MockCrashTrackerClient{}
 			caCommand.CrashTrackerClient = crashTrackerMock
@@ -324,29 +259,13 @@ func Test_ChannelAccountsCommand_ViewCommand(t *testing.T) {
 			defer crashTrackerMock.AssertExpectations(t)
 
 			caServiceMock.
-				On("ViewChannelAccounts", context.Background()).
+				On("ViewChannelAccounts", context.Background(), mock.Anything).
 				Return(customErr).
 				Once()
 			defer caServiceMock.AssertExpectations(t)
 
-			err := parentCmdMock.Execute()
-			require.NoError(t, err)
-
-			return
-		}
-
-		// We're using a strategy to setup a innerCmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		innerCmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		innerCmd.Env = append(os.Environ(), "TEST_FATAL=1")
-
-		err := innerCmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+			_ = parentCmdMock.Execute()
+		}, "unexpected error viewing channel accounts")
 	})
 
 	t.Run("executes the list command successfully", func(t *testing.T) {

--- a/cmd/integration_tests_test.go
+++ b/cmd/integration_tests_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/cmd/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/integrationtests"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
 type mockIntegrationTests struct {
@@ -80,7 +80,7 @@ func Test_IntegrationTestsCommand_StartIntegrationTestsCommand(t *testing.T) {
 	t.Run("exit with status 1 when IntegrationTestsService fails", func(t *testing.T) {
 		utils.AssertFuncExitsWithFatal(t, func() {
 			serviceMock.
-				On("StartIntegrationServe", context.Background(), *integrationTestsOpts).
+				On("StartIntegrationTests", context.Background(), *integrationTestsOpts).
 				Return(errors.New("unexpected error"))
 			_ = parentCmdMock.Execute()
 		}, "Error starting integration tests: unexpected error")

--- a/cmd/integration_tests_test.go
+++ b/cmd/integration_tests_test.go
@@ -144,6 +144,8 @@ func Test_IntegrationTestsCommand_CreateIntegrationTestsDataCommand(t *testing.T
 	t.Setenv("WALLET_NAME", "walletTest")
 	t.Setenv("WALLET_HOMEPAGE", "https://www.test_wallet.com")
 	t.Setenv("WALLET_DEEPLINK", "test-wallet://sdp")
+	t.Setenv("CIRCLE_API_KEY", "")
+	t.Setenv("CIRCLE_USDC_WALLET_ID", "")
 
 	parentCmdMock.SetArgs([]string{
 		"create-data",

--- a/cmd/integration_tests_test.go
+++ b/cmd/integration_tests_test.go
@@ -3,16 +3,13 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/cmd/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/integrationtests"
 )
 
@@ -81,29 +78,12 @@ func Test_IntegrationTestsCommand_StartIntegrationTestsCommand(t *testing.T) {
 	})
 
 	t.Run("exit with status 1 when IntegrationTestsService fails", func(t *testing.T) {
-		if os.Getenv("TEST_FATAL") == "1" {
+		utils.AssertFuncExitsWithFatal(t, func() {
 			serviceMock.
 				On("StartIntegrationServe", context.Background(), *integrationTestsOpts).
 				Return(errors.New("unexpected error"))
-
-			err := parentCmdMock.Execute()
-			require.NoError(t, err)
-
-			return
-		}
-
-		// We're using a strategy to setup a cmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-
-		err := cmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+			_ = parentCmdMock.Execute()
+		}, "Error starting integration tests: unexpected error")
 	})
 
 	t.Run("executes the start integration tests command successfully", func(t *testing.T) {
@@ -152,29 +132,12 @@ func Test_IntegrationTestsCommand_CreateIntegrationTestsDataCommand(t *testing.T
 	})
 
 	t.Run("exit with status 1 when IntegrationTestsService fails", func(t *testing.T) {
-		if os.Getenv("TEST_FATAL") == "1" {
+		utils.AssertFuncExitsWithFatal(t, func() {
 			serviceMock.
 				On("CreateTestData", context.Background(), *integrationTestsOpts).
 				Return(errors.New("unexpected error"))
-
-			err := parentCmdMock.Execute()
-			require.NoError(t, err)
-
-			return
-		}
-
-		// We're using a strategy to setup a cmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-
-		err := cmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+			_ = parentCmdMock.Execute()
+		}, "Error creating integration tests data: unexpected error")
 	})
 
 	t.Run("executes the create integration tests data command successfully", func(t *testing.T) {

--- a/cmd/utils/shared_config_options.go
+++ b/cmd/utils/shared_config_options.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/scheduler"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/scheduler/jobs"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -299,7 +298,7 @@ func SchedulerConfigOptions(opts *scheduler.SchedulerOptions) []*config.ConfigOp
 	return []*config.ConfigOption{
 		{
 			Name:        "scheduler-payment-job-seconds",
-			Usage:       fmt.Sprintf("The interval in seconds for the payment jobs that synchronize transactions between SDP and TSS. Must be greater than %d seconds.", jobs.DefaultMinimumJobIntervalSeconds),
+			Usage:       fmt.Sprintf("The interval in seconds for the payment jobs that synchronize transactions between SDP and TSS. Must be greater than %d seconds.", 5),
 			OptType:     types.Int,
 			ConfigKey:   &opts.PaymentJobIntervalSeconds,
 			FlagDefault: 30,
@@ -307,7 +306,7 @@ func SchedulerConfigOptions(opts *scheduler.SchedulerOptions) []*config.ConfigOp
 		},
 		{
 			Name:        "scheduler-receiver-invitation-job-seconds",
-			Usage:       fmt.Sprintf("The interval in seconds for the receiver invitation job that sends invitations to new receivers. Must be greater than %d seconds.", jobs.DefaultMinimumJobIntervalSeconds),
+			Usage:       fmt.Sprintf("The interval in seconds for the receiver invitation job that sends invitations to new receivers. Must be greater than %d seconds.", 5),
 			OptType:     types.Int,
 			ConfigKey:   &opts.ReceiverInvitationJobIntervalSeconds,
 			FlagDefault: 30,

--- a/cmd/utils/test_helpers.go
+++ b/cmd/utils/test_helpers.go
@@ -1,9 +1,14 @@
 package utils
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // clearTestEnvironment removes all envs from the test environment. It's useful
@@ -14,4 +19,32 @@ func ClearTestEnvironment(t *testing.T) {
 		key := env[:strings.Index(env, "=")]
 		t.Setenv(key, "")
 	}
+}
+
+// AssertFuncExitsWithFatal asserts that a function exits with a fatal error, usually `os.Exit(1)`.
+func AssertFuncExitsWithFatal(t *testing.T, fatalFunc func(), stdErrContains ...string) {
+	t.Helper()
+
+	if os.Getenv("TEST_FATAL") == "1" {
+		// Run the fatal function that will call os.Exit(n)
+		fatalFunc()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = append(os.Environ(), "TEST_FATAL=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if exitError, ok := err.(*exec.ExitError); ok {
+		require.False(t, exitError.Success())
+		return
+	}
+
+	for _, stdErrContain := range stdErrContains {
+		require.Contains(t, stderr.String(), stdErrContain)
+	}
+
+	t.Fatalf("process ran with err %v, want exit status 1", err)
 }

--- a/cmd/utils/test_helpers.go
+++ b/cmd/utils/test_helpers.go
@@ -1,14 +1,9 @@
 package utils
 
 import (
-	"bytes"
-	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 // clearTestEnvironment removes all envs from the test environment. It's useful
@@ -19,32 +14,4 @@ func ClearTestEnvironment(t *testing.T) {
 		key := env[:strings.Index(env, "=")]
 		t.Setenv(key, "")
 	}
-}
-
-// AssertFuncExitsWithFatal asserts that a function exits with a fatal error, usually `os.Exit(1)`.
-func AssertFuncExitsWithFatal(t *testing.T, fatalFunc func(), stdErrContains ...string) {
-	t.Helper()
-
-	if os.Getenv("TEST_FATAL") == "1" {
-		// Run the fatal function that will call os.Exit(n)
-		fatalFunc()
-		return
-	}
-
-	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-	cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	if exitError, ok := err.(*exec.ExitError); ok {
-		require.False(t, exitError.Success())
-		return
-	}
-
-	for _, stdErrContain := range stdErrContains {
-		require.Contains(t, stderr.String(), stdErrContain)
-	}
-
-	t.Fatalf("process ran with err %v, want exit status 1", err)
 }

--- a/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
+++ b/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
@@ -3,8 +3,6 @@ package jobs
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -19,6 +17,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/anchorplatform"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	servicesMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
@@ -31,63 +30,21 @@ func Test_NewPatchAnchorPlatformTransactionCompletionJob(t *testing.T) {
 	defer dbConnectionPool.Close()
 
 	t.Run("exits with status 1 when AP API Client is missing", func(t *testing.T) {
-		if os.Getenv("TEST_FATAL") == "1" {
-			NewPatchAnchorPlatformTransactionsCompletionJob(DefaultMinimumJobIntervalSeconds, nil, nil)
-			return
-		}
-
-		// We're using a strategy to setup a cmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-
-		err := cmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+		utils.AssertFuncExitsWithFatal(t, func() {
+			_ = NewPatchAnchorPlatformTransactionsCompletionJob(DefaultMinimumJobIntervalSeconds, nil, nil)
+		}, "anchor platform API service is required")
 	})
 
 	t.Run("exits with status 1 when SDP Models are missing", func(t *testing.T) {
-		if os.Getenv("TEST_FATAL") == "1" {
-			NewPatchAnchorPlatformTransactionsCompletionJob(DefaultMinimumJobIntervalSeconds, &anchorplatform.AnchorPlatformAPIService{}, nil)
-			return
-		}
-
-		// We're using a strategy to setup a cmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-
-		err := cmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+		utils.AssertFuncExitsWithFatal(t, func() {
+			_ = NewPatchAnchorPlatformTransactionsCompletionJob(DefaultMinimumJobIntervalSeconds, &anchorplatform.AnchorPlatformAPIService{}, nil)
+		}, "SDP models are required")
 	})
 
 	t.Run("exits with status 1 when interval is not set correctly", func(t *testing.T) {
-		if os.Getenv("TEST_FATAL") == "1" {
-			NewPatchAnchorPlatformTransactionsCompletionJob(DefaultMinimumJobIntervalSeconds-1, &anchorplatform.AnchorPlatformAPIService{}, nil)
-			return
-		}
-
-		// We're using a strategy to setup a cmd inside the test that calls the test itself and verifies if it exited with exit status '1'.
-		// Ref: https://go.dev/talks/2014/testing.slide#23
-		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-		cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-
-		err := cmd.Run()
-		if exitError, ok := err.(*exec.ExitError); ok {
-			assert.False(t, exitError.Success())
-			return
-		}
-
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+		utils.AssertFuncExitsWithFatal(t, func() {
+			_ = NewPatchAnchorPlatformTransactionsCompletionJob(DefaultMinimumJobIntervalSeconds-1, &anchorplatform.AnchorPlatformAPIService{}, nil)
+		}, "job interval is not set")
 	})
 
 	t.Run("returns a job instance successfully", func(t *testing.T) {

--- a/internal/services/patch_anchor_platform_transactions_completion.go
+++ b/internal/services/patch_anchor_platform_transactions_completion.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -29,8 +30,10 @@ type PatchAnchorPlatformTransactionCompletionService struct {
 var _ PatchAnchorPlatformTransactionCompletionServiceInterface = new(PatchAnchorPlatformTransactionCompletionService)
 
 func NewPatchAnchorPlatformTransactionCompletionService(apAPISvc anchorplatform.AnchorPlatformAPIServiceInterface, sdpModels *data.Models) (PatchAnchorPlatformTransactionCompletionServiceInterface, error) {
-	if apAPISvc == nil || sdpModels == nil {
-		return nil, fmt.Errorf("anchor platform API service and SDP models are required")
+	if apAPISvc == nil {
+		return nil, errors.New("anchor platform API service is required")
+	} else if sdpModels == nil {
+		return nil, errors.New("SDP models are required")
 	}
 
 	return &PatchAnchorPlatformTransactionCompletionService{

--- a/internal/services/patch_anchor_platform_transactions_completion_test.go
+++ b/internal/services/patch_anchor_platform_transactions_completion_test.go
@@ -21,7 +21,7 @@ import (
 
 func Test_NewPatchAnchorPlatformTransactionCompletionService(t *testing.T) {
 	svc, err := NewPatchAnchorPlatformTransactionCompletionService(nil, nil)
-	assert.EqualError(t, err, "anchor platform API service and SDP models are required")
+	assert.EqualError(t, err, "anchor platform API service is required")
 	assert.Nil(t, svc)
 
 	dbt := dbtest.Open(t)

--- a/internal/utils/test_helpers.go
+++ b/internal/utils/test_helpers.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// AssertFuncExitsWithFatal asserts that a function exits with a fatal error, usually `os.Exit(1)`.
+func AssertFuncExitsWithFatal(t *testing.T, fatalFunc func(), stdErrContains ...string) {
+	t.Helper()
+
+	if os.Getenv("TEST_FATAL") == "1" {
+		// Run the fatal function that will call os.Exit(n)
+		fatalFunc()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = append(os.Environ(), "TEST_FATAL=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	exitError, ok := err.(*exec.ExitError)
+	require.Truef(t, ok, "process ran with err %v, want exit status 1", err)
+	require.False(t, exitError.Success())
+
+	for _, stdErrContain := range stdErrContains {
+		require.Contains(t, stderr.String(), stdErrContain)
+	}
+}

--- a/internal/utils/test_helpers.go
+++ b/internal/utils/test_helpers.go
@@ -14,14 +14,14 @@ import (
 func AssertFuncExitsWithFatal(t *testing.T, fatalFunc func(), stdErrContains ...string) {
 	t.Helper()
 
-	if os.Getenv("TEST_FATAL") == "1" {
+	if os.Getenv("TEST_SUBPROCESS") == "1" {
 		// Run the fatal function that will call os.Exit(n)
 		fatalFunc()
 		return
 	}
 
 	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
-	cmd.Env = append(os.Environ(), "TEST_FATAL=1")
+	cmd.Env = append(os.Environ(), "TEST_SUBPROCESS=1")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 


### PR DESCRIPTION
### What

Fix CLI test assertions and improve DRY

### Why

Some CLI tests would fail due to different reasons from what was expected, and none of them was validating the output error message.

Also, there was a lot of code repetition for a kind of assertion that's not trivial.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [x] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [x] Preview deployment works as expected
- [x] Ready for production
