### PR TITLE
chore: fix flaky assets handler test due to time drift

### DIFF
--- a/internal/serve/httphandler/assets_handler_test.go
+++ b/internal/serve/httphandler/assets_handler_test.go
@@ -1939,7 +1939,7 @@ func Test_AssetHandler_submitChangeTrustTransaction_makeSurePreconditionsAreSetA
 		mocks.Handler.GetPreconditionsFn = nil
 
 		txParams := txParamsWithoutPreconditions
-		txParams.Preconditions = defaultPreconditions
+		txParams.Preconditions = txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(20)}
 		tx, err := txnbuild.NewTransaction(txParams)
 		require.NoError(t, err)
 


### PR DESCRIPTION
### What
Updated the test  `Test_AssetHandler_submitChangeTrustTransaction_makeSurePreconditionsAreSetAsExpected` to use a fresh `txnbuild.Preconditions` instance for its expectations instead of relying on the package-level `defaultPreconditions` variable.

### Why
The `defaultPreconditions` variable is initialized when the package loads. When running the entire test suite, the time elapsed between package initialization and the execution of this specific test exceeds the allowed time drift (30s). This caused the test to fail because the transaction created inside the handler uses a fresh timestamp (time.Now()), while the test expectation was comparing it against the stale timestamp from `defaultPreconditions`. Using a fresh timestamp in the test expectation aligns it with the handler's behavior and prevents the time drift error.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
