### PR TITLE
SDP-1813 - [Kaizen] Refactor packages to reduce circular dependency issues [2/2]

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -18,6 +18,7 @@ import (
 	di "github.com/stellar/stellar-disbursement-platform-backend/internal/dependencyinjection"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/cli"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -110,7 +111,7 @@ func (a *AuthCommand) Command() *cobra.Command {
 				if err != nil {
 					log.Ctx(ctx).Fatalf("error getting tenant by id %s: %s", tenantID, err.Error())
 				}
-				ctx = tenant.SaveTenantInContext(ctx, t)
+				ctx = sdpcontext.SetTenantInContext(ctx, t)
 
 				// 2. Create user using multi-tenant connection pool
 				tr := tenant.NewMultiTenantDataSourceRouter(tm)

--- a/cmd/distribution_account_cmd_service.go
+++ b/cmd/distribution_account_cmd_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go/txnbuild"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
@@ -58,7 +59,7 @@ func (s *DistributionAccountService) rotateDistributionAccount(ctx context.Conte
 	}
 
 	// 3. Update the tenant with the new distribution account
-	t, err := tenant.GetTenantFromContext(ctx)
+	t, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't get tenant from context: %w", err)
 	}

--- a/cmd/distribution_account_cmd_service_test.go
+++ b/cmd/distribution_account_cmd_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
@@ -160,7 +161,7 @@ func Test_DistAccCmdService_RotateDistributionAccount(t *testing.T) {
 			// Create the service under test
 			tenantManager := tenant.NewManager(tenant.WithDatabase(dbConnectionPool))
 			testTenant := tenant.CreateTenantFixture(t, ctx, dbConnectionPool, fmt.Sprintf("tenant-%d", i), oldAccount.Address)
-			ctx = tenant.SaveTenantInContext(ctx, testTenant)
+			ctx = sdpcontext.SetTenantInContext(ctx, testTenant)
 
 			service := DistributionAccountService{
 				distAccService:             distAccServiceMock,

--- a/cmd/distribution_accounts.go
+++ b/cmd/distribution_accounts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	di "github.com/stellar/stellar-disbursement-platform-backend/internal/dependencyinjection"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
@@ -127,7 +128,7 @@ func (c *DistributionAccountCommand) RotateCommand(cmdService DistAccCmdServiceI
 			if err != nil {
 				log.Ctx(ctx).Fatalf("Error getting tenant by ID: %v", err)
 			}
-			ctx = tenant.SaveTenantInContext(ctx, t)
+			ctx = sdpcontext.SetTenantInContext(ctx, t)
 			cmd.SetContext(ctx)
 
 			// Prepare the signature service

--- a/cmd/distribution_accounts_test.go
+++ b/cmd/distribution_accounts_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -37,7 +38,7 @@ func Test_DistributionAccountCommand_RotateCommand(t *testing.T) {
 	tenantName := "tenant1"
 	tenant.PrepareDBForTenant(t, dbt, tenantName)
 	testTenant := tenant.CreateTenantFixture(t, ctx, adminDBConnectionPool, tenantName, oldAccount.Address)
-	ctx = tenant.SaveTenantInContext(ctx, testTenant)
+	ctx = sdpcontext.SetTenantInContext(ctx, testTenant)
 
 	globalOptions.NetworkPassphrase = network.TestNetworkPassphrase
 

--- a/internal/anchorplatform/sep24_auth_middleware.go
+++ b/internal/anchorplatform/sep24_auth_middleware.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/go/support/http/httpdecode"
 	"github.com/stellar/go/support/log"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -113,7 +114,7 @@ func SEP24QueryTokenAuthenticateMiddleware(jwtManager *JWTManager, networkPassph
 
 			// Add the token to the request context
 			ctx = context.WithValue(ctx, SEP24ClaimsContextKey, sep24Claims)
-			ctx = tenant.SaveTenantInContext(ctx, currentTenant)
+			ctx = sdpcontext.SetTenantInContext(ctx, currentTenant)
 			req = req.WithContext(ctx)
 
 			next.ServeHTTP(rw, req)
@@ -169,7 +170,7 @@ func SEP24HeaderTokenAuthenticateMiddleware(jwtManager *JWTManager, networkPassp
 
 			// Add the token to the request context
 			ctx = context.WithValue(ctx, SEP24ClaimsContextKey, sep24Claims)
-			ctx = tenant.SaveTenantInContext(ctx, currentTenant)
+			ctx = sdpcontext.SetTenantInContext(ctx, currentTenant)
 			req = req.WithContext(ctx)
 
 			next.ServeHTTP(rw, req)

--- a/internal/bridge/service_test.go
+++ b/internal/bridge/service_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_ServiceOptions_Validate(t *testing.T) {
@@ -491,7 +491,7 @@ func Test_Service_CreateVirtualAccount(t *testing.T) {
 		ID:      "test-tenant",
 		BaseURL: utils.Ptr("https://example.com"),
 	}
-	ctx = tenant.SaveTenantInContext(ctx, &tnt)
+	ctx = sdpcontext.SetTenantInContext(ctx, &tnt)
 
 	t.Run("integration not found", func(t *testing.T) {
 		data.CleanupBridgeIntegration(t, ctx, dbcp)

--- a/internal/circle/client.go
+++ b/internal/circle/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
@@ -422,7 +423,7 @@ func parseRetryAfter(retryAfter string) time.Duration {
 }
 
 func (client *Client) recordCircleAPIMetrics(ctx context.Context, method, endpoint string, startTime time.Time, resp *http.Response, reqErr error) {
-	t, err := tenant.GetTenantFromContext(ctx)
+	t, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		log.Ctx(ctx).Errorf("getting tenant from context: %v", err)
 		return
@@ -450,7 +451,7 @@ func (client *Client) recordCircleAPIMetrics(ctx context.Context, method, endpoi
 
 func (client *Client) handleError(ctx context.Context, resp *http.Response) error {
 	if slices.Contains(authErrorStatusCodes, resp.StatusCode) {
-		tnt, getCtxTntErr := tenant.GetTenantFromContext(ctx)
+		tnt, getCtxTntErr := sdpcontext.GetTenantFromContext(ctx)
 		if getCtxTntErr != nil {
 			return fmt.Errorf("getting tenant from context: %w", getCtxTntErr)
 		}

--- a/internal/circle/client_test.go
+++ b/internal/circle/client_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	monitorMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/monitor/mocks"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	httpclientMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -126,7 +127,7 @@ func Test_Client_PostTransfer(t *testing.T) {
 		unauthorizedResponse := `{"code": 401, "message": "Malformed key. Does it contain three parts?"}`
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -160,7 +161,7 @@ func Test_Client_PostTransfer(t *testing.T) {
 	t.Run("post transfer successful", func(t *testing.T) {
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -218,7 +219,7 @@ func Test_Client_GetTransferByID(t *testing.T) {
 		unauthorizedResponse := `{"code": 401, "message": "Malformed key. Does it contain three parts?"}`
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -252,7 +253,7 @@ func Test_Client_GetTransferByID(t *testing.T) {
 	t.Run("get transfer by id successful", func(t *testing.T) {
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -323,7 +324,7 @@ func Test_Client_PostRecipient(t *testing.T) {
 		unauthorizedResponse := `{"code": 401, "message": "Malformed key. Does it contain three parts?"}`
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -357,7 +358,7 @@ func Test_Client_PostRecipient(t *testing.T) {
 	t.Run("post transfer successful", func(t *testing.T) {
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -415,7 +416,7 @@ func Test_Client_GetRecipientByID(t *testing.T) {
 		unauthorizedResponse := `{"code": 401, "message": "Malformed key. Does it contain three parts?"}`
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -449,7 +450,7 @@ func Test_Client_GetRecipientByID(t *testing.T) {
 	t.Run("get recipient by id successful", func(t *testing.T) {
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -521,7 +522,7 @@ func Test_Client_PostPayout(t *testing.T) {
 		unauthorizedResponse := `{"code": 401, "message": "Malformed key. Does it contain three parts?"}`
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -555,7 +556,7 @@ func Test_Client_PostPayout(t *testing.T) {
 	t.Run("post transfer successful", func(t *testing.T) {
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -613,7 +614,7 @@ func Test_Client_GetPayoutByID(t *testing.T) {
 		unauthorizedResponse := `{"code": 401, "message": "Malformed key. Does it contain three parts?"}`
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -647,7 +648,7 @@ func Test_Client_GetPayoutByID(t *testing.T) {
 	t.Run("get payout by id successful", func(t *testing.T) {
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -715,7 +716,7 @@ func Test_Client_GetBusinessBalances(t *testing.T) {
 		}`
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -761,7 +762,7 @@ func Test_Client_GetBusinessBalances(t *testing.T) {
 		}`
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
 			Return(&http.Response{
@@ -834,7 +835,7 @@ func Test_Client_GetAccountConfiguration(t *testing.T) {
 		}`
 		cc, cMocks := newClientWithMocks(t)
 		tnt := &schema.Tenant{ID: "test-id"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cMocks.httpClientMock.
 			On("Do", mock.Anything).
@@ -874,7 +875,7 @@ func Test_Client_GetAccountConfiguration(t *testing.T) {
 			}
 		}`
 		tnt := &schema.Tenant{ID: "test-id", Name: "test-tenant"}
-		ctx = tenant.SaveTenantInContext(ctx, tnt)
+		ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 		cc, cMocks := newClientWithMocks(t)
 		cMocks.httpClientMock.
@@ -920,7 +921,7 @@ func Test_Client_GetAccountConfiguration(t *testing.T) {
 func Test_Client_handleError(t *testing.T) {
 	ctx := context.Background()
 	tnt := &schema.Tenant{ID: "test-id"}
-	ctx = tenant.SaveTenantInContext(ctx, tnt)
+	ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 	cc, cMocks := newClientWithMocks(t)
 

--- a/internal/dependencyinjection/mtn_db_connection_pool_test.go
+++ b/internal/dependencyinjection/mtn_db_connection_pool_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_dependencyinjection_NewMtnDBConnectionPool(t *testing.T) {
@@ -38,7 +38,7 @@ func Test_dependencyinjection_NewMtnDBConnectionPool(t *testing.T) {
 
 		// Checks that the search_path is set.
 		tenantInfo := &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "aid-org-1"}
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tenantInfo)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tenantInfo)
 		mtnDatabaseDSN, err := gotDependency.DSN(ctxWithTenant)
 		require.NoError(t, err)
 		assert.Contains(t, mtnDatabaseDSN, "search_path")

--- a/internal/events/eventhandlers/circle_payment_to_submitter_event_handler.go
+++ b/internal/events/eventhandlers/circle_payment_to_submitter_event_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/paymentdispatchers"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
@@ -81,7 +82,7 @@ func (h *CirclePaymentToSubmitterEventHandler) Handle(ctx context.Context, messa
 		return fmt.Errorf("getting tenant by id %s: %w", message.TenantID, err)
 	}
 
-	ctx = tenant.SaveTenantInContext(ctx, t)
+	ctx = sdpcontext.SetTenantInContext(ctx, t)
 
 	distAccount, err := h.distAccountResolver.DistributionAccountFromContext(ctx)
 	if err != nil {

--- a/internal/events/eventhandlers/circle_payment_to_submitter_event_handler_test.go
+++ b/internal/events/eventhandlers/circle_payment_to_submitter_event_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	servicesMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -73,7 +74,7 @@ func Test_CirclePaymentToSubmitterEventHandler_Handle(t *testing.T) {
 			},
 		}
 
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		service.
 			On("SendPaymentsReadyToPay", ctxWithTenant, paymentsReadyToPay).
@@ -102,7 +103,7 @@ func Test_CirclePaymentToSubmitterEventHandler_Handle(t *testing.T) {
 			},
 		}
 
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		service.
 			On("SendPaymentsReadyToPay", ctxWithTenant, paymentsReadyToPay).

--- a/internal/events/eventhandlers/patch_anchor_platform_transaction_completion_event_handler.go
+++ b/internal/events/eventhandlers/patch_anchor_platform_transaction_completion_event_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
@@ -67,7 +68,7 @@ func (h *PatchAnchorPlatformTransactionCompletionEventHandler) Handle(ctx contex
 		return fmt.Errorf("getting tenant by id: %w", err)
 	}
 
-	ctx = tenant.SaveTenantInContext(ctx, tnt)
+	ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 	err = h.service.PatchAPTransactionForPaymentEvent(ctx, payment)
 	if err != nil {
 		return fmt.Errorf("patching anchor platform transaction for payment event: %w", err)

--- a/internal/events/eventhandlers/payment_from_submitter_event_handler.go
+++ b/internal/events/eventhandlers/payment_from_submitter_event_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
@@ -63,7 +64,7 @@ func (h *PaymentFromSubmitterEventHandler) Handle(ctx context.Context, message *
 		return fmt.Errorf("getting tenant by id %s: %w", message.TenantID, err)
 	}
 
-	ctx = tenant.SaveTenantInContext(ctx, t)
+	ctx = sdpcontext.SetTenantInContext(ctx, t)
 
 	if syncErr := h.service.SyncTransaction(ctx, &tx); syncErr != nil {
 		return fmt.Errorf("syncing transaction completion for transaction ID %q: %w", tx.TransactionID, syncErr)

--- a/internal/events/eventhandlers/payment_from_submitter_event_handler_test.go
+++ b/internal/events/eventhandlers/payment_from_submitter_event_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	servicesMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -60,7 +61,7 @@ func Test_PaymentFromSubmitterEventHandler_Handle(t *testing.T) {
 			TransactionID: "tx-id",
 		}
 
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		service.
 			On("SyncTransaction", ctxWithTenant, &tx).
@@ -84,7 +85,7 @@ func Test_PaymentFromSubmitterEventHandler_Handle(t *testing.T) {
 			TransactionID: "tx-id",
 		}
 
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		service.
 			On("SyncTransaction", ctxWithTenant, &tx).

--- a/internal/events/eventhandlers/send_receiver_wallets_invitation_event_handler.go
+++ b/internal/events/eventhandlers/send_receiver_wallets_invitation_event_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
@@ -80,7 +81,7 @@ func (h *SendReceiverWalletsInvitationEventHandler) Handle(ctx context.Context, 
 		return fmt.Errorf("getting tenant by id %s: %w", message.TenantID, err)
 	}
 
-	ctx = tenant.SaveTenantInContext(ctx, t)
+	ctx = sdpcontext.SetTenantInContext(ctx, t)
 
 	if sendErr := h.service.SendInvite(ctx, receiverWalletInvitationData...); sendErr != nil {
 		return fmt.Errorf("sending receiver wallets invitation: %w", sendErr)

--- a/internal/events/eventhandlers/send_receiver_wallets_invitation_event_handler_test.go
+++ b/internal/events/eventhandlers/send_receiver_wallets_invitation_event_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	servicesMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -65,7 +66,7 @@ func Test_SendReceiverWalletsSMSInvitationEventHandler_Handle(t *testing.T) {
 			{ReceiverWalletID: "rw-id-2"},
 		}
 
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		service.
 			On("SendInvite", ctxWithTenant, reqs).
@@ -90,7 +91,7 @@ func Test_SendReceiverWalletsSMSInvitationEventHandler_Handle(t *testing.T) {
 			{ReceiverWalletID: "rw-id-2"},
 		}
 
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		service.
 			On("SendInvite", ctxWithTenant, reqs).

--- a/internal/events/eventhandlers/stellar_payment_to_submitter_event_handler.go
+++ b/internal/events/eventhandlers/stellar_payment_to_submitter_event_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/paymentdispatchers"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
@@ -78,7 +79,7 @@ func (h *StellarPaymentToSubmitterEventHandler) Handle(ctx context.Context, mess
 	if err != nil {
 		return fmt.Errorf("getting tenant by id %s: %w", message.TenantID, err)
 	}
-	ctx = tenant.SaveTenantInContext(ctx, t)
+	ctx = sdpcontext.SetTenantInContext(ctx, t)
 
 	// Bypass Sending payments if tenant doesn't have a Stellar account
 	distAccount, err := h.distAccountResolver.DistributionAccountFromContext(ctx)

--- a/internal/events/eventhandlers/stellar_payment_to_submitter_event_handler_test.go
+++ b/internal/events/eventhandlers/stellar_payment_to_submitter_event_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	servicesMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -74,7 +75,7 @@ func Test_PaymentToSubmitterEventHandler_Handle(t *testing.T) {
 			},
 		}
 
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		service.
 			On("SendPaymentsReadyToPay", ctxWithTenant, paymentsReadyToPay).
@@ -103,7 +104,7 @@ func Test_PaymentToSubmitterEventHandler_Handle(t *testing.T) {
 			},
 		}
 
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		service.
 			On("SendPaymentsReadyToPay", ctxWithTenant, paymentsReadyToPay).

--- a/internal/events/message.go
+++ b/internal/events/message.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type Message struct {
@@ -42,7 +42,7 @@ type HandlerSuccess struct {
 // NewMessage returns a new message with values passed by parameters. It also parses the `TenantID` from the context and inject it into the message.
 // Returns error if the tenant is not found in the context.
 func NewMessage(ctx context.Context, topic, key, messageType string, data any) (*Message, error) {
-	tnt, err := tenant.GetTenantFromContext(ctx)
+	tnt, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting tenant from context: %w", err)
 	}

--- a/internal/events/message_test.go
+++ b/internal/events/message_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_Message_Validate(t *testing.T) {
@@ -75,7 +75,7 @@ func Test_NewPaymentReadyToPayMessage(t *testing.T) {
 	key := "test-key"
 	messageType := "test-type"
 
-	ctxWithTenant := tenant.SaveTenantInContext(context.Background(), &schema.Tenant{ID: tenantID})
+	ctxWithTenant := sdpcontext.SetTenantInContext(context.Background(), &schema.Tenant{ID: tenantID})
 
 	t.Run("unsupported platform", func(t *testing.T) {
 		_, err := NewPaymentReadyToPayMessage(ctxWithTenant, "unsupported-platform", key, messageType)

--- a/internal/integrationtests/integration_tests.go
+++ b/internal/integrationtests/integration_tests.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httphandler"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -156,7 +157,7 @@ func (it *IntegrationTestsService) StartIntegrationTests(ctx context.Context, op
 	if err != nil {
 		return fmt.Errorf("getting tenant %s from database: %w", opts.TenantName, err)
 	}
-	ctx = tenant.SaveTenantInContext(ctx, t)
+	ctx = sdpcontext.SetTenantInContext(ctx, t)
 
 	log.Ctx(ctx).Info("Login user to get server API auth token")
 	authToken, err := it.serverAPI.Login(ctx)
@@ -374,7 +375,7 @@ func (it *IntegrationTestsService) CreateTestData(ctx context.Context, opts Inte
 		return fmt.Errorf("creating tenant: %w", err)
 	}
 
-	ctx = tenant.SaveTenantInContext(ctx, t)
+	ctx = sdpcontext.SetTenantInContext(ctx, t)
 
 	// 2. Reset password for the user
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(opts.UserPassword), bcrypt.DefaultCost)

--- a/internal/scheduler/jobs/mocks.go
+++ b/internal/scheduler/jobs/mocks.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 )
 
 // MockJob is a mock job created for testing purposes
@@ -60,7 +60,7 @@ func (m *MockMultiTenantJob) GetInterval() time.Duration {
 }
 
 func (m *MockMultiTenantJob) Execute(ctx context.Context) error {
-	tnt, err := tenant.GetTenantFromContext(ctx)
+	tnt, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
+++ b/internal/scheduler/jobs/patch_anchor_platform_transactions_job_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/anchorplatform"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	servicesMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_NewPatchAnchorPlatformTransactionCompletionJob(t *testing.T) {
@@ -68,7 +68,7 @@ func Test_PatchAnchorPlatformTransactionsCompletionJob_Execute(t *testing.T) {
 	defer dbConnectionPool.Close()
 
 	tenantInfo := &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "aid-org-1"}
-	ctx := tenant.SaveTenantInContext(context.Background(), tenantInfo)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), tenantInfo)
 
 	apAPISvcMock := anchorplatform.AnchorPlatformAPIServiceMock{}
 	patchAnchorSvcMock := servicesMocks.MockPatchAnchorPlatformTransactionCompletionService{}

--- a/internal/scheduler/jobs/payment_from_submitter_job.go
+++ b/internal/scheduler/jobs/payment_from_submitter_job.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 const (
@@ -48,7 +48,7 @@ func (d paymentFromSubmitterJob) IsJobMultiTenant() bool {
 }
 
 func (d paymentFromSubmitterJob) Execute(ctx context.Context) error {
-	t, err := tenant.GetTenantFromContext(ctx)
+	t, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting tenant from context for %s: %w", paymentFromSubmitterJobName, err)
 	}

--- a/internal/scheduler/jobs/payment_from_submitter_job_test.go
+++ b/internal/scheduler/jobs/payment_from_submitter_job_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_PaymentFromSubmitterJob_GetInterval(t *testing.T) {
@@ -61,7 +61,7 @@ func Test_PaymentFromSubmitterJob_Execute(t *testing.T) {
 				Name:                    "aid-org-1",
 				DistributionAccountType: schema.DistributionAccountStellarEnv,
 			}
-			ctx = tenant.SaveTenantInContext(ctx, tenantInfo)
+			ctx = sdpcontext.SetTenantInContext(ctx, tenantInfo)
 
 			mockPaymentFromSubmitterService := &mocks.MockPaymentFromSubmitterService{}
 			mockPaymentFromSubmitterService.On("SyncBatchTransactions", mock.Anything, paymentFromSubmitterBatchSize, tenantInfo.ID).

--- a/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
+++ b/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_NewSendReceiverWalletsSMSInvitationJob(t *testing.T) {
@@ -103,7 +103,7 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 		Name:    "TestTenant",
 		BaseURL: &tenantBaseURL,
 	}
-	ctx := tenant.SaveTenantInContext(context.Background(), tenantInfo)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), tenantInfo)
 
 	stellarSecretKey := "SBUSPEKAZKLZSWHRSJ2HWDZUK6I3IVDUWA7JJZSGBLZ2WZIUJI7FPNB5"
 	var maxInvitationSMSResendAttempts int64 = 3

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 
@@ -173,7 +174,7 @@ func executeJob(ctx context.Context, job jobs.Job, workerID int, crashTrackerCli
 		}
 		for _, t := range tenants {
 			log.Ctx(ctx).Debugf("Processing job %s for tenant %s on worker %d", job.GetName(), t.ID, workerID)
-			tenantCtx := tenant.SaveTenantInContext(ctx, &t)
+			tenantCtx := sdpcontext.SetTenantInContext(ctx, &t)
 			if err = job.Execute(tenantCtx); err != nil {
 				msg := fmt.Sprintf("error processing job %s for tenant %s on worker %d", job.GetName(), t.ID, workerID)
 				crashTrackerClient.LogAndReportErrors(tenantCtx, err, msg)

--- a/internal/sdpcontext/context.go
+++ b/internal/sdpcontext/context.go
@@ -1,0 +1,62 @@
+package sdpcontext
+
+import (
+	"context"
+	"errors"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
+)
+
+var (
+	ErrTenantNotFoundInContext = errors.New("tenant not found in context")
+	ErrUserIDNotFoundInContext = errors.New("user ID not found in context")
+	ErrTokenNotFoundInContext  = errors.New("token not found in context")
+)
+
+type (
+	tenantContextKey struct{}
+	tokenContextKey  struct{}
+	userIDContextKey struct{}
+)
+
+// GetTenantFromContext retrieves the tenant information from the context.
+func GetTenantFromContext(ctx context.Context) (*schema.Tenant, error) {
+	currentTenant, ok := ctx.Value(tenantContextKey{}).(*schema.Tenant)
+	if !ok {
+		return nil, ErrTenantNotFoundInContext
+	}
+	return currentTenant, nil
+}
+
+// SetTenantInContext stores the tenant information in the context.
+func SetTenantInContext(ctx context.Context, t *schema.Tenant) context.Context {
+	return context.WithValue(ctx, tenantContextKey{}, t)
+}
+
+// GetUserIDFromContext retrieves the user ID from the context.
+func GetUserIDFromContext(ctx context.Context) (string, error) {
+	userID, ok := ctx.Value(userIDContextKey{}).(string)
+	if !ok || userID == "" {
+		return "", ErrUserIDNotFoundInContext
+	}
+	return userID, nil
+}
+
+// SetUserIDInContext stores the user ID in the context.
+func SetUserIDInContext(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, userIDContextKey{}, userID)
+}
+
+// GetTokenFromContext retrieves the authentication token from the context.
+func GetTokenFromContext(ctx context.Context) (string, error) {
+	token, ok := ctx.Value(tokenContextKey{}).(string)
+	if !ok || token == "" {
+		return "", ErrTokenNotFoundInContext
+	}
+	return token, nil
+}
+
+// SetTokenInContext stores the authentication token in the context.
+func SetTokenInContext(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, tokenContextKey{}, token)
+}

--- a/internal/serve/auth/context.go
+++ b/internal/serve/auth/context.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
 
 func GetUserFromContext(ctx context.Context, authManager auth.AuthManager) (*auth.User, error) {
-	userID, ok := ctx.Value(middleware.UserIDContextKey).(string)
-	if !ok || userID == "" {
-		return nil, errors.New("user ID not found in context")
+	userID, err := sdpcontext.GetUserIDFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	user, err := authManager.GetUserByID(ctx, userID)

--- a/internal/serve/httphandler/api_key_handler.go
+++ b/internal/serve/httphandler/api_key_handler.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stellar/go/support/render/httpjson"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 )
 
@@ -65,8 +65,8 @@ func (h APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := ctx.Value(middleware.UserIDContextKey).(string)
-	if !ok {
+	userID, err := sdpcontext.GetUserIDFromContext(ctx)
+	if err != nil {
 		httperror.InternalError(ctx, "User identification error", nil, nil).Render(w)
 		return
 	}
@@ -91,8 +91,8 @@ func (h APIKeyHandler) GetApiKeyByID(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	keyID := chi.URLParam(r, "id")
 
-	userID, ok := ctx.Value(middleware.UserIDContextKey).(string)
-	if !ok {
+	userID, err := sdpcontext.GetUserIDFromContext(ctx)
+	if err != nil {
 		httperror.InternalError(ctx, "User identification error", nil, nil).Render(w)
 		return
 	}
@@ -113,8 +113,8 @@ func (h APIKeyHandler) GetApiKeyByID(w http.ResponseWriter, r *http.Request) {
 func (h APIKeyHandler) GetAllApiKeys(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	userID, ok := ctx.Value(middleware.UserIDContextKey).(string)
-	if !ok {
+	userID, err := sdpcontext.GetUserIDFromContext(ctx)
+	if err != nil {
 		httperror.InternalError(ctx, "User identification error", nil, nil).Render(w)
 		return
 	}
@@ -158,8 +158,8 @@ func (h APIKeyHandler) UpdateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := ctx.Value(middleware.UserIDContextKey).(string)
-	if !ok {
+	userID, err := sdpcontext.GetUserIDFromContext(ctx)
+	if err != nil {
 		httperror.InternalError(ctx, "User identification error", nil, nil).Render(w)
 		return
 	}
@@ -181,8 +181,8 @@ func (h APIKeyHandler) DeleteApiKey(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	keyID := chi.URLParam(r, "id")
 
-	userID, ok := ctx.Value(middleware.UserIDContextKey).(string)
-	if !ok {
+	userID, err := sdpcontext.GetUserIDFromContext(ctx)
+	if err != nil {
 		httperror.InternalError(ctx, "User identification error", nil, nil).Render(w)
 		return
 	}

--- a/internal/serve/httphandler/api_key_handler_test.go
+++ b/internal/serve/httphandler/api_key_handler_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 )
 
 const adminUserID = "b9c29a1a-4d30-4b99-8c5f-0546054be91b"
@@ -42,7 +42,7 @@ func setupHandler(t *testing.T) (APIKeyHandler, context.Context) {
 	require.NoError(t, err)
 
 	handler := APIKeyHandler{Models: models}
-	ctx := context.WithValue(context.Background(), middleware.UserIDContextKey, adminUserID)
+	ctx := sdpcontext.SetUserIDInContext(context.Background(), adminUserID)
 
 	return handler, ctx
 }
@@ -408,9 +408,7 @@ func Test_DeleteApiKeyEndpoints(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		otherCtx := context.WithValue(context.Background(), middleware.UserIDContextKey,
-			"11111111-2222-3333-4444-555555555555",
-		)
+		otherCtx := sdpcontext.SetUserIDInContext(context.Background(), "11111111-2222-3333-4444-555555555555")
 		req := httptest.NewRequestWithContext(otherCtx, http.MethodDelete, "/api-keys/"+key.ID, nil)
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
@@ -482,9 +480,7 @@ func Test_GetApiKeyByIDEndpoints(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		otherCtx := context.WithValue(context.Background(), middleware.UserIDContextKey,
-			"11111111-2222-3333-4444-555555555555",
-		)
+		otherCtx := sdpcontext.SetUserIDInContext(context.Background(), "11111111-2222-3333-4444-555555555555")
 		req := httptest.NewRequestWithContext(otherCtx, http.MethodGet, "/api-keys/"+key.ID, nil)
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
@@ -594,7 +590,7 @@ func Test_UpdateKeyEndpoints(t *testing.T) {
 		b, _ := json.Marshal(reqBody)
 
 		otherUserID := "11111111-2222-3333-4444-555555555555"
-		otherCtx := context.WithValue(context.Background(), middleware.UserIDContextKey, otherUserID)
+		otherCtx := sdpcontext.SetUserIDInContext(context.Background(), otherUserID)
 		req := httptest.NewRequestWithContext(otherCtx, http.MethodPut, "/api-keys/"+originalKey.ID, bytes.NewReader(b))
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)

--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
@@ -37,7 +38,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 var defaultPreconditions = txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)}
@@ -121,7 +121,7 @@ func Test_AssetsHandlerGetAssets(t *testing.T) {
 			DistributionAccountAddress: &[]string{"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"}[0],
 			DistributionAccountStatus:  schema.AccountStatusActive,
 		}
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		distAccount := schema.TransactionAccount{
 			Address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
@@ -188,7 +188,7 @@ func Test_AssetsHandlerGetAssets(t *testing.T) {
 			DistributionAccountAddress: &[]string{"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"}[0],
 			DistributionAccountStatus:  schema.AccountStatusActive,
 		}
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		distAccount := schema.TransactionAccount{
 			Address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
@@ -254,7 +254,7 @@ func Test_AssetsHandlerGetAssets(t *testing.T) {
 			DistributionAccountAddress: &[]string{"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"}[0],
 			DistributionAccountStatus:  schema.AccountStatusActive,
 		}
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		distAccount := schema.TransactionAccount{
 			Address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
@@ -301,7 +301,7 @@ func Test_AssetsHandlerGetAssets(t *testing.T) {
 			DistributionAccountAddress: &[]string{"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"}[0],
 			DistributionAccountStatus:  schema.AccountStatusActive,
 		}
-		ctxWithTenant := tenant.SaveTenantInContext(ctx, tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(ctx, tnt)
 
 		distAccount := schema.TransactionAccount{
 			Address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",

--- a/internal/serve/httphandler/bridge_integration_handler.go
+++ b/internal/serve/httphandler/bridge_integration_handler.go
@@ -15,12 +15,12 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/bridge"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	ctxHelper "github.com/stellar/stellar-disbursement-platform-backend/internal/serve/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 // BridgeIntegrationHandler handles Bridge integration endpoints.
@@ -199,7 +199,7 @@ func (h BridgeIntegrationHandler) optInToBridge(ctx context.Context, user *auth.
 
 // resolveRedirectURL resolves the redirect URL for the Bridge integration based on the tenant's SDP UI Base URL.
 func resolveRedirectURL(ctx context.Context) (*url.URL, error) {
-	t, err := tenant.GetTenantFromContext(ctx)
+	t, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting tenant from context: %w", err)
 	}

--- a/internal/serve/httphandler/bridge_integration_handler_test.go
+++ b/internal/serve/httphandler/bridge_integration_handler_test.go
@@ -17,12 +17,11 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/bridge"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_BridgeIntegrationHandler_Get(t *testing.T) {
@@ -427,7 +426,7 @@ func Test_BridgeIntegrationHandler_Patch_optInToBridge(t *testing.T) {
 				BaseURL:      utils.Ptr("https://example.com"),
 				SDPUIBaseURL: utils.Ptr("https://example.com"),
 			}
-			ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
+			ctx := sdpcontext.SetTenantInContext(context.Background(), &tnt)
 
 			rr := httptest.NewRecorder()
 			req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/bridge-integration", bodyReader)
@@ -435,7 +434,7 @@ func Test_BridgeIntegrationHandler_Patch_optInToBridge(t *testing.T) {
 
 			// Add user context if needed for auth
 			if !strings.Contains(tc.name, "not enabled") && !strings.Contains(tc.name, "invalid JSON") {
-				ctx := context.WithValue(req.Context(), middleware.UserIDContextKey, testUser.ID)
+				ctx := sdpcontext.SetUserIDInContext(req.Context(), testUser.ID)
 				req = req.WithContext(ctx)
 			}
 
@@ -782,8 +781,8 @@ func Test_BridgeIntegrationHandler_Patch_createVirtualAccount(t *testing.T) {
 				ID:      "test-tenant",
 				BaseURL: utils.Ptr("https://example.com"),
 			}
-			ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
-			ctx = context.WithValue(ctx, middleware.UserIDContextKey, testUser.ID)
+			ctx := sdpcontext.SetTenantInContext(context.Background(), &tnt)
+			ctx = sdpcontext.SetUserIDInContext(ctx, testUser.ID)
 
 			rr := httptest.NewRecorder()
 			req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/bridge-integration", bodyReader)

--- a/internal/serve/httphandler/circle_config_handler.go
+++ b/internal/serve/httphandler/circle_config_handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	sdpUtils "github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
@@ -47,7 +48,7 @@ func (r PatchCircleConfigRequest) validate() error {
 func (h CircleConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	tnt, err := tenant.GetTenantFromContext(ctx)
+	tnt, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot retrieve the tenant from the context", err, nil).Render(w)
 		return

--- a/internal/serve/httphandler/circle_config_handler_test.go
+++ b/internal/serve/httphandler/circle_config_handler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
@@ -35,7 +36,7 @@ func TestCircleConfigHandler_Patch(t *testing.T) {
 
 	// Creates a tenant and inserts it in the context
 	tnt := schema.Tenant{ID: "test-tenant-id"}
-	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &tnt)
 
 	kp := keypair.MustRandom()
 	encryptionPassphrase := kp.Seed()

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -24,10 +24,10 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	ctxHelper "github.com/stellar/stellar-disbursement-platform-backend/internal/serve/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpresponse"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
@@ -478,13 +478,15 @@ func (d DisbursementHandler) PatchDisbursementStatus(w http.ResponseWriter, r *h
 
 	disbursementID := chi.URLParam(r, "id")
 
-	token, ok := ctx.Value(middleware.TokenContextKey).(string)
-	if !ok {
+	token, err := sdpcontext.GetTokenFromContext(ctx)
+	if err != nil {
 		httperror.InternalError(ctx, "Cannot get token from context", err, nil).Render(w)
+		return
 	}
 	user, err := d.AuthManager.GetUser(ctx, token)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot get user from token", err, nil).Render(w)
+		return
 	}
 
 	switch toStatus {

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	monitorMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/monitor/mocks"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpresponse"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	svcMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
@@ -190,7 +190,7 @@ func Test_DisbursementHandler_PostDisbursement(t *testing.T) {
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 
-	ctx := context.WithValue(context.Background(), middleware.UserIDContextKey, "user-id")
+	ctx := sdpcontext.SetUserIDInContext(context.Background(), "user-id")
 	user := &auth.User{
 		ID:    "user-id",
 		Email: "email@email.com",
@@ -908,7 +908,7 @@ func Test_DisbursementHandler_PostDisbursementInstructions(t *testing.T) {
 
 	mMonitorService := monitorMocks.NewMockMonitorService(t)
 
-	ctx := context.WithValue(context.Background(), middleware.UserIDContextKey, "user-id")
+	ctx := sdpcontext.SetUserIDInContext(context.Background(), "user-id")
 	authManagerMock := &auth.AuthManagerMock{}
 	authManagerMock.
 		On("GetUserByID", mock.Anything, mock.Anything).
@@ -918,7 +918,8 @@ func Test_DisbursementHandler_PostDisbursementInstructions(t *testing.T) {
 		}, nil).
 		Run(func(args mock.Arguments) {
 			mockCtx := args.Get(0).(context.Context)
-			val := mockCtx.Value(middleware.UserIDContextKey)
+			val, err := sdpcontext.GetUserIDFromContext(mockCtx)
+			assert.NoError(t, err)
 			assert.Equal(t, "user-id", val)
 		})
 
@@ -1553,7 +1554,7 @@ func Test_DisbursementHandler_PatchDisbursementStatus(t *testing.T) {
 
 	token := "token"
 	_, ctx := tenant.LoadDefaultTenantInContext(t, dbConnectionPool)
-	ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+	ctx = sdpcontext.SetTokenInContext(ctx, token)
 	userID := "valid-user-id"
 	user := &auth.User{
 		ID:    userID,
@@ -2154,7 +2155,7 @@ func Test_DisbursementHandler_PostDisbursement_WithInstructions(t *testing.T) {
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 
-	ctx := context.WithValue(context.Background(), middleware.UserIDContextKey, "user-id")
+	ctx := sdpcontext.SetUserIDInContext(context.Background(), "user-id")
 
 	// Setup fixtures
 	wallets := data.ClearAndCreateWalletFixtures(t, ctx, dbConnectionPool)
@@ -2182,7 +2183,8 @@ func Test_DisbursementHandler_PostDisbursement_WithInstructions(t *testing.T) {
 		}, nil).
 		Run(func(args mock.Arguments) {
 			mockCtx := args.Get(0).(context.Context)
-			val := mockCtx.Value(middleware.UserIDContextKey)
+			val, err := sdpcontext.GetUserIDFromContext(mockCtx)
+			assert.NoError(t, err)
 			assert.Equal(t, "user-id", val)
 		})
 

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -16,11 +16,11 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 const forgotPasswordMessageTitle = "Reset Account Password"
@@ -57,7 +57,7 @@ func (h ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	ctx := r.Context()
 
 	// Step 1: Get tenant from context
-	tnt, err := tenant.GetTenantFromContext(ctx)
+	tnt, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		err = fmt.Errorf("getting tenant from context: %w", err)
 		httperror.Unauthorized("", err, nil).Render(w)

--- a/internal/serve/httphandler/forgot_password_handler_test.go
+++ b/internal/serve/httphandler/forgot_password_handler_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_ForgotPasswordHandler_validateRequest(t *testing.T) {
@@ -290,7 +290,7 @@ func Test_ForgotPasswordHandler_ServeHTTP(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.hasTenant {
-				ctx = tenant.SaveTenantInContext(ctx, &tnt)
+				ctx = sdpcontext.SetTenantInContext(ctx, &tnt)
 			}
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/forgot-password", strings.NewReader(tc.reqBody))
 			require.NoError(t, err)

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpresponse"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
@@ -37,7 +37,6 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_PaymentsHandlerGet(t *testing.T) {
@@ -891,7 +890,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 
 	tnt := schema.Tenant{ID: "tenant-id"}
 
-	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &tnt)
 
 	wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "Wallet", "https://www.wallet.com", "www.wallet.com", "wallet://")
 	asset := data.CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
@@ -930,7 +929,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 	})
 
 	t.Run("returns InternalServerError when fails getting user from token", func(t *testing.T) {
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", strings.NewReader("{}"))
 		require.NoError(t, err)
@@ -961,7 +960,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 	})
 
 	t.Run("returns BadRequest when fails decoding body request", func(t *testing.T) {
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		payload := strings.NewReader("invalid")
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", payload)
@@ -993,7 +992,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 	})
 
 	t.Run("returns BadRequest when fails when payload is invalid", func(t *testing.T) {
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		payload := strings.NewReader("{}")
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "/retry", payload)
@@ -1067,7 +1066,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 			Asset:                *asset,
 		})
 
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
@@ -1157,7 +1156,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 			Asset:                *asset,
 		})
 
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
@@ -1263,8 +1262,8 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 		})
 
 		circleTnt := schema.Tenant{ID: "tenant-id", DistributionAccountType: schema.DistributionAccountCircleDBVault}
-		circleCtx := tenant.SaveTenantInContext(context.Background(), &circleTnt)
-		circleCtx = context.WithValue(circleCtx, middleware.TokenContextKey, "mytoken")
+		circleCtx := sdpcontext.SetTenantInContext(context.Background(), &circleTnt)
+		circleCtx = sdpcontext.SetTokenInContext(circleCtx, "mytoken")
 
 		payload := strings.NewReader(fmt.Sprintf(`{ "payment_ids": [%q] } `, failedPayment.ID))
 		req, err := http.NewRequestWithContext(circleCtx, http.MethodPatch, "/retry", payload)
@@ -1355,7 +1354,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 			Asset:                *asset,
 		})
 
-		ctxWithoutTenant := context.WithValue(context.Background(), middleware.TokenContextKey, "mytoken")
+		ctxWithoutTenant := sdpcontext.SetTokenInContext(context.Background(), "mytoken")
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
@@ -1403,7 +1402,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 			Asset:                *asset,
 		})
 
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
@@ -1491,7 +1490,7 @@ func Test_PaymentHandler_RetryPayments(t *testing.T) {
 			Asset:                *asset,
 		})
 
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		payload := strings.NewReader(fmt.Sprintf(`
 			{
@@ -1792,8 +1791,8 @@ func Test_PaymentsHandler_PatchPaymentStatus(t *testing.T) {
 }
 
 func Test_PaymentsHandler_PostPayment(t *testing.T) {
-	ctx := context.WithValue(context.Background(), middleware.UserIDContextKey, "user-id")
-	ctx = tenant.SaveTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
+	ctx := sdpcontext.SetUserIDInContext(context.Background(), "user-id")
+	ctx = sdpcontext.SetTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
 
 	dbConnectionPool := testutils.GetDBConnectionPool(t)
 	models, err := data.NewModels(dbConnectionPool)
@@ -2337,8 +2336,8 @@ func Test_PaymentsHandler_PostPayment(t *testing.T) {
 
 func TestPaymentsHandler_PostPayment_InputValidation(t *testing.T) {
 	dbConnectionPool := testutils.GetDBConnectionPool(t)
-	ctx := context.WithValue(context.Background(), middleware.UserIDContextKey, "user-horus")
-	ctx = tenant.SaveTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
+	ctx := sdpcontext.SetUserIDInContext(context.Background(), "user-horus")
+	ctx = sdpcontext.SetTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/publicfiles"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
@@ -355,7 +355,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			// Inject authenticated token into context:
 			ctx := context.Background()
 			if tc.token != "" {
-				ctx = context.WithValue(ctx, middleware.TokenContextKey, tc.token)
+				ctx = sdpcontext.SetTokenInContext(ctx, tc.token)
 			}
 
 			// Setup password validator
@@ -561,7 +561,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 			// Inject authenticated token into context:
 			ctx := context.Background()
 			if tc.token != "" {
-				ctx = context.WithValue(ctx, middleware.TokenContextKey, tc.token)
+				ctx = sdpcontext.SetTokenInContext(ctx, tc.token)
 			}
 
 			// Assert DB before
@@ -749,7 +749,7 @@ func Test_ProfileHandler_PatchUserProfile(t *testing.T) {
 			// Inject authenticated token into context:
 			ctx := context.Background()
 			if tc.token != "" {
-				ctx = context.WithValue(ctx, middleware.TokenContextKey, tc.token)
+				ctx = sdpcontext.SetTokenInContext(ctx, tc.token)
 			}
 
 			// Setup password validator
@@ -930,7 +930,7 @@ func Test_ProfileHandler_PatchUserPassword(t *testing.T) {
 			// Inject authenticated token into context:
 			ctx := context.Background()
 			if tc.token != "" {
-				ctx = context.WithValue(ctx, middleware.TokenContextKey, tc.token)
+				ctx = sdpcontext.SetTokenInContext(ctx, tc.token)
 			}
 
 			// Setup password validator
@@ -1008,7 +1008,7 @@ func Test_ProfileHandler_GetProfile(t *testing.T) {
 
 	t.Run("returns Unauthorized when AuthManager fails with ErrInvalidToken", func(t *testing.T) {
 		token := "mytoken"
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+		ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 		expectedErr := auth.ErrInvalidToken
 		authManagerMock.
@@ -1039,7 +1039,7 @@ func Test_ProfileHandler_GetProfile(t *testing.T) {
 
 	t.Run("returns BadRequest when user is not found", func(t *testing.T) {
 		token := "mytoken"
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+		ctx = sdpcontext.SetTokenInContext(ctx, token)
 		expectedErr := fmt.Errorf("error getting user ID %s: %w", "user-id", auth.ErrUserNotFound)
 
 		authManagerMock.
@@ -1070,7 +1070,7 @@ func Test_ProfileHandler_GetProfile(t *testing.T) {
 
 	t.Run("returns InternalServerError when AuthManager fails", func(t *testing.T) {
 		token := "mytoken"
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+		ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 		expectedErr := errors.New("error getting user ID user-id: unexpected error")
 		authManagerMock.
@@ -1101,7 +1101,7 @@ func Test_ProfileHandler_GetProfile(t *testing.T) {
 
 	t.Run("returns the profile info successfully", func(t *testing.T) {
 		token := "mytoken"
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+		ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 		u := &auth.User{
 			ID:        "user-id",

--- a/internal/serve/httphandler/receiver_registration_handler.go
+++ b/internal/serve/httphandler/receiver_registration_handler.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/anchorplatform"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type ReceiverRegistrationHandler struct {
@@ -62,7 +62,7 @@ func (h ReceiverRegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		privacyPolicyLink = *organization.PrivacyPolicyLink
 	}
 
-	currentTenant, err := tenant.GetTenantFromContext(ctx)
+	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil || currentTenant == nil {
 		httperror.InternalError(ctx, "Cannot retrieve the tenant from the context", err, nil).WithErrorCode(httperror.Code500_2).Render(w)
 		return

--- a/internal/serve/httphandler/receiver_wallets_handler.go
+++ b/internal/serve/httphandler/receiver_wallets_handler.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type RetryInvitationMessageResponse struct {
@@ -65,7 +65,7 @@ func (h ReceiverWalletsHandler) RetryInvitation(rw http.ResponseWriter, req *htt
 			return
 		}
 
-		if errors.Is(err, tenant.ErrTenantNotFoundInContext) {
+		if errors.Is(err, sdpcontext.ErrTenantNotFoundInContext) {
 			httperror.Forbidden("", err, nil).Render(rw)
 			return
 		}

--- a/internal/serve/httphandler/receiver_wallets_handler_test.go
+++ b/internal/serve/httphandler/receiver_wallets_handler_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_RetryInvitation(t *testing.T) {
@@ -38,7 +38,7 @@ func Test_RetryInvitation(t *testing.T) {
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 	tnt := schema.Tenant{ID: "tenant-id"}
-	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &tnt)
 
 	t.Run("returns error when receiver wallet does not exist", func(t *testing.T) {
 		handler := ReceiverWalletsHandler{Models: models}

--- a/internal/serve/httphandler/refresh_token_handler.go
+++ b/internal/serve/httphandler/refresh_token_handler.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stellar/go/support/render/httpjson"
 
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
 
@@ -18,8 +18,8 @@ type RefreshTokenHandler struct {
 func (h RefreshTokenHandler) PostRefreshToken(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	token, ok := ctx.Value(middleware.TokenContextKey).(string)
-	if !ok {
+	token, err := sdpcontext.GetTokenFromContext(ctx)
+	if err != nil {
 		httperror.Unauthorized("", nil, nil).Render(rw)
 		return
 	}

--- a/internal/serve/httphandler/refresh_token_handler_test.go
+++ b/internal/serve/httphandler/refresh_token_handler_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
 
@@ -44,7 +44,7 @@ func Test_RefreshTokenHandler(t *testing.T) {
 	})
 
 	t.Run("returns BadRequest when token is expired", func(t *testing.T) {
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		w := httptest.NewRecorder()
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
@@ -67,7 +67,7 @@ func Test_RefreshTokenHandler(t *testing.T) {
 	})
 
 	t.Run("returns InternalServerError when AuthManager fails", func(t *testing.T) {
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		w := httptest.NewRecorder()
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
@@ -90,7 +90,7 @@ func Test_RefreshTokenHandler(t *testing.T) {
 	})
 
 	t.Run("returns the refreshed token", func(t *testing.T) {
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, "mytoken")
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		w := httptest.NewRecorder()
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)

--- a/internal/serve/httphandler/stellar_toml_handler.go
+++ b/internal/serve/httphandler/stellar_toml_handler.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type StellarTomlHandler struct {
@@ -100,7 +100,7 @@ func (s *StellarTomlHandler) buildCurrencyInformation(assets []data.Asset) strin
 func (s StellarTomlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var stellarToml string
-	_, err := tenant.GetTenantFromContext(ctx)
+	_, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		// return a general stellar.toml file for this instance because no tenant is present.
 		networkType, innerErr := utils.GetNetworkTypeFromNetworkPassphrase(s.NetworkPassphrase)

--- a/internal/serve/httphandler/stellar_toml_handler_test.go
+++ b/internal/serve/httphandler/stellar_toml_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
@@ -148,7 +149,7 @@ func Test_StellarTomlHandler_buildGeneralInformation(t *testing.T) {
 			} else {
 				mDistAccResolver.
 					On("DistributionAccountFromContext", ctx).
-					Return(schema.TransactionAccount{}, tenant.ErrTenantNotFoundInContext).
+					Return(schema.TransactionAccount{}, sdpcontext.ErrTenantNotFoundInContext).
 					Once()
 			}
 			tc.s.DistributionAccountResolver = mDistAccResolver

--- a/internal/serve/httphandler/update_receiver_handler.go
+++ b/internal/serve/httphandler/update_receiver_handler.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
@@ -58,8 +58,8 @@ func createVerificationInsert(updateReceiverInfo *validators.UpdateReceiverReque
 func (h UpdateReceiverHandler) UpdateReceiver(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	userID, ok := ctx.Value(middleware.UserIDContextKey).(string)
-	if !ok {
+	userID, err := sdpcontext.GetUserIDFromContext(ctx)
+	if err != nil {
 		httperror.Unauthorized("", nil, nil).Render(rw)
 		return
 	}
@@ -82,7 +82,7 @@ func (h UpdateReceiverHandler) UpdateReceiver(rw http.ResponseWriter, req *http.
 	}
 
 	receiverID := chi.URLParam(req, "id")
-	_, err := h.Models.Receiver.Get(ctx, h.DBConnectionPool, receiverID)
+	_, err = h.Models.Receiver.Get(ctx, h.DBConnectionPool, receiverID)
 	if err != nil {
 		if errors.Is(err, data.ErrRecordNotFound) {
 			httperror.NotFound("Receiver not found", err, nil).Render(rw)

--- a/internal/serve/httphandler/update_receiver_handler_test.go
+++ b/internal/serve/httphandler/update_receiver_handler_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
@@ -108,7 +108,7 @@ func Test_UpdateReceiverHandler_400(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, middleware.UserIDContextKey, "my-user-id")
+	ctx = sdpcontext.SetUserIDInContext(ctx, "my-user-id")
 
 	user := &auth.User{
 		ID:    "my-user-id",
@@ -269,7 +269,7 @@ func Test_UpdateReceiverHandler_404(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, middleware.UserIDContextKey, "my-user-id")
+	ctx = sdpcontext.SetUserIDInContext(ctx, "my-user-id")
 
 	// setup
 	authManager := &auth.AuthManagerMock{}
@@ -305,7 +305,7 @@ func Test_UpdateReceiverHandler_409(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, middleware.UserIDContextKey, "my-user-id")
+	ctx = sdpcontext.SetUserIDInContext(ctx, "my-user-id")
 
 	// setup
 	authManager := &auth.AuthManagerMock{}
@@ -384,7 +384,7 @@ func Test_UpdateReceiverHandler_200ok_updateReceiverFields(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, middleware.UserIDContextKey, "my-user-id")
+	ctx = sdpcontext.SetUserIDInContext(ctx, "my-user-id")
 
 	// setup
 	authManager := &auth.AuthManagerMock{}
@@ -507,7 +507,7 @@ func Test_UpdateReceiverHandler_200ok_upsertVerificationFields(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, middleware.UserIDContextKey, "my-user-id")
+	ctx = sdpcontext.SetUserIDInContext(ctx, "my-user-id")
 
 	// setup
 	authManager := &auth.AuthManagerMock{}

--- a/internal/serve/httphandler/user_handler.go
+++ b/internal/serve/httphandler/user_handler.go
@@ -14,13 +14,12 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/crashtracker"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type UserHandler struct {
@@ -115,8 +114,8 @@ func validateRoles(validator *validators.Validator, roles []data.UserRole) {
 func (h UserHandler) UserActivation(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	token, ok := ctx.Value(middleware.TokenContextKey).(string)
-	if !ok {
+	token, err := sdpcontext.GetTokenFromContext(ctx)
+	if err != nil {
 		log.Ctx(ctx).Warn("token not found when updating user activation")
 		httperror.Unauthorized("", nil, nil).Render(rw)
 		return
@@ -176,15 +175,15 @@ func (h UserHandler) UserActivation(rw http.ResponseWriter, req *http.Request) {
 func (h UserHandler) CreateUser(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	tnt, err := tenant.GetTenantFromContext(ctx)
+	tnt, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		err = fmt.Errorf("getting tenant from context: %w", err)
 		httperror.Unauthorized("", err, nil).Render(rw)
 		return
 	}
 
-	token, ok := ctx.Value(middleware.TokenContextKey).(string)
-	if !ok {
+	token, err := sdpcontext.GetTokenFromContext(ctx)
+	if err != nil {
 		log.Ctx(ctx).Warn("token not found when updating user activation")
 		httperror.Unauthorized("", nil, nil).Render(rw)
 		return
@@ -247,8 +246,8 @@ func (h UserHandler) CreateUser(rw http.ResponseWriter, req *http.Request) {
 func (h UserHandler) UpdateUserRoles(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	token, ok := ctx.Value(middleware.TokenContextKey).(string)
-	if !ok {
+	token, err := sdpcontext.GetTokenFromContext(ctx)
+	if err != nil {
 		log.Ctx(ctx).Warn("token not found when updating user roles")
 		httperror.Unauthorized("", nil, nil).Render(rw)
 		return
@@ -305,8 +304,8 @@ func (h UserHandler) GetAllUsers(rw http.ResponseWriter, req *http.Request) {
 
 	ctx := req.Context()
 
-	token, ok := ctx.Value(middleware.TokenContextKey).(string)
-	if !ok {
+	token, err := sdpcontext.GetTokenFromContext(ctx)
+	if err != nil {
 		log.Ctx(ctx).Warn("token not found when getting all users")
 		httperror.Unauthorized("", nil, nil).Render(rw)
 		return

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -22,11 +22,10 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/htmltemplate"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_UserHandler_UserActivation(t *testing.T) {
@@ -61,7 +60,7 @@ func Test_UserHandler_UserActivation(t *testing.T) {
 
 		ctx := context.Background()
 		if token != "" {
-			ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+			ctx = sdpcontext.SetTokenInContext(ctx, token)
 		}
 
 		var bodyReader io.Reader
@@ -506,7 +505,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 	tnt := schema.Tenant{
 		SDPUIBaseURL: &uiBaseURL,
 	}
-	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &tnt)
 
 	const url = "/users"
 
@@ -514,7 +513,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 	t.Run("returns error when request body is invalid", func(t *testing.T) {
 		token := "mytoken"
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+		ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(`{}`))
 		require.NoError(t, err)
@@ -634,7 +633,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 	t.Run("returns error when Auth Manager fails", func(t *testing.T) {
 		token := "mytoken"
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+		ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 		authManagerMock.
 			On("GetUserID", mock.Anything, token).
@@ -709,7 +708,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 	t.Run("returns Bad Request when user is duplicated", func(t *testing.T) {
 		token := "mytoken"
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+		ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 		u := &auth.User{
 			FirstName: "First",
@@ -752,7 +751,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 	t.Run("logs and reports error when sending email fails", func(t *testing.T) {
 		token := "mytoken"
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+		ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 		u := &auth.User{
 			FirstName: "First",
@@ -842,8 +841,8 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 			SDPUIBaseURL: &[]string{"%invalid%"}[0],
 		}
 		token := "mytoken"
-		ctxTenantWithInvalidUIBaseURL := tenant.SaveTenantInContext(context.Background(), &tntInvalidUIBaseURL)
-		ctxTenantWithInvalidUIBaseURL = context.WithValue(ctxTenantWithInvalidUIBaseURL, middleware.TokenContextKey, token)
+		ctxTenantWithInvalidUIBaseURL := sdpcontext.SetTenantInContext(context.Background(), &tntInvalidUIBaseURL)
+		ctxTenantWithInvalidUIBaseURL = sdpcontext.SetTokenInContext(ctxTenantWithInvalidUIBaseURL, token)
 
 		u := &auth.User{
 			FirstName: "First",
@@ -914,7 +913,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 
 	t.Run("creates user successfully", func(t *testing.T) {
 		token := "mytoken"
-		ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+		ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
@@ -1104,7 +1103,7 @@ func Test_UserHandler_UpdateUserRoles(t *testing.T) {
 	})
 
 	t.Run("returns error when request body is invalid", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, "mytoken")
+		ctx := sdpcontext.SetTokenInContext(context.Background(), "mytoken")
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, strings.NewReader(`{}`))
 		require.NoError(t, err)
@@ -1224,7 +1223,7 @@ func Test_UserHandler_UpdateUserRoles(t *testing.T) {
 			Return(false, nil).
 			Once()
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		reqBody := `
 			{	
@@ -1264,7 +1263,7 @@ func Test_UserHandler_UpdateUserRoles(t *testing.T) {
 			Return(auth.ErrNoRowsAffected).
 			Once()
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		reqBody := `
 			{
@@ -1305,7 +1304,7 @@ func Test_UserHandler_UpdateUserRoles(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		reqBody := `
 			{
@@ -1346,7 +1345,7 @@ func Test_UserHandler_UpdateUserRoles(t *testing.T) {
 			Return(nil).
 			Once()
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		reqBody := `
 			{
@@ -1402,7 +1401,7 @@ func Test_UserHandler_GetAllUsers(t *testing.T) {
 	t.Run("returns Unauthorized when token is invalid", func(t *testing.T) {
 		token := "mytoken"
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		require.NoError(t, err)
@@ -1431,7 +1430,7 @@ func Test_UserHandler_GetAllUsers(t *testing.T) {
 		buf := new(strings.Builder)
 		log.DefaultLogger.SetOutput(buf)
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		require.NoError(t, err)
@@ -1463,7 +1462,7 @@ func Test_UserHandler_GetAllUsers(t *testing.T) {
 	t.Run("returns all users ordered by email ASC", func(t *testing.T) {
 		token := "mytoken"
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, orderByEmailAscURL, nil)
 		require.NoError(t, err)
@@ -1557,7 +1556,7 @@ func Test_UserHandler_GetAllUsers(t *testing.T) {
 	t.Run("returns all users ordered by email DESC", func(t *testing.T) {
 		token := "mytoken"
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, orderByEmailDescURL, nil)
 		require.NoError(t, err)
@@ -1651,7 +1650,7 @@ func Test_UserHandler_GetAllUsers(t *testing.T) {
 	t.Run("returns all users ordered by is_active ASC", func(t *testing.T) {
 		token := "mytoken"
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, orderByIsActiveAscURL, nil)
 		require.NoError(t, err)
@@ -1726,7 +1725,7 @@ func Test_UserHandler_GetAllUsers(t *testing.T) {
 	t.Run("returns all users ordered by is_active DESC", func(t *testing.T) {
 		token := "mytoken"
 
-		ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, orderByIsActiveDescURL, nil)
 		require.NoError(t, err)

--- a/internal/serve/httphandler/verify_receiver_registration_handler_test.go
+++ b/internal/serve/httphandler/verify_receiver_registration_handler_test.go
@@ -29,13 +29,13 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_VerifyReceiverRegistrationHandler_validate(t *testing.T) {
@@ -596,7 +596,7 @@ func Test_VerifyReceiverRegistrationHandler_buildPaymentsReadyToPayEventMessage(
 
 	tnt := schema.Tenant{ID: "tenant-id"}
 	ctx := context.Background()
-	ctx = tenant.SaveTenantInContext(ctx, &tnt)
+	ctx = sdpcontext.SetTenantInContext(ctx, &tnt)
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
@@ -1520,7 +1520,7 @@ func Test_VerifyReceiverRegistrationHandler_VerifyReceiverRegistration(t *testin
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				tnt := schema.Tenant{ID: "tenant-id"}
-				ctx = tenant.SaveTenantInContext(ctx, &tnt)
+				ctx = sdpcontext.SetTenantInContext(ctx, &tnt)
 
 				// update database with the entries needed
 				defer data.DeleteAllAssetFixtures(t, ctx, dbConnectionPool)

--- a/internal/serve/middleware/api_keys_middleware.go
+++ b/internal/serve/middleware/api_keys_middleware.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 )
 
@@ -49,7 +50,7 @@ func APIKeyOrJWTAuthenticate(apiKeyModel *data.APIKeyModel, jwtAuth func(http.Ha
 				}
 
 				ctx := context.WithValue(r.Context(), APIKeyContextKey, apiKey)
-				ctx = context.WithValue(ctx, UserIDContextKey, apiKey.CreatedBy)
+				ctx = sdpcontext.SetUserIDInContext(ctx, apiKey.CreatedBy)
 				ctx = log.Set(ctx, log.Ctx(ctx).WithField("user_id", apiKey.CreatedBy))
 
 				next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/serve/middleware/middleware.go
+++ b/internal/serve/middleware/middleware.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"crypto/subtle"
 	"errors"
 	"fmt"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -24,12 +24,8 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
-type ContextKey string
-
 const (
-	TokenContextKey  ContextKey = "auth_token"
-	UserIDContextKey ContextKey = "user_id"
-	TenantHeaderKey  string     = "SDP-Tenant-Name"
+	TenantHeaderKey string = "SDP-Tenant-Name"
 )
 
 // RecoverHandler is a middleware that recovers from panics and logs the error.
@@ -114,15 +110,15 @@ func AuthenticateMiddleware(authManager auth.AuthManager, tenantManager tenant.M
 			}
 
 			// Add the token to the request context
-			ctx = context.WithValue(ctx, TokenContextKey, token)
-			ctx = context.WithValue(ctx, UserIDContextKey, userID)
+			ctx = sdpcontext.SetTokenInContext(ctx, token)
+			ctx = sdpcontext.SetUserIDInContext(ctx, userID)
 
 			// Attempt fetching tenant ID from token
 			tenantID, err := authManager.GetTenantID(ctx, token)
 			if err == nil && tenantID != "" {
 				currentTenant, tenantErr := tenantManager.GetTenantByID(ctx, tenantID)
 				if tenantErr == nil && currentTenant != nil {
-					ctx = tenant.SaveTenantInContext(ctx, currentTenant)
+					ctx = sdpcontext.SetTenantInContext(ctx, currentTenant)
 				}
 			}
 
@@ -143,8 +139,8 @@ func AnyRoleMiddleware(authManager auth.AuthManager, requiredRoles ...data.UserR
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
 
-			token, ok := ctx.Value(TokenContextKey).(string)
-			if !ok {
+			token, err := sdpcontext.GetTokenFromContext(ctx)
+			if err != nil {
 				httperror.Unauthorized("", nil, nil).Render(rw)
 				return
 			}
@@ -209,7 +205,7 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		}
 		logCtx := log.Set(reqCtx, log.Ctx(reqCtx).WithFields(logFields))
 
-		ctxTenant, err := tenant.GetTenantFromContext(reqCtx)
+		ctxTenant, err := sdpcontext.GetTenantFromContext(reqCtx)
 		if err != nil {
 			// Log for auditing purposes when we cannot derive the tenant from the context in the case of
 			// tenant-unaware endpoints
@@ -327,7 +323,7 @@ func ResolveTenantFromRequestMiddleware(tenantManager tenant.ManagerInterface, s
 			}
 
 			if currentTenant != nil {
-				ctx = tenant.SaveTenantInContext(ctx, currentTenant)
+				ctx = sdpcontext.SetTenantInContext(ctx, currentTenant)
 				next.ServeHTTP(rw, req.WithContext(ctx))
 			} else {
 				next.ServeHTTP(rw, req)
@@ -341,7 +337,7 @@ func EnsureTenantMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
-		if _, err := tenant.GetTenantFromContext(ctx); err != nil {
+		if _, err := sdpcontext.GetTenantFromContext(ctx); err != nil {
 			httperror.BadRequest("Tenant not found in context", err, nil).Render(rw)
 			return
 		}

--- a/internal/serve/middleware/middleware_test.go
+++ b/internal/serve/middleware/middleware_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	monitorMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/monitor/mocks"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
@@ -165,7 +166,7 @@ func Test_AuthenticateMiddleware(t *testing.T) {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// Assert that the tenant is properly saved to the context
 				ctx := r.Context()
-				savedTenant, err := tenant.GetTenantFromContext(ctx)
+				savedTenant, err := sdpcontext.GetTenantFromContext(ctx)
 				require.NoError(t, err)
 				assert.Equal(t, "test_tenant_id", savedTenant.ID)
 				assert.Equal(t, "test_tenant", savedTenant.Name)
@@ -384,7 +385,7 @@ func Test_AnyRoleMiddleware(t *testing.T) {
 
 	t.Run("returns Unauthorized when the token is expired and (no error is returned)", func(t *testing.T) {
 		token := "mytoken"
-		ctx := context.WithValue(context.Background(), TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		require.NoError(t, err)
 
@@ -410,7 +411,7 @@ func Test_AnyRoleMiddleware(t *testing.T) {
 
 	t.Run("returns Unauthorized when the token is expired and (no auth.ErrInvalidToken error is returned)", func(t *testing.T) {
 		token := "mytoken"
-		ctx := context.WithValue(context.Background(), TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		require.NoError(t, err)
 
@@ -436,7 +437,7 @@ func Test_AnyRoleMiddleware(t *testing.T) {
 
 	t.Run("returns Unauthorized when the token is expired and (no auth.ErrUserNotFound error is returned)", func(t *testing.T) {
 		token := "mytoken"
-		ctx := context.WithValue(context.Background(), TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		require.NoError(t, err)
 
@@ -462,7 +463,7 @@ func Test_AnyRoleMiddleware(t *testing.T) {
 
 	t.Run("returns Internal Server Error when an unexpected error occurs", func(t *testing.T) {
 		token := "mytoken"
-		ctx := context.WithValue(context.Background(), TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		require.NoError(t, err)
 
@@ -488,7 +489,7 @@ func Test_AnyRoleMiddleware(t *testing.T) {
 
 	t.Run("returns Forbidden error when the user does not have the required roles", func(t *testing.T) {
 		token := "mytoken"
-		ctx := context.WithValue(context.Background(), TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		require.NoError(t, err)
 
@@ -530,7 +531,7 @@ func Test_AnyRoleMiddleware(t *testing.T) {
 
 	t.Run("returns Status Ok when user has the required roles", func(t *testing.T) {
 		token := "mytoken"
-		ctx := context.WithValue(context.Background(), TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		require.NoError(t, err)
 
@@ -572,7 +573,7 @@ func Test_AnyRoleMiddleware(t *testing.T) {
 
 	t.Run("returns Status Ok when no roles is required", func(t *testing.T) {
 		token := "mytoken"
-		ctx := context.WithValue(context.Background(), TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		require.NoError(t, err)
 
@@ -680,7 +681,7 @@ func Test_LoggingMiddleware(t *testing.T) {
 		require.NoError(t, err)
 		req.Header.Set(TenantHeaderKey, tenantName)
 
-		ctx := context.WithValue(req.Context(), TokenContextKey, token)
+		ctx := sdpcontext.SetTokenInContext(req.Context(), token)
 		req = req.WithContext(ctx)
 
 		rr := httptest.NewRecorder()
@@ -987,7 +988,7 @@ func Test_ResolveTenantFromRequestMiddleware(t *testing.T) {
 			assert.JSONEq(t, tc.expectedRespBody, string(respBody))
 
 			// assert tenant in context
-			tnt, err := tenant.GetTenantFromContext(updatedCtx)
+			tnt, err := sdpcontext.GetTenantFromContext(updatedCtx)
 			if tc.expectedTenant != nil {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedTenant, tnt)
@@ -1041,7 +1042,7 @@ func Test_EnsureTenantMiddleware(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, "/test", nil)
 			require.NoError(t, err)
 			if tc.hasTenantInCtx {
-				ctx := tenant.SaveTenantInContext(req.Context(), validTnt)
+				ctx := sdpcontext.SetTenantInContext(req.Context(), validTnt)
 				req = req.WithContext(ctx)
 			}
 

--- a/internal/services/circle_reconciliation_service.go
+++ b/internal/services/circle_reconciliation_service.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 //go:generate mockery --name=CircleReconciliationServiceInterface --case=underscore --structname=MockCircleReconciliationService --filename=circle_reconciliation_service.go
@@ -36,7 +36,7 @@ type CircleReconciliationService struct {
 // reached a successful/failure status, it updates the payment status in the DB as well to reflect that.
 func (s *CircleReconciliationService) Reconcile(ctx context.Context) error {
 	// Step 1: Get the tenant from the context.
-	tnt, outerErr := tenant.GetTenantFromContext(ctx)
+	tnt, outerErr := sdpcontext.GetTenantFromContext(ctx)
 	if outerErr != nil {
 		return fmt.Errorf("getting tenant from context: %w", outerErr)
 	}

--- a/internal/services/circle_reconciliation_service_test.go
+++ b/internal/services/circle_reconciliation_service_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_NewCircleReconciliationService_Reconcile_failure(t *testing.T) {
@@ -130,7 +130,7 @@ func Test_NewCircleReconciliationService_Reconcile_failure(t *testing.T) {
 			// inject tenant in context if configured
 			updatedCtx := ctx
 			if tc.tenant != nil {
-				updatedCtx = tenant.SaveTenantInContext(ctx, tc.tenant)
+				updatedCtx = sdpcontext.SetTenantInContext(ctx, tc.tenant)
 			}
 
 			// run test
@@ -160,7 +160,7 @@ func Test_NewCircleReconciliationService_Reconcile_completeDisbursement(t *testi
 	defer dbConnectionPool.Close()
 
 	tnt := &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "test-tenant"}
-	ctx := tenant.SaveTenantInContext(context.Background(), tnt)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), tnt)
 
 	models, outerErr := data.NewModels(dbConnectionPool)
 	require.NoError(t, outerErr)
@@ -323,7 +323,7 @@ func Test_NewCircleReconciliationService_Reconcile_partialSuccess(t *testing.T) 
 	defer dbConnectionPool.Close()
 
 	tnt := &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "test-tenant"}
-	ctx := tenant.SaveTenantInContext(context.Background(), tnt)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), tnt)
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
@@ -525,7 +525,7 @@ func Test_NewCircleReconciliationService_reconcileTransferRequest(t *testing.T) 
 	defer dbConnectionPool.Close()
 
 	tnt := &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "test-tenant"}
-	ctx := tenant.SaveTenantInContext(context.Background(), tnt)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), tnt)
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)

--- a/internal/services/direct_payment_service_test.go
+++ b/internal/services/direct_payment_service_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func TestDirectPaymentService_CreateDirectPayment_Scenarios(t *testing.T) {
@@ -29,7 +29,7 @@ func TestDirectPaymentService_CreateDirectPayment_Scenarios(t *testing.T) {
 
 	dbConnectionPool := testutils.GetDBConnectionPool(t)
 	ctx := context.Background()
-	ctx = tenant.SaveTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
+	ctx = sdpcontext.SetTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
@@ -532,7 +532,7 @@ func TestDirectPaymentService_CreateDirectPayment_CircleAccount(t *testing.T) {
 
 	dbConnectionPool := testutils.GetDBConnectionPool(t)
 	ctx := context.Background()
-	ctx = tenant.SaveTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
+	ctx = sdpcontext.SetTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
 
 	t.Cleanup(func() {
 		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
@@ -722,7 +722,7 @@ func TestDirectPaymentService_CreateDirectPayment_Success(t *testing.T) {
 	dbConnectionPool := testutils.GetDBConnectionPool(t)
 
 	ctx := context.Background()
-	ctx = tenant.SaveTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
+	ctx = sdpcontext.SetTenantInContext(ctx, &schema.Tenant{ID: "battle-barge-001"})
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 

--- a/internal/services/disbursement_management_service_test.go
+++ b/internal/services/disbursement_management_service_test.go
@@ -22,14 +22,13 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_DisbursementManagementService_GetDisbursementsWithCount(t *testing.T) {
@@ -214,9 +213,9 @@ func Test_DisbursementManagementService_StartDisbursement_success(t *testing.T) 
 
 	// Update context with tenant and auth token
 	tnt := schema.Tenant{ID: "tenant-id"}
-	ctx = tenant.SaveTenantInContext(context.Background(), &tnt)
+	ctx = sdpcontext.SetTenantInContext(context.Background(), &tnt)
 	token := "token"
-	ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+	ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 	// Create distribution accounts
 	distributionAccPubKey := "GAAHIL6ZW4QFNLCKALZ3YOIWPP4TXQ7B7J5IU7RLNVGQAV6GFDZHLDTA"
@@ -502,9 +501,9 @@ func Test_DisbursementManagementService_StartDisbursement_failure(t *testing.T) 
 	require.NoError(t, err)
 
 	tnt := schema.Tenant{ID: "tenant-id"}
-	ctx := tenant.SaveTenantInContext(context.Background(), &tnt)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &tnt)
 	token := "token"
-	ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+	ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 	// Create fixtures: asset, wallet
 	asset := data.GetAssetFixture(t, ctx, dbConnectionPool, data.FixtureAssetUSDC)
@@ -1048,10 +1047,10 @@ func Test_DisbursementManagementService_PauseDisbursement(t *testing.T) {
 	ctx := context.Background()
 
 	tnt := schema.Tenant{ID: "tenant-id"}
-	ctx = tenant.SaveTenantInContext(ctx, &tnt)
+	ctx = sdpcontext.SetTenantInContext(ctx, &tnt)
 
 	token := "token"
-	ctx = context.WithValue(ctx, middleware.TokenContextKey, token)
+	ctx = sdpcontext.SetTokenInContext(ctx, token)
 
 	user := &auth.User{
 		ID:    "user-id",

--- a/internal/services/payment_management_service_test.go
+++ b/internal/services/payment_management_service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 )
 
 func Test_PaymentManagementService_CancelPayment(t *testing.T) {
@@ -24,7 +24,7 @@ func Test_PaymentManagementService_CancelPayment(t *testing.T) {
 	require.NoError(t, outerErr)
 
 	token := "token"
-	ctx := context.WithValue(context.Background(), middleware.TokenContextKey, token)
+	ctx := sdpcontext.SetTokenInContext(context.Background(), token)
 
 	service := NewPaymentManagementService(models, models.DBConnectionPool)
 

--- a/internal/services/payment_to_submitter_service.go
+++ b/internal/services/payment_to_submitter_service.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/paymentdispatchers"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	txSubStore "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/store"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type PaymentToSubmitterServiceInterface interface {
@@ -75,7 +75,7 @@ func (s PaymentToSubmitterService) SendPaymentsReadyToPay(ctx context.Context, p
 
 // SendBatchPayments sends SDP's ready-to-pay payments (in batches) to the transaction submission service.
 func (s PaymentToSubmitterService) SendBatchPayments(ctx context.Context, batchSize int) error {
-	t, tenantErr := tenant.GetTenantFromContext(ctx)
+	t, tenantErr := sdpcontext.GetTenantFromContext(ctx)
 	if tenantErr != nil {
 		return fmt.Errorf("getting tenant from context: %w", tenantErr)
 	}

--- a/internal/services/payment_to_submitter_service_test.go
+++ b/internal/services/payment_to_submitter_service_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/assets"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/paymentdispatchers"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	txSubStore "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/store"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_PaymentToSubmitterService_SendPaymentsMethods(t *testing.T) {
@@ -30,7 +30,7 @@ func Test_PaymentToSubmitterService_SendPaymentsMethods(t *testing.T) {
 
 	// add tenant to context
 	testTenant := schema.Tenant{ID: "tenant-id", Name: "Test Name"}
-	ctx := tenant.SaveTenantInContext(context.Background(), &testTenant)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &testTenant)
 
 	eurcAsset := data.CreateAssetFixture(t, ctx, dbConnectionPool, assets.EURCAssetCode, assets.EURCAssetTestnet.Issuer)
 	nativeAsset := data.CreateAssetFixture(t, ctx, dbConnectionPool, "XLM", "")
@@ -376,7 +376,7 @@ func Test_PaymentToSubmitterService_SendMixedPayments(t *testing.T) {
 	tssModel := txSubStore.NewTransactionModel(dbConnectionPool)
 
 	testTenant := schema.Tenant{ID: "tenant-id", Name: "Test Name"}
-	ctx := tenant.SaveTenantInContext(context.Background(), &testTenant)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &testTenant)
 	eurcAsset := data.CreateAssetFixture(t, ctx, dbConnectionPool, assets.EURCAssetCode, assets.EURCAssetTestnet.Issuer)
 	wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "MixWallet", "https://mix.com", "mix.com", "mix://")
 
@@ -466,7 +466,7 @@ func Test_PaymentToSubmitterService_SendDirectPayments(t *testing.T) {
 	require.NoError(t, err)
 	tssModel := txSubStore.NewTransactionModel(dbConnectionPool)
 	testTenant := schema.Tenant{ID: "tenant-id", Name: "Test Name"}
-	ctx := tenant.SaveTenantInContext(context.Background(), &testTenant)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &testTenant)
 	eurcAsset := data.CreateAssetFixture(t, ctx, dbConnectionPool, assets.EURCAssetCode, assets.EURCAssetTestnet.Issuer)
 	wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "DirectWallet", "https://direct.com", "direct.com", "direct://")
 

--- a/internal/services/paymentdispatchers/circle_payment_payout_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/circle_payment_payout_dispatcher_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -204,7 +205,7 @@ func Test_CirclePaymentPayoutDispatcher_ensureRecipientIsReady_success_assertMem
 	}
 
 	ctx := context.Background()
-	ctx = tenant.SaveTenantInContext(ctx, &tnt)
+	ctx = sdpcontext.SetTenantInContext(ctx, &tnt)
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
 

--- a/internal/services/paymentdispatchers/circle_payment_transfer_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/circle_payment_transfer_dispatcher_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -164,7 +165,7 @@ func Test_CirclePaymentTransferDispatcher_DispatchPayments_success(t *testing.T)
 	}
 
 	ctx := context.Background()
-	ctx = tenant.SaveTenantInContext(ctx, &tnt)
+	ctx = sdpcontext.SetTenantInContext(ctx, &tnt)
 	models, outerErr := data.NewModels(dbConnectionPool)
 	require.NoError(t, outerErr)
 

--- a/internal/services/paymentdispatchers/memo_resolver_test.go
+++ b/internal/services/paymentdispatchers/memo_resolver_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_MemoResolver_GetMemo(t *testing.T) {
@@ -119,7 +119,7 @@ func Test_MemoResolver_GetMemo(t *testing.T) {
 			name: "🟢 return tenant memo when enabled",
 			getCtxFn: func(t *testing.T) context.Context {
 				ctx := context.Background()
-				return tenant.SaveTenantInContext(ctx, &tnt)
+				return sdpcontext.SetTenantInContext(ctx, &tnt)
 			},
 			receiverWallet: data.ReceiverWallet{},
 			orgMemoEnabled: true,

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
@@ -117,7 +118,7 @@ func Test_StellarPaymentDispatcher_DispatchPayments_success(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = tenant.SaveTenantInContext(ctx, &tnt)
+	ctx = sdpcontext.SetTenantInContext(ctx, &tnt)
 	models, outerErr := data.NewModels(dbConnectionPool)
 	require.NoError(t, outerErr)
 

--- a/internal/services/send_receiver_wallets_invite_service.go
+++ b/internal/services/send_receiver_wallets_invite_service.go
@@ -18,8 +18,8 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type SendReceiverWalletInviteServiceInterface interface {
@@ -54,7 +54,7 @@ func (s SendReceiverWalletInviteService) SendInvite(ctx context.Context, receive
 		return fmt.Errorf("SendReceiverWalletInviteService.Models cannot be nil")
 	}
 
-	currentTenant, err := tenant.GetTenantFromContext(ctx)
+	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("getting tenant from context: %w", err)
 	}

--- a/internal/services/send_receiver_wallets_invite_service_test.go
+++ b/internal/services/send_receiver_wallets_invite_service_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_GetSignedRegistrationLink_SchemelessDeepLink(t *testing.T) {
@@ -62,7 +62,7 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 
 	tenantBaseURL := "http://localhost:8000"
 	tenantInfo := &schema.Tenant{ID: uuid.NewString(), Name: "TestTenant", BaseURL: &tenantBaseURL}
-	ctx := tenant.SaveTenantInContext(context.Background(), tenantInfo)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), tenantInfo)
 
 	stellarSecretKey := "SBUSPEKAZKLZSWHRSJ2HWDZUK6I3IVDUWA7JJZSGBLZ2WZIUJI7FPNB5"
 	messageDispatcherMock := message.NewMockMessageDispatcher(t)

--- a/internal/transactionsubmission/engine/signing/distribution_account_resolver.go
+++ b/internal/transactionsubmission/engine/signing/distribution_account_resolver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -71,14 +72,14 @@ func (r *DistributionAccountResolverImpl) DistributionAccount(ctx context.Contex
 	if err != nil {
 		return schema.TransactionAccount{}, fmt.Errorf("getting tenant: %w", err)
 	}
-	tenant.SaveTenantInContext(ctx, tnt)
+	sdpcontext.SetTenantInContext(ctx, tnt)
 	return r.getDistributionAccount(ctx, tnt)
 }
 
 // DistributionAccountFromContext returns the tenant's distribution account from the tenant object stored in the context
 // provided.
 func (r *DistributionAccountResolverImpl) DistributionAccountFromContext(ctx context.Context) (schema.TransactionAccount, error) {
-	tnt, err := tenant.GetTenantFromContext(ctx)
+	tnt, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		return schema.TransactionAccount{}, fmt.Errorf("getting tenant: %w", err)
 	}

--- a/internal/transactionsubmission/engine/signing/distribution_account_resolver_test.go
+++ b/internal/transactionsubmission/engine/signing/distribution_account_resolver_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
@@ -205,13 +206,13 @@ func Test_DistributionAccountResolverImpl_DistributionAccountFromContext(t *test
 	t.Run("return an error if there's no tenant in the context", func(t *testing.T) {
 		distAccount, err := distAccResolver.DistributionAccountFromContext(context.Background())
 		assert.ErrorContains(t, err, "getting tenant")
-		assert.ErrorIs(t, err, tenant.ErrTenantNotFoundInContext)
+		assert.ErrorIs(t, err, sdpcontext.ErrTenantNotFoundInContext)
 		assert.Empty(t, distAccount)
 	})
 
 	t.Run("return an error if the tenant exists in the context but its distribution account is empty", func(t *testing.T) {
 		tnt := &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "aid-org-1"}
-		ctxWithTenant := tenant.SaveTenantInContext(context.Background(), tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(context.Background(), tnt)
 
 		distAccount, err := distAccResolver.DistributionAccountFromContext(ctxWithTenant)
 		assert.Empty(t, distAccount)
@@ -225,7 +226,7 @@ func Test_DistributionAccountResolverImpl_DistributionAccountFromContext(t *test
 			DistributionAccountType:   schema.DistributionAccountCircleDBVault,
 			DistributionAccountStatus: schema.AccountStatusPendingUserActivation,
 		}
-		ctxWithTenant := tenant.SaveTenantInContext(context.Background(), tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(context.Background(), tnt)
 
 		distAccount, err := distAccResolver.DistributionAccountFromContext(ctxWithTenant)
 		assert.NoError(t, err)
@@ -242,7 +243,7 @@ func Test_DistributionAccountResolverImpl_DistributionAccountFromContext(t *test
 			DistributionAccountType:   schema.DistributionAccountCircleDBVault,
 			DistributionAccountStatus: schema.AccountStatusActive,
 		}
-		ctxWithTenant := tenant.SaveTenantInContext(context.Background(), tnt)
+		ctxWithTenant := sdpcontext.SetTenantInContext(context.Background(), tnt)
 
 		circleConfigModel := circle.NewClientConfigModel(dbConnectionPool)
 		err := circleConfigModel.Upsert(context.Background(), circle.ClientConfigUpdate{
@@ -270,7 +271,7 @@ func Test_DistributionAccountResolverImpl_DistributionAccountFromContext(t *test
 			DistributionAccountType:    schema.DistributionAccountStellarEnv,
 			DistributionAccountStatus:  schema.AccountStatusActive,
 		}
-		ctxWithTenant := tenant.SaveTenantInContext(context.Background(), ctxTenant)
+		ctxWithTenant := sdpcontext.SetTenantInContext(context.Background(), ctxTenant)
 
 		distAccount, err := distAccResolver.DistributionAccountFromContext(ctxWithTenant)
 		assert.NoError(t, err)

--- a/stellar-auth/pkg/auth/jwt_manager.go
+++ b/stellar-auth/pkg/auth/jwt_manager.go
@@ -9,7 +9,7 @@ import (
 	jwtgo "github.com/golang-jwt/jwt/v4"
 	"github.com/stellar/go/support/log"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 )
 
 // tokenRefreshWindow is the time window in minutes that we allow to refresh a token. If the token is going to expire in
@@ -78,7 +78,7 @@ func (m *defaultJWTManager) GenerateToken(ctx context.Context, user *User, expir
 	}
 
 	// TODO: Always throw this error after migrations are merged [SDP-953]
-	currentTenant, err := tenant.GetTenantFromContext(ctx)
+	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
 		log.Ctx(ctx).Error(err)
 	} else {

--- a/stellar-auth/pkg/auth/jwt_manager_test.go
+++ b/stellar-auth/pkg/auth/jwt_manager_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
-	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 )
 
 // NEVER use these values in production!
@@ -31,7 +31,7 @@ func Test_DefaultJWTManager_GenerateToken(t *testing.T) {
 		Name: "tenant-name",
 	}
 
-	ctx := tenant.SaveTenantInContext(context.Background(), &currentTenant)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &currentTenant)
 
 	t.Run("returns error when the EC Private Key is invalid", func(t *testing.T) {
 		jwtManager := newDefaultJWTManager(withECKeypair(testPublicKey, "invalid"))
@@ -66,7 +66,7 @@ func Test_DefaultJWTManager_ValidateToken(t *testing.T) {
 		Name: "tenant-name",
 	}
 
-	ctx := tenant.SaveTenantInContext(context.Background(), &currentTenant)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &currentTenant)
 
 	t.Run("returns false when token has a invalid signature", func(t *testing.T) {
 		invalidSignatureToken := "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoidXNlci1pZCIsImVtYWlsIjoiZW1haWxAZW1haWwuY29tIiwicm9sZXMiOlt7Im5hbWUiOiJTdXBlcnZpc29yIn1dfSwiZXhwIjoxNjc1OTYyOTQ3fQ.zK9Jb5EMl5rOTOO18SM-q_WOtD0TbL0f9cFfilW9tWHa_vjVMEaf6xRjold9dTPLICDBrqdw_luhKlT370EAiA"
@@ -115,7 +115,7 @@ func Test_DefaultJWTManager_RefreshToken(t *testing.T) {
 		Name: "tenant-name",
 	}
 
-	ctx := tenant.SaveTenantInContext(context.Background(), &currentTenant)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &currentTenant)
 
 	t.Run("returns the same token when is above the refresh period", func(t *testing.T) {
 		expiresAt := time.Now().Add(time.Minute * (tokenRefreshWindow + 1))
@@ -148,7 +148,7 @@ func Test_DefaultJWTManager_parseToken(t *testing.T) {
 		Name: "tenant-name",
 	}
 
-	ctx := tenant.SaveTenantInContext(context.Background(), &currentTenant)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &currentTenant)
 
 	t.Run("returns error when the EC Public Key is invalid", func(t *testing.T) {
 		jwtManager := newDefaultJWTManager(withECKeypair("invalid", testPrivateKey))
@@ -194,7 +194,7 @@ func Test_DefaultJWTManager_GetUserFromToken(t *testing.T) {
 		Name: "tenant-name",
 	}
 
-	ctx := tenant.SaveTenantInContext(context.Background(), &currentTenant)
+	ctx := sdpcontext.SetTenantInContext(context.Background(), &currentTenant)
 
 	jwtManager := newDefaultJWTManager(withECKeypair(testPublicKey, testPrivateKey))
 

--- a/stellar-auth/pkg/cli/add_user.go
+++ b/stellar-auth/pkg/cli/add_user.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
@@ -172,7 +173,7 @@ func execAddUser(ctx context.Context, dbUrl string, email, firstName, lastName, 
 	if err != nil {
 		return fmt.Errorf("error getting tenant by id %s: %w", tenantID, err)
 	}
-	ctx = tenant.SaveTenantInContext(ctx, t)
+	ctx = sdpcontext.SetTenantInContext(ctx, t)
 
 	// 2. Create user using multi-tenant connection pool
 	tr := tenant.NewMultiTenantDataSourceRouter(tm)

--- a/stellar-multitenant/internal/services/status_change_validator.go
+++ b/stellar-multitenant/internal/services/status_change_validator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
@@ -31,7 +32,7 @@ func ValidateStatus(ctx context.Context, manager tenant.ManagerInterface, models
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrCannotRetrieveTenantByID, err)
 	}
-	ctx = tenant.SaveTenantInContext(ctx, tnt)
+	ctx = sdpcontext.SetTenantInContext(ctx, tnt)
 
 	// if attempting to deactivate tenant, need to check for a few conditions such as
 	// 1. whether tenant is already deactivated

--- a/stellar-multitenant/pkg/tenant/fixtures.go
+++ b/stellar-multitenant/pkg/tenant/fixtures.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/migrations"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/router"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 )
@@ -131,7 +132,7 @@ func LoadDefaultTenantInContext(t *testing.T, dbConnectionPool db.DBConnectionPo
 	ctx := context.Background()
 	const publicKey = "GDIVVKL6QYF6C6K3C5PZZBQ2NQDLN2OSLMVIEQRHS6DZE7WRL33ZDNXL"
 	tnt := CreateTenantFixture(t, ctx, dbConnectionPool, "default-tenant", publicKey)
-	return tnt, SaveTenantInContext(ctx, tnt)
+	return tnt, sdpcontext.SetTenantInContext(ctx, tnt)
 }
 
 func CheckSchemaExistsFixture(t *testing.T, ctx context.Context, dbConnectionPool db.DBConnectionPool, schemaName string) bool {

--- a/stellar-multitenant/pkg/tenant/multitenant_data_source_router.go
+++ b/stellar-multitenant/pkg/tenant/multitenant_data_source_router.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 )
 
@@ -25,9 +26,9 @@ func NewMultiTenantDataSourceRouter(tenantManager ManagerInterface) *MultiTenant
 }
 
 func (m *MultiTenantDataSourceRouter) GetDataSource(ctx context.Context) (db.DBConnectionPool, error) {
-	currentTenant, err := GetTenantFromContext(ctx)
+	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
-		return nil, ErrTenantNotFoundInContext
+		return nil, sdpcontext.ErrTenantNotFoundInContext
 	}
 
 	return m.GetDataSourceForTenant(ctx, *currentTenant)

--- a/stellar-multitenant/pkg/tenant/multitenant_data_source_router_test.go
+++ b/stellar-multitenant/pkg/tenant/multitenant_data_source_router_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 )
 
@@ -28,13 +29,13 @@ func TestMultiTenantDataSourceRouter_GetDataSource(t *testing.T) {
 	t.Run("error tenant not found in context", func(t *testing.T) {
 		dbcp, err := router.GetDataSource(ctx)
 		require.Nil(t, dbcp)
-		require.EqualError(t, err, ErrTenantNotFoundInContext.Error())
+		require.EqualError(t, err, sdpcontext.ErrTenantNotFoundInContext.Error())
 	})
 
 	t.Run("successfully getting data source", func(t *testing.T) {
 		// Create a new context with tenant information
 		tenantInfo := &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "aid-org-1"}
-		ctx = SaveTenantInContext(ctx, tenantInfo)
+		ctx = sdpcontext.SetTenantInContext(ctx, tenantInfo)
 
 		dbcp, err := router.GetDataSource(ctx)
 		require.NotNil(t, dbcp)
@@ -69,7 +70,7 @@ func TestMultiTenantDataSourceRouter_GetAllDataSources(t *testing.T) {
 	t.Run("successfully getting data sources", func(t *testing.T) {
 		// Store DB Connection Pool for aid-org-1
 		tenantInfo := &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "aid-org-1"}
-		ctx := SaveTenantInContext(context.Background(), tenantInfo)
+		ctx := sdpcontext.SetTenantInContext(context.Background(), tenantInfo)
 		dbcp1, err := router.GetDataSource(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, dbcp1)
@@ -77,7 +78,7 @@ func TestMultiTenantDataSourceRouter_GetAllDataSources(t *testing.T) {
 
 		// Store DB Connection Pool for aid-org-2
 		tenantInfo = &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e45", Name: "aid-org-2"}
-		ctx = SaveTenantInContext(context.Background(), tenantInfo)
+		ctx = sdpcontext.SetTenantInContext(context.Background(), tenantInfo)
 		dbcp2, err := router.GetDataSource(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, dbcp2)
@@ -114,7 +115,7 @@ func TestMultiTenantDataSourceRouter_AnyDataSource(t *testing.T) {
 	t.Run("successfully getting data source", func(t *testing.T) {
 		// Store DB Connection Pool for aid-org-1
 		tenantInfo := &schema.Tenant{ID: "95e788b6-c80e-4975-9d12-141001fe6e44", Name: "aid-org-1"}
-		ctx := SaveTenantInContext(context.Background(), tenantInfo)
+		ctx := sdpcontext.SetTenantInContext(context.Background(), tenantInfo)
 		dbcp1, err := router.GetDataSource(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, dbcp1)


### PR DESCRIPTION
### What
- Introduced a new `sdpcontext` package that centralizes context operations for tenant, user ID, and authentication token management. 
- Migrated all existing code from using direct `context.WithValue()` calls with middleware context keys to using the new helper functions:
   - SetTenantInContext()
   - GetTenantFromContext()
   - SetUserIDInContext()
   - GetUserIDFromContext()
   - SetTokenInContext()
   - GetTokenFromContext()

### Why
The previous approach scattered context operations all over the codebase importing context keys from middleware and tenant packages, creating tight coupling and making the code harder to maintain.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [x] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [x] Preview deployment works as expected
- [x] Ready for production
