### PR TITLE
SDP-1597 pubnet recaptcha disble allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - GET `/organization/logo` is changed to be a public (unauthenticated) endpoint. [#564](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/564)
 - ReCAPTCHA is now optional for the SEP-24 interactive deposit flow. [#560](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/560)
 - Simplified Helm Charts, added documentation and instructions for local set-up, auto-generation of secrets. [#596](https://github.com/stellar/stellar-disbursement-platform-backend/pull/596)
+- ReCAPTCHA now allowed to be disabled in pubnet environments. [#618](https://github.com/stellar/stellar-disbursement-platform-backend/pull/618)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Google's reCAPTCHA has been integrated into the SDP to prevent automated attacks
 
 ReCAPTCHA is enabled by default and can be disabled in the development environment by setting the `DISABLE_RECAPTCHA` environment variable to `true`.
 
-**Note:** Disabling reCAPTCHA is not supported for production environments due to security risks.
+**Note:** Disabling reCAPTCHA is supported for pubnet environments but this might reduce security!.
 
 ### Enforcement of Multi-Factor Authentication
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -143,7 +143,7 @@ func (opts *ServeOptions) ValidateSecurity() error {
 		if opts.DisableMFA {
 			return fmt.Errorf("MFA cannot be disabled in pubnet")
 		} else if opts.DisableReCAPTCHA {
-			return fmt.Errorf("reCAPTCHA cannot be disabled in pubnet")
+			log.Warnf("reCAPTCHA is disabled in pubnet. This might reduce security!")
 		}
 	}
 

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -129,12 +129,6 @@ func Test_Serve_callsValidateSecurity(t *testing.T) {
 	serveOptions.DisableMFA = true
 	err = Serve(serveOptions, &mHTTPServer)
 	require.EqualError(t, err, "validating security options: MFA cannot be disabled in pubnet")
-
-	// Make sure reCAPTCHA is enforced in pubnet
-	serveOptions.DisableMFA = false
-	serveOptions.DisableReCAPTCHA = true
-	err = Serve(serveOptions, &mHTTPServer)
-	require.EqualError(t, err, "validating security options: reCAPTCHA cannot be disabled in pubnet")
 }
 
 func Test_ServeOptions_ValidateSecurity(t *testing.T) {
@@ -146,17 +140,6 @@ func Test_ServeOptions_ValidateSecurity(t *testing.T) {
 
 		err := serveOptions.ValidateSecurity()
 		require.EqualError(t, err, "MFA cannot be disabled in pubnet")
-	})
-
-	t.Run("Pubnet + DisableReCAPTCHA: should return error", func(t *testing.T) {
-		// Pubnet + DisableReCAPTCHA: should return error
-		serveOptions := ServeOptions{
-			NetworkPassphrase: network.PublicNetworkPassphrase,
-			DisableReCAPTCHA:  true,
-		}
-
-		err := serveOptions.ValidateSecurity()
-		require.EqualError(t, err, "reCAPTCHA cannot be disabled in pubnet")
 	})
 
 	t.Run("Testnet + DisableMFA: should not return error", func(t *testing.T) {


### PR DESCRIPTION
### What

Remove the restriction that prevents disabling ReCAPTCHA in Pubnet deployments, as requested in [SDP-1597](https://stellarorg.atlassian.net/browse/SDP-1597).

### Why

We currently have safeguards in place that don't allow the option `DISABLE_RECAPTCHA=true` for Pubnet deployments. This PR allows disabling ReCAPTCHA in Pubnet environments while still maintaining the restriction on disabling MFA.

Instead of returning an error when ReCAPTCHA is disabled in Pubnet, the code now logs a warning message to ensure administrators are aware of the potential security implications.

### Known limitations

[TODO or N/A]

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [x] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [x] Preview deployment works as expected
- [ ] Ready for production


[SDP-1597]: https://stellarorg.atlassian.net/browse/SDP-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ