### PR TITLE
Fix: Add `credential_id` request validation

### DIFF
--- a/db/migrations/sdp-migrations/2025-08-13.0-increase-credential-id-column-size.sql
+++ b/db/migrations/sdp-migrations/2025-08-13.0-increase-credential-id-column-size.sql
@@ -1,0 +1,10 @@
+-- +migrate Up
+
+-- WebAuthn credential IDs can be up to 1023 bytes, and after URL encoding they can be longer
+ALTER TABLE embedded_wallets
+ALTER COLUMN credential_id TYPE VARCHAR(2048);
+
+-- +migrate Down
+
+ALTER TABLE embedded_wallets
+ALTER COLUMN credential_id TYPE VARCHAR(64);

--- a/internal/data/embedded_wallet.go
+++ b/internal/data/embedded_wallet.go
@@ -200,6 +200,12 @@ func (ewu EmbeddedWalletUpdate) Validate() error {
 		}
 	}
 
+	if ewu.CredentialID != "" {
+		if len(ewu.CredentialID) > 64 {
+			return fmt.Errorf("credential ID must be 64 characters or less, got %d characters", len(ewu.CredentialID))
+		}
+	}
+
 	return nil
 }
 

--- a/internal/data/embedded_wallet_test.go
+++ b/internal/data/embedded_wallet_test.go
@@ -147,6 +147,17 @@ func Test_EmbeddedWalletUpdate_Validate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("validates CredentialID", func(t *testing.T) {
+		update := EmbeddedWalletUpdate{CredentialID: strings.Repeat("a", 65)}
+		err := update.Validate()
+		require.Error(t, err)
+		assert.EqualError(t, err, "credential ID must be 64 characters or less, got 65 characters")
+
+		update = EmbeddedWalletUpdate{CredentialID: strings.Repeat("a", 64)}
+		err = update.Validate()
+		require.NoError(t, err)
+	})
+
 	t.Run("validates a full valid update", func(t *testing.T) {
 		update := EmbeddedWalletUpdate{
 			WasmHash:        "abcdef123456",

--- a/internal/serve/httphandler/wallet_creation_handler.go
+++ b/internal/serve/httphandler/wallet_creation_handler.go
@@ -32,6 +32,7 @@ func (r CreateWalletRequest) Validate() *httperror.HTTPError {
 	validator.Check(len(strings.TrimSpace(r.Token)) > 0, "token", "token should not be empty")
 	validator.Check(len(strings.TrimSpace(r.PublicKey)) > 0, "public_key", "public_key should not be empty")
 	validator.Check(len(strings.TrimSpace(r.CredentialID)) > 0, "credential_id", "credential_id should not be empty")
+	validator.Check(len(r.CredentialID) <= 64, "credential_id", "credential_id must be 64 characters or less")
 	if pk, err := hex.DecodeString(r.PublicKey); err != nil {
 		validator.AddError("public_key", "public_key is not a valid hex string")
 	} else if !isValidP256PublicKey(pk) {

--- a/internal/serve/httphandler/wallet_creation_handler.go
+++ b/internal/serve/httphandler/wallet_creation_handler.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdh"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -15,6 +16,12 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
+)
+
+const (
+	// WebAuthn credential IDs can be up to 1023 bytes, and after URL encoding they can be longer.
+	// We set this to 2048 to provide sufficient buffer for URL encoding and future compatibility.
+	MaxCredentialIDLength = 2048
 )
 
 type WalletCreationHandler struct {
@@ -32,7 +39,7 @@ func (r CreateWalletRequest) Validate() *httperror.HTTPError {
 	validator.Check(len(strings.TrimSpace(r.Token)) > 0, "token", "token should not be empty")
 	validator.Check(len(strings.TrimSpace(r.PublicKey)) > 0, "public_key", "public_key should not be empty")
 	validator.Check(len(strings.TrimSpace(r.CredentialID)) > 0, "credential_id", "credential_id should not be empty")
-	validator.Check(len(r.CredentialID) <= 64, "credential_id", "credential_id must be 64 characters or less")
+	validator.Check(len(r.CredentialID) <= MaxCredentialIDLength, "credential_id", fmt.Sprintf("credential_id must be %d characters or less", MaxCredentialIDLength))
 	if pk, err := hex.DecodeString(r.PublicKey); err != nil {
 		validator.AddError("public_key", "public_key is not a valid hex string")
 	} else if !isValidP256PublicKey(pk) {

--- a/internal/serve/httphandler/wallet_creation_handler_test.go
+++ b/internal/serve/httphandler/wallet_creation_handler_test.go
@@ -103,7 +103,7 @@ func Test_WalletCreationHandler_CreateWallet_ValidationErrors(t *testing.T) {
 			requestBody: CreateWalletRequest{
 				Token:        "123",
 				PublicKey:    "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23",
-				CredentialID: strings.Repeat("a", 65), // 65 characters, should fail
+				CredentialID: strings.Repeat("a", MaxCredentialIDLength+1),
 			},
 			expectedField: "credential_id",
 		},

--- a/internal/serve/httphandler/wallet_creation_handler_test.go
+++ b/internal/serve/httphandler/wallet_creation_handler_test.go
@@ -98,6 +98,15 @@ func Test_WalletCreationHandler_CreateWallet_ValidationErrors(t *testing.T) {
 			},
 			expectedField: "credential_id",
 		},
+		{
+			name: "credential id too long",
+			requestBody: CreateWalletRequest{
+				Token:        "123",
+				PublicKey:    "04f5549c5ef833ab0ade80d9c1f3fb34fb93092503a8ce105773d676288653df384a024a92cc73cb8089c45ed76ed073433b6a72c64a6ed23630b77327beb65f23",
+				CredentialID: strings.Repeat("a", 65), // 65 characters, should fail
+			},
+			expectedField: "credential_id",
+		},
 	}
 
 	for _, tc := range errorCases {


### PR DESCRIPTION
### What

This adds length validation on the `credential_id` of the create embedded wallet request, and extends the column length.

### Why

Valid credential IDs are up 1023 bytes.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
