### PR TITLE
chore: remove `EVENT_BROKER_TYPE` from sdp docker compose

### DIFF
--- a/dev/docker-compose-sdp.yml
+++ b/dev/docker-compose-sdp.yml
@@ -51,9 +51,6 @@ services:
       SCHEDULER_RECEIVER_INVITATION_JOB_SECONDS: "10"
       SCHEDULER_PAYMENT_JOB_SECONDS: "10"
 
-      # Kafka Configuration - possible values: KAFKA; SCHEDULER
-      EVENT_BROKER_TYPE: "SCHEDULER"
-
       # multi-tenant secrets:
       ADMIN_ACCOUNT: SDP-admin
       ADMIN_API_KEY: api_key_1234567890


### PR DESCRIPTION
### What
* chore: remove `EVENT_BROKER_TYPE` from sdp docker compose

### Why
`EVENT_BROKER_TYPE` is decommissionned. 


### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
