### PR TITLE
SDP-1644:  [Create direct payment] - Remove Receiver Invitation event dispatching. 

### DIFF
--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -384,18 +384,19 @@ func (p PaymentsHandler) PostDirectPayment(w http.ResponseWriter, r *http.Reques
 	payment, err := p.DirectPaymentService.CreateDirectPayment(ctx, serviceReq, user, &distAccount)
 	if err != nil {
 		var (
-			validationErr        services.ValidationError
-			notFoundErr          services.NotFoundError
-			unsupportedErr       services.UnsupportedError
-			ambiguousErr         services.AmbiguousReferenceError
-			insufficientFundsErr services.InsufficientBalanceForDirectPaymentError
-			walletDisabledErr    services.WalletNotEnabledError
-			assetNotSupportedErr services.AssetNotSupportedByWalletError
-			recvErr              services.ReceiverWalletNotFoundError
-			trustErr             services.TrustlineNotFoundError
-			accErr               services.AccountNotFoundError
-			circleAccErr         services.CircleAccountNotActivatedError
-			circleAssetErr       services.CircleAssetNotSupportedError
+			validationErr         services.ValidationError
+			notFoundErr           services.NotFoundError
+			unsupportedErr        services.UnsupportedError
+			ambiguousErr          services.AmbiguousReferenceError
+			insufficientFundsErr  services.InsufficientBalanceForDirectPaymentError
+			walletDisabledErr     services.WalletNotEnabledError
+			assetNotSupportedErr  services.AssetNotSupportedByWalletError
+			recvErr               services.ReceiverWalletNotFoundError
+			recvWalletNotReadyErr services.ReceiverWalletNotReadyForPaymentError
+			trustErr              services.TrustlineNotFoundError
+			accErr                services.AccountNotFoundError
+			circleAccErr          services.CircleAccountNotActivatedError
+			circleAssetErr        services.CircleAssetNotSupportedError
 		)
 
 		switch {
@@ -414,19 +415,21 @@ func (p PaymentsHandler) PostDirectPayment(w http.ResponseWriter, r *http.Reques
 			httperror.BadRequest(walletDisabledErr.Error(), err, nil).Render(w)
 		case errors.As(err, &assetNotSupportedErr):
 			httperror.BadRequest(assetNotSupportedErr.Error(), err, nil).Render(w)
+		case errors.As(err, &recvWalletNotReadyErr):
+			httperror.BadRequest(recvWalletNotReadyErr.Error(), err, nil).Render(w)
 		case errors.As(err, &recvErr):
-			httperror.BadRequest(err.Error(), err, nil).Render(w)
+			httperror.BadRequest(recvErr.Error(), err, nil).Render(w)
 		case errors.As(err, &trustErr):
-			errorMsg := fmt.Sprintf("%s. Please add a trustline for this asset to your distribution account, or choose a different asset that already has a trustline.", err.Error())
+			errorMsg := fmt.Sprintf("%s. Please add a trustline for this asset to your distribution account, or choose a different asset that already has a trustline.", trustErr.Error())
 			httperror.BadRequest(errorMsg, err, nil).Render(w)
 		case errors.As(err, &circleAccErr):
-			errorMsg := fmt.Sprintf("%s. Please complete the Circle account activation process...", err.Error())
+			errorMsg := fmt.Sprintf("%s. Please complete the Circle account activation process...", circleAccErr.Error())
 			httperror.BadRequest(errorMsg, err, nil).Render(w)
 		case errors.As(err, &circleAssetErr):
-			errorMsg := fmt.Sprintf("%s. Please choose a different asset supported by Circle...", err.Error())
+			errorMsg := fmt.Sprintf("%s. Please choose a different asset supported by Circle...", circleAssetErr.Error())
 			httperror.BadRequest(errorMsg, err, nil).Render(w)
 		case errors.As(err, &accErr):
-			errorMsg := fmt.Sprintf("%s. Please ensure your distribution account exists and is funded on the Stellar network.", err.Error())
+			errorMsg := fmt.Sprintf("%s. Please ensure your distribution account exists and is funded on the Stellar network.", accErr.Error())
 			httperror.BadRequest(errorMsg, err, nil).Render(w)
 		default:
 			httperror.InternalError(ctx, "creating payment", err, nil).Render(w)

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -391,7 +391,7 @@ func (p PaymentsHandler) PostDirectPayment(w http.ResponseWriter, r *http.Reques
 			insufficientFundsErr services.InsufficientBalanceForDirectPaymentError
 			walletDisabledErr    services.WalletNotEnabledError
 			assetNotSupportedErr services.AssetNotSupportedByWalletError
-			recvErr              services.ErrReceiverWalletNotFound
+			recvErr              services.ReceiverWalletNotFoundError
 			trustErr             services.TrustlineNotFoundError
 			accErr               services.AccountNotFoundError
 			circleAccErr         services.CircleAccountNotActivatedError

--- a/internal/services/direct_payment_service.go
+++ b/internal/services/direct_payment_service.go
@@ -71,12 +71,12 @@ func (e WalletNotEnabledError) Error() string {
 	return fmt.Sprintf("wallet '%s' is not enabled for payments", e.WalletName)
 }
 
-type ErrReceiverWalletNotFound struct {
+type ReceiverWalletNotFoundError struct {
 	ReceiverID string
 	WalletID   string
 }
 
-func (e ErrReceiverWalletNotFound) Error() string {
+func (e ReceiverWalletNotFoundError) Error() string {
 	return fmt.Sprintf("no receiver wallet: receiver=%s wallet=%s", e.ReceiverID, e.WalletID)
 }
 
@@ -287,7 +287,7 @@ func (s *DirectPaymentService) getReceiverWallet(
 	}
 
 	if len(receiverWallets) == 0 {
-		return nil, &ErrReceiverWalletNotFound{
+		return nil, &ReceiverWalletNotFoundError{
 			ReceiverID: receiverID,
 			WalletID:   walletID,
 		}

--- a/internal/services/direct_payment_service_test.go
+++ b/internal/services/direct_payment_service_test.go
@@ -448,7 +448,7 @@ func TestDirectPaymentService_CreateDirectPayment_Scenarios(t *testing.T) {
 		assert.Nil(t, payment)
 
 		err = unwrapTransactionError(err)
-		var rwErr *ErrReceiverWalletNotFound
+		var rwErr *ReceiverWalletNotFoundError
 		assert.True(t, errors.As(err, &rwErr))
 		assert.Contains(t, err.Error(), "no receiver wallet")
 

--- a/internal/services/direct_payment_service_test.go
+++ b/internal/services/direct_payment_service_test.go
@@ -261,6 +261,43 @@ func TestDirectPaymentService_CreateDirectPayment_Scenarios(t *testing.T) {
 		horizonClientMock.AssertExpectations(t)
 	})
 
+	t.Run("fails when receiver wallet not ready for payment", func(t *testing.T) {
+		t.Cleanup(func() {
+			data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
+			data.DeleteAllReceiverWalletsFixtures(t, ctx, dbConnectionPool)
+		})
+
+		receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{
+			Email: "john.doe@example.com",
+		})
+		data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, enabledWallet.ID, data.DraftReceiversWalletStatus)
+
+		req := CreateDirectPaymentRequest{
+			Amount:   "10.00",
+			Asset:    AssetReference{ID: &asset.ID},
+			Receiver: ReceiverReference{ID: &receiver.ID},
+			Wallet:   WalletReference{ID: &enabledWallet.ID},
+		}
+
+		horizonClientMock := &horizonclient.MockClient{}
+		mockDistService := &mocks.MockDistributionAccountService{}
+		mockEventProducer := events.NewMockProducer(t)
+
+		service := NewDirectPaymentService(models, mockEventProducer, mockDistService, engine.SubmitterEngine{
+			HorizonClient: horizonClientMock,
+		})
+
+		payment, err := service.CreateDirectPayment(ctx, req, user, &stellarDistAccountDBVault)
+
+		require.Error(t, err)
+		assert.Nil(t, payment)
+
+		err = unwrapTransactionError(err)
+		var recvWalletNotReadyErr ReceiverWalletNotReadyForPaymentError
+		assert.True(t, errors.As(err, &recvWalletNotReadyErr))
+		assert.ErrorContains(t, err, "receiver wallet is not ready for payment, current status is DRAFT")
+	})
+
 	t.Run("fails with invalid asset reference", func(t *testing.T) {
 		t.Cleanup(func() {
 			data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)


### PR DESCRIPTION
### What
- Removed `ReceiverWalletNewInvitationTopic` event from Direct Payments 
    - 👉 Why ?  We want invitation to be handled outside of this endpoint by the `Receivers API`. This endpoint may get called multiple times for the receiver, we don't want to spam them with invites. 

- Dispatch the payment event only **when Receiver Wallet is Registered**.  If Receiver wallet is in Ready status, the payment event will get dispatched after Registration by `VerifyReceiverRegistrationHandler` . 

- Small error message fixes. 

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
