### PR TITLE
Fix: Derive passkey name from tenant

### DIFF
--- a/internal/wallet/webauthn_service.go
+++ b/internal/wallet/webauthn_service.go
@@ -124,12 +124,11 @@ func buildPasskeyDisplayName(ctx context.Context, createdAt *time.Time) (string,
 		return "", fmt.Errorf("getting tenant from context: %w", err)
 	}
 
-	date := time.Now().UTC()
-	if createdAt != nil {
-		date = createdAt.UTC()
+	if createdAt == nil {
+		return "", fmt.Errorf("wallet creation time is nil")
 	}
 
-	return fmt.Sprintf("%s Wallet - %s", tenant.Name, date.Format("2006-01-02 15:04 UTC")), nil
+	return fmt.Sprintf("%s Wallet - %s", tenant.Name, createdAt.UTC().Format("2006-01-02 15:04 UTC")), nil
 }
 
 type newUser struct {
@@ -180,7 +179,7 @@ func (w *WebAuthnService) StartPasskeyRegistration(ctx context.Context, token st
 
 	displayName, err := buildPasskeyDisplayName(ctx, embeddedWallet.CreatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("building passkey display name: %w", err)
 	}
 
 	user := &newUser{
@@ -244,7 +243,7 @@ func (w *WebAuthnService) FinishPasskeyRegistration(ctx context.Context, token s
 
 	displayName, err := buildPasskeyDisplayName(ctx, embeddedWallet.CreatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("building passkey display name: %w", err)
 	}
 
 	parsedResponse, err := protocol.ParseCredentialCreationResponseBody(request.Body)
@@ -384,7 +383,7 @@ func (w *WebAuthnService) FinishPasskeyAuthentication(ctx context.Context, reque
 
 		displayName, displayErr := buildPasskeyDisplayName(ctx, embeddedWallet.CreatedAt)
 		if displayErr != nil {
-			return nil, displayErr
+			return nil, fmt.Errorf("building passkey display name: %w", displayErr)
 		}
 
 		return &existingUser{

--- a/internal/wallet/webauthn_service_test.go
+++ b/internal/wallet/webauthn_service_test.go
@@ -27,6 +27,59 @@ func newTestSessionCache(t *testing.T) SessionCacheInterface {
 	return cache
 }
 
+func TestBuildPasskeyDisplayName(t *testing.T) {
+	sdpUIBaseURL := "http://localhost:3000"
+	testTenant := schema.Tenant{ID: "tenant-id", Name: "Test Tenant", SDPUIBaseURL: &sdpUIBaseURL}
+	ctxWithTenant := sdpcontext.SetTenantInContext(context.Background(), &testTenant)
+	createdAt := time.Date(2025, 12, 17, 18, 5, 30, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		ctx            context.Context
+		createdAt      *time.Time
+		expectedName   string
+		expectedErr    error
+		expectedErrMsg string
+	}{
+		{
+			name:         "returns display name with tenant and timestamp",
+			ctx:          ctxWithTenant,
+			createdAt:    &createdAt,
+			expectedName: "Test Tenant Wallet - 2025-12-17 18:05 UTC",
+		},
+		{
+			name:        "returns error when tenant is missing from context",
+			ctx:         context.Background(),
+			createdAt:   &createdAt,
+			expectedErr: sdpcontext.ErrTenantNotFoundInContext,
+		},
+		{
+			name:           "returns error when createdAt is nil",
+			ctx:            ctxWithTenant,
+			expectedErrMsg: "wallet creation time is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			displayName, err := buildPasskeyDisplayName(tt.ctx, tt.createdAt)
+			if tt.expectedErr != nil {
+				assert.Empty(t, displayName)
+				assert.ErrorIs(t, err, tt.expectedErr)
+				return
+			}
+			if tt.expectedErrMsg != "" {
+				assert.Empty(t, displayName)
+				assert.EqualError(t, err, tt.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedName, displayName)
+		})
+	}
+}
+
 func Test_NewWebAuthnService(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()


### PR DESCRIPTION
### What

This updates the passkey name to `{org} Wallet - {2006-01-02 15:04 UTC}`.

### Why

The name is currently a UUID, which makes it difficult to identify the wallet if the user has multiple.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
