### PR TITLE
Fix: Remove admin from contract constructor args

### DIFF
--- a/internal/transactionsubmission/wallet_creation_transaction_handler.go
+++ b/internal/transactionsubmission/wallet_creation_transaction_handler.go
@@ -103,10 +103,6 @@ func (h *WalletCreationTransactionHandler) BuildInnerTransaction(ctx context.Con
 		Type:      xdr.ScAddressTypeScAddressTypeAccount,
 		AccountId: &distributionAccountId,
 	}
-	argAdmin := xdr.ScVal{
-		Type:    xdr.ScValTypeScvAddress,
-		Address: &distributionScAddress,
-	}
 
 	publicKeyScBytes := xdr.ScBytes(publicKeyBytes)
 	argPublicKey := xdr.ScVal{
@@ -142,7 +138,7 @@ func (h *WalletCreationTransactionHandler) BuildInnerTransaction(ctx context.Con
 				Type:     xdr.ContractExecutableTypeContractExecutableWasm,
 				WasmHash: &wasmHash,
 			},
-			ConstructorArgs: []xdr.ScVal{argAdmin, argPublicKey, argRecovery},
+			ConstructorArgs: []xdr.ScVal{argPublicKey, argRecovery},
 		},
 	}
 

--- a/internal/transactionsubmission/wallet_creation_transaction_handler_test.go
+++ b/internal/transactionsubmission/wallet_creation_transaction_handler_test.go
@@ -337,21 +337,12 @@ func Test_WalletCreationHandler_BuildInnerTransaction(t *testing.T) {
 		require.Equal(t, operation.HostFunction.Type, xdr.HostFunctionTypeHostFunctionTypeCreateContractV2)
 		require.NotNil(t, operation.HostFunction.CreateContractV2)
 
-		// Verify constructor arguments are in the correct order: [argAdmin, argPublicKey, argRecovery]
+		// Verify constructor arguments are in the correct order: [argPublicKey, argRecovery]
 		constructorArgs := operation.HostFunction.CreateContractV2.ConstructorArgs
-		require.Len(t, constructorArgs, 3)
+		require.Len(t, constructorArgs, 2)
 
-		// First argument should be argAdmin (distribution account address)
-		argAdmin := constructorArgs[0]
-		assert.Equal(t, xdr.ScValTypeScvAddress, argAdmin.Type)
-		require.NotNil(t, argAdmin.Address)
-		assert.Equal(t, xdr.ScAddressTypeScAddressTypeAccount, argAdmin.Address.Type)
-		require.NotNil(t, argAdmin.Address.AccountId)
-		distributionAccountId := xdr.MustAddress(distributionAccount)
-		assert.Equal(t, distributionAccountId, *argAdmin.Address.AccountId)
-
-		// Second argument should be argPublicKey (public key bytes)
-		argPublicKey := constructorArgs[1]
+		// First argument should be argPublicKey (public key bytes)
+		argPublicKey := constructorArgs[0]
 		assert.Equal(t, xdr.ScValTypeScvBytes, argPublicKey.Type)
 		require.NotNil(t, argPublicKey.Bytes)
 
@@ -360,8 +351,8 @@ func Test_WalletCreationHandler_BuildInnerTransaction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expectedPublicKeyBytes, []byte(*argPublicKey.Bytes))
 
-		// Third argument should be argRecovery (recovery account address)
-		argRecovery := constructorArgs[2]
+		// Second argument should be argRecovery (recovery account address)
+		argRecovery := constructorArgs[1]
 		assert.Equal(t, xdr.ScValTypeScvAddress, argRecovery.Type)
 		require.NotNil(t, argRecovery.Address)
 		assert.Equal(t, xdr.ScAddressTypeScAddressTypeAccount, argRecovery.Address.Type)
@@ -383,6 +374,7 @@ func Test_WalletCreationHandler_BuildInnerTransaction(t *testing.T) {
 		// Verify the address in the preimage matches the distribution account
 		assert.Equal(t, xdr.ScAddressTypeScAddressTypeAccount, contractIdPreimage.FromAddress.Address.Type)
 		require.NotNil(t, contractIdPreimage.FromAddress.Address.AccountId)
+		distributionAccountId := xdr.MustAddress(distributionAccount)
 		assert.Equal(t, distributionAccountId, *contractIdPreimage.FromAddress.Address.AccountId)
 
 		// Verify mocks were called as expected


### PR DESCRIPTION
### What

A previous PR removed the `admin` argument from the contract constructor but did not update the contract deployment code.

### Why

Contract deployments are failing

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
