### PR TITLE
EN-41 Stop failing contract transactions when memo present

### DIFF
--- a/.github/workflows/anchor_platform_integration_check.yml
+++ b/.github/workflows/anchor_platform_integration_check.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Anchor Validation Tests (@stellar/anchor-tests)
         run: |
-          npm install -g @stellar/anchor-tests
-          stellar-anchor-tests --home-domain http://localhost:8000 --seps 1 10
+          docker pull stellar/anchor-tests:latest
+          docker run --network host stellar/anchor-tests:latest --home-domain http://localhost:8000 --seps 1 10
 
       - name: Docker logs
         if: always()

--- a/dev/Dockerfile-demo-wallet
+++ b/dev/Dockerfile-demo-wallet
@@ -1,4 +1,4 @@
-FROM node:18-alpine as builder
+FROM node:20-alpine as builder
 
 RUN apk add --no-cache git
 

--- a/internal/transactionsubmission/payment_transaction_handler.go
+++ b/internal/transactionsubmission/payment_transaction_handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stellar/go/strkey"
+	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/txnbuild"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
@@ -79,7 +80,10 @@ func (h *PaymentTransactionHandler) BuildInnerTransaction(ctx context.Context, t
 		}
 	} else if strkey.IsValidContractAddress(txJob.Transaction.Destination) {
 		if txJob.Transaction.Memo != "" {
-			return nil, fmt.Errorf("memo is not supported for contract destination (%s)", txJob.Transaction.Destination)
+			// TODO: Meridian Pay  specific fix. This issue may pop because someone enables `Memo Tracing` by mistake and blocks the whole flow.
+			// Given that this branch is specific to meridian pay, it's safe to ignore this error.
+			log.Ctx(ctx).Warnf("memo is not supported for contract destination (%s), stripping memo", txJob.Transaction.Destination)
+			txJob.Transaction.Memo = ""
 		}
 		params := txnbuild.PaymentToContractParams{
 			NetworkPassphrase: h.engine.SignatureService.NetworkPassphrase(),

--- a/internal/transactionsubmission/payment_transaction_handler_test.go
+++ b/internal/transactionsubmission/payment_transaction_handler_test.go
@@ -172,13 +172,13 @@ func Test_PaymentHandler_BuildInnerTransaction(t *testing.T) {
 			wantErrorContains: "invalid asset issuer: FOOBAR",
 		},
 		{
-			name:               "returns an error if memo is present for C destination",
+			name:               "🎉 strips memo and successfully builds SAC transfer for C destination",
 			assetCode:          "USDC",
 			assetIssuer:        "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
 			destinationAddress: "CAMAMZUOULVWFAB3KRROW5ELPUFHSEKPUALORCFBLFX7XBWWUCUJLR53",
 			memoType:           schema.MemoTypeText,
 			memoValue:          "HelloWorld!",
-			wantErrorContains:  "memo is not supported for contract destination",
+			wantMemo:           nil,
 		},
 		{
 			name:               "🎉 successfully build a payment transaction for G destination",


### PR DESCRIPTION
### What
- Currently, Meridian Pay TSS is blocked with transactions that are failing with the error `level=error msg="unexpected TSS error: preparing bundle for processing: memo is not supported for contract destination `. 
- The reason is that memo tracing was enabled for the instance, which was injecting memos into c-account transactions (not suppoorted)
- This change is specific to meridian pay branch and will not be ported.

Also cherry-picked this commit to fix anchor tests as per @JiahuiWho 's recommendation [6e60e10](https://github.com/stellar/stellar-disbursement-platform-backend/commit/6e60e1036774e807609dd0238ec54b59983df130) 