### PR TITLE
Fix docker compose hardcoded `SINGLE_TENANT_MODE` to false

### DIFF
--- a/dev/docker-compose-sdp.yml
+++ b/dev/docker-compose-sdp.yml
@@ -45,7 +45,7 @@ services:
       ADMIN_PORT: "8003"
       INSTANCE_NAME: "SDP Testnet on Docker"
       TENANT_XLM_BOOTSTRAP_AMOUNT: ${TENANT_XLM_BOOTSTRAP_AMOUNT:-5}
-      SINGLE_TENANT_MODE: "false"
+      SINGLE_TENANT_MODE: ${SINGLE_TENANT_MODE:-false}
 
       # scheduler options
       SCHEDULER_RECEIVER_INVITATION_JOB_SECONDS: "10"


### PR DESCRIPTION
### What

Load `SINGLE_TENANT_MODE` from env file, default to false.


### Why

This prevents single tenant mode from starting.

### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
