### PR TITLE
Fix BASE_URL in setup wizard

### DIFF
--- a/tools/sdp-setup/internal/config/env.go
+++ b/tools/sdp-setup/internal/config/env.go
@@ -229,6 +229,13 @@ func Write(cfg Config, path string) error {
 	}
 
 	// 1. Start with the configuration values we want to set
+	apiHost := "localhost"
+	uiHost := "localhost"
+	if !cfg.SingleTenantMode {
+		apiHost = "stellar.local"
+		uiHost = "stellar.local"
+	}
+
 	configMap := map[string]string{
 		"NETWORK_TYPE":                               cfg.NetworkType,
 		"NETWORK_PASSPHRASE":                         cfg.NetworkPassphrase,
@@ -244,8 +251,8 @@ func Write(cfg Config, path string) error {
 		"CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE":      cfg.DistributionSeed,
 		"DISTRIBUTION_ACCOUNT_ENCRYPTION_PASSPHRASE": cfg.DistributionSeed,
 		"USE_HTTPS":                                  strconv.FormatBool(cfg.UseHTTPS),
-		"SDP_UI_BASE_URL":                            cfg.FrontendBaseURL("localhost"),
-		"BASE_URL":                                   "http://localhost:8000",
+		"SDP_UI_BASE_URL":                            cfg.FrontendBaseURL(uiHost),
+		"BASE_URL":                                   fmt.Sprintf("http://%s:8000", apiHost),
 		"DATABASE_URL":                               fmt.Sprintf("postgres://postgres@db:5432/%s?sslmode=disable", cfg.DatabaseName),
 	}
 

--- a/tools/sdp-setup/internal/tenant/service.go
+++ b/tools/sdp-setup/internal/tenant/service.go
@@ -63,6 +63,7 @@ func (s *Service) initializeSingleTenantEnvironment(ctx context.Context) error {
 
 	args := []string{
 		"run", "..", "--log-level", "ERROR", "tenants", "ensure-default",
+		"--sdp-ui-base-url", s.cfg.FrontendBaseURL("localhost"),
 		"--database-url", dbURL,
 		"--default-tenant-owner-email", "default@default.local",
 		"--default-tenant-owner-first-name", "Default",


### PR DESCRIPTION
### What

This fixes two things:
- The SDP_UI_BASE_URL is not currently set to the value in the `.env`, causing the embedded wallet link to be sent with the HTTP endpoint
- Set the BASE_URL to `stellar.local` so that SEP-10/SEP-45 can pass the home domain check when testing against a local multitenant instance.

### Why

Fixes issues that prevent local testing of embedded wallets

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
