### PR TITLE
Fix deep link generation for non-embedded wallets

### DIFF
--- a/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
+++ b/internal/scheduler/jobs/send_receiver_wallets_sms_invitation_job_test.go
@@ -99,10 +99,12 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 	require.NoError(t, err)
 
 	tenantBaseURL := "http://localhost:8000"
+	tenantUIBaseURL := "http://localhost:3000"
 	tenantInfo := &schema.Tenant{
-		ID:      uuid.NewString(),
-		Name:    "TestTenant",
-		BaseURL: &tenantBaseURL,
+		ID:           uuid.NewString(),
+		Name:         "TestTenant",
+		BaseURL:      &tenantBaseURL,
+		SDPUIBaseURL: &tenantUIBaseURL,
 	}
 	ctx := sdpcontext.SetTenantInContext(context.Background(), tenantInfo)
 
@@ -168,6 +170,7 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 	walletDeepLink1 := services.WalletDeepLink{
 		DeepLink:         wallet1.DeepLinkSchema,
 		TenantBaseURL:    tenantBaseURL,
+		TenantUIBaseURL:  tenantUIBaseURL,
 		OrganizationName: "MyCustomAid",
 		AssetCode:        asset1.Code,
 		AssetIssuer:      asset1.Issuer,
@@ -180,6 +183,7 @@ func Test_SendReceiverWalletsSMSInvitationJob_Execute(t *testing.T) {
 	walletDeepLink2 := services.WalletDeepLink{
 		DeepLink:         wallet2.DeepLinkSchema,
 		TenantBaseURL:    tenantBaseURL,
+		TenantUIBaseURL:  tenantUIBaseURL,
 		OrganizationName: "MyCustomAid",
 		AssetCode:        asset2.Code,
 		AssetIssuer:      asset2.Issuer,

--- a/internal/services/send_receiver_wallets_invite_service.go
+++ b/internal/services/send_receiver_wallets_invite_service.go
@@ -121,6 +121,7 @@ func (s SendReceiverWalletInviteService) SendInvite(ctx context.Context, receive
 			AssetCode:        rwa.Asset.Code,
 			AssetIssuer:      rwa.Asset.Issuer,
 			TenantBaseURL:    *currentTenant.BaseURL,
+			TenantUIBaseURL:  *currentTenant.SDPUIBaseURL,
 			SelfHosted:       wallet.IsSelfHosted(),
 		}
 
@@ -233,7 +234,7 @@ func (s SendReceiverWalletInviteService) updateEmbeddedWalletDeepLink(ctx contex
 	}
 
 	if wdl.SelfHosted {
-		wdl.DeepLink = wdl.TenantBaseURL
+		wdl.DeepLink = wdl.TenantUIBaseURL
 		wdl.Route = "wallet"
 	}
 
@@ -374,6 +375,8 @@ type WalletDeepLink struct {
 	AssetIssuer string
 	// TenantBaseURL is the base URL for the tenant that the receiver wallet belongs to.
 	TenantBaseURL string
+	// TenantUIBaseURL is the base URL for the tenant UI that the receiver wallet belongs to.
+	TenantUIBaseURL string
 	// Token is a unique token that identifies identifies a receiver wallet creation request.
 	Token string
 	// SelfHosted is set to true when the deep link should be set to the tenant base URL, which is the case only for embedded wallets.


### PR DESCRIPTION
### What

A previous PR incorrectly replaced all tenant base URLs with their UI base URLs in the deep link generation. This commit reverts that change and correctly fixes the embedded wallet deep links so that they still use the UI base URLs.

### Why

Invite links were broken for non-embedded wallets.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
