### PR TITLE
SDP-1736: Implement org level HTML invite customization

### DIFF
--- a/db/migrations/sdp-migrations/2025-07-19.0-add-html-email-template-support.sql
+++ b/db/migrations/sdp-migrations/2025-07-19.0-add-html-email-template-support.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+
+-- Expand messages.text_encrypted to support larger HTML email content
+ALTER TABLE messages ALTER COLUMN text_encrypted TYPE TEXT;
+
+ALTER TABLE organizations
+    ADD COLUMN receiver_registration_html_email_template TEXT;
+
+ALTER TABLE organizations 
+    ADD COLUMN receiver_registration_html_email_subject TEXT;
+
+-- +migrate Down
+
+ALTER TABLE organizations DROP COLUMN IF EXISTS receiver_registration_html_email_subject;
+ALTER TABLE organizations DROP COLUMN IF EXISTS receiver_registration_html_email_template;
+
+ALTER TABLE messages ALTER COLUMN text_encrypted TYPE VARCHAR(1024);

--- a/internal/data/organizations.go
+++ b/internal/data/organizations.go
@@ -38,8 +38,10 @@ type Organization struct {
 	// If it's nil means resending the invitation is deactivated.
 	ReceiverInvitationResendIntervalDays *int64 `json:"receiver_invitation_resend_interval_days" db:"receiver_invitation_resend_interval_days"`
 	// PaymentCancellationPeriodDays is the number of days for a ready payment to be automatically cancelled.
-	PaymentCancellationPeriodDays       *int64 `json:"payment_cancellation_period_days" db:"payment_cancellation_period_days"`
-	ReceiverRegistrationMessageTemplate string `json:"receiver_registration_message_template" db:"receiver_registration_message_template"`
+	PaymentCancellationPeriodDays         *int64  `json:"payment_cancellation_period_days" db:"payment_cancellation_period_days"`
+	ReceiverRegistrationMessageTemplate   string  `json:"receiver_registration_message_template" db:"receiver_registration_message_template"`
+	ReceiverRegistrationHTMLEmailTemplate *string `json:"receiver_registration_html_email_template" db:"receiver_registration_html_email_template"`
+	ReceiverRegistrationHTMLEmailSubject  *string `json:"receiver_registration_html_email_subject" db:"receiver_registration_html_email_subject"`
 	// OTPMessageTemplate is the message template to send the OTP code to the receivers validates their identity when registering their wallets.
 	// The message may have the template values {{.OTP}} and {{.OrganizationName}}, it will be parsed and the values injected when executing the template.
 	// When the {{.OTP}} is not found in the message, it's added at the beginning of the message.
@@ -67,9 +69,11 @@ type OrganizationUpdate struct {
 	PaymentCancellationPeriodDays        *int64 `json:",omitempty"`
 
 	// Using pointers to accept empty strings
-	ReceiverRegistrationMessageTemplate *string `json:",omitempty"`
-	OTPMessageTemplate                  *string `json:",omitempty"`
-	PrivacyPolicyLink                   *string `json:",omitempty"`
+	ReceiverRegistrationMessageTemplate   *string `json:",omitempty"`
+	ReceiverRegistrationHTMLEmailTemplate *string `json:",omitempty"`
+	ReceiverRegistrationHTMLEmailSubject  *string `json:",omitempty"`
+	OTPMessageTemplate                    *string `json:",omitempty"`
+	PrivacyPolicyLink                     *string `json:",omitempty"`
 }
 
 type LogoType string
@@ -221,6 +225,26 @@ func (om *OrganizationModel) Update(ctx context.Context, ou *OrganizationUpdate)
 		} else {
 			// When empty value is passed by parameter we set the DEFAULT value for the column.
 			fields = append(fields, "otp_message_template = DEFAULT")
+		}
+	}
+
+	if ou.ReceiverRegistrationHTMLEmailTemplate != nil {
+		if *ou.ReceiverRegistrationHTMLEmailTemplate != "" {
+			fields = append(fields, "receiver_registration_html_email_template = ?")
+			args = append(args, *ou.ReceiverRegistrationHTMLEmailTemplate)
+		} else {
+			// When empty value is passed by parameter we set it as NULL.
+			fields = append(fields, "receiver_registration_html_email_template = NULL")
+		}
+	}
+
+	if ou.ReceiverRegistrationHTMLEmailSubject != nil {
+		if *ou.ReceiverRegistrationHTMLEmailSubject != "" {
+			fields = append(fields, "receiver_registration_html_email_subject = ?")
+			args = append(args, *ou.ReceiverRegistrationHTMLEmailSubject)
+		} else {
+			// When empty value is passed by parameter we set it as NULL.
+			fields = append(fields, "receiver_registration_html_email_subject = NULL")
 		}
 	}
 

--- a/internal/data/organizations_test.go
+++ b/internal/data/organizations_test.go
@@ -472,6 +472,60 @@ func Test_Organizations_Update(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, o.PrivacyPolicyLink)
 	})
+
+	t.Run("updates the organization's ReceiverRegistrationHTMLEmailTemplate", func(t *testing.T) {
+		defer resetOrganizationInfo(t, ctx, dbConnectionPool)
+
+		o, err := organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, o.ReceiverRegistrationHTMLEmailTemplate)
+
+		htmlTemplate := `<html><body><h1>Welcome to {{.OrganizationName}}!</h1><p>Click <a href="{{.RegistrationLink}}">here</a> to register.</p></body></html>`
+		ou := &OrganizationUpdate{ReceiverRegistrationHTMLEmailTemplate: &htmlTemplate}
+
+		err = organizationModel.Update(ctx, ou)
+		require.NoError(t, err)
+
+		o, err = organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, htmlTemplate, *o.ReceiverRegistrationHTMLEmailTemplate)
+
+		// Set it as nil
+		ou.ReceiverRegistrationHTMLEmailTemplate = new(string)
+		err = organizationModel.Update(ctx, ou)
+		require.NoError(t, err)
+
+		o, err = organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, o.ReceiverRegistrationHTMLEmailTemplate)
+	})
+
+	t.Run("updates the organization's ReceiverRegistrationHTMLEmailSubject", func(t *testing.T) {
+		defer resetOrganizationInfo(t, ctx, dbConnectionPool)
+
+		o, err := organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, o.ReceiverRegistrationHTMLEmailSubject)
+
+		subject := "Payment from {{.OrganizationName}}"
+		ou := &OrganizationUpdate{ReceiverRegistrationHTMLEmailSubject: &subject}
+
+		err = organizationModel.Update(ctx, ou)
+		require.NoError(t, err)
+
+		o, err = organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, subject, *o.ReceiverRegistrationHTMLEmailSubject)
+
+		// Set it as nil
+		ou.ReceiverRegistrationHTMLEmailSubject = new(string)
+		err = organizationModel.Update(ctx, ou)
+		require.NoError(t, err)
+
+		o, err = organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, o.ReceiverRegistrationHTMLEmailSubject)
+	})
 }
 
 func TestOrganizationModel_UpdateMessageChannelPriority(t *testing.T) {

--- a/internal/htmltemplate/htmltemplate_test.go
+++ b/internal/htmltemplate/htmltemplate_test.go
@@ -97,3 +97,122 @@ func Test_ExecuteHTMLTemplateForStaffForgotPasswordEmailMessage(t *testing.T) {
 	assert.Contains(t, content, `<a href="https://sdp.com/reset-password?token=resetToken" class="button">Reset Password</a>`)
 	assert.Contains(t, content, "Organization Name")
 }
+
+func Test_ExecuteCustomHTMLTemplate(t *testing.T) {
+	templateData := map[string]string{
+		"OrganizationName": "Test Organization",
+		"RegistrationLink": "https://example.com/register?token=abc123",
+	}
+	customTemplate := `<html><head><title>Welcome</title></head><body>{{EmailStyle}}<h1>Hello from {{.OrganizationName}}!</h1><p>Click <a href="{{.RegistrationLink}}">here</a> to register.</p></body></html>`
+
+	result, err := ExecuteCustomHTMLTemplate(customTemplate, templateData)
+	require.NoError(t, err)
+	assert.Contains(t, result, "Test Organization")
+	assert.Contains(t, result, "https://example.com/register?token=abc123")
+	assert.Contains(t, result, "<style>")
+	assert.Contains(t, result, ".button {")
+}
+
+func Test_ExecuteCustomHTMLTemplate_WithCustomCSS(t *testing.T) {
+	templateData := map[string]string{
+		"OrganizationName": "Test Organization",
+		"RegistrationLink": "https://example.com/register?token=abc123",
+	}
+	customTemplate := `<html><head><title>Custom Styled Email</title><style>body { background: red; }.custom { color: blue; }</style></head><body>{{EmailStyle}}<h1>Hello from {{.OrganizationName}}!</h1><p class="custom">Click <a href="{{.RegistrationLink}}">here</a> to register.</p></body></html>`
+
+	result, err := ExecuteCustomHTMLTemplate(customTemplate, templateData)
+	require.NoError(t, err)
+	assert.Contains(t, result, "Test Organization")
+	assert.Contains(t, result, "https://example.com/register?token=abc123")
+	assert.Contains(t, result, "background: red")
+	assert.Contains(t, result, "color: blue")
+	assert.NotContains(t, result, ".button {")
+}
+
+func Test_ExecuteCustomHTMLTemplate_EmptyContent(t *testing.T) {
+	templateData := map[string]string{
+		"OrganizationName": "Test Organization",
+		"RegistrationLink": "https://example.com/register?token=abc123",
+	}
+
+	result, err := ExecuteCustomHTMLTemplate("", templateData)
+	require.Empty(t, result)
+	require.EqualError(t, err, "template content cannot be empty")
+}
+
+func Test_ExecuteCustomHTMLTemplate_InvalidSyntax(t *testing.T) {
+	templateData := map[string]string{
+		"OrganizationName": "Test Organization",
+		"RegistrationLink": "https://example.com/register?token=abc123",
+	}
+	invalidTemplate := `<html><body>Hello {{.OrganizationName</body></html>`
+
+	result, err := ExecuteCustomHTMLTemplate(invalidTemplate, templateData)
+	require.Empty(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error parsing custom template")
+}
+
+func Test_ExecuteCustomHTMLTemplate_HTMLInjection(t *testing.T) {
+	maliciousData := map[string]string{
+		"OrganizationName": "<script>alert('xss')</script>Malicious Org",
+		"RegistrationLink": "javascript:alert('xss')",
+	}
+	simpleTemplate := `<html><body><h1>{{.OrganizationName}}</h1><a href="{{.RegistrationLink}}">Link</a></body></html>`
+
+	result, err := ExecuteCustomHTMLTemplate(simpleTemplate, maliciousData)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;") // Script tag is escaped
+	assert.NotContains(t, result, "<script>alert('xss')</script>")
+	assert.Contains(t, result, "#ZgotmplZ") // Go template marker for sanitized content
+	assert.NotContains(t, result, "javascript:alert")
+}
+
+func Test_ProcessSubjectTemplate(t *testing.T) {
+	templateData := map[string]string{
+		"OrganizationName": "Test Organization",
+		"RegistrationLink": "https://example.com/register?token=abc123",
+	}
+	subjectTemplate := "Payment from {{.OrganizationName}} - Action Required"
+
+	result, err := ProcessSubjectTemplate(subjectTemplate, templateData)
+	require.NoError(t, err)
+	assert.Equal(t, "Payment from Test Organization - Action Required", result)
+}
+
+func Test_ProcessSubjectTemplate_EmptyTemplate(t *testing.T) {
+	templateData := map[string]string{
+		"OrganizationName": "Test Organization",
+		"RegistrationLink": "https://example.com/register?token=abc123",
+	}
+
+	result, err := ProcessSubjectTemplate("", templateData)
+	require.NoError(t, err)
+	assert.Equal(t, "", result)
+}
+
+func Test_ProcessSubjectTemplate_MultipleVariables(t *testing.T) {
+	templateData := map[string]string{
+		"OrganizationName": "Test Organization",
+		"RegistrationLink": "https://example.com/register?token=abc123",
+	}
+	subjectTemplate := "{{.OrganizationName}}: Complete registration at {{.RegistrationLink}}"
+
+	result, err := ProcessSubjectTemplate(subjectTemplate, templateData)
+	require.NoError(t, err)
+	assert.Equal(t, "Test Organization: Complete registration at https://example.com/register?token=abc123", result)
+}
+
+func Test_ProcessSubjectTemplate_InvalidSyntax(t *testing.T) {
+	templateData := map[string]string{
+		"OrganizationName": "Test Organization",
+		"RegistrationLink": "https://example.com/register?token=abc123",
+	}
+	invalidTemplate := "Payment from {{.OrganizationName - Action Required"
+
+	result, err := ProcessSubjectTemplate(invalidTemplate, templateData)
+	require.Empty(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error parsing subject template")
+}

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -50,16 +50,18 @@ type ProfileHandler struct {
 }
 
 type PatchOrganizationProfileRequest struct {
-	OrganizationName                    string  `json:"organization_name"`
-	TimezoneUTCOffset                   string  `json:"timezone_utc_offset"`
-	IsApprovalRequired                  *bool   `json:"is_approval_required"`
-	IsLinkShortenerEnabled              *bool   `json:"is_link_shortener_enabled"`
-	IsMemoTracingEnabled                *bool   `json:"is_memo_tracing_enabled"`
-	ReceiverInvitationResendInterval    *int64  `json:"receiver_invitation_resend_interval_days"`
-	PaymentCancellationPeriodDays       *int64  `json:"payment_cancellation_period_days"`
-	ReceiverRegistrationMessageTemplate *string `json:"receiver_registration_message_template"`
-	OTPMessageTemplate                  *string `json:"otp_message_template"`
-	PrivacyPolicyLink                   *string `json:"privacy_policy_link"`
+	OrganizationName                      string  `json:"organization_name"`
+	TimezoneUTCOffset                     string  `json:"timezone_utc_offset"`
+	IsApprovalRequired                    *bool   `json:"is_approval_required"`
+	IsLinkShortenerEnabled                *bool   `json:"is_link_shortener_enabled"`
+	IsMemoTracingEnabled                  *bool   `json:"is_memo_tracing_enabled"`
+	ReceiverInvitationResendInterval      *int64  `json:"receiver_invitation_resend_interval_days"`
+	PaymentCancellationPeriodDays         *int64  `json:"payment_cancellation_period_days"`
+	ReceiverRegistrationMessageTemplate   *string `json:"receiver_registration_message_template"`
+	ReceiverRegistrationHTMLEmailTemplate *string `json:"receiver_registration_html_email_template"`
+	ReceiverRegistrationHTMLEmailSubject  *string `json:"receiver_registration_html_email_subject"`
+	OTPMessageTemplate                    *string `json:"otp_message_template"`
+	PrivacyPolicyLink                     *string `json:"privacy_policy_link"`
 }
 
 func (r *PatchOrganizationProfileRequest) AreAllFieldsEmpty() bool {
@@ -171,17 +173,19 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 	}
 
 	organizationUpdate := data.OrganizationUpdate{
-		Name:                                 reqBody.OrganizationName,
-		Logo:                                 fileContentBytes,
-		TimezoneUTCOffset:                    reqBody.TimezoneUTCOffset,
-		IsApprovalRequired:                   reqBody.IsApprovalRequired,
-		IsLinkShortenerEnabled:               reqBody.IsLinkShortenerEnabled,
-		IsMemoTracingEnabled:                 reqBody.IsMemoTracingEnabled,
-		ReceiverRegistrationMessageTemplate:  reqBody.ReceiverRegistrationMessageTemplate,
-		OTPMessageTemplate:                   reqBody.OTPMessageTemplate,
-		ReceiverInvitationResendIntervalDays: reqBody.ReceiverInvitationResendInterval,
-		PaymentCancellationPeriodDays:        reqBody.PaymentCancellationPeriodDays,
-		PrivacyPolicyLink:                    reqBody.PrivacyPolicyLink,
+		Name:                                  reqBody.OrganizationName,
+		Logo:                                  fileContentBytes,
+		TimezoneUTCOffset:                     reqBody.TimezoneUTCOffset,
+		IsApprovalRequired:                    reqBody.IsApprovalRequired,
+		IsLinkShortenerEnabled:                reqBody.IsLinkShortenerEnabled,
+		IsMemoTracingEnabled:                  reqBody.IsMemoTracingEnabled,
+		ReceiverRegistrationMessageTemplate:   reqBody.ReceiverRegistrationMessageTemplate,
+		ReceiverRegistrationHTMLEmailTemplate: reqBody.ReceiverRegistrationHTMLEmailTemplate,
+		ReceiverRegistrationHTMLEmailSubject:  reqBody.ReceiverRegistrationHTMLEmailSubject,
+		OTPMessageTemplate:                    reqBody.OTPMessageTemplate,
+		ReceiverInvitationResendIntervalDays:  reqBody.ReceiverInvitationResendInterval,
+		PaymentCancellationPeriodDays:         reqBody.PaymentCancellationPeriodDays,
+		PrivacyPolicyLink:                     reqBody.PrivacyPolicyLink,
 	}
 	requestDict, err := utils.ConvertType[data.OrganizationUpdate, map[string]interface{}](organizationUpdate)
 	if err != nil {
@@ -385,6 +389,14 @@ func (h ProfileHandler) GetOrganizationInfo(rw http.ResponseWriter, req *http.Re
 
 	if org.PrivacyPolicyLink != nil {
 		resp["privacy_policy_link"] = *org.PrivacyPolicyLink
+	}
+
+	if org.ReceiverRegistrationHTMLEmailTemplate != nil {
+		resp["receiver_registration_html_email_template"] = *org.ReceiverRegistrationHTMLEmailTemplate
+	}
+
+	if org.ReceiverRegistrationHTMLEmailSubject != nil {
+		resp["receiver_registration_html_email_subject"] = *org.ReceiverRegistrationHTMLEmailSubject
 	}
 
 	httpjson.RenderStatus(rw, http.StatusOK, resp, httpjson.JSON)

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -167,6 +167,9 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 	if reqBody.ReceiverRegistrationMessageTemplate != nil {
 		validator.CheckError(utils.ValidateNoHTML(*reqBody.ReceiverRegistrationMessageTemplate), "receiver_registration_message_template", "receiver_registration_message_template cannot contain HTML, JS or CSS")
 	}
+	if reqBody.ReceiverRegistrationHTMLEmailTemplate != nil && *reqBody.ReceiverRegistrationHTMLEmailTemplate != "" {
+		validator.CheckError(utils.ValidateHTMLEmailTemplate(*reqBody.ReceiverRegistrationHTMLEmailTemplate), "receiver_registration_html_email_template", "receiver_registration_html_email_template must include {{.RegistrationLink}}")
+	}
 	if validator.HasErrors() {
 		httperror.BadRequest("", nil, validator.Errors).Render(rw)
 		return

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -237,3 +237,16 @@ func ValidateContactType(contactType string) error {
 	}
 	return nil
 }
+
+// ValidateHTMLEmailTemplate validates that a custom HTML email template contains {{.RegistrationLink}}.
+func ValidateHTMLEmailTemplate(templateContent string) error {
+	if templateContent == "" {
+		return fmt.Errorf("template content cannot be empty")
+	}
+
+	if !strings.Contains(templateContent, "{{.RegistrationLink}}") {
+		return fmt.Errorf("template must contain {{.RegistrationLink}} variable")
+	}
+
+	return nil
+}

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -48,6 +48,46 @@ func TestValidateContactType(t *testing.T) {
 	}
 }
 
+func TestValidateHTMLEmailTemplate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		template    string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "valid template with RegistrationLink",
+			template:    `<html><body>Click {{.RegistrationLink}} to register.</body></html>`,
+			expectError: false,
+		},
+		{
+			name:        "empty template",
+			template:    "",
+			expectError: true,
+			errorMsg:    "template content cannot be empty",
+		},
+		{
+			name:        "missing RegistrationLink",
+			template:    `<html><body>Click here to register</body></html>`,
+			expectError: true,
+			errorMsg:    "template must contain {{.RegistrationLink}} variable",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateHTMLEmailTemplate(tc.template)
+
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_ValidatePhoneNumber(t *testing.T) {
 	testCases := []struct {
 		phoneNumber string


### PR DESCRIPTION
### What

This implements organization customization for receiver invites with custom HTML.

### Why

We want to send custom HTML/CSS emails for the demo

### Known limitations

Tested locally without actually sending it with Amazon SES or Sendgrid.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
