### PR TITLE
SDP-1625 add create API key endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [UNRELEASED]
+
+### Added
+
+- Add API keys management endpoints [#655](https://github.com/stellar/stellar-disbursement-platform-backend/pull/655)
+
 ## [3.7.0 UNRELEASED](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/3.7.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/3.6.0...3.7.0))
 
 > [!WARNING]

--- a/db/migrations/sdp-migrations/2025-04-30.0-create-api-keys-table.sql
+++ b/db/migrations/sdp-migrations/2025-04-30.0-create-api-keys-table.sql
@@ -1,7 +1,7 @@
 -- +migrate Up
 
 CREATE TABLE IF NOT EXISTS api_keys (
-    id UUID PRIMARY KEY,
+    id VARCHAR(36) PRIMARY KEY DEFAULT public.uuid_generate_v4(),
     name VARCHAR(128) NOT NULL,
     key_hash VARCHAR(64) NOT NULL,
     salt VARCHAR(32) NOT NULL,

--- a/db/migrations/sdp-migrations/2025-04-30.0-create-api-keys-table.sql
+++ b/db/migrations/sdp-migrations/2025-04-30.0-create-api-keys-table.sql
@@ -1,0 +1,30 @@
+-- +migrate Up
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id UUID PRIMARY KEY,
+    name VARCHAR(128) NOT NULL,
+    key_hash VARCHAR(64) NOT NULL,
+    salt VARCHAR(32) NOT NULL,
+    permissions VARCHAR(32) [] NOT NULL,
+    allowed_ips VARCHAR(64) [] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by UUID NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by UUID NOT NULL,
+    expiry_date TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ
+);
+
+-- enforce fast, unique lookups on the hash
+CREATE UNIQUE INDEX IF NOT EXISTS api_keys_key_hash_idx ON api_keys (key_hash);
+
+-- create the audit table/triggers
+SELECT create_audit_table ('api_keys');
+
+-- +migrate Down
+
+-- drop the audit triggers/table first
+SELECT drop_audit_table ('api_keys');
+
+-- drop the table (automatically removes its indexes)
+DROP TABLE IF EXISTS api_keys;

--- a/internal/data/api_keys.go
+++ b/internal/data/api_keys.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"maps"
 	"net"
 	"slices"
 	"strings"
@@ -122,14 +121,6 @@ func ValidatePermissions(perms []APIKeyPermission) error {
 		}
 	}
 	return nil
-}
-
-func GetAllPermissions() []APIKeyPermission {
-	out := make([]APIKeyPermission, 0, len(validPermissionsMap))
-	for perm := range maps.Keys(validPermissionsMap) {
-		out = append(out, perm)
-	}
-	return out
 }
 
 // IPList represents a list of IPs/CIDRs

--- a/internal/data/api_keys.go
+++ b/internal/data/api_keys.go
@@ -26,7 +26,7 @@ const (
 	maxAttempts      = 3
 )
 
-// alphabet is the allowed character set
+// alphabet is the allowed character set for the keygen
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
 type APIKeyPermission string
@@ -154,7 +154,6 @@ func ValidateAllowedIPs(ips []string) error {
 	return nil
 }
 
-// APIKey is the primary model for API keys.
 type APIKey struct {
 	ID          string            `db:"id" json:"id"`
 	Name        string            `db:"name" json:"name"`
@@ -212,7 +211,6 @@ func (a *APIKey) IsAllowedIP(ipStr string) bool {
 	return false
 }
 
-// APIKeyModel encapsulates DB operations around APIKey.
 type APIKeyModel struct {
 	dbConnectionPool db.DBConnectionPool
 }

--- a/internal/data/api_keys.go
+++ b/internal/data/api_keys.go
@@ -1,0 +1,336 @@
+package data
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql/driver"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"maps"
+	"net"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+)
+
+const (
+	APIKeyPrefix     = "SDP_"
+	APIKeySaltSize   = 16
+	APIKeySecretSize = 32
+	maxAttempts      = 3
+)
+
+// alphabet is the allowed character set
+const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+type APIKeyPermission string
+
+const (
+	// General
+	ReadAll  APIKeyPermission = "read:all"
+	WriteAll APIKeyPermission = "write:all"
+
+	// Disbursements
+	ReadDisbursements  APIKeyPermission = "read:disbursements"
+	WriteDisbursements APIKeyPermission = "write:disbursements"
+
+	// Receivers
+	ReadReceivers  APIKeyPermission = "read:receivers"
+	WriteReceivers APIKeyPermission = "write:receivers"
+
+	// Payments
+	ReadPayments  APIKeyPermission = "read:payments"
+	WritePayments APIKeyPermission = "write:payments"
+
+	// Organization
+	ReadOrganization  APIKeyPermission = "read:organization"
+	WriteOrganization APIKeyPermission = "write:organization"
+
+	// Users
+	ReadUsers  APIKeyPermission = "read:users"
+	WriteUsers APIKeyPermission = "write:users"
+
+	// Wallets
+	ReadWallets  APIKeyPermission = "read:wallets"
+	WriteWallets APIKeyPermission = "write:wallets"
+
+	// Statistics
+	ReadStatistics APIKeyPermission = "read:statistics"
+
+	// Exports
+	ReadExports APIKeyPermission = "read:exports"
+)
+
+// validPermissionsMap is the set of all valid permissions for the validation purposes
+var validPermissionsMap = map[APIKeyPermission]struct{}{
+	ReadAll:            {},
+	WriteAll:           {},
+	ReadDisbursements:  {},
+	WriteDisbursements: {},
+	ReadReceivers:      {},
+	WriteReceivers:     {},
+	ReadPayments:       {},
+	WritePayments:      {},
+	ReadOrganization:   {},
+	WriteOrganization:  {},
+	ReadUsers:          {},
+	WriteUsers:         {},
+	ReadWallets:        {},
+	WriteWallets:       {},
+	ReadStatistics:     {},
+	ReadExports:        {},
+}
+
+type APIKeyPermissions []APIKeyPermission
+
+func (p APIKeyPermissions) Value() (driver.Value, error) {
+	arr := make([]string, len(p))
+	for i, perm := range p {
+		arr[i] = string(perm)
+	}
+	return pq.StringArray(arr).Value()
+}
+
+func (p *APIKeyPermissions) Scan(src any) error {
+	var arr pq.StringArray
+	if err := arr.Scan(src); err != nil {
+		return err
+	}
+	perms := make(APIKeyPermissions, len(arr))
+	for i, s := range arr {
+		perm := APIKeyPermission(s)
+		if _, ok := validPermissionsMap[perm]; !ok {
+			return fmt.Errorf("invalid permission from DB: %s", s)
+		}
+		perms[i] = perm
+	}
+	*p = perms
+	return nil
+}
+
+func ValidatePermissions(perms []APIKeyPermission) error {
+	for _, p := range perms {
+		if _, ok := validPermissionsMap[p]; !ok {
+			return fmt.Errorf("invalid permission: %s", p)
+		}
+	}
+	return nil
+}
+
+func GetAllPermissions() []APIKeyPermission {
+	out := make([]APIKeyPermission, 0, len(validPermissionsMap))
+	for perm := range maps.Keys(validPermissionsMap) {
+		out = append(out, perm)
+	}
+	return out
+}
+
+// IPList represents a list of IPs/CIDRs
+type IPList []string
+
+func (ip IPList) Value() (driver.Value, error) {
+	return pq.StringArray(ip).Value()
+}
+
+func (ip *IPList) Scan(src any) error {
+	var arr pq.StringArray
+	if err := arr.Scan(src); err != nil {
+		return err
+	}
+	*ip = IPList(arr)
+	return nil
+}
+
+func ValidateAllowedIPs(ips []string) error {
+	for _, ip := range ips {
+		if strings.Contains(ip, "/") {
+			if _, _, err := net.ParseCIDR(ip); err != nil {
+				return fmt.Errorf("invalid CIDR: %s", ip)
+			}
+		} else {
+			if net.ParseIP(ip) == nil {
+				return fmt.Errorf("invalid IP: %s", ip)
+			}
+		}
+	}
+	return nil
+}
+
+// APIKey is the primary model for API keys.
+type APIKey struct {
+	ID          string            `db:"id" json:"id"`
+	Name        string            `db:"name" json:"name"`
+	KeyHash     string            `db:"key_hash" json:"-"`
+	Salt        string            `db:"salt" json:"-"`
+	ExpiryDate  *time.Time        `db:"expiry_date" json:"expiry_date,omitempty"`
+	Permissions APIKeyPermissions `db:"permissions" json:"permissions"`
+	AllowedIPs  IPList            `db:"allowed_ips" json:"allowed_ips,omitempty"`
+	CreatedAt   time.Time         `db:"created_at" json:"created_at"`
+	CreatedBy   string            `db:"created_by" json:"created_by,omitempty"`
+	UpdatedAt   time.Time         `db:"updated_at" json:"updated_at"`
+	UpdatedBy   string            `db:"updated_by" json:"updated_by,omitempty"`
+	LastUsedAt  *time.Time        `db:"last_used_at" json:"last_used_at,omitempty"`
+	Key         string            `db:"-" json:"key,omitempty"`
+}
+
+func (a *APIKey) HasPermission(req APIKeyPermission) bool {
+	// hierarchy respect and shortcircuit if user has *:all permissions
+	if strings.HasPrefix(string(req), "read:") && slices.Contains(a.Permissions, ReadAll) {
+		return true
+	}
+	if strings.HasPrefix(string(req), "write:") && slices.Contains(a.Permissions, WriteAll) {
+		return true
+	}
+
+	return slices.Contains(a.Permissions, req)
+}
+
+func (a *APIKey) IsExpired() bool {
+	if a.ExpiryDate == nil {
+		return false
+	}
+	return time.Now().UTC().After(*a.ExpiryDate)
+}
+
+// IsAllowedIP checks if an IP falls within AllowedIPs (or none means open)
+func (a *APIKey) IsAllowedIP(ipStr string) bool {
+	if len(a.AllowedIPs) == 0 {
+		return true
+	}
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	for _, cidr := range a.AllowedIPs {
+		if strings.Contains(cidr, "/") {
+			_, netw, err := net.ParseCIDR(cidr)
+			if err == nil && netw.Contains(ip) {
+				return true
+			}
+		} else if cidr == ipStr {
+			return true
+		}
+	}
+	return false
+}
+
+// APIKeyModel encapsulates DB operations around APIKey.
+type APIKeyModel struct {
+	dbConnectionPool db.DBConnectionPool
+}
+
+// Insert creates, stores, and returns a new APIKey (including the raw key once).
+func (m *APIKeyModel) Insert(
+	ctx context.Context,
+	sqlExec db.SQLExecuter,
+	name string,
+	permissions []APIKeyPermission,
+	allowedIPs []string,
+	expiry *time.Time,
+	createdBy string,
+) (*APIKey, error) {
+	const maxAttempts = 3
+	var apiKey *APIKey
+	if allowedIPs == nil {
+		allowedIPs = IPList{}
+	}
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		saltBytes := make([]byte, APIKeySaltSize)
+		if _, err := rand.Read(saltBytes); err != nil {
+			return nil, fmt.Errorf("salt gen: %w", err)
+		}
+		defer func() {
+			for i := range saltBytes {
+				saltBytes[i] = 0
+			}
+		}()
+		salt := hex.EncodeToString(saltBytes)
+
+		secret, err := generateSecret()
+		if err != nil {
+			return nil, err
+		}
+
+		// Compute hash = SHA256(salt || secret)
+		h := sha256.New()
+		h.Write([]byte(salt))
+		h.Write([]byte(secret))
+		keyHash := hex.EncodeToString(h.Sum(nil))
+
+		candidate := &APIKey{
+			ID:          uuid.New().String(),
+			Name:        name,
+			KeyHash:     keyHash,
+			Salt:        salt,
+			ExpiryDate:  expiry,
+			Permissions: APIKeyPermissions(permissions),
+			AllowedIPs:  IPList(allowedIPs),
+			CreatedBy:   createdBy,
+			UpdatedBy:   createdBy,
+		}
+
+		const q = `
+            INSERT INTO api_keys (
+                id, name, key_hash, salt,
+                expiry_date, permissions, allowed_ips,
+                created_by, updated_by
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+            RETURNING created_at, updated_at
+        `
+		row := sqlExec.QueryRowxContext(ctx, q,
+			candidate.ID, candidate.Name, candidate.KeyHash, candidate.Salt,
+			candidate.ExpiryDate, candidate.Permissions, candidate.AllowedIPs,
+			candidate.CreatedBy, candidate.UpdatedBy,
+		)
+		if err := row.Scan(&candidate.CreatedAt, &candidate.UpdatedAt); err != nil {
+			var pgErr *pq.Error
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" && attempt < maxAttempts {
+				// hash collision (unique violation) - retry
+				continue
+			}
+			return nil, fmt.Errorf("insert API key: %w", err)
+		}
+
+		candidate.Key = APIKeyPrefix + secret
+		apiKey = candidate
+		break
+	}
+
+	if apiKey == nil {
+		return nil, fmt.Errorf("could not generate unique API key after %d attempts", maxAttempts)
+	}
+	return apiKey, nil
+}
+
+func generateSecret() (string, error) {
+	secBytes := make([]byte, APIKeySecretSize)
+	if _, err := rand.Read(secBytes); err != nil {
+		return "", fmt.Errorf("secret gen: %w", err)
+	}
+	defer func() {
+		for i := range secBytes {
+			secBytes[i] = 0
+		}
+	}()
+
+	out := make([]byte, APIKeySecretSize)
+	for i, b := range secBytes {
+		out[i] = alphabet[int(b)%len(alphabet)]
+	}
+	return string(out), nil
+}
+
+func hashAPIKey(salt, secret string) string {
+	h := sha256.New()
+	h.Write([]byte(salt))
+	h.Write([]byte(secret))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/data/api_keys_test.go
+++ b/internal/data/api_keys_test.go
@@ -1,0 +1,207 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+)
+
+func Test_APIKey_HasPermission(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		perms []APIKeyPermission
+		check APIKeyPermission
+		want  bool
+	}{
+		{"has specific", []APIKeyPermission{ReadStatistics, ReadExports}, ReadStatistics, true},
+		{"missing specific", []APIKeyPermission{ReadStatistics, ReadExports}, ReadPayments, false},
+		{"read:all grants read", []APIKeyPermission{ReadAll}, ReadStatistics, true},
+		{"write:all grants write", []APIKeyPermission{WriteAll}, WritePayments, true},
+		{"read:all not grant write", []APIKeyPermission{ReadAll}, WritePayments, false},
+		{"none", []APIKeyPermission{}, ReadStatistics, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key := APIKey{Permissions: APIKeyPermissions(tc.perms)}
+			assert.Equal(t, tc.want, key.HasPermission(tc.check))
+		})
+	}
+}
+
+func Test_APIKey_IsExpired(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	future := now.Add(24 * time.Hour)
+	past := now.Add(-24 * time.Hour)
+
+	cases := []struct {
+		name string
+		key  APIKey
+		want bool
+	}{
+		{"no expiry", APIKey{ExpiryDate: nil}, false},
+		{"future", APIKey{ExpiryDate: &future}, false},
+		{"past", APIKey{ExpiryDate: &past}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.key.IsExpired())
+		})
+	}
+}
+
+func Test_APIKey_IsAllowedIP(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		key  APIKey
+		ip   string
+		want bool
+	}{
+		{"open", APIKey{AllowedIPs: IPList{}}, "1.2.3.4", true},
+		{"direct", APIKey{AllowedIPs: IPList{"1.2.3.4"}}, "1.2.3.4", true},
+		{"miss", APIKey{AllowedIPs: IPList{"1.2.3.4"}}, "1.2.3.5", false},
+		{"cidr ok", APIKey{AllowedIPs: IPList{"10.0.0.0/8"}}, "10.1.2.3", true},
+		{"cidr x", APIKey{AllowedIPs: IPList{"10.0.0.0/8"}}, "11.0.0.1", false},
+		{"bad ip", APIKey{AllowedIPs: IPList{"1.2.3.4"}}, "nope", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.key.IsAllowedIP(tc.ip))
+		})
+	}
+}
+
+func Test_ValidatePermissions(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		perms []APIKeyPermission
+		err   bool
+	}{
+		{"all good", []APIKeyPermission{ReadStatistics, ReadExports}, false},
+		{"one bad", []APIKeyPermission{ReadStatistics, "bad"}, true},
+		{"empty", []APIKeyPermission{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.err {
+				require.Error(t, ValidatePermissions(tc.perms))
+			} else {
+				require.NoError(t, ValidatePermissions(tc.perms))
+			}
+		})
+	}
+}
+
+func Test_ValidateAllowedIPs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		ips  []string
+		err  bool
+	}{
+		{"valid IPs", []string{"1.2.3.4", "5.6.7.8"}, false},
+		{"valid CIDR", []string{"192.168.0.0/16"}, false},
+		{"mixed valid", []string{"1.2.3.4", "10.0.0.0/8"}, false},
+		{"bad IP", []string{"1.2.3.4", "nope"}, true},
+		{"bad CIDR", []string{"1.2.3.0/33"}, true},
+		{"empty", []string{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.err {
+				require.Error(t, ValidateAllowedIPs(tc.ips))
+			} else {
+				require.NoError(t, ValidateAllowedIPs(tc.ips))
+			}
+		})
+	}
+}
+
+func Test_generateSecret(t *testing.T) {
+	t.Parallel()
+	sec, err := generateSecret()
+	require.NoError(t, err)
+	assert.Len(t, sec, APIKeySecretSize)
+	for _, ch := range sec {
+		assert.Contains(t, alphabet, string(ch))
+	}
+}
+
+func Test_hashAPIKey(t *testing.T) {
+	t.Parallel()
+	salt, secret := "B0l7", "R3l1c0f0mn1551ah"
+	h1 := hashAPIKey(secret, salt)
+	h2 := hashAPIKey(secret, salt)
+	assert.Equal(t, h1, h2)
+	assert.NotEmpty(t, h1)
+}
+
+func CreateAPIKeyFixture(t *testing.T, ctx context.Context, pool db.DBConnectionPool, perms []APIKeyPermission, ips []string) *APIKey {
+	t.Helper()
+	models, err := NewModels(pool)
+	require.NoError(t, err)
+
+	name := "Relic of the Omnissiah"
+	createdBy := "00000000-0000-0000-0000-000000000000"
+
+	key, err := models.APIKeys.Insert(ctx, pool, name, perms, ips, nil, createdBy)
+	require.NoError(t, err)
+	return key
+}
+
+func Test_APIKeyModel_Insert(t *testing.T) {
+	dbt := dbtest.Open(t)
+	t.Cleanup(func() { dbt.Close() })
+
+	pool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Close() })
+
+	ctx := context.Background()
+	models, err := NewModels(pool)
+	require.NoError(t, err)
+
+	t.Run("insert key", func(t *testing.T) {
+		perms := APIKeyPermissions{ReadStatistics, ReadExports}
+		ips := IPList{"1.2.3.4", "10.0.0.0/8"}
+		key := CreateAPIKeyFixture(t, ctx, pool, perms, ips)
+
+		assert.NotEmpty(t, key.ID)
+		assert.Equal(t, "Relic of the Omnissiah", key.Name)
+		assert.NotEmpty(t, key.KeyHash)
+		assert.NotEmpty(t, key.Salt)
+		assert.Nil(t, key.ExpiryDate)
+		assert.Equal(t, perms, key.Permissions)
+		assert.Equal(t, ips, key.AllowedIPs)
+		assert.Equal(t, "00000000-0000-0000-0000-000000000000", key.CreatedBy)
+		assert.Equal(t, "00000000-0000-0000-0000-000000000000", key.UpdatedBy)
+		assert.NotEmpty(t, key.Key)
+		assert.WithinDuration(t, time.Now().UTC(), key.CreatedAt, time.Second*5)
+		assert.WithinDuration(t, time.Now().UTC(), key.UpdatedAt, time.Second*5)
+		assert.Nil(t, key.LastUsedAt)
+	})
+
+	t.Run("insert new key with minimum fields", func(t *testing.T) {
+		expiry := time.Now().Add(48 * time.Hour)
+		perms := []APIKeyPermission{ReadAll}
+		ips := []string{}
+		name := "Stygies VIII Archive Key"
+		createdBy := "00000000-0000-0000-0000-000000000000"
+
+		key, err := models.APIKeys.Insert(ctx, pool, name, perms, ips, &expiry, createdBy)
+		require.NoError(t, err)
+
+		assert.Equal(t, name, key.Name)
+		require.NotNil(t, key.ExpiryDate)
+		assert.WithinDuration(t, expiry, *key.ExpiryDate, time.Second)
+	})
+}

--- a/internal/data/api_keys_test.go
+++ b/internal/data/api_keys_test.go
@@ -136,15 +136,6 @@ func Test_generateSecret(t *testing.T) {
 	}
 }
 
-func Test_hashAPIKey(t *testing.T) {
-	t.Parallel()
-	salt, secret := "B0l7", "R3l1c0f0mn1551ah"
-	h1 := hashAPIKey(secret, salt)
-	h2 := hashAPIKey(secret, salt)
-	assert.Equal(t, h1, h2)
-	assert.NotEmpty(t, h1)
-}
-
 func CreateAPIKeyFixture(t *testing.T, ctx context.Context, pool db.DBConnectionPool, perms []APIKeyPermission, ips []string) *APIKey {
 	t.Helper()
 	models, err := NewModels(pool)

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -29,6 +29,7 @@ type Models struct {
 	CircleTransferRequests      *CircleTransferRequestModel
 	CircleRecipient             *CircleRecipientModel
 	URLShortener                *URLShortenerModel
+	APIKeys                     *APIKeyModel
 	DBConnectionPool            db.DBConnectionPool
 }
 
@@ -51,6 +52,7 @@ func NewModels(dbConnectionPool db.DBConnectionPool) (*Models, error) {
 		Message:                     &MessageModel{dbConnectionPool: dbConnectionPool},
 		CircleTransferRequests:      &CircleTransferRequestModel{dbConnectionPool: dbConnectionPool},
 		CircleRecipient:             &CircleRecipientModel{dbConnectionPool: dbConnectionPool},
+		APIKeys:                     &APIKeyModel{dbConnectionPool: dbConnectionPool},
 		URLShortener:                NewURLShortenerModel(dbConnectionPool),
 		DBConnectionPool:            dbConnectionPool,
 	}, nil

--- a/internal/serve/httphandler/api_key_handler.go
+++ b/internal/serve/httphandler/api_key_handler.go
@@ -47,8 +47,8 @@ func (h APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	allowedIPs, err := parseAllowedIPs(req.AllowedIPs)
 	if err != nil {
 		v.AddError("allowed_ips", err.Error())
-	} else if err := data.ValidateAllowedIPs(allowedIPs); err != nil {
-		v.AddError("allowed_ips", err.Error())
+	} else if validationErr := data.ValidateAllowedIPs(allowedIPs); validationErr != nil {
+		v.AddError("allowed_ips", validationErr.Error())
 	}
 
 	if req.ExpiryDate != nil && req.ExpiryDate.Before(time.Now()) {

--- a/internal/serve/httphandler/api_key_handler.go
+++ b/internal/serve/httphandler/api_key_handler.go
@@ -1,0 +1,117 @@
+package httphandler
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/stellar/go/support/http/httpdecode"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/render/httpjson"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
+)
+
+type APIKeyHandler struct {
+	Models *data.Models
+}
+
+type CreateAPIKeyRequest struct {
+	Name        string                  `json:"name"`
+	Permissions []data.APIKeyPermission `json:"permissions"`
+	ExpiryDate  *time.Time              `json:"expiry_date,omitempty"`
+	AllowedIPs  any                     `json:"allowed_ips,omitempty"` // Can be a string or array of strings
+}
+
+func (h APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req CreateAPIKeyRequest
+	if err := httpdecode.DecodeJSON(r, &req); err != nil {
+		httperror.BadRequest("Invalid request body", err, nil).Render(w)
+		return
+	}
+
+	v := validators.NewValidator()
+
+	v.Check(req.Name != "", "name", "name is required")
+	v.Check(len(req.Permissions) > 0, "permissions", "at least one permission is required")
+
+	if err := data.ValidatePermissions(req.Permissions); err != nil {
+		v.AddError("permissions", err.Error())
+	}
+
+	allowedIPs, err := parseAllowedIPs(req.AllowedIPs)
+	if err != nil {
+		v.AddError("allowed_ips", err.Error())
+	} else if err := data.ValidateAllowedIPs(allowedIPs); err != nil {
+		v.AddError("allowed_ips", err.Error())
+	}
+
+	if req.ExpiryDate != nil && req.ExpiryDate.Before(time.Now()) {
+		v.AddError("expiry_date", "expiry date must be in the future")
+	}
+
+	if v.HasErrors() {
+		httperror.BadRequest("Request validation failed", nil, v.Errors).Render(w)
+		return
+	}
+
+	// Get user ID from context
+	userID, ok := ctx.Value(middleware.UserIDContextKey).(string)
+	if !ok {
+		log.Ctx(ctx).Error("User ID not found in context")
+		httperror.InternalError(ctx, "User identification error", nil, nil).Render(w)
+		return
+	}
+
+	// Create API key
+	apiKey, err := h.Models.APIKeys.Insert(
+		ctx,
+		h.Models.DBConnectionPool,
+		req.Name,
+		req.Permissions,
+		allowedIPs,
+		req.ExpiryDate,
+		userID,
+	)
+	if err != nil {
+		log.Ctx(ctx).Errorf("Error creating API key: %s", err)
+		httperror.InternalError(ctx, "Failed to create API key", err, nil).Render(w)
+		return
+	}
+
+	httpjson.RenderStatus(w, http.StatusCreated, apiKey, httpjson.JSON)
+}
+
+// parseAllowedIPs converts the allowed_ips field from the request into a string slice
+func parseAllowedIPs(input any) ([]string, error) {
+	if input == nil {
+		return []string{}, nil
+	}
+
+	if strArray, ok := input.([]string); ok {
+		return strArray, nil
+	}
+
+	if arr, ok := input.([]any); ok {
+		strArray := make([]string, 0, len(arr))
+		for i, item := range arr {
+			str, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("item at position %d must be a string", i)
+			}
+			strArray = append(strArray, str)
+		}
+		return strArray, nil
+	}
+
+	if str, ok := input.(string); ok {
+		return []string{str}, nil
+	}
+
+	return nil, fmt.Errorf("must be a string or array of strings")
+}

--- a/internal/serve/httphandler/api_key_handler.go
+++ b/internal/serve/httphandler/api_key_handler.go
@@ -60,7 +60,6 @@ func (h APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get user ID from context
 	userID, ok := ctx.Value(middleware.UserIDContextKey).(string)
 	if !ok {
 		log.Ctx(ctx).Error("User ID not found in context")
@@ -68,7 +67,6 @@ func (h APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create API key
 	apiKey, err := h.Models.APIKeys.Insert(
 		ctx,
 		h.Models.DBConnectionPool,

--- a/internal/serve/httphandler/api_key_handler_test.go
+++ b/internal/serve/httphandler/api_key_handler_test.go
@@ -1,0 +1,308 @@
+package httphandler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+)
+
+const adminUserID = "b9c29a1a-4d30-4b99-8c5f-0546054be91b"
+
+func getDBConnectionPool(t *testing.T) db.DBConnectionPool {
+	dbt := dbtest.Open(t)
+	t.Cleanup(func() {
+		dbt.Close()
+	})
+
+	pool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { pool.Close() })
+
+	return pool
+}
+
+func setupHandler(t *testing.T) (APIKeyHandler, context.Context) {
+	pool := getDBConnectionPool(t)
+	models, err := data.NewModels(pool)
+	require.NoError(t, err)
+
+	handler := APIKeyHandler{Models: models}
+	ctx := context.WithValue(context.Background(), middleware.UserIDContextKey, adminUserID)
+
+	return handler, ctx
+}
+
+func TestCreateAPIKey_WithAllFields(t *testing.T) {
+	handler, ctx := setupHandler(t)
+
+	expiry := time.Now().Add(24 * time.Hour)
+	reqBody := map[string]any{
+		"name":        "Relic of the Omnissiah",
+		"permissions": []string{"read:statistics", "read:exports"},
+		"allowed_ips": data.IPList{"198.51.100.0/24"},
+		"expiry_date": expiry,
+	}
+	b, _ := json.Marshal(reqBody)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api-keys", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+
+	handler.CreateAPIKey(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	var out data.APIKey
+	dataBytes, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(dataBytes, &out))
+
+	assert.NotEmpty(t, out.ID)
+	assert.Equal(t, "Relic of the Omnissiah", out.Name)
+	assert.NotEmpty(t, out.Key)
+	assert.Contains(t, out.Key, "SDP_")
+	assert.ElementsMatch(t, []data.APIKeyPermission{data.ReadStatistics, data.ReadExports}, out.Permissions)
+	assert.Equal(t, data.IPList{"198.51.100.0/24"}, out.AllowedIPs)
+	require.NotNil(t, out.ExpiryDate)
+	assert.WithinDuration(t, expiry, *out.ExpiryDate, time.Second)
+	assert.Equal(t, adminUserID, out.CreatedBy)
+}
+
+func TestCreateAPIKey_WithMinimumFields(t *testing.T) {
+	handler, ctx := setupHandler(t)
+
+	reqBody := map[string]any{
+		"name":        "Magos Dominus Access Key",
+		"permissions": []string{"read:all"},
+	}
+	b, _ := json.Marshal(reqBody)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api-keys", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+
+	handler.CreateAPIKey(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	var out data.APIKey
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+
+	assert.NotEmpty(t, out.ID)
+	assert.Equal(t, "Magos Dominus Access Key", out.Name)
+	assert.NotEmpty(t, out.Key)
+	assert.ElementsMatch(t, []data.APIKeyPermission{data.ReadAll}, out.Permissions)
+	assert.Empty(t, out.AllowedIPs)
+	assert.Nil(t, out.ExpiryDate)
+}
+
+func TestCreateAPIKey_AllowedIPsHandling(t *testing.T) {
+	successCases := []struct {
+		name       string
+		allowedIPs any
+		expected   data.IPList
+	}{
+		{
+			name:       "single string IP",
+			allowedIPs: "203.0.113.5",
+			expected:   data.IPList{"203.0.113.5"},
+		},
+		{
+			name:       "array of IP strings",
+			allowedIPs: data.IPList{"192.168.1.0/24", "10.0.0.0/8"},
+			expected:   data.IPList{"192.168.1.0/24", "10.0.0.0/8"},
+		},
+		{
+			name:       "empty array",
+			allowedIPs: data.IPList{},
+			expected:   nil,
+		},
+		{
+			name:       "no allowed_ips field",
+			allowedIPs: nil,
+			expected:   nil,
+		},
+	}
+
+	for _, tc := range successCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, ctx := setupHandler(t)
+
+			reqBody := map[string]any{
+				"name":        "Magos Explorator Key - " + tc.name,
+				"permissions": []string{"read:statistics"},
+			}
+			if tc.allowedIPs != nil {
+				reqBody["allowed_ips"] = tc.allowedIPs
+			}
+
+			b, _ := json.Marshal(reqBody)
+			req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api-keys", bytes.NewReader(b))
+			rr := httptest.NewRecorder()
+
+			handler.CreateAPIKey(rr, req)
+			resp := rr.Result()
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusCreated, resp.StatusCode)
+			var out data.APIKey
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			assert.Equal(t, tc.expected, out.AllowedIPs)
+		})
+	}
+}
+
+func TestCreateAPIKey_ValidationErrors(t *testing.T) {
+	errorCases := []struct {
+		name          string
+		requestBody   map[string]any
+		expectedField string
+	}{
+		{
+			name:          "missing name",
+			requestBody:   map[string]any{"permissions": []string{"read:statistics"}},
+			expectedField: "name",
+		},
+		{
+			name:          "missing permissions",
+			requestBody:   map[string]any{"name": "Null Permissions Key"},
+			expectedField: "permissions",
+		},
+		{
+			name:          "empty permissions array",
+			requestBody:   map[string]any{"name": "Empty Permissions Key", "permissions": []string{}},
+			expectedField: "permissions",
+		},
+		{
+			name:          "invalid permissions",
+			requestBody:   map[string]any{"name": "Heretical Key", "permissions": []string{"read:statistics", "nope:invalid"}},
+			expectedField: "permissions",
+		},
+		{
+			name: "past expiry date",
+			requestBody: map[string]any{
+				"name":        "Chronometron Key",
+				"permissions": []string{"read:statistics"},
+				"expiry_date": time.Now().Add(-time.Hour),
+			},
+			expectedField: "expiry_date",
+		},
+	}
+
+	for _, tc := range errorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, ctx := setupHandler(t)
+
+			b, _ := json.Marshal(tc.requestBody)
+			req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api-keys", bytes.NewReader(b))
+			rr := httptest.NewRecorder()
+
+			handler.CreateAPIKey(rr, req)
+			resp := rr.Result()
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			var errResp map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+			fields := errResp["extras"].(map[string]any)
+			assert.Contains(t, fields, tc.expectedField)
+		})
+	}
+}
+
+func TestCreateAPIKey_IPValidationErrors(t *testing.T) {
+	ipErrorCases := []struct {
+		name       string
+		allowedIPs any
+	}{
+		{
+			name:       "invalid IP address",
+			allowedIPs: []string{"198.51.100.0/24", "bad-ip"},
+		},
+		{
+			name:       "invalid CIDR notation",
+			allowedIPs: []string{"192.168.1.0/40"}, // Invalid CIDR (max is /32)
+		},
+		{
+			name:       "invalid type (number)",
+			allowedIPs: 12345,
+		},
+		{
+			name:       "mixed types in array",
+			allowedIPs: []any{"192.168.1.1", 12345},
+		},
+	}
+
+	for _, tc := range ipErrorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, ctx := setupHandler(t)
+
+			reqBody := map[string]any{
+				"name":        "Magos Biologis Key - " + tc.name,
+				"permissions": []string{"read:statistics"},
+				"allowed_ips": tc.allowedIPs,
+			}
+			b, _ := json.Marshal(reqBody)
+			req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api-keys", bytes.NewReader(b))
+			rr := httptest.NewRecorder()
+
+			handler.CreateAPIKey(rr, req)
+			resp := rr.Result()
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			var errResp map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+			fields := errResp["extras"].(map[string]any)
+			assert.Contains(t, fields, "allowed_ips")
+		})
+	}
+}
+
+func TestCreateAPIKey_InvalidJSON(t *testing.T) {
+	handler, ctx := setupHandler(t)
+
+	invalid := []byte(`{invalid-json}`)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api-keys", bytes.NewReader(invalid))
+	rr := httptest.NewRecorder()
+
+	handler.CreateAPIKey(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestCreateAPIKey_MissingUserID(t *testing.T) {
+	pool := getDBConnectionPool(t)
+	models, err := data.NewModels(pool)
+	require.NoError(t, err)
+	handler := APIKeyHandler{Models: models}
+
+	emptyCtx := context.Background()
+
+	reqBody := map[string]any{
+		"name":        "Adeptus Mechanicus Key",
+		"permissions": []string{"read:statistics"},
+	}
+	b, _ := json.Marshal(reqBody)
+	req := httptest.NewRequestWithContext(emptyCtx, http.MethodPost, "/api-keys", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+
+	handler.CreateAPIKey(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -1456,7 +1456,7 @@ func Test_AssetHandler_submitChangeTrustTransaction_makeSurePreconditionsAreSetA
 			timeSinceCreation := time.Since(creationTime)
 
 			expectedAdjustedMaxTime := expectedMaxTime.Add(timeSinceCreation)
-			require.WithinDuration(t, expectedAdjustedMaxTime, actualMaxTime, 10*time.Second)
+			require.WithinDuration(t, expectedAdjustedMaxTime, actualMaxTime, 30*time.Second)
 		}
 	}
 

--- a/internal/serve/middleware/middleware.go
+++ b/internal/serve/middleware/middleware.go
@@ -26,8 +26,9 @@ import (
 type ContextKey string
 
 const (
-	TokenContextKey ContextKey = "auth_token"
-	TenantHeaderKey string     = "SDP-Tenant-Name"
+	TokenContextKey  ContextKey = "auth_token"
+	UserIDContextKey ContextKey = "user_id"
+	TenantHeaderKey  string     = "SDP-Tenant-Name"
 )
 
 // RecoverHandler is a middleware that recovers from panics and logs the error.
@@ -113,6 +114,7 @@ func AuthenticateMiddleware(authManager auth.AuthManager, tenantManager tenant.M
 
 			// Add the token to the request context
 			ctx = context.WithValue(ctx, TokenContextKey, token)
+			ctx = context.WithValue(ctx, UserIDContextKey, userID)
 
 			// Attempt fetching tenant ID from token
 			tenantID, err := authManager.GetTenantID(ctx, token)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -231,6 +231,13 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		r.Use(middleware.AuthenticateMiddleware(authManager, o.tenantManager))
 		r.Use(middleware.EnsureTenantMiddleware)
 
+		r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.DeveloperUserRole)).Route("/api-keys", func(r chi.Router) {
+			apiKeyHandler := httphandler.APIKeyHandler{
+				Models: o.Models,
+			}
+			r.Post("/", apiKeyHandler.CreateAPIKey)
+		})
+
 		r.With(middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...)).Route("/statistics", func(r chi.Router) {
 			statisticsHandler := httphandler.StatisticsHandler{DBConnectionPool: o.MtnDBConnectionPool}
 			r.Get("/", statisticsHandler.GetStatistics)

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -470,6 +470,8 @@ func Test_handleHTTP_authenticatedEndpoints(t *testing.T) {
 		{http.MethodGet, "/sep24-interactive-deposit/info"},
 		{http.MethodPost, "/sep24-interactive-deposit/otp"},
 		{http.MethodPost, "/sep24-interactive-deposit/verification"},
+		// api-keys
+		{http.MethodPost, "/api-keys"},
 	}
 
 	// Expect 401 as a response:

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -363,6 +363,8 @@ func Test_TenantHandler_Post(t *testing.T) {
 			"wallets",
 			"wallets_assets",
 			"receiver_registration_attempts",
+			"api_keys",
+			"api_keys_audit",
 		}
 		tenant.CheckSchemaExistsFixture(t, ctx, dbConnectionPool, expectedSchema)
 		tenant.TenantSchemaMatchTablesFixture(t, ctx, dbConnectionPool, expectedSchema, expectedTablesAfterMigrationsApplied)

--- a/stellar-multitenant/internal/provisioning/manager_test.go
+++ b/stellar-multitenant/internal/provisioning/manager_test.go
@@ -470,6 +470,8 @@ func getExpectedTablesAfterMigrationsApplied() []string {
 		"wallets",
 		"wallets_assets",
 		"receiver_registration_attempts",
+		"api_keys",
+		"api_keys_audit",
 	}
 }
 


### PR DESCRIPTION
## What
This PR implements API key authentication for the SDP backend API. The implementation:

- Adds a new `api_keys` database table with audit support
- Creates the API key data model
- Implements the `POST /api-keys` endpoint for creating new API keys
- Adds support for granular permissions through a hierarchical permission system
- Provides IP address allowlisting

API keys follow a secure format `SDP_<random>` where only salted hashes are stored in the database. The full key is returned only once at creation time.

## Why
API keys provide an alternative authentication method to JWT tokens, this change enables:
- More granular access control through specific permissions
- Better security through IP address restrictions
- Audit trail for all API key operations

### Known limitations

[TODO or N/A]

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [x] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
