### PR TITLE
SDP-1728: Add `supported_assets` filter to `GET /wallets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add endpoint for the direct payments [#693](https://github.com/stellar/stellar-disbursement-platform-backend/pull/693)
 - Update wallet POST to allow accept new asset references [#696](https://github.com/stellar/stellar-disbursement-platform-backend/pull/696)
 - Update PATCH endpoint to extend update capabilities [#697](https://github.com/stellar/stellar-disbursement-platform-backend/pull/697)
+- Add `supported_assets` filter to `GET /wallets` endpoint [#734](https://github.com/stellar/stellar-disbursement-platform-backend/pull/734)
 
 ### Changed
 

--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -117,6 +117,23 @@ func (a *AssetModel) GetByCodeAndIssuer(ctx context.Context, code, issuer string
 	return &asset, nil
 }
 
+// ExistsByCodeOrID checks if an asset exists by either code or ID.
+func (a *AssetModel) ExistsByCodeOrID(ctx context.Context, codeOrID string) (bool, error) {
+	query := `
+		SELECT EXISTS(
+			SELECT 1 FROM assets 
+			WHERE (code = $1 OR id = $1) 
+			AND deleted_at IS NULL
+		)
+	`
+	var exists bool
+	err := a.dbConnectionPool.GetContext(ctx, &exists, query, codeOrID)
+	if err != nil {
+		return false, fmt.Errorf("checking asset existence for '%s': %w", codeOrID, err)
+	}
+	return exists, nil
+}
+
 // GetByWalletID returns all assets associated with a wallet.
 func (a *AssetModel) GetByWalletID(ctx context.Context, walletID string) ([]Asset, error) {
 	assets := []Asset{}

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -200,14 +200,19 @@ func DeleteAllWalletFixtures(t *testing.T, ctx context.Context, sqlExec db.SQLEx
 	require.NoError(t, err)
 }
 
-// ClearAndCreateWalletFixtures deletes all wallets in the database then creates new wallets for testing
-func ClearAndCreateWalletFixtures(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter) []Wallet {
-	DeleteAllWalletFixtures(t, ctx, sqlExec)
+// CreateWalletFixtures creates a set of wallets for testing purposes.
+func CreateWalletFixtures(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter) []Wallet {
 	expected := []Wallet{
 		*CreateWalletFixture(t, ctx, sqlExec, "BOSS Money", "https://www.walletbyboss.com", "www.walletbyboss.com", "https://www.walletbyboss.com"),
 		*CreateWalletFixture(t, ctx, sqlExec, "Vibrant Assist", "https://vibrantapp.com", "vibrantapp.com", "vibrantapp://"),
 	}
 	return expected
+}
+
+// ClearAndCreateWalletFixtures deletes all wallets in the database then creates new wallets for testing
+func ClearAndCreateWalletFixtures(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter) []Wallet {
+	DeleteAllWalletFixtures(t, ctx, sqlExec)
+	return CreateWalletFixtures(t, ctx, sqlExec)
 }
 
 func EnableOrDisableWalletFixtures(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, enabled bool, walletIDs ...string) {

--- a/internal/data/wallets_test.go
+++ b/internal/data/wallets_test.go
@@ -204,26 +204,56 @@ func Test_WalletModelGetAll(t *testing.T) {
 }
 
 func Test_WalletModelFindWallets(t *testing.T) {
-	dbConnectionPool := getConnectionPool(t)
+	models := SetupModels(t)
+	dbConnectionPool := models.DBConnectionPool
 
 	ctx := context.Background()
 	walletModel := &WalletModel{dbConnectionPool: dbConnectionPool}
 
+	usdc, outerErr := models.Assets.GetOrCreate(ctx, "USDC", "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
+	require.NoError(t, outerErr)
+	xlm, outerErr := models.Assets.GetOrCreate(ctx, "XLM", "")
+	require.NoError(t, outerErr)
+	eurc, outerErr := models.Assets.GetOrCreate(ctx, "EURC", "GB3Q6QDZYTHWT7E5PVS3W7FUT5GVAFC5KSZFFLPU25GO7VTC3NM2ZTVO")
+	require.NoError(t, outerErr)
+
+	DeleteAllWalletFixtures(t, ctx, dbConnectionPool)
+
+	createTestWallets := func() []*Wallet {
+		// Create wallets
+		wallet0 := CreateWalletFixture(t, ctx, dbConnectionPool, "Wallet0", "https://wallet0.com", "wallet0.com", "wallet0://")
+		wallet1 := CreateWalletFixture(t, ctx, dbConnectionPool, "Wallet1", "https://wallet1.com", "wallet1.com", "wallet1://")
+		wallet2 := CreateWalletFixture(t, ctx, dbConnectionPool, "Wallet2", "https://wallet2.com", "wallet2.com", "wallet2://")
+
+		// Associate assets with wallets
+		// wallet0: USDC, XLM
+		CreateWalletAssets(t, ctx, dbConnectionPool, wallet0.ID, []string{usdc.ID, xlm.ID})
+		// wallet1: USDC, EURC
+		CreateWalletAssets(t, ctx, dbConnectionPool, wallet1.ID, []string{usdc.ID, eurc.ID})
+		// wallet2: XLM only
+		CreateWalletAssets(t, ctx, dbConnectionPool, wallet2.ID, []string{xlm.ID})
+
+		return []*Wallet{wallet0, wallet1, wallet2}
+	}
+
 	t.Run("returns only enabled wallets", func(t *testing.T) {
-		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		wallets := createTestWallets()
 
 		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, false, wallets[0].ID)
-		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, true, wallets[1].ID)
+		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, false, wallets[1].ID)
+		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, true, wallets[2].ID)
 
 		actual, err := walletModel.FindWallets(ctx, NewFilter(FilterEnabledWallets, true))
 		require.NoError(t, err)
 
 		require.Len(t, actual, 1)
-		require.Equal(t, wallets[1].ID, actual[0].ID)
+		require.Equal(t, wallets[2].ID, actual[0].ID)
 	})
 
 	t.Run("returns only disabled wallets", func(t *testing.T) {
-		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		wallets := createTestWallets()
 
 		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, false, wallets[0].ID)
 		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, true, wallets[1].ID)
@@ -236,7 +266,8 @@ func Test_WalletModelFindWallets(t *testing.T) {
 	})
 
 	t.Run("returns user_managed wallet", func(t *testing.T) {
-		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		wallets := createTestWallets()
 
 		MakeWalletUserManaged(t, ctx, dbConnectionPool, wallets[0].ID)
 
@@ -248,7 +279,8 @@ func Test_WalletModelFindWallets(t *testing.T) {
 	})
 
 	t.Run("returns user_managed and enabled wallet", func(t *testing.T) {
-		wallets := ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		wallets := createTestWallets()
 
 		MakeWalletUserManaged(t, ctx, dbConnectionPool, wallets[0].ID)
 		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, true, wallets[0].ID)
@@ -262,11 +294,100 @@ func Test_WalletModelFindWallets(t *testing.T) {
 	})
 
 	t.Run("returns empty array when no wallets", func(t *testing.T) {
-		DeleteAllWalletFixtures(t, ctx, dbConnectionPool)
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+
 		actual, err := walletModel.FindWallets(ctx)
 		require.NoError(t, err)
 
 		require.Equal(t, []Wallet{}, actual)
+	})
+
+	t.Run("returns wallets filtered by supported assets - single asset code", func(t *testing.T) {
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		wallets := createTestWallets()
+
+		// Test filtering by single asset code
+		actual, err := walletModel.FindWallets(ctx, NewFilter(FilterSupportedAssets, []string{"USDC"}))
+		require.NoError(t, err)
+
+		assert.Len(t, actual, 2) // wallet1 and wallet2 support USDC
+		walletIDs := []string{actual[0].ID, actual[1].ID}
+		assert.Contains(t, walletIDs, wallets[0].ID)
+		assert.Contains(t, walletIDs, wallets[1].ID)
+	})
+
+	t.Run("returns wallets filtered by supported assets - multiple asset codes", func(t *testing.T) {
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		wallets := createTestWallets()
+
+		// Only wallet0 supports both USDC and XLM
+		actual, err := walletModel.FindWallets(ctx, NewFilter(FilterSupportedAssets, []string{"USDC", "XLM"}))
+		require.NoError(t, err)
+
+		assert.Len(t, actual, 1)
+		assert.Equal(t, wallets[0].Name, actual[0].Name)
+	})
+
+	t.Run("returns wallets filtered by supported assets - asset ID", func(t *testing.T) {
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		createTestWallets()
+
+		actual, err := walletModel.FindWallets(ctx, NewFilter(FilterSupportedAssets, []string{usdc.ID}))
+		require.NoError(t, err)
+
+		assert.Len(t, actual, 2) // wallet0 and wallet1 support USDC
+		for _, wallet := range actual {
+			assert.Contains(t, []string{"Wallet0", "Wallet1"}, wallet.Name)
+		}
+	})
+
+	t.Run("returns wallets filtered by supported assets - mixed codes and IDs", func(t *testing.T) {
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		createTestWallets()
+
+		actual, err := walletModel.FindWallets(ctx, NewFilter(FilterSupportedAssets, []string{usdc.ID, "XLM"}))
+		require.NoError(t, err)
+
+		assert.Len(t, actual, 1) // Only wallet0 supports both USDC (by ID) and XLM (by code)
+		assert.Equal(t, "Wallet0", actual[0].Name)
+	})
+
+	t.Run("returns empty array when no wallets support specified assets", func(t *testing.T) {
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		createTestWallets()
+
+		bizant := CreateAssetFixture(t, ctx, dbConnectionPool, "BIZANT", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+
+		actual, err := walletModel.FindWallets(ctx, NewFilter(FilterSupportedAssets, []string{bizant.Code}))
+		require.NoError(t, err)
+
+		assert.Empty(t, actual)
+	})
+
+	t.Run("combines asset filtering with other filters", func(t *testing.T) {
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		wallets := createTestWallets()
+
+		// Disable wallet2
+		EnableOrDisableWalletFixtures(t, ctx, dbConnectionPool, false, wallets[1].ID)
+
+		actual, err := walletModel.FindWallets(ctx,
+			NewFilter(FilterSupportedAssets, []string{"USDC"}),
+			NewFilter(FilterEnabledWallets, true))
+		require.NoError(t, err)
+
+		assert.Len(t, actual, 1) // Only wallet0 is enabled and supports USDC
+		assert.Equal(t, "Wallet0", actual[0].Name)
+	})
+
+	t.Run("handles empty asset list in FilterSupportedAssets", func(t *testing.T) {
+		t.Cleanup(func() { DeleteAllWalletFixtures(t, ctx, dbConnectionPool) })
+		wallets := createTestWallets()
+		// Empty asset list should be ignored and return all wallets
+		actual, err := walletModel.FindWallets(ctx, NewFilter(FilterSupportedAssets, []string{}))
+		require.NoError(t, err)
+
+		assert.GreaterOrEqual(t, len(actual), len(wallets))
 	})
 }
 


### PR DESCRIPTION
# Wallets API - `supported_assets` Filter

## Overview
The `GET /wallets` endpoint now supports filtering wallets by the assets they support.

## Query Parameter

| Parameter | Type | Description | Example |
|-----------|------|-------------|---------|
| `supported_assets` | string | Comma-separated list of asset codes or IDs | `USDC,XLM` |

## 🔍 How It Works

### Basic Usage
```http
GET /wallets?supported_assets=USDC,XLM
```
Returns wallets that support **both** USDC and XLM (AND logic).

### Supported Formats
- **Asset codes**: `USDC`, `XLM`, `EURC`
- **Asset IDs**: `550e8400-e29b-41d4-a716-446655440000`
- **Mixed**: `USDC,550e8400-e29b-41d4-a716-446655440000`

### Examples

#### Single Asset
```http
GET /wallets?supported_assets=USDC
```
Returns all wallets that support USDC.

#### Multiple Assets (AND Logic)
```http
GET /wallets?supported_assets=USDC,XLM
```
Returns only wallets that support **both** USDC **and** XLM.

#### Combined with Other Filters
```http
GET /wallets?supported_assets=USDC&enabled=true
```
Returns enabled wallets that support USDC.

## 🚨 Validation & Limits

- **Asset limit**: Maximum 20 assets per request

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [x] Ready for production
