### PR TITLE
SDP-1862: Add public key to embedded wallets table

### DIFF
--- a/db/migrations/sdp-migrations/2025-05-18.1-create-embedded-wallet.sql
+++ b/db/migrations/sdp-migrations/2025-05-18.1-create-embedded-wallet.sql
@@ -11,6 +11,7 @@ CREATE TABLE embedded_wallets (
     token VARCHAR(36) PRIMARY KEY,
     wasm_hash VARCHAR(64),
     contract_address VARCHAR(56),
+    public_key VARCHAR(130),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     wallet_status embedded_wallet_status NOT NULL DEFAULT 'PENDING'::embedded_wallet_status

--- a/internal/data/embedded_wallet.go
+++ b/internal/data/embedded_wallet.go
@@ -51,6 +51,7 @@ type EmbeddedWallet struct {
 	WasmHash        string               `json:"wasm_hash" db:"wasm_hash"`
 	ContractAddress string               `json:"contract_address" db:"contract_address"`
 	CredentialID    string               `json:"credential_id" db:"credential_id"`
+	PublicKey       string               `json:"public_key" db:"public_key"`
 	CreatedAt       *time.Time           `json:"created_at" db:"created_at"`
 	UpdatedAt       *time.Time           `json:"updated_at" db:"updated_at"`
 	WalletStatus    EmbeddedWalletStatus `json:"wallet_status" db:"wallet_status"`
@@ -74,6 +75,7 @@ func EmbeddedWalletColumnNames(tableReference, resultAlias string) string {
 			"wasm_hash",
 			"contract_address",
 			"credential_id",
+			"public_key",
 		},
 	}.Build()
 
@@ -179,6 +181,7 @@ type EmbeddedWalletUpdate struct {
 	WasmHash        string               `db:"wasm_hash"`
 	ContractAddress string               `db:"contract_address"`
 	CredentialID    string               `db:"credential_id"`
+	PublicKey       string               `db:"public_key"`
 	WalletStatus    EmbeddedWalletStatus `db:"wallet_status"`
 }
 

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -706,7 +706,7 @@ func DeleteAllDisbursementFixtures(t *testing.T, ctx context.Context, sqlExec db
 	require.NoError(t, err)
 }
 
-func CreateEmbeddedWalletFixture(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, token, wasmHash, contractAddress, credentialID string, status EmbeddedWalletStatus) *EmbeddedWallet {
+func CreateEmbeddedWalletFixture(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, token, wasmHash, contractAddress, credentialID, publicKey string, status EmbeddedWalletStatus) *EmbeddedWallet {
 	t.Helper()
 
 	if token == "" {
@@ -717,14 +717,14 @@ func CreateEmbeddedWalletFixture(t *testing.T, ctx context.Context, sqlExec db.S
 
 	q := fmt.Sprintf(`
 		INSERT INTO embedded_wallets
-			(token, wasm_hash, contract_address, credential_id, wallet_status)
+			(token, wasm_hash, contract_address, credential_id, public_key, wallet_status)
 		VALUES
-			($1, $2, $3, $4, $5)
+			($1, $2, $3, $4, $5, $6)
 		RETURNING %s
 	`, EmbeddedWalletColumnNames("", ""))
 	wallet := EmbeddedWallet{}
 
-	err := sqlExec.GetContext(ctx, &wallet, q, token, utils.SQLNullString(wasmHash), utils.SQLNullString(contractAddress), utils.SQLNullString(credentialID), status)
+	err := sqlExec.GetContext(ctx, &wallet, q, token, utils.SQLNullString(wasmHash), utils.SQLNullString(contractAddress), utils.SQLNullString(credentialID), utils.SQLNullString(publicKey), status)
 	require.NoError(t, err)
 	return &wallet
 }

--- a/internal/services/embedded_wallet_service.go
+++ b/internal/services/embedded_wallet_service.go
@@ -141,6 +141,7 @@ func (e *EmbeddedWalletService) CreateWallet(ctx context.Context, token, publicK
 			embeddedWalletUpdate := data.EmbeddedWalletUpdate{
 				WasmHash:     e.wasmHash,
 				CredentialID: credentialID,
+				PublicKey:    publicKey,
 				WalletStatus: data.ProcessingWalletStatus,
 			}
 

--- a/internal/services/embedded_wallet_service_test.go
+++ b/internal/services/embedded_wallet_service_test.go
@@ -136,7 +136,7 @@ func Test_EmbeddedWalletService_CreateWallet(t *testing.T) {
 	t.Run("successfully creates a wallet TSS transaction", func(t *testing.T) {
 		defer data.DeleteAllEmbeddedWalletsFixtures(t, ctx, dbConnectionPool)
 
-		initialWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", data.PendingWalletStatus)
+		initialWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", "", data.PendingWalletStatus)
 		walletIDForTest := initialWallet.Token
 
 		err := service.CreateWallet(ctx, walletIDForTest, defaultPublicKey, defaultCredentialID)
@@ -189,7 +189,7 @@ func Test_EmbeddedWalletService_CreateWallet(t *testing.T) {
 	t.Run("returns error if wallet status is not pending", func(t *testing.T) {
 		defer data.DeleteAllEmbeddedWalletsFixtures(t, ctx, dbConnectionPool)
 
-		initialWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", data.SuccessWalletStatus)
+		initialWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", "", data.SuccessWalletStatus)
 		walletIDForTest := initialWallet.Token
 
 		err := service.CreateWallet(ctx, walletIDForTest, defaultPublicKey, defaultCredentialID)
@@ -204,7 +204,7 @@ func Test_EmbeddedWalletService_CreateWallet(t *testing.T) {
 		invalidService, err := NewEmbeddedWalletService(sdpModels, tssModel, "invalid_hash_not_32_bytes")
 		require.NoError(t, err)
 
-		initialWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", data.PendingWalletStatus)
+		initialWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", "", data.PendingWalletStatus)
 		walletIDForTest := initialWallet.Token
 
 		err = invalidService.CreateWallet(ctx, walletIDForTest, defaultPublicKey, defaultCredentialID)
@@ -223,7 +223,7 @@ func Test_EmbeddedWalletService_CreateWallet(t *testing.T) {
 		invalidService, err := NewEmbeddedWalletService(sdpModels, tssModel, testWasmHash)
 		require.NoError(t, err)
 
-		initialWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", data.SuccessWalletStatus)
+		initialWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", "", data.SuccessWalletStatus)
 		walletIDForTest := initialWallet.Token
 
 		err = invalidService.CreateWallet(ctx, walletIDForTest, defaultPublicKey, defaultCredentialID)
@@ -241,7 +241,7 @@ func Test_EmbeddedWalletService_CreateWallet(t *testing.T) {
 		duplicateCredentialID := "duplicate-credential-id"
 
 		// Step 1: Create first wallet successfully
-		wallet1 := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", data.PendingWalletStatus)
+		wallet1 := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", "", data.PendingWalletStatus)
 		err := service.CreateWallet(ctx, wallet1.Token, defaultPublicKey, duplicateCredentialID)
 		require.NoError(t, err)
 
@@ -256,7 +256,7 @@ func Test_EmbeddedWalletService_CreateWallet(t *testing.T) {
 		assert.Len(t, tssTransactions1, 1, "First wallet should have exactly one TSS transaction")
 
 		// Step 2: Try duplicate credential ID (should fail cleanly)
-		wallet2 := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", data.PendingWalletStatus)
+		wallet2 := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", "", data.PendingWalletStatus)
 		otherPublicKey := "04deadbeef" + strings.Repeat("00", 60)
 		err = service.CreateWallet(ctx, wallet2.Token, otherPublicKey, duplicateCredentialID)
 		require.Error(t, err)
@@ -281,12 +281,12 @@ func Test_EmbeddedWalletService_CreateWallet(t *testing.T) {
 		secondCredentialID := "second-credential-id"
 
 		// Step 1: Create first wallet successfully
-		wallet1 := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", data.PendingWalletStatus)
+		wallet1 := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", "", data.PendingWalletStatus)
 		err := service.CreateWallet(ctx, wallet1.Token, defaultPublicKey, firstCredentialID)
 		require.NoError(t, err)
 
 		// Step 2: Try duplicate credential ID (should fail)
-		wallet2 := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", data.PendingWalletStatus)
+		wallet2 := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "", "", "", "", data.PendingWalletStatus)
 		otherPublicKey := "04deadbeef" + strings.Repeat("00", 60)
 		err = service.CreateWallet(ctx, wallet2.Token, otherPublicKey, firstCredentialID)
 		require.Error(t, err)
@@ -336,7 +336,7 @@ func Test_EmbeddedWalletService_GetWalletByCredentialID(t *testing.T) {
 	t.Run("successfully gets a wallet by credential ID", func(t *testing.T) {
 		defer data.DeleteAllEmbeddedWalletsFixtures(t, ctx, dbConnectionPool)
 
-		expectedWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "somehash", "somecontract", "test-credential-id", data.SuccessWalletStatus)
+		expectedWallet := data.CreateEmbeddedWalletFixture(t, ctx, dbConnectionPool, "", "somehash", "somecontract", "test-credential-id", "test-public-key", data.SuccessWalletStatus)
 
 		retrievedWallet, err := service.GetWalletByCredentialID(ctx, expectedWallet.CredentialID)
 		require.NoError(t, err)
@@ -346,6 +346,7 @@ func Test_EmbeddedWalletService_GetWalletByCredentialID(t *testing.T) {
 		assert.Equal(t, expectedWallet.WasmHash, retrievedWallet.WasmHash)
 		assert.Equal(t, expectedWallet.ContractAddress, retrievedWallet.ContractAddress)
 		assert.Equal(t, expectedWallet.CredentialID, retrievedWallet.CredentialID)
+		assert.Equal(t, expectedWallet.PublicKey, retrievedWallet.PublicKey)
 		assert.Equal(t, expectedWallet.WalletStatus, retrievedWallet.WalletStatus)
 		assert.NotNil(t, retrievedWallet.CreatedAt)
 		assert.NotNil(t, retrievedWallet.UpdatedAt)


### PR DESCRIPTION
### What

Persist the passkey's public key in the embedded wallets table so that it can be used to verify the WebAuthn challenge signed by the frontend.

### Why

Wallet authentication

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
