### PR TITLE
SDP-1815: POST /receivers needs to set known wallet status to `REGISTERED`

### DIFF
--- a/internal/serve/httphandler/receiver_handler.go
+++ b/internal/serve/httphandler/receiver_handler.go
@@ -144,20 +144,20 @@ func (rh ReceiverHandler) GetReceiverVerificationTypes(w http.ResponseWriter, r 
 	httpjson.Render(w, data.GetAllVerificationTypes(), httpjson.JSON)
 }
 
-func (rh ReceiverHandler) CreateReceiver(w http.ResponseWriter, r *http.Request) {
+func (rh ReceiverHandler) CreateReceiver(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var err error
 
 	var req dto.CreateReceiverRequest
 	if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperror.BadRequest("invalid request body", err, nil).Render(w)
+		httperror.BadRequest("invalid request body", err, nil).Render(rw)
 		return
 	}
 
 	validator := validators.NewReceiverValidator()
 	validator.ValidateCreateReceiverRequest(&req)
 	if validator.HasErrors() {
-		httperror.BadRequest("validation error", nil, validator.Errors).Render(w)
+		httperror.BadRequest("validation error", nil, validator.Errors).Render(rw)
 		return
 	}
 
@@ -230,7 +230,7 @@ func (rh ReceiverHandler) CreateReceiver(w http.ResponseWriter, r *http.Request)
 
 				// Update wallet with Stellar address and memo details
 				walletUpdate := data.ReceiverWalletUpdate{
-					Status:         data.ReadyReceiversWalletStatus,
+					Status:         data.RegisteredReceiversWalletStatus,
 					StellarAddress: w.Address,
 				}
 
@@ -268,13 +268,13 @@ func (rh ReceiverHandler) CreateReceiver(w http.ResponseWriter, r *http.Request)
 	})
 	if err != nil {
 		if httpErr := parseHttpConflictErrorIfNeeded(err); httpErr != nil {
-			httpErr.Render(w)
+			httpErr.Render(rw)
 			return
 		}
 
-		httperror.InternalError(ctx, "Error creating receiver", err, nil).Render(w)
+		httperror.InternalError(ctx, "Error creating receiver", err, nil).Render(rw)
 		return
 	}
 
-	httpjson.RenderStatus(w, http.StatusCreated, response, httpjson.JSON)
+	httpjson.RenderStatus(rw, http.StatusCreated, response, httpjson.JSON)
 }

--- a/internal/serve/httphandler/receiver_handler_test.go
+++ b/internal/serve/httphandler/receiver_handler_test.go
@@ -1934,7 +1934,7 @@ func Test_ReceiverHandler_CreateReceiver_Success(t *testing.T) {
 				assert.Len(t, receiverWallets, 1)
 
 				wallet := receiverWallets[0]
-				assert.Equal(t, data.ReadyReceiversWalletStatus, wallet.Status)
+				assert.Equal(t, data.RegisteredReceiversWalletStatus, wallet.Status)
 				assert.Equal(t, "GCQFMQ7U33ICSLAVGBJNX6P66M5GGOTQWCRZ5Y3YXYK3EB3DNCWOAD5K", wallet.StellarAddress)
 				assert.Equal(t, "13371337", wallet.StellarMemo)
 				assert.Equal(t, schema.MemoTypeID, wallet.StellarMemoType)


### PR DESCRIPTION
### What
- Set known wallet status to `REGISTERED` instead of `READY` upon receiver creation. 

### Why
- Known wallets don't require a formal registration step. They need to be set directly to `REGISTERED`. 

### Known limitations

[TODO or N/A]

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
