### PR TITLE
Chore - Cleanup logs when resolving tenants from request

### DIFF
--- a/internal/serve/middleware/middleware_test.go
+++ b/internal/serve/middleware/middleware_test.go
@@ -706,18 +706,9 @@ func Test_LoggingMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, expectedRespBody, string(respBody))
 
-		logEntries := debugEntries()
-		assert.Len(t, logEntries, 3)
-
-		// Find the request start and finish logs (skip the warning log)
-		var requestLogs []logrus.Entry
-		for _, e := range logEntries {
-			if e.Message == "starting request" || e.Message == "finished request" {
-				requestLogs = append(requestLogs, e)
-			}
-		}
-
+		requestLogs := debugEntries()
 		assert.Len(t, requestLogs, 2)
+
 		for i, e := range requestLogs {
 			entry, err := e.String()
 			require.NoError(t, err)

--- a/internal/utils/multitenant.go
+++ b/internal/utils/multitenant.go
@@ -2,15 +2,27 @@ package utils
 
 import (
 	"errors"
+	"net"
 	"strings"
 )
 
-var ErrTenantNameNotFound = errors.New("tenant name not found")
+var (
+	ErrTenantNameNotFound  = errors.New("tenant name not found")
+	ErrHostnameIsIPAddress = errors.New("hostname is an IP address")
+)
 
 func ExtractTenantNameFromHostName(hostname string) (string, error) {
-	// Remove port number if present (e.g. aidorg.sdp.com:8000 -> aidorg.sdp.com)
-	hostname = strings.Split(hostname, ":")[0]
-	// Split by dots (e.g. aidorg.sdp.com -> [aidorg, sdp, com])
+	// Strip port if present
+	if host, _, err := net.SplitHostPort(hostname); err == nil {
+		hostname = host
+	}
+
+	// Check if hostname is an IP address
+	if net.ParseIP(hostname) != nil {
+		return "", ErrHostnameIsIPAddress
+	}
+
+	// Extract subdomain from hostname (e.g. aidorg.sdp.com -> aidorg)
 	parts := strings.Split(hostname, ".")
 	// If there's more than 2 parts, it means there's a subdomain
 	if len(parts) > 2 {

--- a/internal/utils/multitenant_test.go
+++ b/internal/utils/multitenant_test.go
@@ -8,21 +8,94 @@ import (
 
 func Test_ExtractTenantNameFromHostName(t *testing.T) {
 	tests := []struct {
+		name     string
 		input    string
 		expected string
 		err      error
 	}{
-		{"invalid", "", ErrTenantNameNotFound},
-		{"", "", ErrTenantNameNotFound},
-		{"aidorg.sdp.com", "aidorg", nil},
-		{"subdomain.aidorg.sdp.com", "subdomain", nil},
-		{"sub-domain.aidorg.sdp.com", "sub-domain", nil},
-		{"aidorg.sdp.com:8000", "aidorg", nil},
+		{
+			name:     "invalid hostname without subdomain",
+			input:    "invalid",
+			expected: "",
+			err:      ErrTenantNameNotFound,
+		},
+		{
+			name:     "empty hostname",
+			input:    "",
+			expected: "",
+			err:      ErrTenantNameNotFound,
+		},
+		{
+			name:     "valid hostname with subdomain",
+			input:    "aidorg.sdp.com",
+			expected: "aidorg",
+			err:      nil,
+		},
+		{
+			name:     "valid hostname with multiple subdomains",
+			input:    "subdomain.aidorg.sdp.com",
+			expected: "subdomain",
+			err:      nil,
+		},
+		{
+			name:     "valid hostname with hyphenated subdomain",
+			input:    "sub-domain.aidorg.sdp.com",
+			expected: "sub-domain",
+			err:      nil,
+		},
+		{
+			name:     "valid hostname with port",
+			input:    "aidorg.sdp.com:8000",
+			expected: "aidorg",
+			err:      nil,
+		},
+		{
+			name:     "IPv4 address",
+			input:    "192.168.1.1",
+			expected: "",
+			err:      ErrHostnameIsIPAddress,
+		},
+		{
+			name:     "IPv4 address with port",
+			input:    "192.168.1.1:8000",
+			expected: "",
+			err:      ErrHostnameIsIPAddress,
+		},
+		{
+			name:     "IPv4 localhost",
+			input:    "127.0.0.1",
+			expected: "",
+			err:      ErrHostnameIsIPAddress,
+		},
+		{
+			name:     "IPv6 address loopback",
+			input:    "::1",
+			expected: "",
+			err:      ErrHostnameIsIPAddress,
+		},
+		{
+			name:     "IPv6 address full form",
+			input:    "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			expected: "",
+			err:      ErrHostnameIsIPAddress,
+		},
+		{
+			name:     "IPv6 address compressed",
+			input:    "2001:db8::1",
+			expected: "",
+			err:      ErrHostnameIsIPAddress,
+		},
 	}
 
 	for _, test := range tests {
-		actualOutput, actualError := ExtractTenantNameFromHostName(test.input)
-		assert.Equal(t, test.expected, actualOutput)
-		assert.Equal(t, test.err, actualError)
+		t.Run(test.name, func(t *testing.T) {
+			actualOutput, actualError := ExtractTenantNameFromHostName(test.input)
+			assert.Equal(t, test.expected, actualOutput)
+			if test.err != nil {
+				assert.ErrorIs(t, actualError, test.err)
+			} else {
+				assert.NoError(t, actualError)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### What
* Improve logging when resolving tenant from request

### Why
* Reduce bogus logs about inability to resolve tenant name during health checks 

```
time="2025-10-24T01:00:57.674Z" level=warning msg="could not find tenant with name 172: tenant does not exist" pid=1 | 
time="2025-10-24T01:00:57.170Z" level=warning msg="could not find tenant with name 172: tenant does not exist" pid=1 |  
time="2025-10-24T01:00:54.991Z" level=warning msg="could not find tenant with name 172: tenant does not exist" pid=14
```

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
