### PR TITLE
Fix: Allow access to embedded-wallet endpoints from BE

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -576,7 +576,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				}
 				r.With(middleware.RequirePermission(
 					data.WriteDisbursements,
-					middleware.AnyRoleMiddleware(authManager, data.FinancialControllerUserRole),
+					middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...),
 				)).Route("/embedded-wallets", func(r chi.Router) {
 					r.Post("/", walletCreationHandler.CreateWallet)
 					r.Get("/{credentialID}", walletCreationHandler.GetWallet)


### PR DESCRIPTION
### What

Grants access to all roles for the embedded wallet APIs so that it's accessible by API

### Why

Not currently accessible by API since it's limited to the financial controller role.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
