### PR TITLE
SDP-1966 Update `GET /wallets` endpoint to exclude soft-deleted wallets by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Add Haitian Creole translations for the SEP-24 interactive deposit flow. [#994](https://github.com/stellar/stellar-disbursement-platform-backend/pull/994)
 
+### Changed
+
+- Update `GET /wallets` endpoint to exclude soft-deleted wallets by default. Add optional `include_deleted` query parameter to include deleted wallets when set to `true`. [#1003](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1003)
+
 ### Security and Dependencies
 
 - Upgrade React to 19.2.3 and @stellar/design-system to 3.2.7 in SEP-24 frontend to address CVE-2025-55184 denial of service and source code exposure vulnerability in React Server Components [#988](https://github.com/stellar/stellar-disbursement-platform-backend/pull/988)

--- a/internal/serve/httphandler/wallets_handler.go
+++ b/internal/serve/httphandler/wallets_handler.go
@@ -46,8 +46,9 @@ func (h WalletsHandler) GetWallets(w http.ResponseWriter, r *http.Request) {
 func (h WalletsHandler) parseFilters(ctx context.Context, r *http.Request) ([]data.Filter, error) {
 	filters := []data.Filter{}
 	boolFilterParams := map[string]data.FilterKey{
-		"enabled":      data.FilterEnabledWallets,
-		"user_managed": data.FilterUserManaged,
+		"enabled":         data.FilterEnabledWallets,
+		"user_managed":    data.FilterUserManaged,
+		"include_deleted": data.FilterIncludeDeleted,
 	}
 
 	for param, filterType := range boolFilterParams {

--- a/internal/serve/httphandler/wallets_handler_test.go
+++ b/internal/serve/httphandler/wallets_handler_test.go
@@ -243,6 +243,130 @@ func Test_WalletsHandlerGetWallets(t *testing.T) {
 				assert.Contains(t, httpErr.Extras["validation_error"], "asset 'NONEXISTENT' not found")
 			},
 		},
+		{
+			name: "excludes deleted wallets by default",
+			setupFn: func(t *testing.T) *testWalletSetup {
+				data.DeleteAllFixtures(t, ctx, dbPool)
+				wallets := data.ClearAndCreateWalletFixtures(t, ctx, dbPool)
+				// Soft delete first wallet
+				_, err := models.Wallets.SoftDelete(ctx, wallets[0].ID)
+				require.NoError(t, err)
+				return &testWalletSetup{wallets: wallets}
+			},
+			queryParams:    "",
+			expectedStatus: http.StatusOK,
+			validateResult: func(t *testing.T, setup *testWalletSetup, respBody []byte) {
+				var resultWallets []data.Wallet
+				err := json.Unmarshal(respBody, &resultWallets)
+				require.NoError(t, err)
+				// Should return only 1 wallet (second one), not the deleted one
+				assert.Len(t, resultWallets, 1)
+				assert.NotEqual(t, setup.wallets[0].ID, resultWallets[0].ID)
+				assert.Equal(t, setup.wallets[1].ID, resultWallets[0].ID)
+			},
+		},
+		{
+			name: "includes deleted wallets when include_deleted=true",
+			setupFn: func(t *testing.T) *testWalletSetup {
+				data.DeleteAllFixtures(t, ctx, dbPool)
+				wallets := data.ClearAndCreateWalletFixtures(t, ctx, dbPool)
+				// Soft delete first wallet
+				_, err := models.Wallets.SoftDelete(ctx, wallets[0].ID)
+				require.NoError(t, err)
+				return &testWalletSetup{wallets: wallets}
+			},
+			queryParams:    "include_deleted=true",
+			expectedStatus: http.StatusOK,
+			validateResult: func(t *testing.T, setup *testWalletSetup, respBody []byte) {
+				var resultWallets []data.Wallet
+				err := json.Unmarshal(respBody, &resultWallets)
+				require.NoError(t, err)
+				// Should return all wallets including deleted
+				assert.Len(t, resultWallets, 2)
+			},
+		},
+		{
+			name: "excludes deleted wallets when include_deleted=false",
+			setupFn: func(t *testing.T) *testWalletSetup {
+				data.DeleteAllFixtures(t, ctx, dbPool)
+				wallets := data.ClearAndCreateWalletFixtures(t, ctx, dbPool)
+				// Soft delete second wallet
+				_, err := models.Wallets.SoftDelete(ctx, wallets[1].ID)
+				require.NoError(t, err)
+				return &testWalletSetup{wallets: wallets}
+			},
+			queryParams:    "include_deleted=false",
+			expectedStatus: http.StatusOK,
+			validateResult: func(t *testing.T, setup *testWalletSetup, respBody []byte) {
+				var resultWallets []data.Wallet
+				err := json.Unmarshal(respBody, &resultWallets)
+				require.NoError(t, err)
+				// Should return only 1 wallet
+				assert.Len(t, resultWallets, 1)
+				assert.Equal(t, setup.wallets[0].ID, resultWallets[0].ID)
+			},
+		},
+		{
+			name: "combines include_deleted with enabled filter",
+			setupFn: func(t *testing.T) *testWalletSetup {
+				data.DeleteAllFixtures(t, ctx, dbPool)
+				wallets := data.ClearAndCreateWalletFixtures(t, ctx, dbPool)
+				// Soft delete first wallet
+				_, err := models.Wallets.SoftDelete(ctx, wallets[0].ID)
+				require.NoError(t, err)
+				// Disable second wallet
+				data.EnableOrDisableWalletFixtures(t, ctx, dbPool, false, wallets[1].ID)
+				return &testWalletSetup{wallets: wallets}
+			},
+			queryParams:    "include_deleted=true&enabled=true",
+			expectedStatus: http.StatusOK,
+			validateResult: func(t *testing.T, setup *testWalletSetup, respBody []byte) {
+				var resultWallets []data.Wallet
+				err := json.Unmarshal(respBody, &resultWallets)
+				require.NoError(t, err)
+				// Should return only enabled wallets (including deleted one)
+				assert.Len(t, resultWallets, 1)
+				assert.Equal(t, setup.wallets[0].ID, resultWallets[0].ID)
+				assert.True(t, resultWallets[0].Enabled)
+			},
+		},
+		{
+			name: "combines deleted filter with asset filtering",
+			setupFn: func(t *testing.T) *testWalletSetup {
+				setup := createWalletAssetsTestSetup(t, ctx, dbPool)
+				// Soft delete wallet1 which has USDC and XLM
+				_, err := models.Wallets.SoftDelete(ctx, setup.wallet1.ID)
+				require.NoError(t, err)
+				return setup
+			},
+			queryParams:    "supported_assets=USDC&include_deleted=true",
+			expectedStatus: http.StatusOK,
+			validateResult: func(t *testing.T, setup *testWalletSetup, respBody []byte) {
+				var resultWallets []data.Wallet
+				err := json.Unmarshal(respBody, &resultWallets)
+				require.NoError(t, err)
+				// Should return both wallet1 (deleted) and wallet2 (not deleted) that support USDC
+				assert.Len(t, resultWallets, 2)
+				walletIDs := []string{resultWallets[0].ID, resultWallets[1].ID}
+				assert.Contains(t, walletIDs, setup.wallet1.ID)
+				assert.Contains(t, walletIDs, setup.wallet2.ID)
+			},
+		},
+		{
+			name: "returns bad request for invalid include_deleted parameter",
+			setupFn: func(t *testing.T) *testWalletSetup {
+				data.DeleteAllFixtures(t, ctx, dbPool)
+				return &testWalletSetup{}
+			},
+			queryParams:    "include_deleted=invalid",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody: `{
+				"error": "Error parsing request filters",
+				"extras": {
+					"validation_error": "invalid 'include_deleted' parameter value"
+				}
+			}`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What

- Update `GET /wallets` endpoint to exclude soft-deleted wallets by default. 
- Add optional `include_deleted` query parameter to include deleted wallets when set to `true`.

### Why

- The default behaviour for `GET /wallets` shouldn't return deleted wallets. 

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
