### PR TITLE
SDP-1631: Delete Tenant fails when Stellar Account is DB_VAULT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Fix CLI tests and test assertions. [#587](https://github.com/stellar/stellar-disbursement-platform-backend/pull/587)
 - Fix error message for duplicate instructions in a disbursement. [#662](https://github.com/stellar/stellar-disbursement-platform-backend/pull/662)
+- Fix `DELETE /tenants/:id` when tenant is a DB Vault tenant.[#664](https://github.com/stellar/stellar-disbursement-platform-backend/pull/664)
 
 ### Security and Dependencies
 

--- a/internal/transactionsubmission/engine/signing/distribution_account_resolver.go
+++ b/internal/transactionsubmission/engine/signing/distribution_account_resolver.go
@@ -67,7 +67,7 @@ type DistributionAccountResolverImpl struct {
 
 // DistributionAccount returns the tenant's distribution account stored in the database.
 func (r *DistributionAccountResolverImpl) DistributionAccount(ctx context.Context, tenantID string) (schema.TransactionAccount, error) {
-	tnt, err := r.tenantManager.GetTenantByID(ctx, tenantID)
+	tnt, err := r.tenantManager.GetTenantByIDIncludingDeactivated(ctx, tenantID)
 	if err != nil {
 		return schema.TransactionAccount{}, fmt.Errorf("getting tenant: %w", err)
 	}

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -109,7 +109,7 @@ func (m *Manager) GetTenant(ctx context.Context, queryParams *QueryParams) (*Ten
 	return &t, nil
 }
 
-// GetTenantByIDIncludingDeactivated returns the tenant with a given id, including deleted tenants.
+// GetTenantByIDIncludingDeactivated returns the tenant with a given id, including deactivated tenants.
 func (m *Manager) GetTenantByIDIncludingDeactivated(ctx context.Context, id string) (*Tenant, error) {
 	queryParams := &QueryParams{
 		Filters: map[FilterKey]interface{}{

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -31,6 +31,7 @@ type ManagerInterface interface {
 	GetDSNForTenantByID(ctx context.Context, id string) (string, error)
 	GetAllTenants(ctx context.Context, queryParams *QueryParams) ([]Tenant, error)
 	GetTenant(ctx context.Context, queryParams *QueryParams) (*Tenant, error)
+	GetTenantByIDIncludingDeactivated(ctx context.Context, id string) (*Tenant, error)
 	GetTenantByID(ctx context.Context, id string) (*Tenant, error)
 	GetTenantByName(ctx context.Context, name string) (*Tenant, error)
 	GetTenantByIDOrName(ctx context.Context, arg string) (*Tenant, error)
@@ -106,6 +107,17 @@ func (m *Manager) GetTenant(ctx context.Context, queryParams *QueryParams) (*Ten
 		return nil, fmt.Errorf("getting tenant: %w", err)
 	}
 	return &t, nil
+}
+
+// GetTenantByIDIncludingDeactivated returns the tenant with a given id, including deleted tenants.
+func (m *Manager) GetTenantByIDIncludingDeactivated(ctx context.Context, id string) (*Tenant, error) {
+	queryParams := &QueryParams{
+		Filters: map[FilterKey]interface{}{
+			FilterKeyID: id,
+		},
+	}
+
+	return m.GetTenant(ctx, queryParams)
 }
 
 func (m *Manager) GetTenantByID(ctx context.Context, id string) (*Tenant, error) {

--- a/stellar-multitenant/pkg/tenant/manager.go
+++ b/stellar-multitenant/pkg/tenant/manager.go
@@ -113,7 +113,8 @@ func (m *Manager) GetTenant(ctx context.Context, queryParams *QueryParams) (*Ten
 func (m *Manager) GetTenantByIDIncludingDeactivated(ctx context.Context, id string) (*Tenant, error) {
 	queryParams := &QueryParams{
 		Filters: map[FilterKey]interface{}{
-			FilterKeyID: id,
+			FilterKeyID:      id,
+			FilterKeyDeleted: true,
 		},
 	}
 

--- a/stellar-multitenant/pkg/tenant/manager_test.go
+++ b/stellar-multitenant/pkg/tenant/manager_test.go
@@ -338,12 +338,6 @@ func Test_Manager_GetTenantByIDIncludingDeactivated(t *testing.T) {
 	deletedTenant, outerErr = m.SoftDeleteTenantByID(ctx, deletedTenant.ID)
 	require.NoError(t, outerErr)
 
-	t.Run("error when tenant is deleted", func(t *testing.T) {
-		tntDB, err := m.GetTenantByIDIncludingDeactivated(ctx, deletedTenant.ID)
-		require.NoError(t, err)
-		assert.Equal(t, deletedTenant, tntDB)
-	})
-
 	t.Run("gets deactivated tenant successfully", func(t *testing.T) {
 		tntDB, err := m.GetTenantByIDIncludingDeactivated(ctx, deactivatedTenant.ID)
 		require.NoError(t, err)
@@ -354,6 +348,12 @@ func Test_Manager_GetTenantByIDIncludingDeactivated(t *testing.T) {
 		tntDB, err := m.GetTenantByIDIncludingDeactivated(ctx, activeTenant.ID)
 		require.NoError(t, err)
 		assert.Equal(t, activeTenant, tntDB)
+	})
+
+	t.Run("error when tenant is deleted", func(t *testing.T) {
+		tntDB, err := m.GetTenantByIDIncludingDeactivated(ctx, deletedTenant.ID)
+		assert.ErrorIs(t, err, ErrTenantDoesNotExist)
+		assert.Nil(t, tntDB)
 	})
 
 	t.Run("returns error when tenant is not found", func(t *testing.T) {

--- a/stellar-multitenant/pkg/tenant/mocks.go
+++ b/stellar-multitenant/pkg/tenant/mocks.go
@@ -54,6 +54,14 @@ func (m *TenantManagerMock) GetTenantByID(ctx context.Context, id string) (*Tena
 	return args.Get(0).(*Tenant), args.Error(1)
 }
 
+func (m *TenantManagerMock) GetTenantByIDIncludingDeactivated(ctx context.Context, id string) (*Tenant, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*Tenant), args.Error(1)
+}
+
 func (m *TenantManagerMock) GetTenantByIDOrName(ctx context.Context, arg string) (*Tenant, error) {
 	args := m.Called(ctx, arg)
 	if args.Get(0) == nil {


### PR DESCRIPTION
### What
Introduce a new method `GetTenantByIDIncludingDeactivated` for resolving distribution accounts for tenants.

### Why
Fetching distribution account fails when the tenant is deactivated. We should be able to fetch distribution account for deactivated tenants (not yet deleted). 

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [x] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [] Preview deployment works as expected
- [x] Ready for production
