### PR TITLE
SDP-2073: Add ownership check to SEP-24 GET /transaction endpoint         

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add ownership check to SEP-24 GET /transaction endpoint. [#1115](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1115)
+
 ## [6.4.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/6.4.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.3.0...6.4.0))
 
 ### Added

--- a/internal/data/receivers_wallet.go
+++ b/internal/data/receivers_wallet.go
@@ -302,7 +302,7 @@ func (rw *ReceiverWalletModel) GetByReceiverIDsAndWalletID(ctx context.Context, 
 	return receiverWallets, nil
 }
 
-func (rw *ReceiverWalletModel) GetBySEP24TransactionID(ctx context.Context, transactionID string) (*ReceiverWallet, error) {
+func (rw *ReceiverWalletModel) GetBySEP24TransactionIDAndAccount(ctx context.Context, transactionID, stellarAccount, stellarMemo string) (*ReceiverWallet, error) {
 	var receiverWallet ReceiverWallet
 
 	query := `
@@ -312,10 +312,11 @@ func (rw *ReceiverWalletModel) GetBySEP24TransactionID(ctx context.Context, tran
 			receiver_wallets rw
 		WHERE
 			rw.sep24_transaction_id = $1
+			AND (rw.stellar_address = '' OR (rw.stellar_address = $2 AND rw.stellar_memo = $3))
 		LIMIT 1
 	`
 
-	err := rw.dbConnectionPool.GetContext(ctx, &receiverWallet, query, transactionID)
+	err := rw.dbConnectionPool.GetContext(ctx, &receiverWallet, query, transactionID, stellarAccount, stellarMemo)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrRecordNotFound

--- a/internal/serve/httphandler/sep24_handler.go
+++ b/internal/serve/httphandler/sep24_handler.go
@@ -136,7 +136,8 @@ func (h SEP24Handler) GetTransaction(w http.ResponseWriter, r *http.Request) {
 		"refunded": false, // Always false for registration
 	}
 
-	receiverWallet, err := h.Models.ReceiverWallet.GetBySEP24TransactionID(ctx, transactionID)
+	account, memo := sepauth.ParseAccountAndMemo(webAuthClaims.Subject)
+	receiverWallet, err := h.Models.ReceiverWallet.GetBySEP24TransactionIDAndAccount(ctx, transactionID, account, memo)
 	if err != nil {
 		if errors.Is(err, data.ErrRecordNotFound) {
 			transaction["status"] = SEP24StatusIncomplete
@@ -153,15 +154,6 @@ func (h SEP24Handler) GetTransaction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		// Ownership check: verify the authenticated account matches the receiver wallet
-		if receiverWallet.StellarAddress != "" {
-			account, memo := sepauth.ParseAccountAndMemo(webAuthClaims.Subject)
-			if receiverWallet.StellarAddress != account || receiverWallet.StellarMemo != memo {
-				httperror.NotFound("transaction not found", nil, nil).Render(w)
-				return
-			}
-		}
-
 		switch receiverWallet.Status {
 		case data.RegisteredReceiversWalletStatus:
 			transaction["status"] = SEP24StatusCompleted

--- a/internal/serve/httphandler/sep24_handler.go
+++ b/internal/serve/httphandler/sep24_handler.go
@@ -153,6 +153,15 @@ func (h SEP24Handler) GetTransaction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
+		// Ownership check: verify the authenticated account matches the receiver wallet
+		if receiverWallet.StellarAddress != "" {
+			account, memo := sepauth.ParseAccountAndMemo(webAuthClaims.Subject)
+			if receiverWallet.StellarAddress != account || receiverWallet.StellarMemo != memo {
+				httperror.NotFound("transaction not found", nil, nil).Render(w)
+				return
+			}
+		}
+
 		switch receiverWallet.Status {
 		case data.RegisteredReceiversWalletStatus:
 			transaction["status"] = SEP24StatusCompleted

--- a/internal/serve/httphandler/sep24_handler_test.go
+++ b/internal/serve/httphandler/sep24_handler_test.go
@@ -94,14 +94,14 @@ func Test_SEP24Handler_GetTransaction(t *testing.T) {
 		update := data.ReceiverWalletUpdate{
 			SEP24TransactionID: "test-transaction-id",
 			StellarAddress:     "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU",
-			StellarMemo:        &[]string{"memo123"}[0],
+			StellarMemo:        &[]string{"12345"}[0],
 			StellarMemoType:    &[]schema.MemoType{schema.MemoTypeID}[0],
 		}
 		err := models.ReceiverWallet.Update(ctx, receiverWallet.ID, update, models.DBConnectionPool)
 		require.NoError(t, err)
 
 		webAuthClaims := &sepauth.WebAuthClaims{
-			Subject:      "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU:memo123",
+			Subject:      "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU:12345",
 			ClientDomain: "example.com",
 			HomeDomain:   "example.com",
 			TokenType:    sepauth.WebAuthTokenTypeSEP10,
@@ -124,7 +124,7 @@ func Test_SEP24Handler_GetTransaction(t *testing.T) {
 		assert.Equal(t, false, transaction["refunded"])
 		assert.Equal(t, "completed", transaction["status"])
 		assert.Equal(t, "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU", transaction["to"])
-		assert.Equal(t, "memo123", transaction["deposit_memo"])
+		assert.Equal(t, "12345", transaction["deposit_memo"])
 		assert.Equal(t, "id", transaction["deposit_memo_type"])
 		assert.Equal(t, "", transaction["stellar_transaction_id"])
 		assert.NotEmpty(t, transaction["completed_at"])
@@ -139,14 +139,14 @@ func Test_SEP24Handler_GetTransaction(t *testing.T) {
 
 		update := data.ReceiverWalletUpdate{
 			SEP24TransactionID: "test-transaction-id-owned",
-			StellarAddress:     "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU",
+			StellarAddress:     "GCBIRB7Q5T53H4L6P5QSI3O6LPD5MBWGM5GHE7A5NY4XT5OT4VCOEZFX",
 		}
 		err := models.ReceiverWallet.Update(ctx, receiverWallet.ID, update, models.DBConnectionPool)
 		require.NoError(t, err)
 
 		// Authenticate as a different account
 		webAuthClaims := &sepauth.WebAuthClaims{
-			Subject:      "GDKIJJKFAOGCBXD7FCMHBFLCIGSMAFQTSXE3LBHFZWOJAF4GVMQMIGAX",
+			Subject:      "GCECPFQBQS2ESW6XSLBMXNXM3A45XIVRPG4IO3CFD5HN6FZM5BMFSW5Y",
 			ClientDomain: "example.com",
 			HomeDomain:   "example.com",
 			TokenType:    sepauth.WebAuthTokenTypeSEP10,
@@ -154,6 +154,42 @@ func Test_SEP24Handler_GetTransaction(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 		req := setupRequestWithWebAuthClaims("GET", "/transaction?id=test-transaction-id-owned", nil, webAuthClaims)
+		http.HandlerFunc(handler.GetTransaction).ServeHTTP(rr, req)
+
+		resp := rr.Result()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+		var errResp httperror.HTTPError
+		err = json.Unmarshal(rr.Body.Bytes(), &errResp)
+		require.NoError(t, err)
+		assert.Equal(t, "transaction not found", errResp.Message)
+	})
+
+	t.Run("returns 404 when account matches but memo differs", func(t *testing.T) {
+		wallet := data.CreateWalletFixture(t, ctx, models.DBConnectionPool, "Orbit", "https://orbit.com", "orbit.com", "orbit://")
+		receiver := data.CreateReceiverFixture(t, ctx, models.DBConnectionPool, &data.Receiver{})
+
+		receiverWallet := data.CreateReceiverWalletFixture(t, ctx, models.DBConnectionPool, receiver.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+
+		update := data.ReceiverWalletUpdate{
+			SEP24TransactionID: "test-transaction-id-memo-mismatch",
+			StellarAddress:     "GCECPFQBQS2ESW6XSLBMXNXM3A45XIVRPG4IO3CFD5HN6FZM5BMFSW5Y",
+			StellarMemo:        &[]string{"99999"}[0],
+			StellarMemoType:    &[]schema.MemoType{schema.MemoTypeID}[0],
+		}
+		err := models.ReceiverWallet.Update(ctx, receiverWallet.ID, update, models.DBConnectionPool)
+		require.NoError(t, err)
+
+		// Same account but different memo
+		webAuthClaims := &sepauth.WebAuthClaims{
+			Subject:      "GCECPFQBQS2ESW6XSLBMXNXM3A45XIVRPG4IO3CFD5HN6FZM5BMFSW5Y:11111",
+			ClientDomain: "example.com",
+			HomeDomain:   "example.com",
+			TokenType:    sepauth.WebAuthTokenTypeSEP10,
+		}
+
+		rr := httptest.NewRecorder()
+		req := setupRequestWithWebAuthClaims("GET", "/transaction?id=test-transaction-id-memo-mismatch", nil, webAuthClaims)
 		http.HandlerFunc(handler.GetTransaction).ServeHTTP(rr, req)
 
 		resp := rr.Result()

--- a/internal/serve/httphandler/sep24_handler_test.go
+++ b/internal/serve/httphandler/sep24_handler_test.go
@@ -101,7 +101,7 @@ func Test_SEP24Handler_GetTransaction(t *testing.T) {
 		require.NoError(t, err)
 
 		webAuthClaims := &sepauth.WebAuthClaims{
-			Subject:      "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU",
+			Subject:      "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU:memo123",
 			ClientDomain: "example.com",
 			HomeDomain:   "example.com",
 			TokenType:    sepauth.WebAuthTokenTypeSEP10,
@@ -129,6 +129,40 @@ func Test_SEP24Handler_GetTransaction(t *testing.T) {
 		assert.Equal(t, "", transaction["stellar_transaction_id"])
 		assert.NotEmpty(t, transaction["completed_at"])
 		assert.NotEmpty(t, transaction["started_at"])
+	})
+
+	t.Run("returns 404 when authenticated account does not own the transaction", func(t *testing.T) {
+		wallet := data.CreateWalletFixture(t, ctx, models.DBConnectionPool, "Aurora", "https://aurora.com", "aurora.com", "aurora://")
+		receiver := data.CreateReceiverFixture(t, ctx, models.DBConnectionPool, &data.Receiver{})
+
+		receiverWallet := data.CreateReceiverWalletFixture(t, ctx, models.DBConnectionPool, receiver.ID, wallet.ID, data.RegisteredReceiversWalletStatus)
+
+		update := data.ReceiverWalletUpdate{
+			SEP24TransactionID: "test-transaction-id-owned",
+			StellarAddress:     "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU",
+		}
+		err := models.ReceiverWallet.Update(ctx, receiverWallet.ID, update, models.DBConnectionPool)
+		require.NoError(t, err)
+
+		// Authenticate as a different account
+		webAuthClaims := &sepauth.WebAuthClaims{
+			Subject:      "GDKIJJKFAOGCBXD7FCMHBFLCIGSMAFQTSXE3LBHFZWOJAF4GVMQMIGAX",
+			ClientDomain: "example.com",
+			HomeDomain:   "example.com",
+			TokenType:    sepauth.WebAuthTokenTypeSEP10,
+		}
+
+		rr := httptest.NewRecorder()
+		req := setupRequestWithWebAuthClaims("GET", "/transaction?id=test-transaction-id-owned", nil, webAuthClaims)
+		http.HandlerFunc(handler.GetTransaction).ServeHTTP(rr, req)
+
+		resp := rr.Result()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+		var errResp httperror.HTTPError
+		err = json.Unmarshal(rr.Body.Bytes(), &errResp)
+		require.NoError(t, err)
+		assert.Equal(t, "transaction not found", errResp.Message)
 	})
 
 	t.Run("ready receiver wallet returns pending status", func(t *testing.T) {

--- a/internal/serve/httphandler/sep24_handler_test.go
+++ b/internal/serve/httphandler/sep24_handler_test.go
@@ -131,7 +131,7 @@ func Test_SEP24Handler_GetTransaction(t *testing.T) {
 		assert.NotEmpty(t, transaction["started_at"])
 	})
 
-	t.Run("returns 404 when authenticated account does not own the transaction", func(t *testing.T) {
+	t.Run("non-owner gets incomplete status instead of transaction details", func(t *testing.T) {
 		wallet := data.CreateWalletFixture(t, ctx, models.DBConnectionPool, "Aurora", "https://aurora.com", "aurora.com", "aurora://")
 		receiver := data.CreateReceiverFixture(t, ctx, models.DBConnectionPool, &data.Receiver{})
 
@@ -157,15 +157,19 @@ func Test_SEP24Handler_GetTransaction(t *testing.T) {
 		http.HandlerFunc(handler.GetTransaction).ServeHTTP(rr, req)
 
 		resp := rr.Result()
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		var errResp httperror.HTTPError
-		err = json.Unmarshal(rr.Body.Bytes(), &errResp)
+		var response map[string]any
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
 		require.NoError(t, err)
-		assert.Equal(t, "transaction not found", errResp.Message)
+
+		transaction := response["transaction"].(map[string]any)
+		assert.Equal(t, "incomplete", transaction["status"])
+		assert.Nil(t, transaction["to"], "should not leak victim's stellar address")
+		assert.Nil(t, transaction["deposit_memo"], "should not leak victim's memo")
 	})
 
-	t.Run("returns 404 when account matches but memo differs", func(t *testing.T) {
+	t.Run("matching account but different memo gets incomplete status", func(t *testing.T) {
 		wallet := data.CreateWalletFixture(t, ctx, models.DBConnectionPool, "Orbit", "https://orbit.com", "orbit.com", "orbit://")
 		receiver := data.CreateReceiverFixture(t, ctx, models.DBConnectionPool, &data.Receiver{})
 
@@ -193,12 +197,16 @@ func Test_SEP24Handler_GetTransaction(t *testing.T) {
 		http.HandlerFunc(handler.GetTransaction).ServeHTTP(rr, req)
 
 		resp := rr.Result()
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		var errResp httperror.HTTPError
-		err = json.Unmarshal(rr.Body.Bytes(), &errResp)
+		var response map[string]any
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
 		require.NoError(t, err)
-		assert.Equal(t, "transaction not found", errResp.Message)
+
+		transaction := response["transaction"].(map[string]any)
+		assert.Equal(t, "incomplete", transaction["status"])
+		assert.Nil(t, transaction["to"], "should not leak victim's stellar address")
+		assert.Nil(t, transaction["deposit_memo"], "should not leak victim's memo")
 	})
 
 	t.Run("ready receiver wallet returns pending status", func(t *testing.T) {


### PR DESCRIPTION
### What

Add account ownership verification to `GET /sep24/transaction` so it only returns transaction details when the authenticated SEP-10/SEP-45 subject matches the receiver wallet on file, returns 404 when the caller does not own the requested transaction.

### Why

To align with the SEP-24 spec requirement
https://hackerone.com/reports/3681382

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
