### PR TITLE
SDP-1616: Fix WebAuthn client_data_json field extraction

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -978,6 +978,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-json-core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b81787e655bd59cecadc91f7b6b8651330b2be6c33246039a65e5cd6f4e0828"
+dependencies = [
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1090,8 @@ dependencies = [
  "hex",
  "p256",
  "rand_core",
+ "serde",
+ "serde-json-core",
  "soroban-sdk",
 ]
 

--- a/contracts/smart-wallet/Cargo.toml
+++ b/contracts/smart-wallet/Cargo.toml
@@ -9,6 +9,8 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+serde = { version = "1", default-features = false, features = ["derive"] }
+serde-json-core = { version = "0.6.0", default-features = false }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/smart-wallet/src/lib.rs
+++ b/contracts/smart-wallet/src/lib.rs
@@ -21,10 +21,11 @@ pub enum DataKey {
 #[contracterror]
 pub enum AccountContractError {
     MissingSigner = 0,
-    WebAuthnInvalidType = 1,
-    WebAuthnUserNotPresent = 2,
-    WebAuthnUserNotVerified = 3,
-    WebAuthnInvalidChallenge = 4,
+    WebAuthnInvalidClientData = 1,
+    WebAuthnInvalidType = 2,
+    WebAuthnUserNotPresent = 3,
+    WebAuthnUserNotVerified = 4,
+    WebAuthnInvalidChallenge = 5,
 }
 
 #[contract]

--- a/contracts/smart-wallet/src/webauthn.rs
+++ b/contracts/smart-wallet/src/webauthn.rs
@@ -21,13 +21,13 @@ pub(crate) const ENCODED_CHALLENGE_LEN: u32 = 43;
 ///
 /// - `type`: ~20 bytes (`"type":"webauthn.get"`).
 ///
-/// - `challenge`: ~43 bytes (`"challenge":"<base64url_32_byte_challenge>",`).
+/// - `challenge`: ~58 bytes (`"challenge":"<base64url_32_byte_challenge>",`).
 ///
 /// - `origin`: ~100-200 bytes (`"origin":"https://example.com",`)
 ///
 /// - `crossOrigin`: ~20 bytes (`"crossOrigin":false,`).
 ///
-/// Total length: ~283 bytes.
+/// Total length: ~298 bytes.
 ///
 /// This is a conservative estimate, as the actual length may vary based on the specific values used.
 /// The maximum length is set to 1024 bytes to accommodate any additional fields or whitespace.

--- a/contracts/smart-wallet/src/webauthn.rs
+++ b/contracts/smart-wallet/src/webauthn.rs
@@ -2,16 +2,45 @@ use soroban_sdk::{contracttype, crypto::Hash, panic_with_error, Bytes, BytesN, E
 
 use crate::{base64_url, AccountContractError};
 
+/// The WebAuthn type for the get operation.
+pub(crate) const WEBAUTHN_TYPE_GET: &str = "webauthn.get";
+
 /// Authenticator data flag offset. It appears after the RP ID hash in the authenticator data.
 pub(crate) const AUTH_DATA_FLAG_OFFSET: u32 = 32;
 /// Authenticator data flags for user presence
 pub(crate) const AUTH_DATA_FLAG_UP: u8 = 0x01;
 /// Authenticator data flags for user verification
 pub(crate) const AUTH_DATA_FLAG_UV: u8 = 0x04;
+
 /// Length of the encoded challenge in the client data JSON.
 pub(crate) const ENCODED_CHALLENGE_LEN: u32 = 43;
-/// The WebAuthn type for the get operation.
-pub(crate) const WEBAUTHN_TYPE_GET: &str = "webauthn.get";
+
+/// Max length of the client data JSON in bytes.
+///
+/// #### Explanation of the length:
+///
+/// - `type`: ~20 bytes (`"type":"webauthn.get"`).
+///
+/// - `challenge`: ~43 bytes (`"challenge":"<base64url_32_byte_challenge>",`).
+///
+/// - `origin`: ~100-200 bytes (`"origin":"https://example.com",`)
+///
+/// - `crossOrigin`: ~20 bytes (`"crossOrigin":false,`).
+///
+/// Total length: ~283 bytes.
+///
+/// This is a conservative estimate, as the actual length may vary based on the specific values used.
+/// The maximum length is set to 1024 bytes to accommodate any additional fields or whitespace.
+pub(crate) const MAX_CLIENT_DATA_JSON_LEN: usize = 1024;
+
+/// The Client Data JSON structure.
+#[derive(serde::Deserialize, Clone, Debug, PartialEq, PartialOrd)]
+struct ClientDataJson<'a> {
+    /// The type of the WebAuthn operation.
+    pub r#type: &'a str,
+    /// The challenge used in the WebAuthn operation.
+    pub challenge: &'a str,
+}
 
 /// A WebAuthn credential.
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
@@ -21,10 +50,6 @@ pub struct WebAuthnCredential {
     pub authenticator_data: Bytes,
     /// The client data JSON is a base64url encoded string.
     pub client_data_json: Bytes,
-    /// The type index is the starting index of the type in the client data JSON.
-    pub type_index: u32,
-    /// The challenge index is the starting index of the challenge in the client data JSON.
-    pub challenge_index: u32,
     /// The signature over the authenticator data and client data JSON hash.
     pub signature: BytesN<64>,
 }
@@ -53,16 +78,19 @@ pub fn verify(
     credential: &WebAuthnCredential,
     public_key: &BytesN<65>,
 ) {
-    // 1. Verify the Webauthn type
-    const WEBAUTHN_TYPE_GET_LEN: u32 = 12;
-
-    let type_slice = credential
+    // Parse the client data JSON
+    let client_data_json = credential
         .client_data_json
-        .slice(credential.type_index..(credential.type_index + WEBAUTHN_TYPE_GET_LEN));
+        .to_buffer::<MAX_CLIENT_DATA_JSON_LEN>();
+    let client_data_json = client_data_json.as_slice();
 
-    let expected_type = Bytes::from_slice(env, WEBAUTHN_TYPE_GET.as_bytes());
+    let (client_data, _): (ClientDataJson, _) = serde_json_core::de::from_slice(client_data_json)
+        .unwrap_or_else(|_| {
+            panic_with_error!(env, AccountContractError::WebAuthnInvalidClientData);
+        });
 
-    if !type_slice.eq(&expected_type) {
+    // 1. Verify the Webauthn type
+    if client_data.r#type != WEBAUTHN_TYPE_GET {
         panic_with_error!(env, AccountContractError::WebAuthnInvalidType);
     }
 
@@ -83,23 +111,10 @@ pub fn verify(
     }
 
     // 3. Verify the challenge
-    let challenge_start = credential.challenge_index;
-    let challenge_end = challenge_start + ENCODED_CHALLENGE_LEN;
+    let mut expected_challenge = [0_u8; ENCODED_CHALLENGE_LEN as usize];
+    base64_url::encode(&mut expected_challenge, &signature_payload.to_array());
 
-    if challenge_end > credential.client_data_json.len() {
-        panic_with_error!(env, AccountContractError::WebAuthnInvalidChallenge);
-    }
-
-    // Compare actual challenge with expected challenge
-    let actual_challenge = credential
-        .client_data_json
-        .slice(challenge_start..challenge_end);
-
-    let mut encoded_challenge_buffer = [0_u8; ENCODED_CHALLENGE_LEN as usize];
-    base64_url::encode(&mut encoded_challenge_buffer, &signature_payload.to_array());
-    let expected_challenge = Bytes::from_slice(env, &encoded_challenge_buffer);
-
-    if expected_challenge != actual_challenge {
+    if client_data.challenge.as_bytes() != expected_challenge {
         panic_with_error!(env, AccountContractError::WebAuthnInvalidChallenge);
     }
 


### PR DESCRIPTION
### What

This fixes how the `challenge` and `type` fields are extracted from the client data JSON. Instead of asking the user to provide the offsets of these fields, the client data JSON is parsed by `serde_json_core`.

### Why

Asking the client to provide the offsets can result in the user unintentionally authorizing transactions if the challenge offset provided is outside of the `challenge` field.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
