### PR TITLE
Fix: Move SEP-10/45 domain functions to shared utility

### DIFF
--- a/internal/services/sep10_service.go
+++ b/internal/services/sep10_service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sepauth"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpclient"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/seputil"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 )
 
@@ -130,7 +131,7 @@ func NewSEP10Service(
 }
 
 func (s *sep10Service) CreateChallenge(ctx context.Context, req ChallengeRequest) (*ChallengeResponse, error) {
-	webAuthDomain := s.getWebAuthDomain(ctx)
+	webAuthDomain := seputil.GetWebAuthDomain(ctx, s.BaseURL)
 
 	req.ClientDomain = strings.TrimSpace(req.ClientDomain)
 	req.HomeDomain = strings.TrimSpace(req.HomeDomain)
@@ -141,14 +142,14 @@ func (s *sep10Service) CreateChallenge(ctx context.Context, req ChallengeRequest
 	}
 
 	if req.HomeDomain == "" {
-		req.HomeDomain = s.getBaseDomain()
+		req.HomeDomain = seputil.GetBaseDomain(s.BaseURL)
 		if req.HomeDomain == "" {
 			return nil, fmt.Errorf("home_domain is required")
 		}
 	}
 
-	if !s.isValidHomeDomain(req.HomeDomain) {
-		return nil, fmt.Errorf("invalid home_domain must match %s", s.getBaseDomain())
+	if !seputil.IsValidHomeDomain(s.BaseURL, req.HomeDomain) {
+		return nil, fmt.Errorf("invalid home_domain must match %s", seputil.GetBaseDomain(s.BaseURL))
 	}
 
 	if _, err := xdr.AddressToAccountId(req.Account); err != nil {
@@ -196,7 +197,7 @@ func (s *sep10Service) CreateChallenge(ctx context.Context, req ChallengeRequest
 
 func (s *sep10Service) ValidateChallenge(ctx context.Context, req ValidationRequest) (*ValidationResponse, error) {
 	allowedHomeDomains := s.getAllowedHomeDomains(ctx)
-	webAuthDomain := s.getWebAuthDomain(ctx)
+	webAuthDomain := seputil.GetWebAuthDomain(ctx, s.BaseURL)
 
 	result, err := s.validateChallengeCustom(
 		req.Transaction,
@@ -551,7 +552,7 @@ func (s *sep10Service) generateToken(
 }
 
 func (s *sep10Service) getAllowedHomeDomains(ctx context.Context) []string {
-	baseDomain := s.getBaseDomain()
+	baseDomain := seputil.GetBaseDomain(s.BaseURL)
 	if baseDomain == "" {
 		return []string{}
 	}
@@ -567,42 +568,6 @@ func (s *sep10Service) getAllowedHomeDomains(ctx context.Context) []string {
 	}
 
 	return allowedDomains
-}
-
-func (s *sep10Service) getWebAuthDomain(ctx context.Context) string {
-	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
-	if err == nil && currentTenant != nil && currentTenant.BaseURL != nil {
-		parsedURL, parseErr := url.Parse(*currentTenant.BaseURL)
-		if parseErr == nil {
-			return parsedURL.Host
-		}
-	}
-
-	return s.getBaseDomain()
-}
-
-func (s *sep10Service) getBaseDomain() string {
-	parsedURL, err := url.Parse(s.BaseURL)
-	if err != nil {
-		return ""
-	}
-	return parsedURL.Host
-}
-
-func (s *sep10Service) isValidHomeDomain(homeDomain string) bool {
-	baseDomain := s.getBaseDomain()
-	if baseDomain == "" || homeDomain == "" {
-		return false
-	}
-
-	baseDomainLower := strings.ToLower(baseDomain)
-	homeDomainLower := strings.ToLower(homeDomain)
-
-	if homeDomainLower == baseDomainLower {
-		return true
-	}
-
-	return strings.HasSuffix(homeDomainLower, "."+baseDomainLower)
 }
 
 func (s *sep10Service) buildChallengeTx(clientAccountID, webAuthDomain, homeDomain, clientDomain string, clientDomainAccountID string, memo *txnbuild.MemoID) (*txnbuild.Transaction, error) {

--- a/internal/services/sep45_service.go
+++ b/internal/services/sep45_service.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
-	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sepauth"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/seputil"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/stellar"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
@@ -168,7 +168,7 @@ func (s *sep45Service) CreateChallenge(ctx context.Context, req SEP45ChallengeRe
 		return nil, fmt.Errorf("%w: %w", ErrSEP45Validation, err)
 	}
 
-	webAuthDomain := s.getWebAuthDomain(ctx)
+	webAuthDomain := seputil.GetWebAuthDomain(ctx, s.baseURL)
 	if strings.TrimSpace(webAuthDomain) == "" {
 		return nil, fmt.Errorf("%w: unable to determine web_auth_domain", ErrSEP45Internal)
 	}
@@ -179,8 +179,8 @@ func (s *sep45Service) CreateChallenge(ctx context.Context, req SEP45ChallengeRe
 		return nil, fmt.Errorf("%w: home_domain is required", ErrSEP45Validation)
 	}
 
-	if !s.isValidHomeDomain(homeDomain) {
-		return nil, fmt.Errorf("%w: home_domain must match %s", ErrSEP45Validation, s.getBaseDomain())
+	if !seputil.IsValidHomeDomain(s.baseURL, homeDomain) {
+		return nil, fmt.Errorf("%w: home_domain must match %s", ErrSEP45Validation, seputil.GetBaseDomain(s.baseURL))
 	}
 
 	clientDomain := ""
@@ -363,7 +363,7 @@ func (t *authEntryTracker) processEntry(entry xdr.SorobanAuthorizationEntry, par
 }
 
 func (s *sep45Service) ValidateChallenge(ctx context.Context, req SEP45ValidationRequest) (*SEP45ValidationResponse, error) {
-	webAuthDomain := strings.TrimSpace(s.getWebAuthDomain(ctx))
+	webAuthDomain := strings.TrimSpace(seputil.GetWebAuthDomain(ctx, s.baseURL))
 	if webAuthDomain == "" {
 		return nil, fmt.Errorf("%w: unable to determine web_auth_domain", ErrSEP45Internal)
 	}
@@ -646,8 +646,8 @@ func (s *sep45Service) buildChallengeArgs(args map[string]string, argsXDR xdr.Sc
 	if homeDomain == "" {
 		return nil, fmt.Errorf("home_domain is required")
 	}
-	if !s.isValidHomeDomain(homeDomain) {
-		return nil, fmt.Errorf("home_domain must match %s", s.getBaseDomain())
+	if !seputil.IsValidHomeDomain(s.baseURL, homeDomain) {
+		return nil, fmt.Errorf("home_domain must match %s", seputil.GetBaseDomain(s.baseURL))
 	}
 
 	challengeWebAuthDomain := strings.TrimSpace(args["web_auth_domain"])
@@ -788,41 +788,4 @@ func (s *sep45Service) wrapSimErr(simErr *stellar.SimulationError) error {
 	default:
 		return fmt.Errorf("%w: simulating transaction: %w", ErrSEP45Internal, simErr)
 	}
-}
-
-// TODO(philip): Below methods are shared with sep10_service.go so they can be moved to a common utility package later.
-
-func (s *sep45Service) getWebAuthDomain(ctx context.Context) string {
-	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
-	if err == nil && currentTenant != nil && currentTenant.BaseURL != nil {
-		parsedURL, parseErr := url.Parse(*currentTenant.BaseURL)
-		if parseErr == nil {
-			return parsedURL.Host
-		}
-	}
-	return s.getBaseDomain()
-}
-
-func (s *sep45Service) getBaseDomain() string {
-	parsed, err := url.Parse(s.baseURL)
-	if err != nil {
-		return ""
-	}
-	return parsed.Host
-}
-
-func (s *sep45Service) isValidHomeDomain(homeDomain string) bool {
-	baseDomain := s.getBaseDomain()
-	if baseDomain == "" || homeDomain == "" {
-		return false
-	}
-
-	baseDomainLower := strings.ToLower(baseDomain)
-	homeDomainLower := strings.ToLower(homeDomain)
-
-	if homeDomainLower == baseDomainLower {
-		return true
-	}
-
-	return strings.HasSuffix(homeDomainLower, "."+baseDomainLower)
 }

--- a/internal/services/seputil/domains.go
+++ b/internal/services/seputil/domains.go
@@ -1,0 +1,45 @@
+package seputil
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
+)
+
+func GetWebAuthDomain(ctx context.Context, baseURL string) string {
+	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
+	if err == nil && currentTenant != nil && currentTenant.BaseURL != nil {
+		parsedURL, parseErr := url.Parse(*currentTenant.BaseURL)
+		if parseErr == nil {
+			return parsedURL.Host
+		}
+	}
+
+	return GetBaseDomain(baseURL)
+}
+
+func GetBaseDomain(baseURL string) string {
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+	return parsedURL.Host
+}
+
+func IsValidHomeDomain(baseURL, homeDomain string) bool {
+	baseDomain := GetBaseDomain(baseURL)
+	if baseDomain == "" || homeDomain == "" {
+		return false
+	}
+
+	baseDomainLower := strings.ToLower(baseDomain)
+	homeDomainLower := strings.ToLower(homeDomain)
+
+	if homeDomainLower == baseDomainLower {
+		return true
+	}
+
+	return strings.HasSuffix(homeDomainLower, "."+baseDomainLower)
+}


### PR DESCRIPTION
### What

These functions are shared by both services to work with domains. We should move it into a shared utility to reduce code duplication.

### Why

N/A

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
