### PR TITLE
SDP-2065: Add option to disable receiver wallet invitations per tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- Add `receiver_invitations_disabled` organization setting that skips the scheduled receiver wallet invitation job when enabled. [#1119](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1119)
+
 ### Fixed
 
 - Reject payment amounts that exceed Stellar's 7-decimal-place precision in `utils.ValidateAmount`. [#1116](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1116)

--- a/db/migrations/sdp-migrations/2026-04-24.0-add-receiver-invitations-disabled-to-organizations.sql
+++ b/db/migrations/sdp-migrations/2026-04-24.0-add-receiver-invitations-disabled-to-organizations.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+ALTER TABLE organizations
+ADD COLUMN receiver_invitations_disabled BOOLEAN;
+
+COMMENT ON COLUMN organizations.receiver_invitations_disabled
+    IS 'When true, the scheduled receiver wallet invitation job sends no invites for this organization.';
+
+-- +migrate Down
+
+ALTER TABLE organizations
+DROP COLUMN IF EXISTS receiver_invitations_disabled;

--- a/internal/data/organizations.go
+++ b/internal/data/organizations.go
@@ -45,17 +45,18 @@ type Organization struct {
 	// When the {{.OTP}} is not found in the message, it's added at the beginning of the message.
 	// Example:
 	//	{{.OTP}} OTPMessageTemplate
-	OTPMessageTemplate     string                 `json:"otp_message_template" db:"otp_message_template"`
-	PrivacyPolicyLink      *string                `json:"privacy_policy_link" db:"privacy_policy_link"`
-	Logo                   []byte                 `db:"logo"`
-	IsApprovalRequired     bool                   `json:"is_approval_required" db:"is_approval_required"`
-	IsLinkShortenerEnabled bool                   `json:"is_link_shortener_enabled" db:"is_link_shortener_enabled"`
-	IsMemoTracingEnabled   bool                   `json:"is_memo_tracing_enabled" db:"is_memo_tracing_enabled"`
-	MessageChannelPriority MessageChannelPriority `json:"message_channel_priority" db:"message_channel_priority"`
-	MFADisabled            *bool                  `json:"mfa_disabled" db:"mfa_disabled"`
-	CAPTCHADisabled        *bool                  `json:"captcha_disabled" db:"captcha_disabled"`
-	CreatedAt              time.Time              `json:"created_at" db:"created_at"`
-	UpdatedAt              time.Time              `json:"updated_at" db:"updated_at"`
+	OTPMessageTemplate          string                 `json:"otp_message_template" db:"otp_message_template"`
+	PrivacyPolicyLink           *string                `json:"privacy_policy_link" db:"privacy_policy_link"`
+	Logo                        []byte                 `db:"logo"`
+	IsApprovalRequired          bool                   `json:"is_approval_required" db:"is_approval_required"`
+	IsLinkShortenerEnabled      bool                   `json:"is_link_shortener_enabled" db:"is_link_shortener_enabled"`
+	IsMemoTracingEnabled        bool                   `json:"is_memo_tracing_enabled" db:"is_memo_tracing_enabled"`
+	MessageChannelPriority      MessageChannelPriority `json:"message_channel_priority" db:"message_channel_priority"`
+	MFADisabled                 *bool                  `json:"mfa_disabled" db:"mfa_disabled"`
+	CAPTCHADisabled             *bool                  `json:"captcha_disabled" db:"captcha_disabled"`
+	ReceiverInvitationsDisabled *bool                  `json:"receiver_invitations_disabled" db:"receiver_invitations_disabled"`
+	CreatedAt                   time.Time              `json:"created_at" db:"created_at"`
+	UpdatedAt                   time.Time              `json:"updated_at" db:"updated_at"`
 }
 
 type OrganizationUpdate struct {
@@ -76,6 +77,8 @@ type OrganizationUpdate struct {
 	// MFA and CAPTCHA settings
 	MFADisabled     *bool `json:",omitempty"`
 	CAPTCHADisabled *bool `json:",omitempty"`
+
+	ReceiverInvitationsDisabled *bool `json:",omitempty"`
 }
 
 type LogoType string
@@ -270,6 +273,11 @@ func (om *OrganizationModel) Update(ctx context.Context, ou *OrganizationUpdate)
 	if ou.CAPTCHADisabled != nil {
 		fields = append(fields, "captcha_disabled = ?")
 		args = append(args, *ou.CAPTCHADisabled)
+	}
+
+	if ou.ReceiverInvitationsDisabled != nil {
+		fields = append(fields, "receiver_invitations_disabled = ?")
+		args = append(args, *ou.ReceiverInvitationsDisabled)
 	}
 
 	query = om.dbConnectionPool.Rebind(fmt.Sprintf(query, strings.Join(fields, ", ")))

--- a/internal/data/organizations_test.go
+++ b/internal/data/organizations_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
 func Test_Organizations_DatabaseTriggers(t *testing.T) {
@@ -294,6 +295,30 @@ func Test_Organizations_Update(t *testing.T) {
 		o, err = organizationModel.Get(ctx)
 		require.NoError(t, err)
 		require.True(t, o.IsApprovalRequired)
+	})
+
+	t.Run("updates only organization's receiver_invitations_disabled successfully", func(t *testing.T) {
+		defer resetOrganizationInfo(t, ctx, dbConnectionPool)
+
+		o, err := organizationModel.Get(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, o.ReceiverInvitationsDisabled)
+
+		err = organizationModel.Update(ctx, &OrganizationUpdate{ReceiverInvitationsDisabled: utils.Ptr(true)})
+		require.NoError(t, err)
+
+		o, err = organizationModel.Get(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, o.ReceiverInvitationsDisabled)
+		assert.True(t, *o.ReceiverInvitationsDisabled)
+
+		err = organizationModel.Update(ctx, &OrganizationUpdate{ReceiverInvitationsDisabled: utils.Ptr(false)})
+		require.NoError(t, err)
+
+		o, err = organizationModel.Get(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, o.ReceiverInvitationsDisabled)
+		assert.False(t, *o.ReceiverInvitationsDisabled)
 	})
 
 	t.Run("updates organization's name, timezone UTC offset and logo successfully", func(t *testing.T) {

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -61,6 +61,7 @@ type PatchOrganizationProfileRequest struct {
 	PrivacyPolicyLink                   *string `json:"privacy_policy_link"`
 	MFADisabled                         *bool   `json:"mfa_disabled"`
 	CAPTCHADisabled                     *bool   `json:"captcha_disabled"`
+	ReceiverInvitationsDisabled         *bool   `json:"receiver_invitations_disabled"`
 }
 
 func (r *PatchOrganizationProfileRequest) AreAllFieldsEmpty() bool {
@@ -193,6 +194,7 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 		PrivacyPolicyLink:                    reqBody.PrivacyPolicyLink,
 		MFADisabled:                          reqBody.MFADisabled,
 		CAPTCHADisabled:                      reqBody.CAPTCHADisabled,
+		ReceiverInvitationsDisabled:          reqBody.ReceiverInvitationsDisabled,
 	}
 	requestDict, err := utils.ConvertType[data.OrganizationUpdate, map[string]interface{}](organizationUpdate)
 	if err != nil {
@@ -378,6 +380,7 @@ func (h ProfileHandler) GetOrganizationInfo(rw http.ResponseWriter, req *http.Re
 		"message_channel_priority":                 org.MessageChannelPriority,
 		"mfa_disabled":                             org.MFADisabled,
 		"captcha_disabled":                         org.CAPTCHADisabled,
+		"receiver_invitations_disabled":            org.ReceiverInvitationsDisabled,
 	}
 
 	if org.ReceiverRegistrationMessageTemplate != data.DefaultReceiverRegistrationMessageTemplate {

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -529,6 +529,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 					"payment_cancellation_period_days": 2,
 					"receiver_registration_message_template": "My custom receiver wallet registration invite. MyOrg 👋",
 					"receiver_invitation_resend_interval_days": 2,
+					"receiver_invitations_disabled": true,
 					"timezone_utc_offset": "-03:00",
 					"is_memo_tracing_enabled": false,
 					"is_link_shortener_enabled": true,
@@ -544,12 +545,13 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 				"PaymentCancellationPeriodDays":        int64(2),
 				"ReceiverRegistrationMessageTemplate":  "My custom receiver wallet registration invite. MyOrg 👋",
 				"ReceiverInvitationResendIntervalDays": int64(2),
+				"ReceiverInvitationsDisabled":          true,
 				"TimezoneUTCOffset":                    "-03:00",
 				"IsMemoTracingEnabled":                 false,
 				"IsLinkShortenerEnabled":               true,
 				"PrivacyPolicyLink":                    "https://example.com/privacy-policy",
 			},
-			wantLogEntries: []string{"[PatchOrganizationProfile] - userID user-id will update the organization fields [IsApprovalRequired='true', IsLinkShortenerEnabled='true', IsMemoTracingEnabled='false', Logo='...', Name='My Org Name', OTPMessageTemplate='Here's your OTP Code to complete your registration. MyOrg 👋', PaymentCancellationPeriodDays='2', PrivacyPolicyLink='https://example.com/privacy-policy', ReceiverInvitationResendIntervalDays='2', ReceiverRegistrationMessageTemplate='My custom receiver wallet registration invite. MyOrg 👋', TimezoneUTCOffset='-03:00']"},
+			wantLogEntries: []string{"[PatchOrganizationProfile] - userID user-id will update the organization fields [IsApprovalRequired='true', IsLinkShortenerEnabled='true', IsMemoTracingEnabled='false', Logo='...', Name='My Org Name', OTPMessageTemplate='Here's your OTP Code to complete your registration. MyOrg 👋', PaymentCancellationPeriodDays='2', PrivacyPolicyLink='https://example.com/privacy-policy', ReceiverInvitationResendIntervalDays='2', ReceiverInvitationsDisabled='true', ReceiverRegistrationMessageTemplate='My custom receiver wallet registration invite. MyOrg 👋', TimezoneUTCOffset='-03:00']"},
 		},
 		{
 			name:  "🎉 successfully updates organization back to its default values",
@@ -1304,7 +1306,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"payment_cancellation_period_days": 0,
 				"message_channel_priority": ["SMS", "EMAIL"],
 				"mfa_disabled": null,
-				"captcha_disabled": null
+				"captcha_disabled": null,
+				"receiver_invitations_disabled": null
 			}
 		`, *currentTenant.BaseURL, *currentTenant.BaseURL, newDistAccountJSON(t, *currentTenant.DistributionAccountAddress), *currentTenant.DistributionAccountAddress)
 
@@ -1346,7 +1349,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"privacy_policy_link": null,
 				"message_channel_priority": ["SMS", "EMAIL"],
 				"mfa_disabled": null,
-				"captcha_disabled": null
+				"captcha_disabled": null,
+				"receiver_invitations_disabled": null
 			}
 		`, *currentTenant.BaseURL, *currentTenant.BaseURL, newDistAccountJSON(t, *currentTenant.DistributionAccountAddress), *currentTenant.DistributionAccountAddress)
 
@@ -1387,7 +1391,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"privacy_policy_link": null,
 				"message_channel_priority": ["SMS", "EMAIL"],
 				"mfa_disabled": null,
-				"captcha_disabled": null
+				"captcha_disabled": null,
+				"receiver_invitations_disabled": null
 			}
 		`, *currentTenant.BaseURL, *currentTenant.BaseURL, newDistAccountJSON(t, *currentTenant.DistributionAccountAddress), *currentTenant.DistributionAccountAddress)
 
@@ -1430,7 +1435,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"privacy_policy_link": null,
 				"message_channel_priority": ["SMS", "EMAIL"],
 				"mfa_disabled": null,
-				"captcha_disabled": null
+				"captcha_disabled": null,
+				"receiver_invitations_disabled": null
 			}
 		`, *currentTenant.BaseURL, *currentTenant.BaseURL, newDistAccountJSON(t, *currentTenant.DistributionAccountAddress), *currentTenant.DistributionAccountAddress)
 
@@ -1473,7 +1479,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"privacy_policy_link": null,
 				"message_channel_priority": ["SMS", "EMAIL"],
 				"mfa_disabled": null,
-				"captcha_disabled": null
+				"captcha_disabled": null,
+				"receiver_invitations_disabled": null
 			}
 		`, *currentTenant.BaseURL, *currentTenant.BaseURL, newDistAccountJSON(t, *currentTenant.DistributionAccountAddress), *currentTenant.DistributionAccountAddress)
 
@@ -1516,7 +1523,8 @@ func Test_ProfileHandler_GetOrganizationInfo(t *testing.T) {
 				"privacy_policy_link": "https://example.com/privacy-policy",
 				"message_channel_priority": ["SMS", "EMAIL"],
 				"mfa_disabled": null,
-				"captcha_disabled": null
+				"captcha_disabled": null,
+				"receiver_invitations_disabled": null
 			}
 		`, *currentTenant.BaseURL, *currentTenant.BaseURL, newDistAccountJSON(t, *currentTenant.DistributionAccountAddress), *currentTenant.DistributionAccountAddress)
 

--- a/internal/services/send_receiver_wallets_invite_service.go
+++ b/internal/services/send_receiver_wallets_invite_service.go
@@ -69,6 +69,14 @@ func (s SendReceiverWalletInviteService) SendInvite(ctx context.Context) error {
 		return fmt.Errorf("getting organization: %w", err)
 	}
 
+	if organization.ReceiverInvitationsDisabled != nil && *organization.ReceiverInvitationsDisabled {
+		log.Ctx(ctx).Debugf(
+			"receiver wallet invitations are disabled for tenant %s; skipping scheduled run",
+			currentTenant.ID,
+		)
+		return nil
+	}
+
 	// Debug purposes
 	if organization.ReceiverInvitationResendIntervalDays == nil {
 		log.Ctx(ctx).Debug("automatic resend invitation is deactivated. Set a valid value to the organization's receiver_invitation_resend_interval_days to activate it.")

--- a/internal/services/send_receiver_wallets_invite_service_test.go
+++ b/internal/services/send_receiver_wallets_invite_service_test.go
@@ -1312,6 +1312,125 @@ func TestSendReceiverWalletInviteService_SendInvite(t *testing.T) {
 	messageDispatcherMock.AssertExpectations(t)
 }
 
+func Test_SendReceiverWalletInviteService_SendInvite_DisabledForOrg(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	tenantBaseURL := "http://localhost:8000"
+	tenantUIBaseURL := "http://localhost:3000"
+	tenantInfo := &schema.Tenant{
+		ID:           uuid.NewString(),
+		Name:         "TestTenant",
+		BaseURL:      &tenantBaseURL,
+		SDPUIBaseURL: &tenantUIBaseURL,
+	}
+	ctx := sdpcontext.SetTenantInContext(context.Background(), tenantInfo)
+
+	stellarSecretKey := "SBUSPEKAZKLZSWHRSJ2HWDZUK6I3IVDUWA7JJZSGBLZ2WZIUJI7FPNB5"
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+
+	wallet := data.CreateWalletFixture(t, ctx, dbConnectionPool, "Wallet1", "https://wallet1.com", "www.wallet1.com", "wallet1://sdp")
+	asset := data.CreateAssetFixture(t, ctx, dbConnectionPool, "FOO1", "GCKGCKZ2PFSCRQXREJMTHAHDMOZQLS2R4V5LZ6VLU53HONH5FI6ACBSX")
+	receiver := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+	disbursement := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
+		Wallet: wallet,
+		Status: data.ReadyDisbursementStatus,
+		Asset:  asset,
+	})
+
+	setupReadyReceiverWallet := func(t *testing.T) *data.ReceiverWallet {
+		t.Helper()
+		data.DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
+		data.DeleteAllMessagesFixtures(t, ctx, dbConnectionPool)
+		data.DeleteAllReceiverWalletsFixtures(t, ctx, dbConnectionPool)
+		rw := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, data.ReadyReceiversWalletStatus)
+		_ = data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+			Status:         data.ReadyPaymentStatus,
+			Disbursement:   disbursement,
+			Asset:          *asset,
+			ReceiverWallet: rw,
+			Amount:         "1",
+		})
+		return rw
+	}
+
+	t.Run("skips scheduled run when receiver_invitations_disabled is true", func(t *testing.T) {
+		var err error
+		rw := setupReadyReceiverWallet(t)
+
+		err = models.Organizations.Update(ctx, &data.OrganizationUpdate{
+			ReceiverInvitationsDisabled: utils.Ptr(true),
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			resetErr := models.Organizations.Update(ctx, &data.OrganizationUpdate{
+				ReceiverInvitationsDisabled: utils.Ptr(false),
+			})
+			require.NoError(t, resetErr)
+		})
+
+		// No `.On(...)` registered — mockery with `t` fails the test if SendMessage is called.
+		messageDispatcherMock := message.NewMockMessageDispatcher(t)
+		embeddedWalletServiceMock := mocks.NewMockEmbeddedWalletService(t)
+		mockCrashTrackerClient := &crashtracker.MockCrashTrackerClient{}
+
+		s, err := NewSendReceiverWalletInviteService(models, messageDispatcherMock, embeddedWalletServiceMock, stellarSecretKey, 3, mockCrashTrackerClient)
+		require.NoError(t, err)
+
+		err = s.SendInvite(ctx)
+		require.NoError(t, err)
+
+		receivers, err := models.ReceiverWallet.GetByReceiverIDsAndWalletID(ctx, dbConnectionPool, []string{receiver.ID}, wallet.ID)
+		require.NoError(t, err)
+		require.Len(t, receivers, 1)
+		assert.Equal(t, rw.ID, receivers[0].ID)
+		assert.Nil(t, receivers[0].InvitationSentAt)
+
+		var messageCount int
+		err = dbConnectionPool.GetContext(ctx, &messageCount,
+			`SELECT COUNT(*) FROM messages WHERE receiver_wallet_id = $1`, rw.ID)
+		require.NoError(t, err)
+		assert.Zero(t, messageCount)
+	})
+
+	t.Run("sends invites normally when receiver_invitations_disabled is false", func(t *testing.T) {
+		var err error
+		rw := setupReadyReceiverWallet(t)
+
+		err = models.Organizations.Update(ctx, &data.OrganizationUpdate{
+			ReceiverInvitationsDisabled: utils.Ptr(false),
+		})
+		require.NoError(t, err)
+
+		messageDispatcherMock := message.NewMockMessageDispatcher(t)
+		messageDispatcherMock.
+			On("SendMessage", mock.Anything, mock.AnythingOfType("message.Message"), mock.Anything).
+			Return(message.MessengerTypeTwilioSMS, nil).
+			Once()
+
+		embeddedWalletServiceMock := mocks.NewMockEmbeddedWalletService(t)
+		mockCrashTrackerClient := &crashtracker.MockCrashTrackerClient{}
+
+		s, err := NewSendReceiverWalletInviteService(models, messageDispatcherMock, embeddedWalletServiceMock, stellarSecretKey, 3, mockCrashTrackerClient)
+		require.NoError(t, err)
+
+		err = s.SendInvite(ctx)
+		require.NoError(t, err)
+
+		receivers, err := models.ReceiverWallet.GetByReceiverIDsAndWalletID(ctx, dbConnectionPool, []string{receiver.ID}, wallet.ID)
+		require.NoError(t, err)
+		require.Len(t, receivers, 1)
+		assert.Equal(t, rw.ID, receivers[0].ID)
+		assert.NotNil(t, receivers[0].InvitationSentAt)
+	})
+}
+
 func Test_SendReceiverWalletInviteService_shouldSendInvitation(t *testing.T) {
 	var maxInvitationResendAttempts int64 = 3
 	s := SendReceiverWalletInviteService{maxInvitationResendAttempts: maxInvitationResendAttempts}


### PR DESCRIPTION
## What

Adds a new `receiver_invitations_disabled` boolean setting on the organization profile. When set to `true`, the scheduled receiver wallet invitation job skips sending invitations for that tenant. 

The flag is readable via `GET /profile/organization` and updatable via `PATCH /profile/organization`, and is backed by a new nullable column on the `organizations` table.

## Why

Tenants need a way to pause outbound receiver wallet invitations.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
