### PR TITLE
SDP-2072: Fix payment amount precision loss in dispatch and transaction builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix payment amount precision loss in dispatch and transaction builder. [#1114](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1114)
+
 ## [6.4.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/6.4.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.3.0...6.4.0))
 
 ### Added

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher.go
@@ -3,7 +3,6 @@ package paymentdispatchers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/shopspring/decimal"
 	"github.com/stellar/go-stellar-sdk/support/log"
@@ -59,8 +58,7 @@ var _ PaymentDispatcherInterface = (*StellarPaymentDispatcher)(nil)
 func (s *StellarPaymentDispatcher) sendPaymentsToTSS(ctx context.Context, sdpDBTx, tssDBTx db.DBTransaction, tenantID string, pendingPayments []*data.Payment) error {
 	var transactions []txSubStore.Transaction
 	for _, payment := range pendingPayments {
-		// TODO: change TSS to use string amount [SDP-483]
-		amount, err := strconv.ParseFloat(payment.Amount, 64)
+		amount, err := decimal.NewFromString(payment.Amount)
 		if err != nil {
 			return fmt.Errorf("parsing payment amount %s for payment ID %s: %w", payment.Amount, payment.ID, err)
 		}
@@ -76,7 +74,7 @@ func (s *StellarPaymentDispatcher) sendPaymentsToTSS(ctx context.Context, sdpDBT
 			Payment: txSubStore.Payment{
 				AssetCode:   payment.Asset.Code,
 				AssetIssuer: payment.Asset.Issuer,
-				Amount:      decimal.NewFromFloat(amount),
+				Amount:      amount,
 				Destination: payment.ReceiverWallet.StellarAddress,
 				Memo:        memo.Value,
 				MemoType:    memo.Type,

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher.go
@@ -63,6 +63,10 @@ func (s *StellarPaymentDispatcher) sendPaymentsToTSS(ctx context.Context, sdpDBT
 			return fmt.Errorf("parsing payment amount %s for payment ID %s: %w", payment.Amount, payment.ID, err)
 		}
 
+		if amount.Exponent() < -7 {
+			return fmt.Errorf("payment amount %s for payment ID %s exceeds Stellar's 7 decimal place precision", payment.Amount, payment.ID)
+		}
+
 		memo, err := s.memoResolver.GetMemo(ctx, *payment.ReceiverWallet)
 		if err != nil {
 			return fmt.Errorf("getting memo: %w", err)

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher.go
@@ -63,8 +63,9 @@ func (s *StellarPaymentDispatcher) sendPaymentsToTSS(ctx context.Context, sdpDBT
 			return fmt.Errorf("parsing payment amount %s for payment ID %s: %w", payment.Amount, payment.ID, err)
 		}
 
-		if amount.Exponent() < -7 {
-			return fmt.Errorf("payment amount %s for payment ID %s exceeds Stellar's 7 decimal place precision", payment.Amount, payment.ID)
+		const stellarMaxDecimalPlaces = 7
+		if !amount.Equal(amount.Truncate(stellarMaxDecimalPlaces)) {
+			return fmt.Errorf("payment amount %s for payment ID %s exceeds Stellar's %d decimal place precision", payment.Amount, payment.ID, stellarMaxDecimalPlaces)
 		}
 
 		memo, err := s.memoResolver.GetMemo(ctx, *payment.ReceiverWallet)

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
@@ -78,7 +78,7 @@ func Test_StellarPaymentDispatcher_DispatchPayments_failure(t *testing.T) {
 			paymentsToDispatch: []*data.Payment{
 				{ID: "123", Amount: "invalid-amount"},
 			},
-			wantErr: fmt.Errorf("parsing payment amount invalid-amount for payment ID 123: strconv.ParseFloat: parsing \"invalid-amount\": invalid syntax"),
+			wantErr: fmt.Errorf("parsing payment amount invalid-amount for payment ID 123: can't convert invalid-amount to decimal"),
 			fnSetup: func(t *testing.T, mDistAccountResolver *mocks.MockDistributionAccountResolver) {
 				mDistAccountResolver.On("DistributionAccountFromContext", ctx).
 					Return(schema.TransactionAccount{Type: schema.DistributionAccountStellarEnv}, nil).
@@ -239,6 +239,73 @@ func Test_StellarPaymentDispatcher_DispatchPayments_success(t *testing.T) {
 
 			// Assert the memo is correct according with the ReceiverWallet and Organization settings
 			tc.fnAssertMemo(t, p, tx)
+		})
+	}
+}
+
+func Test_StellarPaymentDispatcher_DispatchPayments_precision(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	tenantID := "tenant-id"
+	tnt := schema.Tenant{
+		ID:      tenantID,
+		BaseURL: utils.Ptr("https://example.com"),
+	}
+
+	ctx := context.Background()
+	ctx = sdpcontext.SetTenantInContext(ctx, &tnt)
+	models, outerErr := data.NewModels(dbConnectionPool)
+	require.NoError(t, outerErr)
+
+	tssModel := txSubStore.NewTransactionModel(models.DBConnectionPool)
+
+	wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "precisionWallet", "https://www.precision.com", "www.precision.com", "precision://")
+	disbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{Wallet: wallet})
+	receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+	rw := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, disbursement.Wallet.ID, data.RegisteredReceiversWalletStatus)
+
+	// Amounts that would lose precision through float64 round-trip
+	precisionAmounts := []string{
+		"1.1234567",
+		"0.0000001",
+		"999999.9999999",
+		"123456.7890123",
+	}
+
+	for _, amount := range precisionAmounts {
+		t.Run("preserves full 7dp precision for "+amount, func(t *testing.T) {
+			defer data.DeleteAllTransactionsFixtures(t, ctx, dbConnectionPool)
+			defer data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
+
+			payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+				ReceiverWallet: rw,
+				Disbursement:   disbursement,
+				Asset:          *disbursement.Asset,
+				Amount:         amount,
+				Status:         data.ReadyPaymentStatus,
+			})
+
+			outerErr = models.Organizations.Update(ctx, &data.OrganizationUpdate{IsMemoTracingEnabled: utils.Ptr(false)})
+			require.NoError(t, outerErr)
+
+			mDistAccountResolver := mocks.NewMockDistributionAccountResolver(t)
+			mDistAccountResolver.On("DistributionAccountFromContext", ctx).
+				Return(schema.TransactionAccount{Type: schema.DistributionAccountStellarEnv}, nil).
+				Once()
+
+			tssTx := testutils.BeginTxWithRollback(t, ctx, tssModel.DBConnectionPool)
+			dispatcher := NewStellarPaymentDispatcher(models, tssModel, mDistAccountResolver)
+			err := dispatcher.DispatchPayments(ctx, tssTx, tenantID, []*data.Payment{payment})
+			require.NoError(t, err)
+
+			transactions, err := tssModel.GetAllByExternalIDs(ctx, []string{payment.ID})
+			require.NoError(t, err)
+			require.Len(t, transactions, 1)
+			assert.Equal(t, amount, transactions[0].Amount.StringFixed(7), "amount precision must be preserved through dispatch")
 		})
 	}
 }

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
@@ -280,23 +280,28 @@ func Test_StellarPaymentDispatcher_DispatchPayments_precision(t *testing.T) {
 	receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
 	rw := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, disbursement.Wallet.ID, data.RegisteredReceiversWalletStatus)
 
-	// Amounts that would lose precision through float64 round-trip
-	precisionAmounts := []string{
-		"1.1234567",
-		"0.0000001",
-		"999999.9999999",
-		"123456.7890123",
+	// Amounts that would lose precision through float64 round-trip,
+	// plus a padded amount to verify value-based truncation check accepts it.
+	precisionAmounts := []struct {
+		input    string
+		expected string
+	}{
+		{"1.1234567", "1.1234567"},
+		{"0.0000001", "0.0000001"},
+		{"999999.9999999", "999999.9999999"},
+		{"123456.7890123", "123456.7890123"},
+		{"1.00000000", "1.0000000"},
 	}
 
-	for _, amount := range precisionAmounts {
-		t.Run("preserves full 7dp precision for "+amount, func(t *testing.T) {
+	for _, tc := range precisionAmounts {
+		t.Run("preserves full 7dp precision for "+tc.input, func(t *testing.T) {
 			defer data.DeleteAllTransactionsFixtures(t, ctx, dbConnectionPool)
 
 			payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
 				ReceiverWallet: rw,
 				Disbursement:   disbursement,
 				Asset:          *disbursement.Asset,
-				Amount:         amount,
+				Amount:         tc.input,
 				Status:         data.ReadyPaymentStatus,
 			})
 
@@ -316,7 +321,7 @@ func Test_StellarPaymentDispatcher_DispatchPayments_precision(t *testing.T) {
 			transactions, err := tssModel.GetAllByExternalIDs(ctx, []string{payment.ID})
 			require.NoError(t, err)
 			require.Len(t, transactions, 1)
-			assert.Equal(t, amount, transactions[0].Amount.StringFixed(7), "amount precision must be preserved through dispatch")
+			assert.Equal(t, tc.expected, transactions[0].Amount.StringFixed(7), "amount precision must be preserved through dispatch")
 		})
 	}
 }

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
@@ -291,7 +291,6 @@ func Test_StellarPaymentDispatcher_DispatchPayments_precision(t *testing.T) {
 	for _, amount := range precisionAmounts {
 		t.Run("preserves full 7dp precision for "+amount, func(t *testing.T) {
 			defer data.DeleteAllTransactionsFixtures(t, ctx, dbConnectionPool)
-			defer data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
 
 			payment := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
 				ReceiverWallet: rw,

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
@@ -85,6 +85,18 @@ func Test_StellarPaymentDispatcher_DispatchPayments_failure(t *testing.T) {
 					Once()
 			},
 		},
+		{
+			name: "payment amount exceeds 7 decimal places",
+			paymentsToDispatch: []*data.Payment{
+				{ID: "456", Amount: "1.12345678"},
+			},
+			wantErr: fmt.Errorf("payment amount 1.12345678 for payment ID 456 exceeds Stellar's 7 decimal place precision"),
+			fnSetup: func(t *testing.T, mDistAccountResolver *mocks.MockDistributionAccountResolver) {
+				mDistAccountResolver.On("DistributionAccountFromContext", ctx).
+					Return(schema.TransactionAccount{Type: schema.DistributionAccountStellarEnv}, nil).
+					Once()
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/transactionsubmission/payment_transaction_handler.go
+++ b/internal/transactionsubmission/payment_transaction_handler.go
@@ -57,7 +57,7 @@ func (h *PaymentTransactionHandler) BuildInnerTransaction(ctx context.Context, t
 
 	var operation txnbuild.Operation
 	var txMemo txnbuild.Memo
-	amount := txJob.Transaction.Amount.StringFixed(6)
+	amount := txJob.Transaction.Amount.StringFixed(7)
 
 	if strkey.IsValidEd25519PublicKey(txJob.Transaction.Destination) {
 		memo, err := txJob.Transaction.BuildMemo()

--- a/internal/transactionsubmission/payment_transaction_handler_test.go
+++ b/internal/transactionsubmission/payment_transaction_handler_test.go
@@ -261,7 +261,7 @@ func Test_PaymentHandler_BuildInnerTransaction(t *testing.T) {
 				}
 
 				var operation txnbuild.Operation
-				amount := txJob.Transaction.Amount.StringFixed(6)
+				amount := txJob.Transaction.Amount.StringFixed(7)
 				if strkey.IsValidEd25519PublicKey(tc.destinationAddress) {
 					operation = &txnbuild.Payment{
 						SourceAccount: distributionKP.Address(),

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -1921,7 +1921,7 @@ func Test_TransactionWorker_buildAndSignTransaction(t *testing.T) {
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
 					SourceAccount: distributionKP.Address(),
-					Amount:        txJob.Transaction.Amount.StringFixed(6),
+					Amount:        txJob.Transaction.Amount.StringFixed(7),
 					Destination:   txJob.Transaction.Destination,
 					Asset:         &txnbuild.CreditAsset{Code: txJob.Transaction.AssetCode, Issuer: txJob.Transaction.AssetIssuer},
 				},


### PR DESCRIPTION
### What

- Replace `strconv.ParseFloat` + `decimal.NewFromFloat` with `decimal.NewFromString` in `StellarPaymentDispatcher.sendPaymentsToTSS`, eliminating the float64 round-trip that could silently alter payment amounts                             
- Change `StringFixed(6)` to `StringFixed(7)` in `PaymentTransactionHandler.BuildInnerTransaction` to 
  match Stellar's native 7-decimal-place (stroop) precision                                         
- Add precision regression test covering 7dp amounts including boundary values  

### Why

Fix amount precision loss
https://hackerone.com/reports/3683774

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
