### PR TITLE
Chore: Add GH Workflow to automatically set the pull request assignee

### DIFF
--- a/.github/workflows/assign-pr-author.yml
+++ b/.github/workflows/assign-pr-author.yml
@@ -1,0 +1,31 @@
+name: Assign PR Author
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Assign PR author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+            // Check if the author is dependabot
+            if (prAuthor === "dependabot[bot]") {
+              console.log("Skipping assignment for Dependabot PR.");
+            } else {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                assignees: [prAuthor],
+              });
+              console.log(`Assigned PR #${prNumber} to ${prAuthor}.`);
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Update integration test to wait for the payment to be processed by TSS/Circle with a retry mechanism. [#585](https://github.com/stellar/stellar-disbursement-platform-backend/pull/585)
 - Add Circle Payouts API to the e2e integration test. [#586](https://github.com/stellar/stellar-disbursement-platform-backend/pull/586)
+- Add GH Workflow to automatically set the pull request assignee. [#591](https://github.com/stellar/stellar-disbursement-platform-backend/pull/591)
 
 ### Changed
 


### PR DESCRIPTION
### What

Add GH Workflow to automatically set the pull request assignee.

### Why

📈 Kaizen

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] ~Tests are included (if applicable)~
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] ~CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)~
- [x] Preview deployment works as expected
- [x] Ready for production
