### PR TITLE
SDP-1736: Implement invite resend API for embedded wallets

### DIFF
--- a/db/migrations/sdp-migrations/2025-07-17.0-add-receiver-contact-index-to-embedded-wallets.sql
+++ b/db/migrations/sdp-migrations/2025-07-17.0-add-receiver-contact-index-to-embedded-wallets.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+
+CREATE INDEX idx_embedded_wallets_receiver_contact_type_created_at 
+ON embedded_wallets (receiver_contact, contact_type, created_at DESC);
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_embedded_wallets_receiver_contact_type_created_at;

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -661,6 +661,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 					r.Post("/", walletCreationHandler.CreateWallet)
 					r.Get("/{credentialID}", walletCreationHandler.GetWallet)
 					r.Get("/status/{token}", walletCreationHandler.GetWalletStatus)
+					r.Post("/resend-invite", walletCreationHandler.ResendInvite)
 				})
 			})
 		}

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -724,6 +724,7 @@ func Test_handleHTTP_authenticatedEndpoints(t *testing.T) {
 		{http.MethodPost, "/embedded-wallets"},
 		{http.MethodGet, "/embedded-wallets/test-credential-id"},
 		{http.MethodGet, "/embedded-wallets/status/test-token"},
+		{http.MethodPost, "/embedded-wallets/resend-invite"},
 	}
 
 	// Expect 401 as a response:

--- a/internal/services/mocks/embedded_wallet_service.go
+++ b/internal/services/mocks/embedded_wallet_service.go
@@ -90,6 +90,36 @@ func (_m *MockEmbeddedWalletService) GetWalletByCredentialID(ctx context.Context
 	return r0, r1
 }
 
+// GetWalletByReceiverContact provides a mock function with given fields: ctx, receiverContact, contactType
+func (_m *MockEmbeddedWalletService) GetWalletByReceiverContact(ctx context.Context, receiverContact string, contactType string) (*data.EmbeddedWallet, error) {
+	ret := _m.Called(ctx, receiverContact, contactType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWalletByReceiverContact")
+	}
+
+	var r0 *data.EmbeddedWallet
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*data.EmbeddedWallet, error)); ok {
+		return rf(ctx, receiverContact, contactType)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *data.EmbeddedWallet); ok {
+		r0 = rf(ctx, receiverContact, contactType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*data.EmbeddedWallet)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, receiverContact, contactType)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetWalletByToken provides a mock function with given fields: ctx, token
 func (_m *MockEmbeddedWalletService) GetWalletByToken(ctx context.Context, token string) (*data.EmbeddedWallet, error) {
 	ret := _m.Called(ctx, token)
@@ -118,6 +148,24 @@ func (_m *MockEmbeddedWalletService) GetWalletByToken(ctx context.Context, token
 	}
 
 	return r0, r1
+}
+
+// ResendInvite provides a mock function with given fields: ctx, receiverContact, contactType
+func (_m *MockEmbeddedWalletService) ResendInvite(ctx context.Context, receiverContact string, contactType string) error {
+	ret := _m.Called(ctx, receiverContact, contactType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResendInvite")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, receiverContact, contactType)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // NewMockEmbeddedWalletService creates a new instance of MockEmbeddedWalletService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/internal/services/send_receiver_wallets_invite_service_test.go
+++ b/internal/services/send_receiver_wallets_invite_service_test.go
@@ -401,6 +401,7 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 		require.NoError(t, err)
 
 		mockToken := uuid.New().String()
+		embeddedWalletServiceMock.On("GetWalletByReceiverContact", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("wallet not found")).Once()
 		embeddedWalletServiceMock.On("CreateInvitationToken", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockToken, nil).Once()
 
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)


### PR DESCRIPTION
### What

This implements the `/embedded-wallets/resend-invite` endpoint, which allows wallets to resend invitations to receivers who have not set up their wallets.

### Why

Need to resend invitation emails for the demo.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
