### PR TITLE
SDP-1614: Use path parameter instead of query parameter

### DIFF
--- a/internal/serve/httphandler/wallet_creation_handler.go
+++ b/internal/serve/httphandler/wallet_creation_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/stellar/go/support/http/httpdecode"
 	"github.com/stellar/go/support/render/httpjson"
 
@@ -78,7 +79,7 @@ func (h WalletCreationHandler) CreateWallet(rw http.ResponseWriter, req *http.Re
 
 func (h WalletCreationHandler) GetWallet(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	token := strings.TrimSpace(req.URL.Query().Get("token"))
+	token := strings.TrimSpace(chi.URLParam(req, "token"))
 	if len(token) == 0 {
 		httperror.BadRequest("Token is required", nil, nil).Render(rw)
 		return

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -515,7 +515,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 					EmbeddedWalletService: o.EmbeddedWalletService,
 				}
 				r.Post("/", walletCreationHandler.CreateWallet)
-				r.Get("/status", walletCreationHandler.GetWallet)
+				r.Get("/{token}", walletCreationHandler.GetWallet)
 			})
 		}
 


### PR DESCRIPTION
### What

Use the path parameter instead of the query parameter in the wallet creation status endpoint.

### Why

Using path parameters is more RESTful.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
