### PR TITLE
SDP-1116 Reject over-precision amounts in ValidateAmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Reject payment amounts that exceed Stellar's 7-decimal-place precision in `utils.ValidateAmount`. [#1116](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1116)
+
 ## [6.4.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/6.4.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.3.0...6.4.0))
 
 ### Added

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -6,13 +6,13 @@ import (
 	"net/url"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/nyaruka/phonenumbers"
+	"github.com/stellar/go-stellar-sdk/amount"
 	"golang.org/x/net/html"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
@@ -58,17 +58,25 @@ func ValidatePhoneNumber(phoneNumberStr string) error {
 	return nil
 }
 
-func ValidateAmount(amount string) error {
-	if amount == "" {
+// ValidateAmount checks that s is a positive Stellar classic-asset amount.
+func ValidateAmount(s string) error {
+	if s == "" {
 		return fmt.Errorf("amount cannot be empty")
 	}
 
-	value, err := strconv.ParseFloat(amount, 64)
+	parsed, err := amount.ParseInt64(s)
 	if err != nil {
-		return fmt.Errorf("the provided amount is not a valid number")
+		switch {
+		case strings.Contains(err.Error(), "more than 7 significant digits"):
+			return fmt.Errorf("the provided amount exceeds the maximum supported precision of 7 decimal places")
+		case strings.Contains(err.Error(), "outside bounds of int64"):
+			return fmt.Errorf("the provided amount exceeds the maximum supported value")
+		default:
+			return fmt.Errorf("the provided amount is not a valid number")
+		}
 	}
 
-	if value <= 0 {
+	if parsed <= 0 {
 		return fmt.Errorf("the provided amount must be greater than zero")
 	}
 

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -74,23 +74,70 @@ func Test_ValidatePathIsNotTraversal(t *testing.T) {
 }
 
 func Test_ValidateAmount(t *testing.T) {
+	const (
+		emptyMsg       = "amount cannot be empty"
+		notPositiveMsg = "the provided amount must be greater than zero"
+		invalidMsg     = "the provided amount is not a valid number"
+		tooPreciseMsg  = "the provided amount exceeds the maximum supported precision of 7 decimal places"
+		tooLargeMsg    = "the provided amount exceeds the maximum supported value"
+	)
+
 	testCases := []struct {
-		amount  string
-		wantErr error
+		name       string
+		amount     string
+		wantErrMsg string // empty means no error expected
 	}{
-		{"", fmt.Errorf("amount cannot be empty")},
-		{"notvalidamount", fmt.Errorf("the provided amount is not a valid number")},
-		{"0", fmt.Errorf("the provided amount must be greater than zero")},
-		{"0.00", fmt.Errorf("the provided amount must be greater than zero")},
-		{"1", nil},
-		{"1.00", nil},
-		{"1.01", nil},
+		// empty / unparseable
+		{name: "empty", amount: "", wantErrMsg: emptyMsg},
+		{name: "whitespace", amount: "   ", wantErrMsg: invalidMsg},
+		{name: "non-numeric", amount: "notvalidamount", wantErrMsg: invalidMsg},
+		{name: "trailing garbage", amount: "1.23abc", wantErrMsg: invalidMsg},
+		{name: "hex", amount: "0xFF", wantErrMsg: invalidMsg},
+		{name: "plus sign prefix", amount: "+1.0", wantErrMsg: invalidMsg},
+		{name: "comma decimal separator", amount: "1,23", wantErrMsg: invalidMsg},
+		{name: "multiple dots", amount: "1.2.3", wantErrMsg: invalidMsg},
+		{name: "scientific notation", amount: "1e-7", wantErrMsg: invalidMsg},
+		{name: "over 20 chars", amount: "0.12345678901234567890", wantErrMsg: invalidMsg},
+
+		// non-positive
+		{name: "zero int", amount: "0", wantErrMsg: notPositiveMsg},
+		{name: "zero decimal", amount: "0.00", wantErrMsg: notPositiveMsg},
+		{name: "zero padded to 7dp", amount: "0.0000000", wantErrMsg: notPositiveMsg},
+		{name: "negative int", amount: "-1", wantErrMsg: notPositiveMsg},
+		{name: "negative fractional", amount: "-0.5", wantErrMsg: notPositiveMsg},
+
+		// valid amounts at various precisions
+		{name: "integer", amount: "1"},
+		{name: "2dp", amount: "1.00"},
+		{name: "2dp non-zero", amount: "1.01"},
+		{name: "7dp max precision", amount: "1.1234567"},
+		{name: "smallest unit", amount: "0.0000001"},
+		{name: "large value at 7dp", amount: "999999.9999999"},
+		{name: "7dp with trailing zeros", amount: "1.1000000"},
+		{name: "leading zero integer part", amount: "0.5"},
+		{name: "max int64 amount", amount: "922337203685.4775807"},
+
+		// exceeding 7 decimal places — SDP-2072 silent-rounding scenarios
+		{name: "8dp non-zero last digit", amount: "1.12345678", wantErrMsg: tooPreciseMsg},
+		{name: "8dp padded zero but numerically valid", amount: "1.00000000"},
+		{name: "8dp trailing zero but numerically 7dp", amount: "1.12345670"},
+		{name: "sub-unit rounded up", amount: "0.00000009", wantErrMsg: tooPreciseMsg},
+		{name: "sub-unit rounded to zero", amount: "0.00000001", wantErrMsg: tooPreciseMsg},
+		{name: "9dp", amount: "1.123456789", wantErrMsg: tooPreciseMsg},
+
+		// beyond int64 range — caught by SDK bounds check
+		{name: "overflow just above int64 max", amount: "922337203685.4775808", wantErrMsg: tooLargeMsg},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.amount, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			gotError := ValidateAmount(tc.amount)
-			assert.Equalf(t, tc.wantErr, gotError, "ValidateAmount(%q) should be %v, but got %v", tc.amount, tc.wantErr, gotError)
+			if tc.wantErrMsg == "" {
+				assert.NoErrorf(t, gotError, "ValidateAmount(%q) should be nil, but got %v", tc.amount, gotError)
+				return
+			}
+			require.Errorf(t, gotError, "ValidateAmount(%q) should error, but got nil", tc.amount)
+			assert.Equalf(t, tc.wantErrMsg, gotError.Error(), "ValidateAmount(%q) error mismatch", tc.amount)
 		})
 	}
 }


### PR DESCRIPTION
### What

- Delegate `utils.ValidateAmount` to the Stellar SDK's `amount.ParseInt64`, the authoritative parser for amounts accepted by `stellar-core`. This covers format, 7-decimal-place precision, and int64 bounds in a single call.
- Map the SDK's error categories to stable user-facing messages:
  - over 7 decimal places → `the provided amount exceeds the maximum supported precision of 7 decimal places`
  - out of int64 range → `the provided amount exceeds the maximum supported value`
  - other parse failures → `the provided amount is not a valid number` *(preserved)*
- Expand `Test_ValidateAmount` from 7 cases to 31 named sub-tests covering empty/whitespace, unparseable input, hex, scientific notation, zero/negative, 7dp boundaries, padded-zero 8dp amounts (accepted — numerically ≤ 7dp), sub-unit rounding scenarios, and int64 overflow.

### Why

`utils.ValidateAmount` previously only checked `> 0` via `strconv.ParseFloat`, letting amounts with more than 7 fractional digits flow through to the `payments.amount numeric(19, 7)` column. Postgres silently rounded on insert, so the dispatched amount differed from what the caller submitted — with no error surfaced. In edge cases (e.g. `0.00000001` USDC), the rounded value was `0`, destroying the payment entirely.

This rejects such amounts at the input-validation layer, where the caller receives a clear 400 and their original amount is still intact. Delegating to `amount.ParseInt64` ties our validator to the same parser the Stellar SDK uses inside `txnbuild.Payment` and `txnbuild.NewPaymentToContract`, so anything we accept will be accepted at dispatch time, and anything rejected would have failed at dispatch anyway. Follow-up to #1114, which addressed float-round-trip precision loss at the dispatch layer.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
