### PR TITLE
Feat: Turn on service account use in the ap deployment in the helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - Add API keys management endpoints [#677](https://github.com/stellar/stellar-disbursement-platform-backend/pull/677)
+- Allow the serviceaccount to be set for the ap deployment in the helm chart [#679](https://github.com/stellar/stellar-disbursement-platform-backend/pull/679)
 
 ## [3.7.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/3.7.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/3.6.0...3.7.0))
 

--- a/helmchart/sdp/templates/02.2-deployment-ap.yaml
+++ b/helmchart/sdp/templates/02.2-deployment-ap.yaml
@@ -31,9 +31,9 @@ spec:
       labels:
         {{- include "sdp.selectorLabelsWithSuffix" (list . "-ap") | nindent 8 }}
     spec:
-      # {{- if .Values.global.serviceAccount.name }}
-      # serviceAccountName: {{ tpl .Values.global.serviceAccount.name $ }}
-      # {{- end }}
+      {{- if .Values.global.serviceAccount.name }}
+      serviceAccountName: {{ tpl .Values.global.serviceAccount.name $ }}
+      {{- end }}
       {{- if or .Values.anchorPlatform.deployment.priorityClassName .Values.global.deployment.priorityClassName }}
       priorityClassName: {{ .Values.anchorPlatform.deployment.priorityClassName | default .Values.global.deployment.priorityClassName | quote }}
       {{- end }}


### PR DESCRIPTION
### What

Turn on the service account in the helm chart for the ap deployment

### Why

Currently the serviceaccount name is commented out while all the other deployments have the serviceaccountname set up

### Known limitations

[TODO or N/A]

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [x] Ready for production
