### PR TITLE
Append `--disable-mfa` to single tenant creation cli

### DIFF
--- a/tools/sdp-setup/internal/tenant/service.go
+++ b/tools/sdp-setup/internal/tenant/service.go
@@ -74,6 +74,7 @@ func (s *Service) initializeSingleTenantEnvironment(ctx context.Context) error {
 		"--default-tenant-distribution-account-type", "DISTRIBUTION_ACCOUNT.STELLAR.ENV",
 		"--distribution-account-encryption-passphrase", s.cfg.DistributionSeed,
 		"--channel-account-encryption-passphrase", s.cfg.DistributionSeed,
+		"--disable-mfa", s.cfg.DisableMFA,
 	}
 
 	cmd := exec.CommandContext(ctx, "go", args...)


### PR DESCRIPTION
### What

Forward `DISABLE_MFA` to cli to ensure single-tenant wizard honors MFA env flags

### Why

In single tenant mode, organization  didn't inherits the `DISABLE_MFA` security settings

### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
