### PR TITLE
Fix Meridian Pay deep link schema

### DIFF
--- a/internal/services/wallets/wallets_pubnet.go
+++ b/internal/services/wallets/wallets_pubnet.go
@@ -46,7 +46,7 @@ var PubnetWallets = []data.Wallet{
 	{
 		Name:              "Meridian Pay",
 		Homepage:          "https://meridianpay.stellar.org",
-		DeepLinkSchema:    "https://meridianpay.stellar.org",
+		DeepLinkSchema:    "https://meridianpay.stellar.org/invite",
 		SEP10ClientDomain: "",
 		UserManaged:       false,
 		Embedded:          true,


### PR DESCRIPTION
### What

This fixes Meridian Pay deep link schema. It currently sends the user to `/?token` but it should send them to `/invite?token`

### Why

Invite links are broken

### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
