### PR TITLE
SDP-1873: Use numbered Twilio ContentVariables instead of named to guarantee order

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -149,11 +149,11 @@ func (a *AuthCommand) Command() *cobra.Command {
 					Title:   "Welcome to Stellar Disbursement Platform",
 					Body:    msgBody,
 					Type:    message.MessageTypeUserInvitation,
-					TemplateVariables: map[string]string{
-						"FirstName":          firstName,
-						"Role":               role,
-						"ForgotPasswordLink": forgotPasswordLink,
-						"OrganizationName":   organization.Name,
+					TemplateVariables: map[message.TemplateVariable]string{
+						message.TemplateVarFirstName:          firstName,
+						message.TemplateVarRole:               role,
+						message.TemplateVarForgotPasswordLink: forgotPasswordLink,
+						message.TemplateVarOrgName:            organization.Name,
 					},
 				})
 				if err != nil {

--- a/dev/docker-compose-sdp-anchor.yml
+++ b/dev/docker-compose-sdp-anchor.yml
@@ -108,7 +108,7 @@ services:
 
   anchor-platform:
     container_name: anchor-platform
-    image: stellar/anchor-platform:2.6.0
+    image: stellar/anchor-platform:2.6.1
     platform: linux/amd64
     depends_on:
       - db

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -17,6 +17,19 @@ const (
 	MessageTypeReceiverOTP        MessageType = "receiver_otp"
 )
 
+type TemplateVariable string
+
+const (
+	TemplateVarOrgName                  TemplateVariable = "org_name"
+	TemplateVarReceiverOTP              TemplateVariable = "receiver_otp"
+	TemplateVarReceiverRegistrationLink TemplateVariable = "registration_link"
+	TemplateVarResetPasswordLink        TemplateVariable = "reset_password_link"
+	TemplateVarMFACode                  TemplateVariable = "mfa_code"
+	TemplateVarFirstName                TemplateVariable = "first_name"
+	TemplateVarRole                     TemplateVariable = "role"
+	TemplateVarForgotPasswordLink       TemplateVariable = "forgot_password_link"
+)
+
 // receiverMessageTypes returns MessageType values related to receivers.
 func receiverMessageTypes() []MessageType {
 	return []MessageType{
@@ -31,7 +44,7 @@ type Message struct {
 	ToEmail           string
 	Body              string
 	Title             string
-	TemplateVariables map[string]string
+	TemplateVariables map[TemplateVariable]string
 }
 
 // ValidateFor validates if the message object is valid for the given messengerType.

--- a/internal/message/twilio_whatsapp_client.go
+++ b/internal/message/twilio_whatsapp_client.go
@@ -45,11 +45,11 @@ func (t *twilioWhatsAppClient) SendMessage(ctx context.Context, message Message)
 	params.SetContentSid(templateID)
 
 	if len(message.TemplateVariables) > 0 {
-		varsJSON, jsonErr := json.Marshal(message.TemplateVariables)
-		if jsonErr != nil {
-			return fmt.Errorf("converting template variables to JSON: %w", jsonErr)
+		contentVariables, contentVarErr := formatContentVariables(message.Type, message.TemplateVariables)
+		if contentVarErr != nil {
+			return fmt.Errorf("formatting WhatsApp content variables: %w", contentVarErr)
 		}
-		params.SetContentVariables(string(varsJSON))
+		params.SetContentVariables(contentVariables)
 	}
 
 	log.Ctx(ctx).Debugf("📞 Sending WhatsApp template message with SID %s to phoneNumber %q",
@@ -66,6 +66,58 @@ func (t *twilioWhatsAppClient) SendMessage(ctx context.Context, message Message)
 	}
 
 	return nil
+}
+
+// templateMapping defines the required variables and their position for each message type
+type templateMapping struct {
+	requiredVars map[TemplateVariable]string // maps variable to position key
+}
+
+var messageTemplateConfig = map[MessageType]templateMapping{
+	MessageTypeReceiverInvitation: {
+		requiredVars: map[TemplateVariable]string{
+			TemplateVarOrgName:                  "1",
+			TemplateVarReceiverRegistrationLink: "2",
+		},
+	},
+	MessageTypeReceiverOTP: {
+		requiredVars: map[TemplateVariable]string{
+			TemplateVarReceiverOTP: "1",
+			TemplateVarOrgName:     "2",
+		},
+	},
+}
+
+// formatContentVariables formats the template variables into a JSON string as required by Twilio's API.
+func formatContentVariables(messageType MessageType, vars map[TemplateVariable]string) (string, error) {
+	config, ok := messageTemplateConfig[messageType]
+	if !ok {
+		return "", fmt.Errorf("unsupported message type %s for WhatsApp template variables", messageType)
+	}
+
+	// Validate all required variables are present
+	if len(vars) != len(config.requiredVars) {
+		return "", fmt.Errorf("expected %d template variables for message type %s, got %d",
+			len(config.requiredVars), messageType, len(vars))
+	}
+
+	// Build content variables map with position mapping
+	contentVars := make(map[string]string, len(config.requiredVars))
+	for templateVar, position := range config.requiredVars {
+		value, ok := vars[templateVar]
+		if !ok {
+			return "", fmt.Errorf("missing template variable %s for message type %s",
+				templateVar, messageType)
+		}
+		contentVars[position] = value
+	}
+
+	contentVarsJSON, err := json.Marshal(contentVars)
+	if err != nil {
+		return "", fmt.Errorf("marshaling WhatsApp content variables to JSON: %w", err)
+	}
+
+	return string(contentVarsJSON), nil
 }
 
 // formatWhatsAppNumber ensures the phone number has the `whatsapp:` prefix.

--- a/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
+++ b/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
@@ -194,9 +194,9 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 			ToEmail:       receiver1.Email,
 			Body:          contentWallet1,
 			Title:         titleWallet1,
-			TemplateVariables: map[string]string{
-				"OrganizationName": walletDeepLink1.OrganizationName,
-				"RegistrationLink": deepLink1,
+			TemplateVariables: map[message.TemplateVariable]string{
+				message.TemplateVarOrgName:                  walletDeepLink1.OrganizationName,
+				message.TemplateVarReceiverRegistrationLink: deepLink1,
 			},
 		}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 		Return(message.MessengerTypeTwilioSMS, mockErr).
@@ -207,9 +207,9 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 			ToEmail:       receiver2.Email,
 			Body:          contentWallet2,
 			Title:         titleWallet2,
-			TemplateVariables: map[string]string{
-				"OrganizationName": walletDeepLink2.OrganizationName,
-				"RegistrationLink": deepLink2,
+			TemplateVariables: map[message.TemplateVariable]string{
+				message.TemplateVarOrgName:                  walletDeepLink2.OrganizationName,
+				message.TemplateVarReceiverRegistrationLink: deepLink2,
 			},
 		}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 		Return(message.MessengerTypeTwilioSMS, nil).

--- a/internal/serve/httphandler/forgot_password_handler.go
+++ b/internal/serve/httphandler/forgot_password_handler.go
@@ -154,9 +154,9 @@ func (h ForgotPasswordHandler) SendForgotPasswordMessage(ctx context.Context, ui
 		Title:   forgotPasswordMessageTitle,
 		Body:    messageContent,
 		Type:    message.MessageTypeUserForgotPassword,
-		TemplateVariables: map[string]string{
-			"ResetPasswordLink": resetPasswordURL.String(),
-			"OrganizationName":  organization.Name,
+		TemplateVariables: map[message.TemplateVariable]string{
+			message.TemplateVarResetPasswordLink: resetPasswordURL.String(),
+			message.TemplateVarOrgName:           organization.Name,
 		},
 	}
 	err = h.MessengerClient.SendMessage(ctx, msg)

--- a/internal/serve/httphandler/login_handler.go
+++ b/internal/serve/httphandler/login_handler.go
@@ -178,9 +178,9 @@ func (h LoginHandler) sendMFAEmail(ctx context.Context, user *auth.User, code st
 		Title:   mfaMessageTitle,
 		Body:    msgContent,
 		Type:    message.MessageTypeUserMFA,
-		TemplateVariables: map[string]string{
-			"MFACode":          code,
-			"OrganizationName": organization.Name,
+		TemplateVariables: map[message.TemplateVariable]string{
+			message.TemplateVarMFACode: code,
+			message.TemplateVarOrgName: organization.Name,
 		},
 	}
 	if err = h.MessengerClient.SendMessage(ctx, msg); err != nil {

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -235,9 +235,9 @@ func (h ReceiverSendOTPHandler) sendOTP(ctx context.Context, contactType data.Re
 	msg := message.Message{
 		Type: message.MessageTypeReceiverOTP,
 		Body: builder.String(),
-		TemplateVariables: map[string]string{
-			"OTP":              otp,
-			"OrganizationName": organization.Name,
+		TemplateVariables: map[message.TemplateVariable]string{
+			message.TemplateVarReceiverOTP: otp,
+			message.TemplateVarOrgName:     organization.Name,
 		},
 	}
 	switch contactType {

--- a/internal/serve/httphandler/receiver_send_otp_handler_test.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler_test.go
@@ -538,9 +538,9 @@ func Test_ReceiverSendOTPHandler_sendOTP(t *testing.T) {
 						Type:          message.MessageTypeReceiverOTP,
 						ToPhoneNumber: phoneNumber,
 						Body:          tc.wantMessage,
-						TemplateVariables: map[string]string{
-							"OTP":              otp,
-							"OrganizationName": organization.Name,
+						TemplateVariables: map[message.TemplateVariable]string{
+							message.TemplateVarReceiverOTP: otp,
+							message.TemplateVarOrgName:     organization.Name,
 						},
 					}
 					contactInfo = phoneNumber
@@ -551,9 +551,9 @@ func Test_ReceiverSendOTPHandler_sendOTP(t *testing.T) {
 						ToEmail: email,
 						Body:    tc.wantMessage,
 						Title:   "Your One-Time Password: " + otp,
-						TemplateVariables: map[string]string{
-							"OTP":              otp,
-							"OrganizationName": organization.Name,
+						TemplateVariables: map[message.TemplateVariable]string{
+							message.TemplateVarReceiverOTP: otp,
+							message.TemplateVarOrgName:     organization.Name,
 						},
 					}
 					contactInfo = email

--- a/internal/serve/httphandler/user_handler_test.go
+++ b/internal/serve/httphandler/user_handler_test.go
@@ -812,11 +812,11 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 			ToEmail: u.Email,
 			Title:   "Welcome to Stellar Disbursement Platform",
 			Body:    content,
-			TemplateVariables: map[string]string{
-				"FirstName":          u.FirstName,
-				"Role":               u.Roles[0],
-				"ForgotPasswordLink": forgotPasswordLink,
-				"OrganizationName":   "MyCustomAid",
+			TemplateVariables: map[message.TemplateVariable]string{
+				message.TemplateVarFirstName:          u.FirstName,
+				message.TemplateVarRole:               u.Roles[0],
+				message.TemplateVarForgotPasswordLink: forgotPasswordLink,
+				message.TemplateVarOrgName:            "MyCustomAid",
 			},
 		}
 		messengerClientMock.
@@ -986,11 +986,11 @@ func Test_UserHandler_CreateUser(t *testing.T) {
 			ToEmail: u.Email,
 			Title:   "Welcome to Stellar Disbursement Platform",
 			Body:    content,
-			TemplateVariables: map[string]string{
-				"FirstName":          u.FirstName,
-				"Role":               u.Roles[0],
-				"ForgotPasswordLink": forgotPasswordLink,
-				"OrganizationName":   "MyCustomAid",
+			TemplateVariables: map[message.TemplateVariable]string{
+				message.TemplateVarFirstName:          u.FirstName,
+				message.TemplateVarRole:               u.Roles[0],
+				message.TemplateVarForgotPasswordLink: forgotPasswordLink,
+				message.TemplateVarOrgName:            "MyCustomAid",
 			},
 		}
 		messengerClientMock.

--- a/internal/services/send_invitation_message.go
+++ b/internal/services/send_invitation_message.go
@@ -73,11 +73,11 @@ func SendInvitationMessage(ctx context.Context, messengerClient message.Messenge
 		Body:    messageContent,
 		Title:   invitationMessageTitle,
 		Type:    message.MessageTypeUserInvitation,
-		TemplateVariables: map[string]string{
-			"FirstName":          opts.FirstName,
-			"Role":               opts.Role,
-			"ForgotPasswordLink": forgotPasswordLink,
-			"OrganizationName":   organization.Name,
+		TemplateVariables: map[message.TemplateVariable]string{
+			message.TemplateVarFirstName:          opts.FirstName,
+			message.TemplateVarRole:               opts.Role,
+			message.TemplateVarForgotPasswordLink: forgotPasswordLink,
+			message.TemplateVarOrgName:            organization.Name,
 		},
 	}
 

--- a/internal/services/send_invitation_message_test.go
+++ b/internal/services/send_invitation_message_test.go
@@ -127,11 +127,11 @@ func Test_SendInvitationMessage(t *testing.T) {
 						ToEmail: email,
 						Title:   invitationMessageTitle,
 						Body:    content,
-						TemplateVariables: map[string]string{
-							"FirstName":          firstName,
-							"Role":               roles[0],
-							"ForgotPasswordLink": forgotPasswordLink,
-							"OrganizationName":   "MyCustomAid",
+						TemplateVariables: map[message.TemplateVariable]string{
+							message.TemplateVarFirstName:          firstName,
+							message.TemplateVarRole:               roles[0],
+							message.TemplateVarForgotPasswordLink: forgotPasswordLink,
+							message.TemplateVarOrgName:            "MyCustomAid",
 						},
 					}).
 					Return(errors.New("foobar")).
@@ -154,11 +154,11 @@ func Test_SendInvitationMessage(t *testing.T) {
 						ToEmail: email,
 						Title:   invitationMessageTitle,
 						Body:    content,
-						TemplateVariables: map[string]string{
-							"FirstName":          firstName,
-							"Role":               roles[0],
-							"ForgotPasswordLink": forgotPasswordLink,
-							"OrganizationName":   "MyCustomAid",
+						TemplateVariables: map[message.TemplateVariable]string{
+							message.TemplateVarFirstName:          firstName,
+							message.TemplateVarRole:               roles[0],
+							message.TemplateVarForgotPasswordLink: forgotPasswordLink,
+							message.TemplateVarOrgName:            "MyCustomAid",
 						},
 					}).
 					Return(nil).

--- a/internal/services/send_receiver_wallets_invite_service.go
+++ b/internal/services/send_receiver_wallets_invite_service.go
@@ -155,9 +155,9 @@ func (s SendReceiverWalletInviteService) SendInvite(ctx context.Context, receive
 		msg := message.Message{
 			Type: message.MessageTypeReceiverInvitation,
 			Body: content.String(),
-			TemplateVariables: map[string]string{
-				"OrganizationName": organization.Name,
-				"RegistrationLink": registrationLink,
+			TemplateVariables: map[message.TemplateVariable]string{
+				message.TemplateVarOrgName:                  organization.Name,
+				message.TemplateVarReceiverRegistrationLink: registrationLink,
 			},
 		}
 		if rwa.ReceiverWallet.Receiver.PhoneNumber != "" {

--- a/internal/services/send_receiver_wallets_invite_service_test.go
+++ b/internal/services/send_receiver_wallets_invite_service_test.go
@@ -165,9 +165,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				ToEmail:       receiver1.Email,
 				Body:          contentWallet1,
 				Title:         titleWallet1,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink1.OrganizationName,
-					"RegistrationLink": deepLink1,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink1.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink1,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeTwilioSMS, errors.New("unexpected error")).
@@ -178,9 +178,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				ToEmail:       receiver2.Email,
 				Body:          contentWallet2,
 				Title:         titleWallet2,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink2.OrganizationName,
-					"RegistrationLink": deepLink2,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink2.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink2,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeTwilioSMS, nil).
@@ -318,9 +318,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				Type:          message.MessageTypeReceiverInvitation,
 				ToPhoneNumber: receiverPhoneOnly.PhoneNumber,
 				Body:          contentWallet1,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink1.OrganizationName,
-					"RegistrationLink": deepLink1,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink1.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink1,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeTwilioSMS, nil).
@@ -330,9 +330,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				ToEmail: receiverEmailOnly.Email,
 				Body:    contentWallet2,
 				Title:   titleWallet2,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink2.OrganizationName,
-					"RegistrationLink": deepLink2,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink2.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink2,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeAWSEmail, nil).
@@ -468,9 +468,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				ToEmail:       receiver1.Email,
 				Body:          contentWallet1,
 				Title:         titleWallet1,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink1.OrganizationName,
-					"RegistrationLink": deepLink1,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink1.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink1,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeTwilioSMS, nil).
@@ -481,9 +481,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				ToEmail:       receiver2.Email,
 				Body:          contentWallet2,
 				Title:         titleWallet2,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink2.OrganizationName,
-					"RegistrationLink": deepLink2,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink2.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink2,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeTwilioSMS, nil).
@@ -776,9 +776,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				ToEmail:       receiver1.Email,
 				Body:          contentWallet1,
 				Title:         titleWallet1,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink1.OrganizationName,
-					"RegistrationLink": deepLink1,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink1.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink1,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeTwilioSMS, nil).
@@ -901,9 +901,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				ToEmail:       receiver1.Email,
 				Body:          contentDisbursement3,
 				Title:         titleDisbursement3,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink1.OrganizationName,
-					"RegistrationLink": deepLink1,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink1.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink1,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeTwilioSMS, nil).
@@ -914,9 +914,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				ToEmail:       receiver2.Email,
 				Body:          contentDisbursement4,
 				Title:         titleDisbursement4,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink2.OrganizationName,
-					"RegistrationLink": deepLink2,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink2.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink2,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeTwilioSMS, nil).
@@ -1044,9 +1044,9 @@ func Test_SendReceiverWalletInviteService_SendInvite(t *testing.T) {
 				ToEmail:       receiver1.Email,
 				Body:          contentDisbursement,
 				Title:         titleDisbursement,
-				TemplateVariables: map[string]string{
-					"OrganizationName": walletDeepLink1.OrganizationName,
-					"RegistrationLink": deepLink1,
+				TemplateVariables: map[message.TemplateVariable]string{
+					message.TemplateVarOrgName:                  walletDeepLink1.OrganizationName,
+					message.TemplateVarReceiverRegistrationLink: deepLink1,
 				},
 			}, []message.MessageChannel{message.MessageChannelSMS, message.MessageChannelEmail}).
 			Return(message.MessengerTypeTwilioSMS, nil).


### PR DESCRIPTION
### What
* Change ContentVariables in Twilio Whatsapp implementation to be numbered instead of named. 
* Numbered variables guarantee order during tokenization process
* Things worked up to now because we only have two parameters per message and changes of a mix-up are low. 

### Why
* Guarantee order. 

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
