### PR TITLE
SDP-1485: add API endpoint to unregistering a receiver wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - Add API keys management endpoints [#677](https://github.com/stellar/stellar-disbursement-platform-backend/pull/677)
+- Added a new endpoint to unregister a receiver wallet `PATCH /receivers/wallets/:id/status`. [#675](https://github.com/stellar/stellar-disbursement-platform-backend/pull/675)
 
 ## [3.7.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/3.7.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/3.6.0...3.7.0))
 
@@ -17,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- Update integration test to wait for the payment to be processed by TSS/Circle with a retry mechanism. [#585](https://github.com/stellar/stellar-disbursement-platform-backend/pull/585)
+- Update integration tests to wait for the payment to be processed by TSS/Circle with a retry mechanism. [#585](https://github.com/stellar/stellar-disbursement-platform-backend/pull/585)
 - Add Circle Payouts API to the e2e integration test. [#586](https://github.com/stellar/stellar-disbursement-platform-backend/pull/586)
 - A React app for the SEP-24 interactive deposit flow. This app is served by the backend and is accessible at `/wallet-registration/start`. [#560](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/560)
 - A new endpoint `GET /sep24-interactive-deposit/info` to kick off the SEP-24 interactive deposit flow. [#560](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/560)

--- a/db/migrations/sdp-migrations/2025-05-18.0-receiver-wallets-add-status-message.sql
+++ b/db/migrations/sdp-migrations/2025-05-18.0-receiver-wallets-add-status-message.sql
@@ -1,0 +1,91 @@
+-- This migration extends status_history JSON objects with a status_message key for the receiver_wallets table.
+-- It also adds an audit table to the receiver_wallets table to track changes.
+
+-- +migrate Up
+
+-- 1. Extend status_history JSON objects with a status_message key for the receiver_wallets table.
+ALTER TABLE receiver_wallets
+    ALTER COLUMN status_history DROP DEFAULT;
+
+DROP FUNCTION IF EXISTS create_receiver_wallet_status_history(
+    TIMESTAMP WITH TIME ZONE,
+    receiver_wallet_status
+) CASCADE;
+
+-- +migrate StatementBegin
+CREATE FUNCTION create_receiver_wallet_status_history(
+    time_stamp TIMESTAMP WITH TIME ZONE,
+    rw_status receiver_wallet_status,
+    status_message TEXT
+) RETURNS JSONB AS $$
+    BEGIN
+        RETURN json_build_object(
+                'timestamp',     time_stamp,
+                'status',        rw_status,
+                'status_message', status_message
+               );
+    END;
+$$ LANGUAGE plpgsql;
+-- +migrate StatementEnd
+
+UPDATE receiver_wallets
+SET status_history = (
+    SELECT array_agg(jsonb_set(s.elem, '{status_message}', '""'::jsonb))
+    FROM (
+        SELECT elem
+        FROM   unnest(status_history) WITH ORDINALITY AS t(elem, ord)
+        ORDER BY ord, elem
+    ) s
+);
+
+ALTER TABLE receiver_wallets
+    ALTER COLUMN status_history
+        SET DEFAULT ARRAY[
+            create_receiver_wallet_status_history(
+                    NOW(),
+                    receiver_wallet_status('DRAFT'),
+                    ''
+            )
+        ];
+
+
+-- 2. Create the audit table for receiver_wallets
+SELECT 1 FROM create_audit_table('receiver_wallets');
+
+-- +migrate Down
+
+-- 1. Remove the status_message field from the receiver_wallets table
+ALTER TABLE receiver_wallets
+    ALTER COLUMN status_history DROP DEFAULT;
+
+DROP FUNCTION IF EXISTS create_receiver_wallet_status_history(
+    TIMESTAMP WITH TIME ZONE,
+    receiver_wallet_status,
+    TEXT
+);
+
+-- +migrate StatementBegin
+CREATE FUNCTION create_receiver_wallet_status_history(
+    time_stamp TIMESTAMP WITH TIME ZONE,
+    rw_status receiver_wallet_status
+) RETURNS JSONB AS $$
+    BEGIN
+        RETURN json_build_object(
+                'timestamp', time_stamp,
+                'status',    rw_status
+               );
+    END;
+$$ LANGUAGE plpgsql;
+-- +migrate StatementEnd
+
+ALTER TABLE receiver_wallets
+    ALTER COLUMN status_history
+        SET DEFAULT ARRAY[
+            create_receiver_wallet_status_history(
+                    NOW(),
+                    receiver_wallet_status('DRAFT')
+            )
+        ];
+
+-- 2. Drop the audit table for receiver_wallets
+SELECT 1 FROM drop_audit_table('receiver_wallets');

--- a/internal/data/receiver_verification_audit_test.go
+++ b/internal/data/receiver_verification_audit_test.go
@@ -128,6 +128,8 @@ func getLastReceiverVerificationsAuditEntry(
 	receiverID string,
 	verificationField VerificationType,
 ) receiverVerificationAuditEntry {
+	t.Helper()
+
 	const query = `
 		SELECT *, operation, changed_at 
 		FROM receiver_verifications_audit 

--- a/internal/data/receiver_wallets_audit_test.go
+++ b/internal/data/receiver_wallets_audit_test.go
@@ -1,0 +1,107 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/db"
+)
+
+type receiverWalletsAuditEntry struct {
+	ReceiverWallet
+	Operation string    `db:"operation"`
+	ChangedAt time.Time `db:"changed_at"`
+}
+
+func Test_ReceiverWalletsAudit(t *testing.T) {
+	ctx := context.Background()
+	models := SetupModels(t)
+	wallet := CreateDefaultWalletFixture(t, ctx, models.DBConnectionPool)
+
+	testCases := []struct {
+		name      string
+		operation string
+		setup     func(*testing.T, context.Context, db.DBConnectionPool) *ReceiverWallet
+	}{
+		{
+			name:      "🎉 insert operation is logged",
+			operation: "INSERT",
+			setup: func(t *testing.T, ctx context.Context, db db.DBConnectionPool) *ReceiverWallet {
+				receiver := CreateReceiverFixture(t, ctx, models.DBConnectionPool, &Receiver{})
+				return CreateReceiverWalletFixture(t, ctx, db, receiver.ID, wallet.ID, ReadyReceiversWalletStatus)
+			},
+		},
+		{
+			name:      "🎉 update operation is logged",
+			operation: "UPDATE",
+			setup: func(t *testing.T, ctx context.Context, db db.DBConnectionPool) *ReceiverWallet {
+				receiver := CreateReceiverFixture(t, ctx, models.DBConnectionPool, &Receiver{})
+				rw := CreateReceiverWalletFixture(t, ctx, db, receiver.ID, wallet.ID, ReadyReceiversWalletStatus)
+
+				err := models.ReceiverWallet.Update(ctx, rw.ID, ReceiverWalletUpdate{
+					StellarAddress: keypair.MustRandom().Address(),
+				}, models.DBConnectionPool)
+				require.NoError(t, err)
+
+				return rw
+			},
+		},
+		{
+			name:      "🎉 delete operation is logged",
+			operation: "DELETE",
+			setup: func(t *testing.T, ctx context.Context, db db.DBConnectionPool) *ReceiverWallet {
+				receiver := CreateReceiverFixture(t, ctx, models.DBConnectionPool, &Receiver{})
+				rw := CreateReceiverWalletFixture(t, ctx, db, receiver.ID, wallet.ID, ReadyReceiversWalletStatus)
+				_, err := db.ExecContext(ctx, `DELETE FROM receiver_wallets WHERE id = $1`, rw.ID)
+				require.NoError(t, err)
+				return rw
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rw := tc.setup(t, ctx, models.DBConnectionPool)
+			latestEntry := getLastReceiverWalletsAuditEntry(t, ctx, models.DBConnectionPool, rw.ID)
+
+			// ☑️ check audit metadata fields
+			assert.Equal(t, tc.operation, latestEntry.Operation)
+			assert.WithinDuration(t, time.Now(), latestEntry.ChangedAt, 5*time.Second)
+
+			// ☑️ check receiver wallet fields
+			assert.Equal(t, rw.Status, latestEntry.Status)
+			assert.Equal(t, rw.Receiver.ID, latestEntry.Receiver.ID)
+		})
+	}
+}
+
+// getLastReceiverWalletsAuditEntry retrieves the last audit entry for a receiver wallet
+func getLastReceiverWalletsAuditEntry(
+	t *testing.T,
+	ctx context.Context,
+	db db.DBConnectionPool,
+	receiverWalletID string,
+) receiverWalletsAuditEntry {
+	query := `
+		SELECT operation, changed_at,
+			` + ReceiverWalletColumnNames("rw", "") + `,
+			` + WalletColumnNames("w", "wallet", false) + `
+		FROM
+			receiver_wallets_audit rw
+		JOIN
+			wallets w ON rw.wallet_id = w.id
+		WHERE rw.id = $1  
+		ORDER BY rw.changed_at DESC
+	`
+
+	var lastEntry receiverWalletsAuditEntry
+	err := db.GetContext(ctx, &lastEntry, query, receiverWalletID)
+	require.NoError(t, err)
+
+	return lastEntry
+}

--- a/internal/data/receiver_wallets_audit_test.go
+++ b/internal/data/receiver_wallets_audit_test.go
@@ -87,6 +87,8 @@ func getLastReceiverWalletsAuditEntry(
 	db db.DBConnectionPool,
 	receiverWalletID string,
 ) receiverWalletsAuditEntry {
+	t.Helper()
+
 	query := `
 		SELECT operation, changed_at,
 			` + ReceiverWalletColumnNames("rw", "") + `,

--- a/internal/data/receiver_wallets_state_machine.go
+++ b/internal/data/receiver_wallets_state_machine.go
@@ -46,3 +46,17 @@ func (status ReceiversWalletStatus) Validate() error {
 		return fmt.Errorf("invalid receiver wallet status %q", status)
 	}
 }
+
+// ToReceiversWalletStatus converts a string to a ReceiversWalletStatus.
+func ToReceiversWalletStatus(s string) (ReceiversWalletStatus, error) {
+	err := ReceiversWalletStatus(s).Validate()
+	if err != nil {
+		return "", fmt.Errorf("invalid status: %w", err)
+	}
+	return ReceiversWalletStatus(strings.ToUpper(s)), nil
+}
+
+// ReceiversWalletStatuses returns a list of all possible receiver wallet statuses
+func ReceiversWalletStatuses() []ReceiversWalletStatus {
+	return []ReceiversWalletStatus{DraftReceiversWalletStatus, ReadyReceiversWalletStatus, RegisteredReceiversWalletStatus, FlaggedReceiversWalletStatus}
+}

--- a/internal/data/receiver_wallets_state_machine_test.go
+++ b/internal/data/receiver_wallets_state_machine_test.go
@@ -1,9 +1,11 @@
 package data
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ReceiversWalletStatus_TransitionTo(t *testing.T) {
@@ -106,6 +108,58 @@ func Test_ReceiversWalletStatus_Validate(t *testing.T) {
 				assert.NoError(t, err)
 			} else {
 				assert.EqualError(t, err, tt.err)
+			}
+		})
+	}
+}
+
+func Test_ReceiversWalletStatus_ReceiversWalletStatuses(t *testing.T) {
+	expectedStatuses := []ReceiversWalletStatus{DraftReceiversWalletStatus, ReadyReceiversWalletStatus, RegisteredReceiversWalletStatus, FlaggedReceiversWalletStatus}
+	require.Equal(t, expectedStatuses, ReceiversWalletStatuses())
+}
+
+func Test_ReceiversWalletStatus_ToReceiversWalletStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		actual string
+		want   ReceiversWalletStatus
+		err    error
+	}{
+		{
+			name:   "valid status",
+			actual: "DRAFT",
+			want:   DraftReceiversWalletStatus,
+			err:    nil,
+		},
+		{
+			name:   "valid status with lower case",
+			actual: "draft",
+			want:   DraftReceiversWalletStatus,
+			err:    nil,
+		},
+		{
+			name:   "valid status with mixed case",
+			actual: "DrAfT",
+			want:   DraftReceiversWalletStatus,
+			err:    nil,
+		},
+		{
+			name:   "invalid status",
+			actual: "INVALID",
+			want:   "",
+			err:    fmt.Errorf("invalid receiver wallet status \"INVALID\""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToReceiversWalletStatus(tt.actual)
+
+			if tt.err != nil {
+				assert.ErrorContains(t, err, tt.err.Error())
+				return
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}

--- a/internal/serve/httphandler/receiver_send_otp_handler_test.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler_test.go
@@ -420,7 +420,7 @@ func Test_ReceiverSendOTPHandler_ServeHTTP_otpHandlerIsCalled(t *testing.T) {
 					PhoneNumber: tc.receiverSendOTPRequest.PhoneNumber,
 					Email:       tc.receiverSendOTPRequest.Email,
 				})
-				data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+				data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
 				data.CreateReceiverVerificationFixture(t, ctx, dbConnectionPool, data.ReceiverVerificationInsert{
 					ReceiverID:        receiver.ID,
 					VerificationField: tc.verificationField,
@@ -793,7 +793,7 @@ func Test_ReceiverSendOTPHandler_handleOTPForReceiver(t *testing.T) {
 					VerificationField: data.VerificationTypePin,
 					VerificationValue: "123456",
 				})
-				_ = data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiverWithWallet.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+				_ = data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiverWithWallet.ID, wallet.ID, data.ReadyReceiversWalletStatus)
 
 				getEntries := log.DefaultLogger.StartTest(logrus.DebugLevel)
 

--- a/internal/serve/httphandler/receiver_wallets_handler.go
+++ b/internal/serve/httphandler/receiver_wallets_handler.go
@@ -1,9 +1,12 @@
 package httphandler
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -86,4 +89,68 @@ func (h ReceiverWalletsHandler) RetryInvitation(rw http.ResponseWriter, req *htt
 	}
 
 	httpjson.RenderStatus(rw, http.StatusOK, response, httpjson.JSON)
+}
+
+type PatchReceiverWalletStatusRequest struct {
+	Status string `json:"status"`
+}
+
+var ErrUnsupportedStatusTransition = errors.New("invalid target status")
+
+// PatchReceiverWalletStatus updates a receiver wallet’s status.
+func (h ReceiverWalletsHandler) PatchReceiverWalletStatus(rw http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	receiverWalletID := chi.URLParam(req, "receiver_wallet_id")
+	if strings.TrimSpace(receiverWalletID) == "" {
+		httperror.BadRequest("receiver_wallet_id is required", nil, nil).Render(rw)
+		return
+	}
+
+	var patchRequest PatchReceiverWalletStatusRequest
+	err := json.NewDecoder(req.Body).Decode(&patchRequest)
+	if err != nil {
+		httperror.BadRequest("invalid request", err, nil).Render(rw)
+		return
+	}
+
+	// validate request
+	toStatus, err := data.ToReceiversWalletStatus(patchRequest.Status)
+	if err != nil {
+		errMsg := fmt.Sprintf("invalid status %q; valid values %v", patchRequest.Status, data.ReceiversWalletStatuses())
+		httperror.BadRequest(errMsg, nil, nil).Render(rw)
+		return
+	}
+
+	if err = h.validateAndUpdateStatus(ctx, receiverWalletID, toStatus); err != nil {
+		if errors.Is(err, data.ErrRecordNotFound) {
+			httperror.NotFound("receiver wallet not found", err, nil).Render(rw)
+			return
+		} else if errors.Is(err, ErrUnsupportedStatusTransition) {
+			errMsg := fmt.Sprintf("switching to status %q is not supported", toStatus)
+			httperror.BadRequest(errMsg, nil, nil).Render(rw)
+			return
+		} else if errors.Is(err, data.ErrWalletNotRegistered) {
+			httperror.BadRequest("receiver wallet is not registered", err, nil).Render(rw)
+			return
+		}
+		httperror.InternalError(ctx, "", err, nil).Render(rw)
+		return
+	}
+
+	okMessage := fmt.Sprintf("receiver wallet status updated to %q", toStatus)
+	httpjson.RenderStatus(rw, http.StatusOK, map[string]string{"message": okMessage}, httpjson.JSON)
+}
+
+// validateAndUpdateStatus validates the status transition and updates the receiver wallet status.
+func (h ReceiverWalletsHandler) validateAndUpdateStatus(ctx context.Context, receiverWalletID string, toStatus data.ReceiversWalletStatus) error {
+	switch toStatus {
+	case data.ReadyReceiversWalletStatus:
+		err := h.Models.ReceiverWallet.UpdateStatusToReady(ctx, receiverWalletID)
+		if err != nil {
+			return fmt.Errorf("updating receiver wallet %s: %w", receiverWalletID, err)
+		}
+		return nil
+	default:
+		return ErrUnsupportedStatusTransition
+	}
 }

--- a/internal/serve/httphandler/receiver_wallets_handler_test.go
+++ b/internal/serve/httphandler/receiver_wallets_handler_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -230,4 +232,157 @@ func Test_RetryInvitation(t *testing.T) {
 		require.Len(t, entries, 1)
 		assert.Equal(t, fmt.Sprintf("event producer is nil, could not publish messages %+v", []events.Message{msg}), entries[0].Message)
 	})
+}
+
+func Test_ReceiverWalletsHandler_PatchReceiverWalletStatus(t *testing.T) {
+	type TestCase struct {
+		name           string
+		setup          func(ctx context.Context, t *testing.T) (models *data.Models, receiverWalletID string)
+		body           string
+		expectedStatus int
+		expectedJSON   string
+	}
+
+	ctx := context.Background()
+
+	tests := []TestCase{
+		{
+			name: "400 – missing receiver_wallet_id URL param",
+			setup: func(_ context.Context, _ *testing.T) (*data.Models, string) {
+				return data.SetupModels(t), ""
+			},
+			body:           `{"status":"READY"}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedJSON:   `{"error":"receiver_wallet_id is required"}`,
+		},
+		{
+			name: "400 – invalid JSON in request body",
+			setup: func(_ context.Context, _ *testing.T) (*data.Models, string) {
+				return data.SetupModels(t), "irrelevant-id"
+			},
+			body:           `{"status": READY}`, // malformed JSON
+			expectedStatus: http.StatusBadRequest,
+			expectedJSON:   `{"error":"invalid request"}`,
+		},
+		{
+			name: "400 – unknown status value",
+			setup: func(_ context.Context, _ *testing.T) (*data.Models, string) {
+				return data.SetupModels(t), "wallet-id"
+			},
+			body:           `{"status":"UNKNOWN_STATUS"}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedJSON:   `{"error":"invalid status \"UNKNOWN_STATUS\"; valid values [DRAFT READY REGISTERED FLAGGED]"}`,
+		},
+		{
+			name: "404 – receiver wallet not found",
+			setup: func(ctx context.Context, _ *testing.T) (*data.Models, string) {
+				return data.SetupModels(t), "non-existent-id"
+			},
+			body:           `{"status":"READY"}`,
+			expectedStatus: http.StatusNotFound,
+			expectedJSON:   `{"error":"receiver wallet not found"}`,
+		},
+		{
+			name: "400 – receiver wallet not registered",
+			setup: func(ctx context.Context, t *testing.T) (*data.Models, string) {
+				models := data.SetupModels(t)
+				dbPool := models.DBConnectionPool
+				// create wallet & receiver wallet already in READY (≠ REGISTERED)
+				wallet := data.CreateDefaultWalletFixture(t, ctx, dbPool)
+				recv := data.CreateReceiverFixture(t, ctx, dbPool, &data.Receiver{})
+				rw := data.CreateReceiverWalletFixture(t, ctx, dbPool, recv.ID, wallet.ID,
+					data.ReadyReceiversWalletStatus)
+
+				return models, rw.ID
+			},
+			body:           `{"status":"READY"}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedJSON:   `{"error":"receiver wallet is not registered"}`,
+		},
+		{
+			name: "400 – unsupported status transition to [FLAGGED]",
+			setup: func(ctx context.Context, t *testing.T) (*data.Models, string) {
+				models := data.SetupModels(t)
+				dbPool := models.DBConnectionPool
+
+				wallet := data.CreateDefaultWalletFixture(t, ctx, dbPool)
+				recv := data.CreateReceiverFixture(t, ctx, dbPool, &data.Receiver{})
+				rw := data.CreateReceiverWalletFixture(t, ctx, dbPool, recv.ID, wallet.ID,
+					data.RegisteredReceiversWalletStatus)
+
+				return models, rw.ID
+			},
+			body:           `{"status":"FLAGGED"}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedJSON:   `{"error":"switching to status \"FLAGGED\" is not supported"}`,
+		},
+		{
+			name: "500 – unexpected DB error bubbles up as internal error",
+			setup: func(ctx context.Context, t *testing.T) (*data.Models, string) {
+				models := data.SetupModels(t)
+				dbPool := models.DBConnectionPool
+
+				wallet := data.CreateDefaultWalletFixture(t, ctx, dbPool)
+				recv := data.CreateReceiverFixture(t, ctx, dbPool, &data.Receiver{})
+				rw := data.CreateReceiverWalletFixture(t, ctx, dbPool, recv.ID, wallet.ID,
+					data.RegisteredReceiversWalletStatus)
+
+				// close pool so UpdateStatusToReady fails with a generic error
+				dbPool.Close()
+
+				return models, rw.ID
+			},
+			body:           `{"status":"READY"}`,
+			expectedStatus: http.StatusInternalServerError,
+			expectedJSON:   `{"error":"An internal error occurred while processing this request."}`,
+		},
+		{
+			name: "200 – happy path, status updated to READY",
+			setup: func(ctx context.Context, t *testing.T) (*data.Models, string) {
+				models := data.SetupModels(t)
+				dbPool := models.DBConnectionPool
+
+				wallet := data.CreateDefaultWalletFixture(t, ctx, dbPool)
+				recv := data.CreateReceiverFixture(t, ctx, dbPool, &data.Receiver{})
+				rw := data.CreateReceiverWalletFixture(t, ctx, dbPool, recv.ID, wallet.ID,
+					data.RegisteredReceiversWalletStatus)
+
+				return models, rw.ID
+			},
+			body:           `{"status":"READY"}`,
+			expectedStatus: http.StatusOK,
+			expectedJSON:   `{"message":"receiver wallet status updated to \"READY\""}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			models, receiverWalletID := tc.setup(ctx, t)
+
+			handler := ReceiverWalletsHandler{Models: models}
+			router := chi.NewRouter()
+			router.Patch("/receivers/wallets/{receiver_wallet_id}/status", handler.PatchReceiverWalletStatus)
+
+			url := fmt.Sprintf("/receivers/wallets/%s/status", receiverWalletID)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(tc.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			resp := rr.Result()
+			assert.Equal(t, tc.expectedStatus, resp.StatusCode)
+
+			respBody, readErr := io.ReadAll(resp.Body)
+			require.NoError(t, readErr)
+
+			if tc.expectedJSON != "" {
+				assert.JSONEq(t, tc.expectedJSON, string(respBody))
+			}
+		})
+	}
 }

--- a/internal/serve/httphandler/verify_receiver_registration_handler.go
+++ b/internal/serve/httphandler/verify_receiver_registration_handler.go
@@ -177,15 +177,13 @@ func (v VerifyReceiverRegistrationHandler) processReceiverVerificationPII(
 	}
 
 	// STEP 4: update the receiver verification row with the confirmation that the value was successfully validated
-	if receiverVerification.ConfirmedAt == nil {
-		rvu.ConfirmedAt = &now
-		rvu.ConfirmedByID = receiver.ID
-		rvu.ConfirmedByType = data.ConfirmedByTypeReceiver
+	rvu.ConfirmedAt = &now
+	rvu.ConfirmedByID = receiver.ID
+	rvu.ConfirmedByType = data.ConfirmedByTypeReceiver
 
-		err = v.Models.ReceiverVerification.UpdateReceiverVerification(ctx, rvu, dbTx)
-		if err != nil {
-			return fmt.Errorf("updating successfully verified user: %w", err)
-		}
+	err = v.Models.ReceiverVerification.UpdateReceiverVerification(ctx, rvu, dbTx)
+	if err != nil {
+		return fmt.Errorf("updating successfully verified user: %w", err)
 	}
 
 	return nil

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -344,6 +344,8 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			}
 			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
 				Patch("/wallets/{receiver_wallet_id}", receiverWalletHandler.RetryInvitation)
+			r.With(middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole)).
+				Patch("/wallets/{receiver_wallet_id}/status", receiverWalletHandler.PatchReceiverWalletStatus)
 		})
 
 		r.

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -438,6 +438,7 @@ func Test_handleHTTP_authenticatedEndpoints(t *testing.T) {
 		{http.MethodGet, "/receivers/1234"},
 		{http.MethodPatch, "/receivers/1234"},
 		{http.MethodPatch, "/receivers/wallets/1234"},
+		{http.MethodPatch, "/receivers/wallets/1234/status"},
 		{http.MethodGet, "/receivers/verification-types"},
 		// Receiver Contact Types
 		{http.MethodGet, "/registration-contact-types"},

--- a/stellar-multitenant/internal/httphandler/tenants_handler_test.go
+++ b/stellar-multitenant/internal/httphandler/tenants_handler_test.go
@@ -356,6 +356,7 @@ func Test_TenantHandler_Post(t *testing.T) {
 			"receiver_verifications",
 			"receiver_verifications_audit",
 			"receiver_wallets",
+			"receiver_wallets_audit",
 			"receivers",
 			"receivers_audit",
 			"sdp_migrations",

--- a/stellar-multitenant/internal/provisioning/manager_test.go
+++ b/stellar-multitenant/internal/provisioning/manager_test.go
@@ -463,6 +463,7 @@ func getExpectedTablesAfterMigrationsApplied() []string {
 		"receiver_verifications",
 		"receiver_verifications_audit",
 		"receiver_wallets",
+		"receiver_wallets_audit",
 		"receivers",
 		"receivers_audit",
 		"sdp_migrations",


### PR DESCRIPTION
### What
- Add a new endpoint `PATCH /receivers/wallets/:receiver-wallet-id/status` that allows for switching the status of a receiver-wallet. Currently, only path supported is `REGISTERED` -> `READY`, which means we're unregistering the receiver-wallet. We may later decide to also allow marking a wallet as flagged. 

### Why
- Allow users to unregister a wallet in order to force registration again. 



### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [x] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [x] Ready for production
