### PR TITLE
Fix: Only generate new wallet tokens if previous failed

### DIFF
--- a/internal/services/send_receiver_wallets_invite_service.go
+++ b/internal/services/send_receiver_wallets_invite_service.go
@@ -280,7 +280,7 @@ func (s SendReceiverWalletInviteService) getOrCreateInvitationToken(ctx context.
 		return token, nil
 	}
 
-	if existingWallet.WalletStatus == data.PendingWalletStatus {
+	if existingWallet.WalletStatus != data.FailedWalletStatus {
 		return existingWallet.Token, nil
 	}
 


### PR DESCRIPTION
### What

This updates the token generation process so that it only generates new tokens if the previous token is in the FAILED status.

### Why

This fixes a bug where a new token is generated when a receiver creates a wallet successfully.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
