### PR TITLE
Fix: email color overrides

### DIFF
--- a/internal/htmltemplate/htmltemplate.go
+++ b/internal/htmltemplate/htmltemplate.go
@@ -100,5 +100,21 @@ const emailStyle = template.HTML(`
 		.button:hover {
 			background-color: #404040;
 		}
+		/* Email client overrides */
+		a.button {
+			color: #ffffff !important;
+		}
+		a.button:link {
+			color: #ffffff !important;
+		}
+		a.button:visited {
+			color: #ffffff !important;
+		}
+		a.button:hover {
+			color: #ffffff !important;
+		}
+		a.button:active {
+			color: #ffffff !important;
+		}
     </style>
 `)


### PR DESCRIPTION
### What

Enforce the color of the email button texts to white

### Why

Even though we were formatting things correctly, some email clients add extra css formatting that was overriding our CSS configuration.

**How gmail rendered things before:**
<img width="819" height="274" alt="Screenshot 2025-07-16 at 5 13 18 PM" src="https://github.com/user-attachments/assets/16715f10-bea6-49b7-a2f0-6f0b8bb72771" />

**How gmail renders things after this PR's changes:**
<img width="818" height="260" alt="Screenshot 2025-07-16 at 5 13 31 PM" src="https://github.com/user-attachments/assets/ea725b50-ad78-4142-a047-a93d26cc4e10" />

### Known limitations

[TODO or N/A]

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
