### PR TITLE
SDP-1845: Parse correct memo type in receiver creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Add Support For Twilio WhatsApp messaging [#855](https://github.com/stellar/stellar-disbursement-platform-backend/pull/855)
 - Added initiator and approver user roles with mutual exclusivity validation for separation of duties in disbursement workflows. [#865](https://github.com/stellar/stellar-disbursement-platform-backend/pull/865)
+- Add endpoint for patch receiver wallet. [#848](https://github.com/stellar/stellar-disbursement-platform-backend/pull/848)
 
 ### Fixed
 
 - Return proper error when calling `POST /disbursements` with a duplicate wallet address. [#862](https://github.com/stellar/stellar-disbursement-platform-backend/pull/862)
+- Properly detect memo type in receiver creation. [#870](https://github.com/stellar/stellar-disbursement-platform-backend/pull/870)
 
 ## [4.0.1](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/4.0.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/4.0.0...4.0.1))
 

--- a/internal/serve/httphandler/receiver_handler.go
+++ b/internal/serve/httphandler/receiver_handler.go
@@ -236,7 +236,10 @@ func (rh ReceiverHandler) CreateReceiver(rw http.ResponseWriter, r *http.Request
 
 				// Only set memo and memo type if memo is provided
 				if w.Memo != "" {
-					memoType := schema.MemoTypeID
+					_, memoType, txErr := schema.ParseMemo(w.Memo)
+					if txErr != nil {
+						return nil, fmt.Errorf("parsing memo value: %w", txErr)
+					}
 					walletUpdate.StellarMemo = &w.Memo
 					walletUpdate.StellarMemoType = &memoType
 				}

--- a/internal/serve/httphandler/receiver_handler.go
+++ b/internal/serve/httphandler/receiver_handler.go
@@ -236,9 +236,9 @@ func (rh ReceiverHandler) CreateReceiver(rw http.ResponseWriter, r *http.Request
 
 				// Only set memo and memo type if memo is provided
 				if w.Memo != "" {
-					_, memoType, txErr := schema.ParseMemo(w.Memo)
-					if txErr != nil {
-						return nil, fmt.Errorf("parsing memo value: %w", txErr)
+					_, memoType, parseErr := schema.ParseMemo(w.Memo)
+					if parseErr != nil {
+						return nil, fmt.Errorf("parsing memo value: %w", parseErr)
 					}
 					walletUpdate.StellarMemo = &w.Memo
 					walletUpdate.StellarMemoType = &memoType

--- a/internal/serve/validators/receiver_validator.go
+++ b/internal/serve/validators/receiver_validator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/dto"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 )
 
 type ReceiverValidator struct {
@@ -79,7 +80,8 @@ func (rv *ReceiverValidator) ValidateCreateReceiverRequest(req *dto.CreateReceiv
 		}
 
 		if memo != "" {
-			rv.Check(len(memo) <= 28, fmt.Sprintf("wallets[%d].memo", i), "memo must be at most 28 characters")
+			_, _, err := schema.ParseMemo(memo)
+			rv.CheckError(err, fmt.Sprintf("wallets[%d].memo", i), "invalid memo format. For more information about memo formats, visit https://docs.stellar.org/learn/encyclopedia/transactions-specialized/memos")
 		}
 
 		req.Wallets[i].Address = address


### PR DESCRIPTION
### What

  - Replace hardcoded `MemoTypeID` in  _receiver_handler_ with `schema.ParseMemo()`
  - Replace the memo length check in _receiver_validator_ with `schema.ParseMemo()` 
  - Add test coverage for memo type detection

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
