### PR TITLE
SDP-1832: Fix console and login email mismatch in main.sh

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -109,13 +109,13 @@ The main.sh setup script will print Login information for each tenant.
 🎉🎉🎉🎉 SUCCESS! 🎉🎉🎉🎉  
 Login URLs for each tenant:
 🔗Tenant `redcorp`: [http://redcorp.stellar.local:3000](http://redcorp.stellar.local:3000)
-  username: `init_owner@redcorp.local`
+  username: `owner@redcorp.local`
   password: `Password123!`
 🔗Tenant `bluecorp`: [http://bluecorp.stellar.local:3000](http://bluecorp.stellar.local:3000)
-  username: `init_owner@bluecorp.local`
+  username: `owner@bluecorp.local`
   password: `Password123!`
 🔗Tenant `pinkcorp`: [http://pinkcorp.stellar.local:3000](http://pinkcorp.stellar.local:3000)
-  username: `init_owner@pinkcorp.local`
+  username: `owner@pinkcorp.local`
   password: `Password123!`
 ```
 

--- a/dev/main.sh
+++ b/dev/main.sh
@@ -158,7 +158,7 @@ echo "Login URLs for each tenant:"
 for tenant in "${tenants[@]}"; do
     url="http://$tenant.stellar.local:3000"
     echo -e "🔗Tenant $tenant: \033]8;;$url\033\\$url\033]8;;\033\\"
-    echo "username: init_owner@$tenant.local  password: Password123!"
+    echo "username: owner@$tenant.local  password: Password123!"
 
     if ! grep -q $tenant /etc/hosts; then
         echo >&2 "WARN $tenant.stellar.local missing from /etc/hosts"


### PR DESCRIPTION
### What

`./main.sh` print out 
```
🎉🎉🎉🎉 SUCCESS! 🎉🎉🎉🎉
Login URLs for each tenant:
🔗Tenant redcorp: http://redcorp.stellar.local:3000
username: init_owner@redcorp.local  password: Password123!
🔗Tenant bluecorp: http://bluecorp.stellar.local:3000
username: init_owner@bluecorp.local  password: Password123!
🔗Tenant pinkcorp: http://pinkcorp.stellar.local:3000
username: init_owner@pinkcorp.local  password: Password123!
```
But the actual login email is **owner**@bluecorp.local

### Why

Test users added at `Step 4: initialize test users` via ./dev/scripts/add_test_users.sh have passwords set and are eligible for login and testing, not the initial user

### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
