### PR TITLE
Add `assets_futurenet.go`

### DIFF
--- a/internal/services/assets/assets_futurenet.go
+++ b/internal/services/assets/assets_futurenet.go
@@ -1,0 +1,10 @@
+package assets
+
+import "github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+
+// AllAssetsFuturenet represents the assets available on the Futurenet network.
+// At the moment Futurenet only supports the native asset, so we intentionally
+// keep this list scoped to XLM.
+var AllAssetsFuturenet = []data.Asset{
+	XLMAsset,
+}

--- a/internal/services/wallets/wallets_futurenet.go
+++ b/internal/services/wallets/wallets_futurenet.go
@@ -12,13 +12,12 @@ var FuturenetWallets = []data.Wallet{
 		DeepLinkSchema:    "https://demo-wallet.stellar.org",
 		SEP10ClientDomain: "demo-wallet-server.stellar.org",
 		Assets: []data.Asset{
-			assets.USDCAssetTestnet,
 			assets.XLMAsset,
 		},
 	},
 	{
 		Name:        "User Managed Wallet",
-		Assets:      assets.AllAssetsTestnet,
+		Assets:      assets.AllAssetsFuturenet,
 		UserManaged: true,
 	},
 }


### PR DESCRIPTION
### What

Futurenet was referencing testnet assets, and this is causing integration test fail due to the assets on testnet does not exist on futurenet

https://github.com/stellar/stellar-disbursement-platform-backend/actions/runs/18352444749/job/52289393276

### Why

Repro on local got error msg


`time="2025-10-08T20:10:40.165Z" level=error msg="[DRY_RUN Crash Reporter] Could not provision a new tenant: provisioning error: tenant update failed. provisioning trustlines for distribution account: submitting change trust transaction: submitting change trust transaction to network: horizon response error: StatusCode=400, Type=https://stellar.org/horizon-errors/transaction_failed, Title=Transaction Failed, Detail=The transaction failed when submitted to the stellar network. The `extras.result_codes` field on this response contains further details. Descriptions of each code can be found at: [https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-failed/,⁠](https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-failed/,) Extras=transaction: tx_failed - operation codes: [ op_no_issuer ]" pid=60 req=`


check USDC and EURC doesn't exist on future net 

### Known limitations

[TODO or N/A]

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
