### PR TITLE
SDP-1843: Add initiator and Approver Roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - Add Support For Twilio WhatsApp messaging [#855](https://github.com/stellar/stellar-disbursement-platform-backend/pull/855)
+- Added initiator and approver user roles with mutual exclusivity validation for separation of duties in disbursement workflows. [#865](https://github.com/stellar/stellar-disbursement-platform-backend/pull/865)
 
 ### Fixed
+
 - Return proper error when calling `POST /disbursements` with a duplicate wallet address. [#862](https://github.com/stellar/stellar-disbursement-platform-backend/pull/862)
 
 ## [4.0.1](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/4.0.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/4.0.0...4.0.1))

--- a/internal/data/roles.go
+++ b/internal/data/roles.go
@@ -1,5 +1,7 @@
 package data
 
+import "fmt"
+
 type UserRole string
 
 func (u UserRole) String() string {
@@ -8,7 +10,7 @@ func (u UserRole) String() string {
 
 func (u UserRole) IsValid() bool {
 	switch u {
-	case OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole:
+	case OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole, InitiatorUserRole, ApproverUserRole:
 		return true
 	}
 	return false
@@ -24,23 +26,62 @@ const (
 	DeveloperUserRole UserRole = "developer"
 	// BusinessUserRole has read-only permissions - except for user management that they can't read any data.
 	BusinessUserRole UserRole = "business"
+	// InitiatorUserRole can create and save disbursements but not submit them. Mutually exclusive with ApproverUserRole.
+	InitiatorUserRole UserRole = "initiator"
+	// ApproverUserRole can submit disbursements but not create or save new ones. Mutually exclusive with InitiatorUserRole.
+	ApproverUserRole UserRole = "approver"
 )
 
-// GetAllRoles returns all roles available
+// GetAllRoles returns all roles available.
 func GetAllRoles() []UserRole {
 	return []UserRole{
 		OwnerUserRole,
 		FinancialControllerUserRole,
 		DeveloperUserRole,
 		BusinessUserRole,
+		InitiatorUserRole,
+		ApproverUserRole,
 	}
 }
 
-// FromUserRoleArrayToStringArray converts an array of UserRole type to an array of string
+// GetBusinessOperationRoles returns roles related to business operations.
+func GetBusinessOperationRoles() []UserRole {
+	return []UserRole{
+		OwnerUserRole,
+		FinancialControllerUserRole,
+		BusinessUserRole,
+		InitiatorUserRole,
+		ApproverUserRole,
+	}
+}
+
+// FromUserRoleArrayToStringArray converts an array of UserRole type to an array of string.
 func FromUserRoleArrayToStringArray(roles []UserRole) []string {
 	rolesString := make([]string, 0, len(roles))
 	for _, role := range roles {
 		rolesString = append(rolesString, role.String())
 	}
 	return rolesString
+}
+
+// ValidateRoleMutualExclusivity checks if the provided roles contain mutually exclusive combinations.
+// Currently, InitiatorUserRole and ApproverUserRole are mutually exclusive.
+func ValidateRoleMutualExclusivity(roles []UserRole) error {
+	hasInitiator := false
+	hasApprover := false
+
+	for _, role := range roles {
+		if role == InitiatorUserRole {
+			hasInitiator = true
+		}
+		if role == ApproverUserRole {
+			hasApprover = true
+		}
+	}
+
+	if hasInitiator && hasApprover {
+		return fmt.Errorf("initiator and approver roles are mutually exclusive")
+	}
+
+	return nil
 }

--- a/internal/data/roles_test.go
+++ b/internal/data/roles_test.go
@@ -7,9 +7,111 @@ import (
 )
 
 func Test_UserRole_IsValid(t *testing.T) {
-	role := UserRole("unknown")
-	assert.False(t, role.IsValid())
+	testCases := []struct {
+		role     UserRole
+		expected bool
+	}{
+		{OwnerUserRole, true},
+		{FinancialControllerUserRole, true},
+		{DeveloperUserRole, true},
+		{BusinessUserRole, true},
+		{InitiatorUserRole, true},
+		{ApproverUserRole, true},
+		{UserRole("invalid"), false},
+		{UserRole(""), false},
+		{UserRole("unknown"), false},
+	}
 
-	role = UserRole("developer")
-	assert.True(t, role.IsValid())
+	for _, tc := range testCases {
+		t.Run(string(tc.role), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.role.IsValid())
+		})
+	}
+}
+
+func Test_GetAllRoles(t *testing.T) {
+	roles := GetAllRoles()
+	expectedRoles := []UserRole{
+		OwnerUserRole,
+		FinancialControllerUserRole,
+		DeveloperUserRole,
+		BusinessUserRole,
+		InitiatorUserRole,
+		ApproverUserRole,
+	}
+
+	assert.Equal(t, len(expectedRoles), len(roles))
+
+	for _, expectedRole := range expectedRoles {
+		assert.Contains(t, roles, expectedRole)
+	}
+}
+
+func Test_ValidateRoleMutualExclusivity(t *testing.T) {
+	testCases := []struct {
+		name          string
+		roles         []UserRole
+		expectedError string
+	}{
+		{
+			name:          "initiator and approver roles are mutually exclusive",
+			roles:         []UserRole{InitiatorUserRole, ApproverUserRole},
+			expectedError: "initiator and approver roles are mutually exclusive",
+		},
+		{
+			name:          "single initiator role is not mutually exclusive",
+			roles:         []UserRole{InitiatorUserRole},
+			expectedError: "",
+		},
+		{
+			name:          "single approver role is not mutually exclusive",
+			roles:         []UserRole{ApproverUserRole},
+			expectedError: "",
+		},
+		{
+			name:          "owner role with initiator is not mutually exclusive",
+			roles:         []UserRole{OwnerUserRole, InitiatorUserRole},
+			expectedError: "",
+		},
+		{
+			name:          "owner role with approver is not mutually exclusive",
+			roles:         []UserRole{OwnerUserRole, ApproverUserRole},
+			expectedError: "",
+		},
+		{
+			name:          "all non-initiator-approver roles are not mutually exclusive",
+			roles:         []UserRole{OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole},
+			expectedError: "",
+		},
+		{
+			name:          "empty roles are not mutually exclusive",
+			roles:         []UserRole{},
+			expectedError: "",
+		},
+		{
+			name:          "three roles including both initiator and approver are mutually exclusive",
+			roles:         []UserRole{OwnerUserRole, InitiatorUserRole, ApproverUserRole},
+			expectedError: "initiator and approver roles are mutually exclusive",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRoleMutualExclusivity(tc.roles)
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+func Test_FromUserRoleArrayToStringArray(t *testing.T) {
+	roles := []UserRole{OwnerUserRole, InitiatorUserRole, ApproverUserRole}
+	expected := []string{"owner", "initiator", "approver"}
+
+	result := FromUserRoleArrayToStringArray(roles)
+	assert.Equal(t, expected, result)
 }

--- a/internal/serve/httphandler/list_roles_handler_test.go
+++ b/internal/serve/httphandler/list_roles_handler_test.go
@@ -28,5 +28,5 @@ func Test_ListRoles(t *testing.T) {
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	assert.JSONEq(t, `{"roles": ["owner", "financial_controller",  "developer", "business"]}`, string(respBody))
+	assert.JSONEq(t, `{"roles": ["owner", "financial_controller",  "developer", "business", "initiator", "approver"]}`, string(respBody))
 }

--- a/internal/serve/httphandler/user_handler.go
+++ b/internal/serve/httphandler/user_handler.go
@@ -104,6 +104,9 @@ func validateRoles(validator *validators.Validator, roles []data.UserRole) {
 	// NOTE: in the MVP, users should have only one role.
 	validator.Check(len(roles) == 1, "roles", "the number of roles required is exactly one")
 
+	// Check for mutually exclusive roles
+	validator.CheckError(data.ValidateRoleMutualExclusivity(roles), "roles", "")
+
 	// Validating the role of the request is a valid value
 	if _, ok := validator.Errors["roles"]; !ok {
 		role := roles[0]

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -440,16 +440,36 @@ func Test_CreateUserRequest_validate(t *testing.T) {
 			},
 			expectError: true,
 			errorExtras: map[string]interface{}{
-				"roles": "unexpected value for roles[0]=invalid_role. Expect one of these values: [owner financial_controller developer business]",
+				"roles": "unexpected value for roles[0]=invalid_role. Expect one of these values: [owner financial_controller developer business initiator approver]",
 			},
 		},
 		{
-			name: "🟢success - valid request",
+			name: "🟢success - valid request with developer role",
 			request: CreateUserRequest{
 				FirstName: "First",
 				LastName:  "Last",
 				Email:     "email@email.com",
 				Roles:     []data.UserRole{data.DeveloperUserRole},
+			},
+			expectError: false,
+		},
+		{
+			name: "🟢success - valid request with initiator role",
+			request: CreateUserRequest{
+				FirstName: "First",
+				LastName:  "Last",
+				Email:     "email@email.com",
+				Roles:     []data.UserRole{data.InitiatorUserRole},
+			},
+			expectError: false,
+		},
+		{
+			name: "🟢success - valid request with approver role",
+			request: CreateUserRequest{
+				FirstName: "First",
+				LastName:  "Last",
+				Email:     "email@email.com",
+				Roles:     []data.UserRole{data.ApproverUserRole},
 			},
 			expectError: false,
 		},
@@ -598,7 +618,7 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 			{
 				"error": "Request invalid",
 				"extras": {
-					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [owner financial_controller developer business]"
+					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [owner financial_controller developer business initiator approver]"
 				}
 			}
 		`
@@ -1083,6 +1103,23 @@ func Test_UpdateRolesRequest_validate(t *testing.T) {
 
 	err = upr.validate()
 	assert.Nil(t, err)
+
+	// Test new roles are accepted
+	upr = UpdateRolesRequest{
+		UserID: "user_id",
+		Roles:  []data.UserRole{data.InitiatorUserRole},
+	}
+
+	err = upr.validate()
+	assert.Nil(t, err)
+
+	upr = UpdateRolesRequest{
+		UserID: "user_id",
+		Roles:  []data.UserRole{data.ApproverUserRole},
+	}
+
+	err = upr.validate()
+	assert.Nil(t, err)
 }
 
 func Test_UserHandler_UpdateUserRoles(t *testing.T) {
@@ -1196,7 +1233,7 @@ func Test_UserHandler_UpdateUserRoles(t *testing.T) {
 			{
 				"error": "Request invalid",
 				"extras": {
-					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [owner financial_controller developer business]"
+					"roles": "unexpected value for roles[0]=role1. Expect one of these values: [owner financial_controller developer business initiator approver]"
 				}
 			}
 		`

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -233,6 +233,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		r.Use(middleware.APIKeyOrJWTAuthenticate(o.Models.APIKeys, middleware.AuthenticateMiddleware(authManager, o.tenantManager)))
 		r.Use(middleware.EnsureTenantMiddleware)
 
+		// API Key management endpoints
 		r.With(middleware.RequirePermission(
 			data.WriteAll,
 			middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.DeveloperUserRole),
@@ -247,6 +248,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.Delete("/{id}", apiKeyHandler.DeleteApiKey)
 		})
 
+		// Statistics endpoints
 		r.With(middleware.RequirePermission(
 			data.ReadStatistics,
 			middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...),
@@ -256,6 +258,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			r.Get("/{id}", h.GetStatisticsByDisbursement)
 		})
 
+		// User management endpoints
 		r.Route("/users", func(r chi.Router) {
 			userHandler := httphandler.UserHandler{
 				AuthManager:        authManager,
@@ -281,12 +284,12 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				r.Patch("/activation", userHandler.UserActivation)
 			})
 		})
-
 		r.With(middleware.RequirePermission(
 			data.ReadAll,
 			middleware.AnyRoleMiddleware(authManager),
 		)).Post("/refresh-token", httphandler.RefreshTokenHandler{AuthManager: authManager}.PostRefreshToken)
 
+		// Disbursement endpoints
 		r.Route("/disbursements", func(r chi.Router) {
 			handler := httphandler.DisbursementHandler{
 				Models:                      o.Models,
@@ -305,7 +308,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			// Group all READ operations
 			r.With(middleware.RequirePermission(
 				data.ReadDisbursements,
-				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole),
+				middleware.AnyRoleMiddleware(authManager, data.GetBusinessOperationRoles()...),
 			)).Group(func(r chi.Router) {
 				r.Get("/", handler.GetDisbursements)
 				r.Get("/{id}", handler.GetDisbursement)
@@ -313,18 +316,26 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				r.Get("/{id}/instructions", handler.GetDisbursementInstructions)
 			})
 
-			// Group all WRITE operations
+			// Group CREATE/EDIT operations (accessible to initiators)
 			r.With(middleware.RequirePermission(
 				data.WriteDisbursements,
-				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole),
+				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.InitiatorUserRole),
 			)).Group(func(r chi.Router) {
 				r.Post("/", handler.PostDisbursement)
 				r.Delete("/{id}", handler.DeleteDisbursement)
 				r.Post("/{id}/instructions", handler.PostDisbursementInstructions)
+			})
+
+			// Group STATUS operations (accessible to approvers)
+			r.With(middleware.RequirePermission(
+				data.WriteDisbursements,
+				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.ApproverUserRole),
+			)).Group(func(r chi.Router) {
 				r.Patch("/{id}/status", handler.PatchDisbursementStatus)
 			})
 		})
 
+		// Payment endpoints
 		r.Route("/payments", func(r chi.Router) {
 			paymentsHandler := httphandler.PaymentsHandler{
 				Models:                      o.Models,
@@ -344,7 +355,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			// Read operations
 			r.With(middleware.RequirePermission(
 				data.ReadPayments,
-				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole),
+				middleware.AnyRoleMiddleware(authManager, data.GetBusinessOperationRoles()...),
 			)).Group(func(r chi.Router) {
 				r.Get("/", paymentsHandler.GetPayments)
 				r.Get("/{id}", paymentsHandler.GetPayment)
@@ -365,6 +376,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			)).Patch("/{id}/status", paymentsHandler.PatchPaymentStatus)
 		})
 
+		// Receiver endpoints
 		r.Route("/receivers", func(r chi.Router) {
 			receiversHandler := httphandler.ReceiverHandler{Models: o.Models, DBConnectionPool: o.MtnDBConnectionPool}
 
@@ -376,7 +388,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 			r.With(middleware.RequirePermission(
 				data.ReadReceivers,
-				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.BusinessUserRole),
+				middleware.AnyRoleMiddleware(authManager, data.GetBusinessOperationRoles()...),
 			)).Group(func(r chi.Router) {
 				r.Get("/", receiversHandler.GetReceivers)
 				r.Get("/{id}", receiversHandler.GetReceiver)
@@ -396,7 +408,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 			r.With(middleware.RequirePermission(
 				data.WriteReceivers,
-				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole),
+				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.ApproverUserRole, data.InitiatorUserRole),
 			)).Group(func(r chi.Router) {
 				r.Post("/", receiversHandler.CreateReceiver)
 				r.Patch("/{id}", updateReceiverHandler.UpdateReceiver)
@@ -551,7 +563,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		}
 		r.With(middleware.RequirePermission(
 			data.ReadExports,
-			middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole),
+			middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.ApproverUserRole, data.InitiatorUserRole),
 		)).Route("/exports", func(r chi.Router) {
 			r.Get("/disbursements", exportHandler.ExportDisbursements)
 			r.Get("/payments", exportHandler.ExportPayments)


### PR DESCRIPTION
### What
- Added initiator and approver user roles. 

### Why
-  To implement a separation of duties workflow where initiator users can create/save disbursements but cannot submit them, while approver users can submit disbursements but cannot create new ones. 

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
