### PR TITLE
Fix: Check wallet creation distribution account only when successful

### DIFF
--- a/internal/services/wallet_creation_from_submitter_service.go
+++ b/internal/services/wallet_creation_from_submitter_service.go
@@ -164,11 +164,13 @@ func (s *WalletCreationFromSubmitterService) syncTransactions(ctx context.Contex
 
 	// 1. Validate all transactions
 	for _, transaction := range transactions {
-		if transaction.Status == store.TransactionStatusSuccess && !transaction.StellarTransactionHash.Valid {
-			return fmt.Errorf("expected successful transaction %s to have a stellar transaction hash", transaction.ID)
-		}
-		if !transaction.DistributionAccount.Valid {
-			return fmt.Errorf("expected transaction %s to have a distribution account", transaction.ID)
+		if transaction.Status == store.TransactionStatusSuccess {
+			if !transaction.StellarTransactionHash.Valid {
+				return fmt.Errorf("expected successful transaction %s to have a stellar transaction hash", transaction.ID)
+			}
+			if !transaction.DistributionAccount.Valid {
+				return fmt.Errorf("expected successful transaction %s to have a distribution account", transaction.ID)
+			}
 		}
 		if transaction.WalletCreation.PublicKey == "" {
 			return fmt.Errorf("expected transaction %s to have a public key in wallet creation", transaction.ID)


### PR DESCRIPTION
### What

When a wallet creation transaction fails during simulation, the distribution account is not assigned. This PR updates the sync job to only check this field when the transaction was successful.

### Why

Wallet creation sync job fails

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
