### PR TITLE
SDP-1615: Require authorization on tx sponsorship

### DIFF
--- a/internal/serve/httphandler/sponsored_transaction_handler.go
+++ b/internal/serve/httphandler/sponsored_transaction_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/go/xdr"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
@@ -66,8 +67,11 @@ func (h SponsoredTransactionHandler) CreateSponsoredTransaction(w http.ResponseW
 		return
 	}
 
-	// TODO: Extract account from JWT token/authentication context
-	account := "PLACEHOLDER"
+	account, err := sdpcontext.GetWalletContractAddressFromContext(ctx)
+	if err != nil {
+		httperror.Unauthorized("Wallet contract address not found in context", err, nil).Render(w)
+		return
+	}
 
 	transactionID, err := h.EmbeddedWalletService.SponsorTransaction(ctx, account, reqBody.OperationXDR)
 	if err != nil {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -690,9 +690,12 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 					// Wallet creation routes
 					r.Post("/", walletCreationHandler.CreateWallet)
 					r.Get("/{credentialID}", walletCreationHandler.GetWallet)
+
 					// Sponsored transactions routes
-					r.Post("/sponsored-transactions", sponsoredTransactionHandler.CreateSponsoredTransaction)
-					r.Get("/sponsored-transactions/{id}", sponsoredTransactionHandler.GetSponsoredTransaction)
+					r.With(middleware.WalletAuthMiddleware(o.walletJWTManager)).Route("/sponsored-transactions", func(r chi.Router) {
+						r.Post("/", sponsoredTransactionHandler.CreateSponsoredTransaction)
+						r.Get("/{id}", sponsoredTransactionHandler.GetSponsoredTransaction)
+					})
 
 					// Passkey registration + authentication routes
 					if passkeyHandler != nil {


### PR DESCRIPTION
### What

This PR enables wallet authentication on the sponsored transaction routes.

### Why

Transaction sponsorship should only be available to SDP embedded wallets.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
