### PR TITLE
chore - rebuild docker image when running `make setup`

### DIFF
--- a/tools/sdp-setup/internal/docker/service.go
+++ b/tools/sdp-setup/internal/docker/service.go
@@ -138,7 +138,7 @@ func (s *Service) composeUp(ctx context.Context) error {
 	for _, file := range s.files {
 		args = append(args, "-f", file)
 	}
-	args = append(args, "up", "-d")
+	args = append(args, "up", "-d", "--build")
 
 	if err := s.executor.Execute(ctx, "docker", args...); err != nil {
 		return fmt.Errorf("running docker compose up: %w", err)


### PR DESCRIPTION
### What

- add `--build` to  `docker compose` for the `make setup` tool 

### Why

- enables local development and testing on current builds of the SDP. 

### Known limitations

- Later: add an option to configure build/image of the SDP backend and frontend from the `.env` file. 

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
