### PR TITLE
chore: replace the standalone `exhaustive` CI check with the `exhaustive` linter in golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,6 @@ jobs:
           go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@v0.31.0
           shadow ./... | { grep -v "generated.go" || true; }
 
-      - name: Run `exhaustive@v0.12.0`
-        run: |
-          go install github.com/nishanths/exhaustive/cmd/exhaustive@v0.12.0
-          exhaustive -default-signifies-exhaustive ./...
-
       - name: Run `deadcode@v0.31.0`
         run: |
           go install golang.org/x/tools/cmd/deadcode@v0.31.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - errcheck
     - errname
     - errorlint
+    - exhaustive
     - govet
     - nilerr
     - nilnesserr
@@ -29,6 +30,10 @@ linters:
     errcheck:
       # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
       check-blank: true
+
+    exhaustive:
+      # Treat a `default` clause as covering all unlisted cases
+      default-signifies-exhaustive: true
 
     wrapcheck:
       extra-ignore-sigs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Add `receiver_invitations_disabled` organization setting that skips the scheduled receiver wallet invitation job when enabled. [#1119](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1119)
 
+### Changed
+
+- Replace the standalone `exhaustive` CI check with the `exhaustive` linter in golangci-lint. [#1121](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1121)
+
 ### Fixed
 
 - Reject payment amounts that exceed Stellar's 7-decimal-place precision in `utils.ValidateAmount`. [#1116](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1116)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export PATH := $(GOPATH_BIN):$(PATH)
 
 # Always run these targets (they don't create files named after the target)
 .PHONY: docker-build docker-push go-install setup go-install-tools \
-	go-test go-lint go-shadow go-mod go-deadcode go-exhaustive go-goimports go-build go-check ci
+	go-test go-lint go-shadow go-mod go-deadcode go-goimports go-build go-check ci
 
 docker-build:
 	$(SUDO) docker build -f Dockerfile.development --pull --label org.opencontainers.image.created="$(BUILD_DATE)" -t $(TAG) --build-arg GIT_COMMIT=$(LABEL) .
@@ -33,7 +33,6 @@ go-install-tools:
 	@echo "🔧 Installing CI tools..."
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.2
 	go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@v0.31.0
-	go install github.com/nishanths/exhaustive/cmd/exhaustive@v0.12.0
 	go install golang.org/x/tools/cmd/deadcode@v0.31.0
 	go install golang.org/x/tools/cmd/goimports@v0.31.0
 	go install gotest.tools/gotestsum@v1.11.0
@@ -83,12 +82,6 @@ go-deadcode:
 	fi
 	@echo "✅ Dead code check completed successfully"
 
-go-exhaustive:
-	@echo ""
-	@echo "🔄 Running exhaustive enum checking..."
-	exhaustive -default-signifies-exhaustive ./...
-	@echo "✅ Exhaustive check completed successfully"
-
 go-goimports:
 	@echo ""
 	@echo "📐 Checking goimports compliance..."
@@ -101,7 +94,7 @@ go-goimports:
 	fi
 	@echo "✅ All files are compliant with goimports"
 
-go-check: go-mod go-lint go-shadow go-exhaustive go-deadcode go-goimports
+go-check: go-mod go-lint go-shadow go-deadcode go-goimports
 	@echo ""
 	@echo "🎉🎉🎉 All Go checks completed successfully! 🎉🎉🎉"
 


### PR DESCRIPTION
### What
- Remove standalone `exhaustive` check from https://github.com/nishanths/exhaustive/
- Enable `exhaustive` in golangci 

### Why
- exhaustive from https://github.com/nishanths/exhaustive/ doesn't seem maintained. 
- currently incompatible with go versions > 1.26
- functionality already exists in golangci 

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
