### PR TITLE
SDP-1870: Fix Receiver Invitation for direct payments

### DIFF
--- a/internal/data/assets.go
+++ b/internal/data/assets.go
@@ -274,17 +274,18 @@ func (a *AssetModel) GetAssetsPerReceiverWallet(ctx context.Context, receiverWal
 			-- Gets the latest payment by wallet with its asset
 			SELECT
 				p.id AS payment_id,
-				d.wallet_id,
+				rw.wallet_id,
 				COALESCE(d.receiver_registration_message_template, '') as receiver_registration_message_template,
 				p.asset_id
 			FROM
 				payments p
-				INNER JOIN disbursements d ON d.id = p.disbursement_id
+				INNER JOIN receiver_wallets rw ON rw.id = p.receiver_wallet_id
 				INNER JOIN assets a ON a.id = p.asset_id
+				LEFT JOIN disbursements d ON (p.type = 'DISBURSEMENT' AND d.id = p.disbursement_id)
 			WHERE
 				p.status = $1
 			GROUP BY
-				p.id, p.asset_id, d.wallet_id, d.receiver_registration_message_template
+				p.id, p.asset_id, rw.wallet_id, d.receiver_registration_message_template
 			ORDER BY
 				p.updated_at DESC
 		), messages_resent_since_invitation AS (


### PR DESCRIPTION
### What
* Change way to resolve payments that require invitation to not depend on disbursements
* Explanation: Currently `latest_payments_by_wallet` which is used to determine wallets that have ready payments does an INNER JOIN on disbursements. Meaning if the only payment is DIRECT, there will be no invitation sent to receiver. 

### Why
* Allow sending invitations for Direct Payments to SEP24 wallets. 


### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
