### PR TITLE
Fix NULL handling in SEP-24 transaction ownership query   

### DIFF
--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -1,7 +1,6 @@
 name: Integration Tests
 
 on:
-  pull_request: # temporary: trigger on PR for testing
   workflow_call: # allows this workflow to be called from another workflow, like `docker_image_public_release`
 
 env:

--- a/.github/workflows/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test.yml
@@ -1,6 +1,7 @@
 name: Integration Tests
 
 on:
+  pull_request: # temporary: trigger on PR for testing
   workflow_call: # allows this workflow to be called from another workflow, like `docker_image_public_release`
 
 env:

--- a/internal/data/receivers_wallet.go
+++ b/internal/data/receivers_wallet.go
@@ -312,7 +312,7 @@ func (rw *ReceiverWalletModel) GetBySEP24TransactionIDAndAccount(ctx context.Con
 			receiver_wallets rw
 		WHERE
 			rw.sep24_transaction_id = $1
-			AND (rw.stellar_address = '' OR (rw.stellar_address = $2 AND rw.stellar_memo = $3))
+			AND (COALESCE(rw.stellar_address, '') = '' OR (rw.stellar_address = $2 AND COALESCE(rw.stellar_memo, '') = $3))
 		LIMIT 1
 	`
 

--- a/internal/data/receivers_wallet_test.go
+++ b/internal/data/receivers_wallet_test.go
@@ -1639,6 +1639,79 @@ func Test_ReceiverWalletModel_GetByIDs(t *testing.T) {
 	})
 }
 
+func Test_ReceiverWalletModel_GetBySEP24TransactionIDAndAccount(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+	rwModel := ReceiverWalletModel{dbConnectionPool: dbConnectionPool}
+
+	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{})
+
+	t.Run("not found for non-existent transaction ID", func(t *testing.T) {
+		_, err := rwModel.GetBySEP24TransactionIDAndAccount(ctx, "non-existent", "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU", "")
+		require.ErrorIs(t, err, ErrRecordNotFound)
+	})
+
+	t.Run("matches when stellar_address is NULL (pre-registration)", func(t *testing.T) {
+		wallet := CreateWalletFixture(t, ctx, dbConnectionPool, "walletA", "https://a.com", "a.com", "a://")
+		rw := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, ReadyReceiversWalletStatus)
+		err := rwModel.Update(ctx, rw.ID, ReceiverWalletUpdate{
+			SEP24TransactionID: "tx-null-address",
+		}, dbConnectionPool)
+		require.NoError(t, err)
+
+		result, err := rwModel.GetBySEP24TransactionIDAndAccount(ctx, "tx-null-address", "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU", "")
+		require.NoError(t, err)
+		assert.Equal(t, rw.ID, result.ID)
+	})
+
+	t.Run("matches when stellar_memo is NULL and subject has no memo", func(t *testing.T) {
+		wallet := CreateWalletFixture(t, ctx, dbConnectionPool, "walletB", "https://b.com", "b.com", "b://")
+		rw := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, RegisteredReceiversWalletStatus)
+		// Set address and explicitly NULL out memo via raw SQL to simulate registration without memo
+		_, err := dbConnectionPool.ExecContext(ctx,
+			"UPDATE receiver_wallets SET sep24_transaction_id = $1, stellar_address = $2, stellar_memo = NULL, stellar_memo_type = NULL WHERE id = $3",
+			"tx-null-memo", "GCBIRB7Q5T53H4L6P5QSI3O6LPD5MBWGM5GHE7A5NY4XT5OT4VCOEZFX", rw.ID)
+		require.NoError(t, err)
+
+		// stellar_memo is NULL in DB, caller has empty memo — should match via COALESCE
+		result, err := rwModel.GetBySEP24TransactionIDAndAccount(ctx, "tx-null-memo", "GCBIRB7Q5T53H4L6P5QSI3O6LPD5MBWGM5GHE7A5NY4XT5OT4VCOEZFX", "")
+		require.NoError(t, err)
+		assert.Equal(t, rw.ID, result.ID)
+	})
+
+	t.Run("matches when account and memo both match", func(t *testing.T) {
+		wallet := CreateWalletFixture(t, ctx, dbConnectionPool, "walletC", "https://c.com", "c.com", "c://")
+		rw := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, RegisteredReceiversWalletStatus)
+		err := rwModel.Update(ctx, rw.ID, ReceiverWalletUpdate{
+			SEP24TransactionID: "tx-with-memo",
+			StellarAddress:     "GCECPFQBQS2ESW6XSLBMXNXM3A45XIVRPG4IO3CFD5HN6FZM5BMFSW5Y",
+			StellarMemo:        utils.Ptr("12345"),
+			StellarMemoType:    utils.Ptr(schema.MemoTypeID),
+		}, dbConnectionPool)
+		require.NoError(t, err)
+
+		result, err := rwModel.GetBySEP24TransactionIDAndAccount(ctx, "tx-with-memo", "GCECPFQBQS2ESW6XSLBMXNXM3A45XIVRPG4IO3CFD5HN6FZM5BMFSW5Y", "12345")
+		require.NoError(t, err)
+		assert.Equal(t, rw.ID, result.ID)
+	})
+
+	t.Run("not found when account differs", func(t *testing.T) {
+		_, err := rwModel.GetBySEP24TransactionIDAndAccount(ctx, "tx-with-memo", "GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU", "12345")
+		require.ErrorIs(t, err, ErrRecordNotFound)
+	})
+
+	t.Run("not found when memo differs", func(t *testing.T) {
+		_, err := rwModel.GetBySEP24TransactionIDAndAccount(ctx, "tx-with-memo", "GCECPFQBQS2ESW6XSLBMXNXM3A45XIVRPG4IO3CFD5HN6FZM5BMFSW5Y", "99999")
+		require.ErrorIs(t, err, ErrRecordNotFound)
+	})
+}
+
 func Test_ReceiverWalletModel_UpdateStatusToReady(t *testing.T) {
 	ctx := context.Background()
 	models := SetupModels(t)


### PR DESCRIPTION
### What

Add `COALESCE` to `stellar_address` and `stellar_memo` in the ownership query to handle NULL vs empty string comparison in Postgres, which caused the query to return no rows for wallets without a memo. 

Force trigger the integration tests on this PR and tests are passing now: https://github.com/stellar/stellar-disbursement-platform-backend/actions/runs/24730536598/job/72343415661

### Why

Causing integration tests failure: https://github.com/stellar/stellar-disbursement-platform-backend/actions/runs/24726898437/job/72334276826

### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
