### PR TITLE
SDP-1817 Enable direct payments to SEP-24 wallets

### DIFF
--- a/internal/services/direct_payment_service.go
+++ b/internal/services/direct_payment_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
@@ -283,22 +284,97 @@ func (s *DirectPaymentService) getReceiverWallet(
 		return nil, fmt.Errorf("checking for existing receiver wallet: %w", err)
 	}
 
-	if len(receiverWallets) == 0 {
+	// If receiver wallet exists, return it
+	if len(receiverWallets) > 0 {
+		receiverWallet := receiverWallets[0]
+
+		if walletAddress != nil && *walletAddress != "" {
+			if receiverWallet.StellarAddress != *walletAddress {
+				return nil, fmt.Errorf("wallet address mismatch - receiver is registered with a different address for this wallet")
+			}
+		}
+
+		return receiverWallet, nil
+	}
+
+	// No receiver wallet exists - check if this is a SEP-24 wallet and receiver has verifications
+	wallet, err := s.Models.Wallets.Get(ctx, walletID)
+	if err != nil {
+		return nil, fmt.Errorf("getting wallet: %w", err)
+	}
+
+	if wallet.UserManaged {
 		return nil, &ReceiverWalletNotFoundError{
 			ReceiverID: receiverID,
 			WalletID:   walletID,
 		}
 	}
 
-	receiverWallet := receiverWallets[0]
+	// Check if receiver has any verifications
+	receiverVerifications, err := s.Models.ReceiverVerification.GetAllByReceiverId(ctx, dbTx, receiverID)
+	if err != nil {
+		return nil, fmt.Errorf("checking receiver verifications: %w", err)
+	}
 
-	if walletAddress != nil && *walletAddress != "" {
-		if receiverWallet.StellarAddress != *walletAddress {
-			return nil, fmt.Errorf("wallet address mismatch - receiver is registered with a different address for this wallet")
+	if len(receiverVerifications) == 0 {
+		return nil, &ReceiverWalletNotFoundError{
+			ReceiverID: receiverID,
+			WalletID:   walletID,
 		}
 	}
 
-	return receiverWallet, nil
+	rwInsert := data.ReceiverWalletInsert{
+		ReceiverID: receiverID,
+		WalletID:   walletID,
+	}
+
+	newReceiverWalletID, err := s.Models.ReceiverWallet.Insert(ctx, dbTx, rwInsert)
+	if err != nil {
+		return nil, fmt.Errorf("creating receiver wallet: %w", err)
+	}
+
+	// Update the status to READY using the data package method
+	rwUpdate := data.ReceiverWalletUpdate{
+		Status: data.ReadyReceiversWalletStatus,
+	}
+
+	err = s.Models.ReceiverWallet.Update(ctx, newReceiverWalletID, rwUpdate, dbTx)
+	if err != nil {
+		return nil, fmt.Errorf("updating receiver wallet status to READY: %w", err)
+	}
+
+	createdReceiverWallet, err := s.Models.ReceiverWallet.GetByID(ctx, dbTx, newReceiverWalletID)
+	if err != nil {
+		return nil, fmt.Errorf("getting created receiver wallet: %w", err)
+	}
+
+	// Dispatch invitation event for the newly created wallet
+	// This will trigger the invitation flow to get the receiver onboarded
+	if s.EventProducer != nil {
+		tenant, tenantErr := sdpcontext.GetTenantFromContext(ctx)
+		if tenantErr != nil {
+			log.Ctx(ctx).Errorf("failed to get tenant from context for invitation event: %v", tenantErr)
+		} else {
+			eventData := schemas.EventReceiverWalletInvitationData{
+				ReceiverWalletID: newReceiverWalletID,
+			}
+
+			msg := events.Message{
+				Topic:    events.ReceiverWalletNewInvitationTopic,
+				Key:      newReceiverWalletID,
+				TenantID: tenant.ID,
+				Type:     events.BatchReceiverWalletInvitationType,
+				Data:     eventData,
+			}
+
+			writeErr := s.EventProducer.WriteMessages(ctx, msg)
+			if writeErr != nil {
+				log.Ctx(ctx).Errorf("failed to dispatch receiver wallet invitation event: %v", writeErr)
+			}
+		}
+	}
+
+	return createdReceiverWallet, nil
 }
 
 func (s *DirectPaymentService) validateBalance(

--- a/internal/services/direct_payment_service_test.go
+++ b/internal/services/direct_payment_service_test.go
@@ -804,3 +804,154 @@ func createPayment(
 		Status:         status,
 	})
 }
+
+func TestDirectPaymentService_CreateDirectPayment_WithVerifiedReceiver(t *testing.T) {
+	t.Parallel()
+
+	dbConnectionPool := testutils.GetDBConnectionPool(t)
+	ctx := context.Background()
+	ctx = sdpcontext.SetTenantInContext(ctx, &schema.Tenant{ID: "test-tenant-001"})
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+
+	asset := data.CreateAssetFixture(t, ctx, dbConnectionPool, "TEST", "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON")
+
+	sep24Wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "SEP24 Wallet", "https://sep24.com", "sep24.com", "sep24://")
+	_, err = dbConnectionPool.ExecContext(ctx, "UPDATE wallets SET user_managed = false WHERE id = $1", sep24Wallet.ID)
+	require.NoError(t, err)
+
+	_, err = dbConnectionPool.ExecContext(ctx, "INSERT INTO wallets_assets (wallet_id, asset_id) VALUES ($1, $2)", sep24Wallet.ID, asset.ID)
+	require.NoError(t, err)
+
+	receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{
+		Email: "verified@example.com",
+	})
+
+	_, err = dbConnectionPool.ExecContext(ctx, `
+		INSERT INTO receiver_verifications (receiver_id, verification_field, hashed_value)
+		VALUES ($1, $2, $3)
+	`, receiver.ID, data.VerificationTypeDateOfBirth, "hashed_dob_value")
+	require.NoError(t, err)
+
+	user := &auth.User{ID: "test-user", Email: "admin@test.com"}
+	distAccount := &schema.TransactionAccount{
+		Address: "GDUKZH7LPVPDNWJ5JHQFAR4J5DQWQK3F3H2O5XZZ7MXUX7K3RBQNQOKT",
+		Type:    schema.DistributionAccountStellarEnv,
+		Status:  schema.AccountStatusActive,
+	}
+
+	mockDistAccountService := &mocks.MockDistributionAccountService{}
+	mockDistAccountService.On("GetBalance", mock.Anything, distAccount, mock.MatchedBy(func(a data.Asset) bool {
+		return a.ID == asset.ID
+	})).Return(1000.0, nil).Once()
+
+	mockHorizonClient := &horizonclient.MockClient{}
+	mockAccountReq := horizonclient.AccountRequest{AccountID: distAccount.Address}
+	mockHorizonClient.On("AccountDetail", mockAccountReq).Return(horizon.Account{
+		Balances: []horizon.Balance{
+			{Asset: base.Asset{Type: "native"}},
+			{Asset: base.Asset{Type: "credit_alphanum4", Code: asset.Code, Issuer: asset.Issuer}},
+		},
+	}, nil).Once()
+
+	service := &DirectPaymentService{
+		Models:                     models,
+		EventProducer:              nil,
+		DistributionAccountService: mockDistAccountService,
+		Resolvers:                  NewResolverFactory(models),
+		SubmitterEngine: engine.SubmitterEngine{
+			HorizonClient: mockHorizonClient,
+		},
+	}
+
+	t.Run("creates_receiver_wallet_for_verified_receiver_with_sep24_wallet", func(t *testing.T) {
+		receiverWallets, err := models.ReceiverWallet.GetByReceiverIDsAndWalletID(ctx, dbConnectionPool, []string{receiver.ID}, sep24Wallet.ID)
+		require.NoError(t, err)
+		require.Len(t, receiverWallets, 0, "No receiver wallet should exist initially")
+
+		req := CreateDirectPaymentRequest{
+			Amount: "100.00",
+			Asset: AssetReference{
+				ID: &asset.ID,
+			},
+			Receiver: ReceiverReference{
+				ID: &receiver.ID,
+			},
+			Wallet: WalletReference{
+				ID: &sep24Wallet.ID,
+			},
+		}
+
+		payment, err := service.CreateDirectPayment(ctx, req, user, distAccount)
+		require.NoError(t, err)
+		require.NotNil(t, payment)
+
+		assert.Equal(t, receiver.ID, payment.ReceiverWallet.Receiver.ID)
+		assert.Equal(t, asset.ID, payment.Asset.ID)
+		assert.Equal(t, "100.0000000", payment.Amount)
+		assert.Equal(t, data.PaymentTypeDirect, payment.Type)
+
+		receiverWallets, err = models.ReceiverWallet.GetByReceiverIDsAndWalletID(ctx, dbConnectionPool, []string{receiver.ID}, sep24Wallet.ID)
+		require.NoError(t, err)
+		require.Len(t, receiverWallets, 1, "Receiver wallet should have been created")
+
+		createdRW := receiverWallets[0]
+		assert.Equal(t, receiver.ID, createdRW.Receiver.ID)
+		assert.Equal(t, sep24Wallet.ID, createdRW.Wallet.ID)
+		assert.Equal(t, data.ReadyReceiversWalletStatus, createdRW.Status)
+	})
+
+	t.Run("does_not_create_receiver_wallet_for_user_managed_wallet", func(t *testing.T) {
+		userManagedWallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "User Wallet", "https://user.com", "user.com", "user://")
+		_, err = dbConnectionPool.ExecContext(ctx, "UPDATE wallets SET user_managed = true WHERE id = $1", userManagedWallet.ID)
+		require.NoError(t, err)
+
+		req := CreateDirectPaymentRequest{
+			Amount: "100.00",
+			Asset: AssetReference{
+				ID: &asset.ID,
+			},
+			Receiver: ReceiverReference{
+				ID: &receiver.ID,
+			},
+			Wallet: WalletReference{
+				ID: &userManagedWallet.ID,
+			},
+		}
+
+		payment, err := service.CreateDirectPayment(ctx, req, user, distAccount)
+		require.Error(t, err)
+		require.Nil(t, payment)
+
+		require.Contains(t, err.Error(), "no receiver wallet")
+	})
+
+	t.Run("does_not_create_receiver_wallet_for_receiver_without_verifications", func(t *testing.T) {
+		unverifiedReceiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{
+			Email: "unverified@example.com",
+		})
+
+		req := CreateDirectPaymentRequest{
+			Amount: "100.00",
+			Asset: AssetReference{
+				ID: &asset.ID,
+			},
+			Receiver: ReceiverReference{
+				ID: &unverifiedReceiver.ID,
+			},
+			Wallet: WalletReference{
+				ID: &sep24Wallet.ID,
+			},
+		}
+
+		payment, err := service.CreateDirectPayment(ctx, req, user, distAccount)
+		require.Error(t, err)
+		require.Nil(t, payment)
+
+		require.Contains(t, err.Error(), "no receiver wallet")
+	})
+
+	mockDistAccountService.AssertExpectations(t)
+	mockHorizonClient.AssertExpectations(t)
+}


### PR DESCRIPTION
### What

Added additional checks to the direct payment service, in case if the unregistered wallet selected, the event with invitation will be emitted and wallet with READY status created awaiting for the registration to be finished.

### Why

Currently, when creating a Direct Payment, only wallets already associated with the receiver are displayed. This creates an issue for receivers created through Direct Receiver Onboarding, as they don't have any associated wallets.

### Known limitations

[TODO or N/A]

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
