### PR TITLE
Fix: Use `sh` instead of `bash` in e2e tests

### DIFF
--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Create integration test data
         run: |
-          docker exec e2e-sdp-api bash -c "./stellar-disbursement-platform integration-tests create-data"
+          docker exec e2e-sdp-api sh -c "./stellar-disbursement-platform integration-tests create-data"
         shell: bash
 
       - name: Restart Anchor Platform
@@ -157,7 +157,7 @@ jobs:
 
       - name: Start integration test command
         run: |
-          docker exec e2e-sdp-api bash -c "./stellar-disbursement-platform integration-tests start"
+          docker exec e2e-sdp-api sh -c "./stellar-disbursement-platform integration-tests start"
         shell: bash
 
       - name: Docker logs

--- a/internal/integrationtests/scripts/e2e_integration_test.sh
+++ b/internal/integrationtests/scripts/e2e_integration_test.sh
@@ -122,7 +122,7 @@ for config_name in "${options[@]}"; do
   # Create integration test data
   echo $DIVIDER
   echo "====> 👀Step 3: provision new tenant and populate new asset and test wallet on database"
-  docker exec e2e-sdp-api bash -c "./stellar-disbursement-platform integration-tests create-data"
+  docker exec e2e-sdp-api sh -c "./stellar-disbursement-platform integration-tests create-data"
   echo "====> ✅Step 3: finish creating integration test data ($DESCRIPTION)"
 
   # Restart anchor platform container
@@ -137,7 +137,7 @@ for config_name in "${options[@]}"; do
   # Run integration tests
   echo $DIVIDER
   echo "====> 👀Step 5: run integration tests command"
-  docker exec e2e-sdp-api bash -c "./stellar-disbursement-platform integration-tests start"
+  docker exec e2e-sdp-api sh -c "./stellar-disbursement-platform integration-tests start"
   echo "====> ✅Step 5: finish running integration test data ($DESCRIPTION)"
 
   # Cleanup container and volumes

--- a/internal/integrationtests/scripts/singletenant_to_multitenant_db_migration_test.sh
+++ b/internal/integrationtests/scripts/singletenant_to_multitenant_db_migration_test.sh
@@ -40,7 +40,7 @@ echo "====> ✅Step 2: finishing build"
 echo $DIVIDER
 echo "====> 👀Step 3: copy DB dump to container and restore it into the newly created database"
 docker cp ../resources/single_tenant_dump.sql e2e-sdp-v2-database:/tmp/single_tenant_dump.sql
-docker exec e2e-sdp-v2-database bash -c "psql -d $DATABASE_URL -f /tmp/single_tenant_dump.sql"
+docker exec e2e-sdp-v2-database sh -c "psql -d $DATABASE_URL -f /tmp/single_tenant_dump.sql"
 echo "====> ✅Step 3: finish copying and restoring DB dump"
 
 echo $DIVIDER
@@ -82,12 +82,12 @@ fi
 
 echo $DIVIDER
 echo "====> 👀Step 5: run migration"
-docker exec e2e-sdp-v2-database bash -c "psql -d $DATABASE_URL -c \"SELECT admin.migrate_tenant_data_from_v1_to_v2('migrated-tenant');\""
+docker exec e2e-sdp-v2-database sh -c "psql -d $DATABASE_URL -c \"SELECT admin.migrate_tenant_data_from_v1_to_v2('migrated-tenant');\"" 
 echo "====> ✅Step 5: run migration"
 
 echo $DIVIDER
 echo "====> 👀Step 6: exclude deprecated tables"
-docker exec e2e-sdp-v2-database bash -c "psql -d $DATABASE_URL -c \"
+docker exec e2e-sdp-v2-database sh -c "psql -d $DATABASE_URL -c \"
   BEGIN TRANSACTION;
     DROP TABLE public.messages CASCADE;
     DROP TABLE public.payments CASCADE;


### PR DESCRIPTION
### What

The SDP images were updated to use golang:1.24.2-alpine, which does not include `bash`, causing the e2e tests to fail with 
```
Run docker exec e2e-sdp-api bash -c "./stellar-disbursement-platform integration-tests create-data"
OCI runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH: unknown
```

Example: https://github.com/stellar/stellar-disbursement-platform-backend/actions/runs/15881981520/job/44864347506

This updates e2e workflows to use `sh` instead of `bash`.

### Why

Fix e2e tests.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
