### PR TITLE
Chore: Make POST /wallets and PATCH /wallets permissions consistent

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -464,7 +464,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			// Write operations
 			r.With(middleware.RequirePermission(
 				data.WriteWallets,
-				middleware.AnyRoleMiddleware(authManager, data.DeveloperUserRole),
+				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.DeveloperUserRole),
 			)).Group(func(r chi.Router) {
 				r.Post("/", walletsHandler.PostWallets)
 				r.Delete("/{id}", walletsHandler.DeleteWallet)
@@ -472,7 +472,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 			r.With(middleware.RequirePermission(
 				data.WriteWallets,
-				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole),
+				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.DeveloperUserRole),
 			)).Patch("/{id}", walletsHandler.PatchWallets)
 		})
 


### PR DESCRIPTION
### What
- Change `POST /wallets` and `PATCH /wallets/:id` permissions to be consistent. Both endpoints will accept users with Developer and Owner roles. 

### Why
- Consistency. 


### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
