### PR TITLE
Fix: Validate wallet public_key more thoroughly

### DIFF
--- a/internal/serve/httphandler/wallet_creation_handler.go
+++ b/internal/serve/httphandler/wallet_creation_handler.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"crypto/ecdh"
 	"encoding/hex"
 	"errors"
 	"net/http"
@@ -31,8 +32,10 @@ func (r CreateWalletRequest) Validate() *httperror.HTTPError {
 	validator.Check(len(strings.TrimSpace(r.Token)) > 0, "token", "token should not be empty")
 	validator.Check(len(strings.TrimSpace(r.PublicKey)) > 0, "public_key", "public_key should not be empty")
 	validator.Check(len(strings.TrimSpace(r.CredentialID)) > 0, "credential_id", "credential_id should not be empty")
-	if _, err := hex.DecodeString(r.PublicKey); err != nil {
-		validator.AddError("public_key", "public_key should be a valid hex string")
+	if pk, err := hex.DecodeString(r.PublicKey); err != nil {
+		validator.AddError("public_key", "public_key is not a valid hex string")
+	} else if !isValidP256PublicKey(pk) {
+		validator.AddError("public_key", "public_key is not a valid uncompressed P256 public key")
 	}
 
 	if validator.HasErrors() {
@@ -40,6 +43,14 @@ func (r CreateWalletRequest) Validate() *httperror.HTTPError {
 	}
 
 	return nil
+}
+
+func isValidP256PublicKey(pubKeyBytes []byte) bool {
+	if len(pubKeyBytes) != 65 || pubKeyBytes[0] != 0x04 {
+		return false
+	}
+	_, err := ecdh.P256().NewPublicKey(pubKeyBytes)
+	return err == nil
 }
 
 type WalletResponse struct {

--- a/internal/serve/httphandler/wallet_creation_handler_test.go
+++ b/internal/serve/httphandler/wallet_creation_handler_test.go
@@ -28,12 +28,12 @@ func Test_WalletCreationHandler_CreateWallet(t *testing.T) {
 	rr := httptest.NewRecorder()
 	requestBody, _ := json.Marshal(CreateWalletRequest{
 		Token:        "123",
-		PublicKey:    "04f5",
+		PublicKey:    "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23",
 		CredentialID: "test-credential-id",
 	})
 	ctx := context.Background()
 
-	walletService.On("CreateWallet", mock.Anything, "123", "04f5", "test-credential-id").Return(nil)
+	walletService.On("CreateWallet", mock.Anything, "123", "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23", "test-credential-id").Return(nil)
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/embedded-wallet/", strings.NewReader(string(requestBody)))
 	http.HandlerFunc(handler.CreateWallet).ServeHTTP(rr, req)
@@ -72,10 +72,19 @@ func Test_WalletCreationHandler_CreateWallet_ValidationErrors(t *testing.T) {
 			expectedField: "public_key",
 		},
 		{
-			name: "invalid public key",
+			name: "invalid hex public key",
 			requestBody: CreateWalletRequest{
 				Token:        "123",
-				PublicKey:    "invalid_key",
+				PublicKey:    "invalid_hex",
+				CredentialID: "test-credential-id",
+			},
+			expectedField: "public_key",
+		},
+		{
+			name: "invalid P256 public key",
+			requestBody: CreateWalletRequest{
+				Token:        "123",
+				PublicKey:    "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f22", // Invalid - last byte changed
 				CredentialID: "test-credential-id",
 			},
 			expectedField: "public_key",
@@ -84,7 +93,7 @@ func Test_WalletCreationHandler_CreateWallet_ValidationErrors(t *testing.T) {
 			name: "empty credential id",
 			requestBody: CreateWalletRequest{
 				Token:        "123",
-				PublicKey:    "04f5",
+				PublicKey:    "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23",
 				CredentialID: "",
 			},
 			expectedField: "credential_id",
@@ -122,12 +131,12 @@ func Test_WalletCreationHandler_CreateWallet_InternalError(t *testing.T) {
 	rr := httptest.NewRecorder()
 	requestBody, _ := json.Marshal(CreateWalletRequest{
 		Token:        "123",
-		PublicKey:    "04f5",
+		PublicKey:    "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23",
 		CredentialID: "test-credential-id",
 	})
 	ctx := context.Background()
 
-	walletService.On("CreateWallet", mock.Anything, "123", "04f5", "test-credential-id").Return(errors.New("foobar"))
+	walletService.On("CreateWallet", mock.Anything, "123", "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23", "test-credential-id").Return(errors.New("foobar"))
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/embedded-wallet/", strings.NewReader(string(requestBody)))
 	http.HandlerFunc(handler.CreateWallet).ServeHTTP(rr, req)
@@ -144,12 +153,12 @@ func Test_WalletCreationHandler_CreateWallet_InvalidToken(t *testing.T) {
 	rr := httptest.NewRecorder()
 	requestBody, _ := json.Marshal(CreateWalletRequest{
 		Token:        "123",
-		PublicKey:    "04f5",
+		PublicKey:    "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23",
 		CredentialID: "test-credential-id",
 	})
 	ctx := context.Background()
 
-	walletService.On("CreateWallet", mock.Anything, "123", "04f5", "test-credential-id").Return(services.ErrInvalidToken)
+	walletService.On("CreateWallet", mock.Anything, "123", "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23", "test-credential-id").Return(services.ErrInvalidToken)
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/embedded-wallet/", strings.NewReader(string(requestBody)))
 	http.HandlerFunc(handler.CreateWallet).ServeHTTP(rr, req)
@@ -166,12 +175,12 @@ func Test_WalletCreationHandler_CreateWallet_InvalidStatus(t *testing.T) {
 	rr := httptest.NewRecorder()
 	requestBody, _ := json.Marshal(CreateWalletRequest{
 		Token:        "123",
-		PublicKey:    "04f5",
+		PublicKey:    "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23",
 		CredentialID: "test-credential-id",
 	})
 	ctx := context.Background()
 
-	walletService.On("CreateWallet", mock.Anything, "123", "04f5", "test-credential-id").Return(services.ErrCreateWalletInvalidStatus)
+	walletService.On("CreateWallet", mock.Anything, "123", "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23", "test-credential-id").Return(services.ErrCreateWalletInvalidStatus)
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/embedded-wallet/", strings.NewReader(string(requestBody)))
 	http.HandlerFunc(handler.CreateWallet).ServeHTTP(rr, req)
@@ -188,12 +197,12 @@ func Test_WalletCreationHandler_CreateWallet_CredentialIDConflict(t *testing.T) 
 	rr := httptest.NewRecorder()
 	requestBody, _ := json.Marshal(CreateWalletRequest{
 		Token:        "123",
-		PublicKey:    "04f5",
+		PublicKey:    "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23",
 		CredentialID: "duplicate-credential-id",
 	})
 	ctx := context.Background()
 
-	walletService.On("CreateWallet", mock.Anything, "123", "04f5", "duplicate-credential-id").Return(services.ErrCredentialIDAlreadyExists)
+	walletService.On("CreateWallet", mock.Anything, "123", "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23", "duplicate-credential-id").Return(services.ErrCredentialIDAlreadyExists)
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/embedded-wallet/", strings.NewReader(string(requestBody)))
 	http.HandlerFunc(handler.CreateWallet).ServeHTTP(rr, req)


### PR DESCRIPTION
### What

This checks that the `public_key` is a valid P256 public key.

### Why

We want to avoid invalid public keys before a transaction is created in TSS.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
