### PR TITLE
SDP-2004: Automate Release

### DIFF
--- a/.github/workflows/automated_release_process.yml
+++ b/.github/workflows/automated_release_process.yml
@@ -48,9 +48,113 @@ jobs:
       - name: Create release/${{ inputs.version }} branch
         run: |
           git checkout -b release/${{ inputs.version }} origin/${{ github.ref_name }}
-          sed -i 's/const Version = ".*"/const Version = "${{ inputs.version }}"/' main.go
-          git add main.go
-          git commit -m "chore: bump version to ${{ inputs.version }}"
+
+      - name: Install Node.js for tooling
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot@0.0.410
+
+      - name: Bump all version references
+        run: |
+          VERSION="${{ inputs.version }}"
+          sed -i "s/^const Version = \".*\"/const Version = \"$VERSION\"/" main.go
+          sed -i "s/^version: \".*\"/version: \"$VERSION\"/" helmchart/sdp/Chart.yaml
+          sed -i "s/^appVersion: \".*\"/appVersion: \"$VERSION\"/" helmchart/sdp/Chart.yaml
+          sed -i "/^  image:/,/^  [a-z]/ { s|^    tag: \".*\"|    tag: \"$VERSION\"| }" helmchart/sdp/values.yaml
+          sed -i "s|fullName: stellar/stellar-disbursement-platform-frontend:.*|fullName: stellar/stellar-disbursement-platform-frontend:$VERSION|" helmchart/sdp/values.yaml
+          git add main.go helmchart/sdp/Chart.yaml helmchart/sdp/values.yaml
+
+      - name: Generate CHANGELOG entry
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ inputs.version }}"
+          REPO="${{ github.repository }}"
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          BASE="${LAST_TAG:-$(git rev-list --max-parents=0 HEAD)}"
+
+          git log "$BASE"..HEAD --pretty=format:"%h %s" --no-merges > /tmp/commits.txt
+          awk '
+            /^## \[Unreleased\]/ { in_section=1; next }
+            /^## \[/ { if (in_section) exit }
+            in_section { print }
+          ' CHANGELOG.md > /tmp/unreleased-body.md
+
+          : > /tmp/new-entries.md
+          if [ -s /tmp/commits.txt ] && [ -n "${GH_TOKEN:-}" ]; then
+            copilot -sp "$(cat <<PROMPT
+          You are a CHANGELOG generator for ${REPO}.
+
+          Below are git commits since the last release (${BASE}):
+          $(cat /tmp/commits.txt)
+
+          The current Unreleased section of CHANGELOG.md is:
+          $(cat /tmp/unreleased-body.md)
+
+          Your job:
+          1. Identify commits NOT already covered in the Unreleased section above.
+          2. For each missing commit, categorize it: Added, Changed, Fixed, or Security and Dependencies.
+          3. Format: - Description [#PR](https://github.com/${REPO}/pull/PR)
+          4. Extract PR numbers from subjects (e.g. (#1049) -> 1049).
+          5. Skip merge commits and chore-only commits that don't add functionality.
+          6. Output ONLY the new entries grouped by category (### Added, ### Changed, etc). No header, no explanation, no code blocks.
+          7. If all commits are already covered, output nothing.
+          PROMPT
+          )" > /tmp/new-entries.md 2>/dev/null || true
+          else
+            echo "Skipping Copilot changelog gap fill (no commits or missing COPILOT_GITHUB_TOKEN)"
+          fi
+
+          python3 scripts/release/update_changelog.py \
+            --changelog CHANGELOG.md \
+            --version "$VERSION" \
+            --repo "$REPO" \
+            --base "$BASE" \
+            --new-entries-file /tmp/new-entries.md
+
+          if ! git diff --quiet CHANGELOG.md 2>/dev/null; then
+            git add CHANGELOG.md
+          fi
+
+      - name: Regenerate Helm README
+        run: |
+          npm install -g @bitnami/readme-generator-for-helm@2.7.0 2>/dev/null
+          readme-generator -v helmchart/sdp/values.yaml -r helmchart/sdp/README.md
+          if ! git diff --quiet helmchart/sdp/README.md; then
+            git add helmchart/sdp/README.md
+          fi
+
+      - name: Detect contract changes
+        id: detect_contracts
+        run: |
+          set -euo pipefail
+
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          BASE="${LAST_TAG:-origin/main}"
+
+          if CHANGED=$(git diff --name-only "$BASE"...HEAD -- contracts/ wasms/ 2>/dev/null); then
+            if [ -n "$CHANGED" ]; then
+              echo "contracts_changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "contracts_changed=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "contracts_changed=unknown" >> "$GITHUB_OUTPUT"
+            echo "Unable to determine contract changes. Manual verification required."
+          fi
+
+      - name: Commit automated changes
+        run: |
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: automated release preparation for ${{ inputs.version }}"
+          else
+            echo "No changes to commit"
+          fi
           git push origin release/${{ inputs.version }}
 
       - name: Create main PR
@@ -74,8 +178,18 @@ jobs:
       - name: Create develop PR
         id: create_dev_pr
         run: |
+          CONTRACTS_STATUS="${{ steps.detect_contracts.outputs.contracts_changed }}"
+          if [ "$CONTRACTS_STATUS" = "true" ]; then
+            CONTRACTS_MSG="⚠️ **Contracts changed** - WASM artifacts need to be updated"
+          elif [ "$CONTRACTS_STATUS" = "unknown" ]; then
+            CONTRACTS_MSG="⚠️ **Contract change detection failed** - verify contract/WASM changes manually"
+          else
+            CONTRACTS_MSG="✅ No contract changes detected"
+          fi
+
           DEV_PR_URL=$(sed -e "s/{{version}}/${{ inputs.version }}/g" \
               -e "s|{{ main_pr_url }}|${{ steps.create_main_pr.outputs.main_pr_url }}|g" \
+              -e "s|{{contracts_changed}}|${CONTRACTS_MSG}|g" \
               .github/workflows/templates/release-pr-dev.md | \
           gh pr create --repo ${{ env.REPO_ORG }}/${{ env.REPO_NAME }} \
             --base develop \
@@ -86,13 +200,27 @@ jobs:
             --reviewer "${{ env.REVIEWER }}")
           echo "dev_pr_url=${DEV_PR_URL}" >> $GITHUB_OUTPUT
 
+      - name: Extract release notes from CHANGELOG
+        run: |
+          VERSION="${{ inputs.version }}"
+          python3 -c "
+          import re, sys
+          text = open('CHANGELOG.md').read()
+          m = re.search(r'(## \[' + re.escape('$VERSION') + r'\].*?)(?=\n## \[|\Z)', text, re.DOTALL)
+          sys.stdout.write(m.group(1) if m else '')
+          " > /tmp/release-notes.md
+
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "Initial draft for release \`$VERSION\`" > /tmp/release-notes.md
+          fi
+
       - name: Create Draft Release
         id: create_release
         run: |
-          RELEASE_URL=$(gh release create ${{ inputs.version }} \
+          RELEASE_URL=$(gh release create "${{ inputs.version }}" \
             --title "${{ inputs.version }}" \
             --draft \
-            --notes "Initial draft for release \`${{ inputs.version }}\`")
+            --notes-file /tmp/release-notes.md)
           echo "release_url=${RELEASE_URL}" >> $GITHUB_OUTPUT
 
       - name: Create Issue

--- a/.github/workflows/templates/release-issue.md
+++ b/.github/workflows/templates/release-issue.md
@@ -20,5 +20,6 @@ Release `{{version}}`
 ### Publishing the Release
 
 - [ ] After the main PR is merged, publish the draft release: {{ release_url }} -> [Release Page](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/{{version}})
+  - Release notes have been pre-populated from CHANGELOG.md — review before publishing
   - [ ] Verify the Docker image is published to [Docker Hub](https://hub.docker.com/r/stellar/stellar-disbursement-platform-backend/tags)
 - [ ] Propagate the helmchart version update to the [stellar/helm-charts](https://github.com/stellar/helm-charts) repository

--- a/.github/workflows/templates/release-pr-dev.md
+++ b/.github/workflows/templates/release-pr-dev.md
@@ -1,8 +1,22 @@
 Release `{{version}}` to `dev`
 
-### Pending
+### Pending Tasks
 
-- [ ] Merge the main PR {{ main_pr_url }}
-- [ ] Rebase this branch onto `main`
-- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow on `develop` and submit a PR to update the WASMs on `dev`
-- [ ] 🚨 Merge this PR using the **`Merge pull request`** button
+- [ ] **Merge the main PR first**: {{ main_pr_url }}
+- [ ] **Rebase this branch** onto `main` after main PR is merged
+- [ ] **Review CI checks** - Ensure all checks pass
+
+### Contract Changes Detection
+
+Contract change detection ran automatically during release preparation.
+
+**Status**: {{contracts_changed}}
+
+If contracts were modified:
+- [ ] Run the `Contract WASM Artifacts` workflow on `develop`
+- [ ] Attach generated WASM files to the GitHub release draft
+- [ ] Update release notes to mention contract changes
+
+### Merge Instructions 🚨
+
+- [ ] Merge this PR using the **`Merge pull request`** button (do NOT squash or rebase)

--- a/.github/workflows/templates/release-pr-main.md
+++ b/.github/workflows/templates/release-pr-main.md
@@ -1,11 +1,24 @@
 Release `{{version}}` to `main`
 
-### Pending
+### Automated Preparation ✅
+
+The following tasks have been completed automatically by the release workflow:
 
 - [x] Bump version in main.go
-- [ ] Update CHANGELOG.md
-- [ ] Bump version in helmchart/sdp/Chart.yaml
-- [ ] Bump backend version in helmchart/sdp/values.yaml
-- [ ] Bump frontend version in helmchart/sdp/values.yaml
-- [ ] Regenerate the helm charts README.md with `readme-generator -v values.yaml -r README.md`
-- [ ] 🚨 Merge this PR using the **`Merge pull request`** button
+- [x] Bump version in helmchart/sdp/Chart.yaml (version and appVersion)
+- [x] Bump backend image tag in helmchart/sdp/values.yaml
+- [x] Bump frontend image tag in helmchart/sdp/values.yaml
+- [x] Update CHANGELOG.md release entry (Unreleased + optional AI gap-fill)
+- [x] Regenerate helmchart/sdp/README.md
+
+### Manual Review Required 👀
+
+Please review the automated changes before merging:
+
+- [ ] **CHANGELOG.md** - Verify release notes are accurate and include missing merged PRs
+- [ ] **Version consistency** - Verify all version bumps are correct across files
+- [ ] **Helm README** - Ensure it's in sync with values.yaml
+
+### Merge Instructions 🚨
+
+- [ ] Merge this PR using the **`Merge pull request`** button (do NOT squash or rebase)

--- a/scripts/release/update_changelog.py
+++ b/scripts/release/update_changelog.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Promote CHANGELOG Unreleased section into a versioned release section."
+    )
+    parser.add_argument("--changelog", default="CHANGELOG.md")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--new-entries-file", default="")
+    return parser.parse_args()
+
+
+def load_optional_file(path: str) -> str:
+    if not path:
+        return ""
+    file_path = Path(path)
+    if not file_path.exists():
+        return ""
+    return file_path.read_text(encoding="utf-8").strip()
+
+
+def main() -> int:
+    args = parse_args()
+
+    changelog_path = Path(args.changelog)
+    changelog_text = changelog_path.read_text(encoding="utf-8")
+
+    pattern = r"## \[Unreleased\](.*?)(?=\n## \[|\Z)"
+    match = re.search(pattern, changelog_text, re.DOTALL)
+    if not match:
+        raise RuntimeError("CHANGELOG.md is missing the '## [Unreleased]' section")
+
+    unreleased_body = match.group(1).strip()
+    new_entries = load_optional_file(args.new_entries_file)
+
+    chunks = [part for part in [unreleased_body, new_entries] if part]
+    body = "\n\n".join(chunks).strip() if chunks else ""
+    if not body:
+        body = f"- Release {args.version}"
+
+    release_url = f"https://github.com/{args.repo}/releases/tag/{args.version}"
+    compare_url = f"https://github.com/{args.repo}/compare/{args.base}...{args.version}"
+    version_header = f"## [{args.version}]({release_url}) ([diff]({compare_url}))"
+
+    replacement = f"## [Unreleased]\n\n{version_header}\n\n{body}\n"
+    updated = changelog_text[: match.start()] + replacement + changelog_text[match.end() :]
+    changelog_path.write_text(updated, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### What
Automate the following steps in the release process: 
- Bump version references in `main.go`, `Chart.yaml`, and `values.yaml`.
- Generate/update `CHANGELOG.md` using a new script `update_changelog.py` and Copilot CLI. 
- Regenerate `README.md` 
- Detect contract/WASM changes and surface status in the dev release PR body.
- Extract release notes from `CHANGELOG.md` and use them when creating the draft GitHub release.

### Why
- Reduce manual release work and eliminate repetitive release-edit steps.

### Testing 
- Tested this with a bogus release: `0.0.0-rc.1` 
- Successful Run: https://github.com/stellar/stellar-disbursement-platform-backend/actions/runs/22077821409/job/63796664212
- Main release PR: https://github.com/stellar/stellar-disbursement-platform-backend/pull/1059
- Dev release PR: https://github.com/stellar/stellar-disbursement-platform-backend/pull/1060
- Release Issue: https://github.com/stellar/stellar-disbursement-platform-backend/issues/1061
- GH Release Draft: 
<img width="1245" height="493" alt="Screenshot 2026-02-16 at 4 29 33 PM" src="https://github.com/user-attachments/assets/8052c6df-850b-4f4d-94da-d008e67d9cac" />


### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
