### PR TITLE
SDP-1965: Prevent wallet deletion when pending registrations exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 
 - Update `GET /wallets` endpoint to exclude soft-deleted wallets by default. Add optional `include_deleted` query parameter to include deleted wallets when set to `true`. [#1005](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1005)
+- Update `DELETE /wallets/:id` endpoint to check if a wallet has pending registrations before deletion. Returns a user-friendly error if the wallet has receiver_wallets in 'DRAFT' or 'READY' status. [#1007](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1007)
 
 ### Security and Dependencies
 

--- a/internal/data/fixtures.go
+++ b/internal/data/fixtures.go
@@ -190,11 +190,15 @@ func GetWalletAssetsFixture(t *testing.T, ctx context.Context, sqlExec db.SQLExe
 
 // DeleteAllWalletFixtures deletes all wallets in the database
 func DeleteAllWalletFixtures(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter) {
-	query := "DELETE FROM wallets_assets"
+	query := "DELETE FROM receiver_wallets"
 	_, err := sqlExec.ExecContext(ctx, query)
 	require.NoError(t, err)
 
-	query = "DELETE FROM wallets"
+	query = "DELETE FROM wallets_assets"
+	_, err = sqlExec.ExecContext(ctx, query)
+	require.NoError(t, err)
+
+	query = "DELETE FROM wallets CASCADE"
 	_, err = sqlExec.ExecContext(ctx, query)
 	require.NoError(t, err)
 }

--- a/internal/serve/httphandler/wallets_handler.go
+++ b/internal/serve/httphandler/wallets_handler.go
@@ -189,6 +189,10 @@ func (h WalletsHandler) DeleteWallet(rw http.ResponseWriter, req *http.Request) 
 			httperror.NotFound("", err, nil).Render(rw)
 			return
 		}
+		if errors.Is(err, data.ErrWalletInUse) {
+			httperror.BadRequest("wallet has pending registrations and cannot be deleted", err, nil).Render(rw)
+			return
+		}
 		httperror.InternalError(ctx, "", err, nil).Render(rw)
 		return
 	}


### PR DESCRIPTION
### What

- Add validation to `DELETE /wallets/:id` to check for pending receiver_wallets before soft delete
- Return 400 Bad Request with user-friendly error when wallet has receiver_wallets in DRAFT or READY status
- Use atomic CTE query to prevent race conditions between check and delete

### Why

Prevent mistakenly deleting wallets that are still in use. 

### Known limitations

[TODO or N/A]

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
