### PR TITLE
SDP-1577: Return `recaptcha_site_key` in the `/sep24-interactive-deposit/init` body response

### DIFF
--- a/internal/serve/httphandler/receiver_registration_handler.go
+++ b/internal/serve/httphandler/receiver_registration_handler.go
@@ -29,6 +29,7 @@ type ReceiverRegistrationResponse struct {
 	TruncatedContactInfo string `json:"truncated_contact_info,omitempty"`
 	IsRegistered         bool   `json:"is_registered"`
 	IsRecaptchaDisabled  bool   `json:"is_recaptcha_disabled"`
+	ReCAPTCHASiteKey     string `json:"recaptcha_site_key"`
 }
 
 // ServeHTTP will serve the SEP-24 deposit page needed to register users.
@@ -78,6 +79,7 @@ func (h ReceiverRegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		OrganizationName:    organization.Name,
 		OrganizationLogo:    logoURL,
 		IsRecaptchaDisabled: h.ReCAPTCHADisabled,
+		ReCAPTCHASiteKey:    h.ReCAPTCHASiteKey,
 	}
 
 	rw, err := h.ReceiverWalletModel.GetByStellarAccountAndMemo(ctx, sep24Claims.SEP10StellarAccount(), sep24Claims.SEP10StellarMemo(), sep24Claims.ClientDomain())

--- a/internal/serve/httphandler/receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/receiver_registration_handler_test.go
@@ -113,7 +113,8 @@ func Test_ReceiverRegistrationHandler_ServeHTTP(t *testing.T) {
 			"organization_name": "MyCustomAid",
 			"organization_logo": "%s/organization/logo",
 			"is_registered": false,
-			"is_recaptcha_disabled": true
+			"is_recaptcha_disabled": true,
+			"recaptcha_site_key": "reCAPTCHASiteKey"
 		}`, *currentTenant.BaseURL)
 		assert.JSONEq(t, expectedJSON, string(respBody))
 	})
@@ -157,7 +158,8 @@ func Test_ReceiverRegistrationHandler_ServeHTTP(t *testing.T) {
 			"organization_logo": "%s/organization/logo",
 			"truncated_contact_info": "`+truncatedContactInfo+`",
 			"is_registered": true,
-			"is_recaptcha_disabled": true
+			"is_recaptcha_disabled": true,
+			"recaptcha_site_key": "reCAPTCHASiteKey"
 		}`, *currentTenant.BaseURL)
 		assert.JSONEq(t, expectedJSON, string(respBody))
 	})
@@ -186,7 +188,8 @@ func Test_ReceiverRegistrationHandler_ServeHTTP(t *testing.T) {
 			"organization_name": "MyCustomAid",
 			"organization_logo": "%s/organization/logo",
 			"is_registered": false,
-			"is_recaptcha_disabled": true
+			"is_recaptcha_disabled": true,
+			"recaptcha_site_key": "reCAPTCHASiteKey"
 		}`, *currentTenant.BaseURL)
 		assert.JSONEq(t, expectedJSON, string(respBody))
 	})


### PR DESCRIPTION
### What

Return `recaptcha_site_key` in the `/sep24-interactive-deposit/init` body response.

### Why

With this change, the SEP-24 react application won't need to rely on the `.env` anymore.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [x] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [x] Preview deployment works as expected
- [ ] Ready for production
