### PR TITLE
Port HackerOne security fixes from develop to meridian-pay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fix unbounded CSV upload size and pagination `page_limit` allowing resource exhaustion. [#1064](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1064)
+
 ### Added
 
 - Added Bridge Integration API endpoints to the backend:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [UNRELEASED]
 
-### Fixed
-
-- Reject payment amounts that exceed Stellar's 7-decimal-place precision in `utils.ValidateAmount`. [#1116](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1116)
-
 ### Security
 
 - Add global `MaxBodySize` middleware (10 MB) to all routes on both the SDP and admin servers to prevent unbounded request body sizes (CWE-770). [#1066](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1066)
 
 ### Fixed
 
+- Reject payment amounts that exceed Stellar's 7-decimal-place precision in `utils.ValidateAmount`. [#1116](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1116)
 - Fix unbounded CSV upload size and pagination `page_limit` allowing resource exhaustion. [#1064](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1064)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [UNRELEASED]
 
+### Security
+
+- Add global `MaxBodySize` middleware (10 MB) to all routes on both the SDP and admin servers to prevent unbounded request body sizes (CWE-770). [#1066](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1066)
+
 ### Fixed
 
 - Fix unbounded CSV upload size and pagination `page_limit` allowing resource exhaustion. [#1064](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1064)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Reject payment amounts that exceed Stellar's 7-decimal-place precision in `utils.ValidateAmount`. [#1116](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1116)
+
 ### Security
 
 - Add global `MaxBodySize` middleware (10 MB) to all routes on both the SDP and admin servers to prevent unbounded request body sizes (CWE-770). [#1066](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1066)

--- a/go.list
+++ b/go.list
@@ -213,7 +213,7 @@ github.com/segmentio/kafka-go v0.4.48
 github.com/sendgrid/rest v2.6.9+incompatible
 github.com/sendgrid/sendgrid-go v3.16.1+incompatible
 github.com/sergi/go-diff v1.3.1
-github.com/shopspring/decimal v1.3.1
+github.com/shopspring/decimal v1.4.0
 github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c
 github.com/sirupsen/logrus v1.9.3
 github.com/sourcegraph/conc v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/segmentio/kafka-go v0.4.48
 	github.com/sendgrid/rest v2.6.9+incompatible
 	github.com/sendgrid/sendgrid-go v3.16.1+incompatible
+	github.com/shopspring/decimal v1.4.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/sendgrid/sendgrid-go v3.16.1+incompatible h1:zWhTmB0Y8XCDzeWIm2/BIt1G
 github.com/sendgrid/sendgrid-go v3.16.1+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/dimchansky/utfbom"
@@ -44,6 +43,8 @@ type DisbursementHandler struct {
 	DistributionAccountResolver           signing.DistributionAccountResolver
 	DisableInitialDisbursementInvitations bool
 }
+
+const DefaultMaxCSVUploadSizeBytes = 500 * data.MaxInstructionsPerDisbursement // 500 bytes per instruction.
 
 type PostDisbursementRequest struct {
 	Name                                string                       `json:"name"`
@@ -93,15 +94,19 @@ func (d DisbursementHandler) PostDisbursement(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	if httpErr := d.limitCSVUploadRequestSize(w, r); httpErr != nil {
+		httpErr.Render(w)
+		return
+	}
+
 	// Handle request based on content type.
 	var disbursement *data.Disbursement
 	var httpErr *httperror.HTTPError
-	contentType := r.Header.Get("Content-Type")
-	if strings.HasPrefix(contentType, "multipart/form-data") {
+	if utils.IsMultipartFormData(r) {
 		disbursement, httpErr = d.postDisbursementWithInstructions(ctx, r, user)
 	} else {
 		var req PostDisbursementRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
 			httperror.BadRequest(err.Error(), err, nil).Render(w)
 			return
 		}
@@ -286,7 +291,12 @@ func (d DisbursementHandler) PostDisbursementInstructions(w http.ResponseWriter,
 		return
 	}
 
-	if err := db.RunInTransaction(ctx, d.Models.DBConnectionPool, nil, func(dbTx db.DBTransaction) error {
+	if httpErr := d.limitCSVUploadRequestSize(w, r); httpErr != nil {
+		httpErr.Render(w)
+		return
+	}
+
+	if err = db.RunInTransaction(ctx, d.Models.DBConnectionPool, nil, func(dbTx db.DBTransaction) error {
 		// check if disbursement exists
 		disbursement, getErr := d.Models.Disbursements.Get(ctx, dbTx, disbursementID)
 		if getErr != nil {
@@ -306,6 +316,7 @@ func (d DisbursementHandler) PostDisbursementInstructions(w http.ResponseWriter,
 		} else {
 			httperror.InternalError(ctx, "Cannot process instructions for disbursement", err, nil).Render(w)
 		}
+		return
 	}
 
 	response := map[string]string{
@@ -313,6 +324,29 @@ func (d DisbursementHandler) PostDisbursementInstructions(w http.ResponseWriter,
 	}
 
 	httpjson.Render(w, response, httpjson.JSON)
+}
+
+func (d DisbursementHandler) limitCSVUploadRequestSize(w http.ResponseWriter, r *http.Request) *httperror.HTTPError {
+	if !utils.IsMultipartFormData(r) {
+		return nil
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, DefaultMaxCSVUploadSizeBytes)
+	if err := r.ParseMultipartForm(DefaultMaxCSVUploadSizeBytes); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			err = fmt.Errorf("request body too large: %w", err)
+			log.Ctx(r.Context()).Error(err)
+			return httperror.BadRequest("could not parse multipart form data", err, map[string]interface{}{
+				"details": fmt.Sprintf("request too large. Max size %d bytes.", DefaultMaxCSVUploadSizeBytes),
+			})
+		}
+
+		err = fmt.Errorf("parsing multipart form: %w", err)
+		return httperror.BadRequest("could not parse multipart form data", err, nil)
+	}
+
+	return nil
 }
 
 func (d DisbursementHandler) validateAndProcessInstructions(ctx context.Context, r *http.Request, dbTx db.DBTransaction, authUser *auth.User, disbursement *data.Disbursement) error {

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpresponse"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	svcMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
@@ -477,6 +479,22 @@ func Test_DisbursementHandler_GetDisbursements_Errors(t *testing.T) {
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"error":"request invalid", "extras":{"page_limit":"parameter must be an integer"}}`,
+		},
+		{
+			name: "returns error when page_limit is zero",
+			queryParams: map[string]string{
+				"page_limit": "0",
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   `{"error":"request invalid", "extras":{"page_limit":"parameter must be a positive integer"}}`,
+		},
+		{
+			name: "returns error when page_limit exceeds max",
+			queryParams: map[string]string{
+				"page_limit": fmt.Sprintf("%d", validators.MaxPageLimit+1),
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   fmt.Sprintf(`{"error":"request invalid", "extras":{"page_limit":"parameter must be less than or equal to %d"}}`, validators.MaxPageLimit),
 		},
 		{
 			name: "returns error when status is invalid",
@@ -1035,6 +1053,16 @@ func Test_DisbursementHandler_PostDisbursementInstructions(t *testing.T) {
 			},
 			expectedStatus:  http.StatusOK,
 			expectedMessage: "File uploaded successfully",
+		},
+		{
+			name:           "🔴 csv upload too large",
+			disbursementID: phoneDraftDisbursement.ID,
+			csvRecords: [][]string{
+				{"phone", "id", "amount", "verification"},
+				{strings.Repeat("a", int(DefaultMaxCSVUploadSizeBytes)+1024*1024), "123456789", "100.5", "1990-01-01"},
+			},
+			expectedStatus:  http.StatusBadRequest,
+			expectedMessage: "request too large",
 		},
 		{
 			name:           "🔴 .bat is rejected",

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/events/schemas"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httpresponse"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/middleware"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
@@ -388,6 +389,22 @@ func Test_PaymentHandler_GetPayments_Errors(t *testing.T) {
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"error":"request invalid", "extras":{"page_limit":"parameter must be an integer"}}`,
+		},
+		{
+			name: "returns error when page_limit is zero",
+			queryParams: map[string]string{
+				"page_limit": "0",
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   `{"error":"request invalid", "extras":{"page_limit":"parameter must be a positive integer"}}`,
+		},
+		{
+			name: "returns error when page_limit exceeds max",
+			queryParams: map[string]string{
+				"page_limit": fmt.Sprintf("%d", validators.MaxPageLimit+1),
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   fmt.Sprintf(`{"error":"request invalid", "extras":{"page_limit":"parameter must be less than or equal to %d"}}`, validators.MaxPageLimit),
 		},
 		{
 			name: "returns error when status is invalid",

--- a/internal/serve/httphandler/receiver_handler_test.go
+++ b/internal/serve/httphandler/receiver_handler_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/message"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 )
@@ -404,6 +405,22 @@ func Test_ReceiverHandler_GetReceivers_Errors(t *testing.T) {
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"error":"request invalid", "extras":{"page_limit":"parameter must be an integer"}}`,
+		},
+		{
+			name: "returns error when page_limit is zero",
+			queryParams: map[string]string{
+				"page_limit": "0",
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   `{"error":"request invalid", "extras":{"page_limit":"parameter must be a positive integer"}}`,
+		},
+		{
+			name: "returns error when page_limit exceeds max",
+			queryParams: map[string]string{
+				"page_limit": fmt.Sprintf("%d", validators.MaxPageLimit+1),
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   fmt.Sprintf(`{"error":"request invalid", "extras":{"page_limit":"parameter must be less than or equal to %d"}}`, validators.MaxPageLimit),
 		},
 		{
 			name: "returns error when status is invalid",

--- a/internal/serve/httpresponse/paginated_response.go
+++ b/internal/serve/httpresponse/paginated_response.go
@@ -34,6 +34,9 @@ func NewEmptyPaginatedResponse() PaginatedResponse {
 
 // NewPaginatedResponse returns a PaginatedResponse with pagination information.
 func NewPaginatedResponse(r *http.Request, data interface{}, currentPage, pageLimit, totalItems int) (PaginatedResponse, error) {
+	if pageLimit <= 0 {
+		return PaginatedResponse{}, fmt.Errorf("page_limit must be a positive integer")
+	}
 	totalPages := (totalItems + pageLimit - 1) / pageLimit
 	pagination := PaginationInfo{Pages: totalPages, Total: totalItems}
 

--- a/internal/serve/httpresponse/paginated_response_test.go
+++ b/internal/serve/httpresponse/paginated_response_test.go
@@ -1,0 +1,25 @@
+package httpresponse
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewPaginatedResponse_ErrorsOnInvalidPageLimit(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/payments?page=1&page_limit=0", nil)
+	_, err := NewPaginatedResponse(req, []string{"a"}, 1, 0, 1)
+	assert.ErrorContains(t, err, "page_limit must be a positive integer")
+}
+
+func Test_NewPaginatedResponse_BuildsPaginationLinks(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/payments?page=1&page_limit=2", nil)
+	resp, err := NewPaginatedResponse(req, []string{"a", "b"}, 1, 2, 5)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, resp.Pagination.Pages)
+	assert.Equal(t, 5, resp.Pagination.Total)
+	assert.Equal(t, "http://example.com/payments?page=2&page_limit=2", resp.Pagination.Next)
+	assert.Empty(t, resp.Pagination.Prev)
+}

--- a/internal/serve/middleware/middleware.go
+++ b/internal/serve/middleware/middleware.go
@@ -377,6 +377,19 @@ func BasicAuthMiddleware(adminAccount, adminApiKey string) func(http.Handler) ht
 	}
 }
 
+// DefaultMaxRequestBodySize is the default maximum request body size (10 MB) applied globally (CWE-770).
+const DefaultMaxRequestBodySize int64 = 10 * 1024 * 1024
+
+// MaxBodySize is a middleware that limits the size of the request body using http.MaxBytesReader (CWE-770).
+func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			req.Body = http.MaxBytesReader(rw, req.Body, maxBytes)
+			next.ServeHTTP(rw, req)
+		})
+	}
+}
+
 // extractTenantNameFromRequest attempts to extract the tenant name from the request HEADER[tenantHeaderKey] or the hostname prefix.
 func extractTenantNameFromRequest(r *http.Request) (string, error) {
 	// 1. Try extracting from the TenantHeaderKey header first

--- a/internal/serve/middleware/middleware_test.go
+++ b/internal/serve/middleware/middleware_test.go
@@ -1144,6 +1144,85 @@ func Test_BasicAuthMiddleware(t *testing.T) {
 	})
 }
 
+func Test_MaxBodySize(t *testing.T) {
+	testCases := []struct {
+		name           string
+		maxBytes       int64
+		bodySize       int
+		expectedStatus int
+	}{
+		{
+			name:           "rejects body exceeding limit",
+			maxBytes:       100,
+			bodySize:       200,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+		},
+		{
+			name:           "allows body at exactly the limit",
+			maxBytes:       100,
+			bodySize:       100,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "allows body under the limit",
+			maxBytes:       100,
+			bodySize:       50,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "allows empty body",
+			maxBytes:       100,
+			bodySize:       0,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "rejects when limit is zero and body is non-empty",
+			maxBytes:       0,
+			bodySize:       1,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Use(MaxBodySize(tc.maxBytes))
+			r.Post("/", func(w http.ResponseWriter, r *http.Request) {
+				_, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, "body too large", http.StatusRequestEntityTooLarge)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+
+			body := strings.NewReader(strings.Repeat("x", tc.bodySize))
+			req, err := http.NewRequest(http.MethodPost, "/", body)
+			require.NoError(t, err)
+
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			assert.Equal(t, tc.expectedStatus, rr.Code)
+		})
+	}
+
+	t.Run("GET requests with no body are unaffected", func(t *testing.T) {
+		r := chi.NewRouter()
+		r.Use(MaxBodySize(100))
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
 func Test_ExtractTenantNameFromRequest(t *testing.T) {
 	t.Run("extract tenant name from header", func(t *testing.T) {
 		expectedTenant := "tenant123"

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -286,6 +286,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 	mux.Use(middleware.CSPMiddleware())
 	mux.Use(chimiddleware.CleanPath)
 	mux.Use(chimiddleware.Compress(5))
+	mux.Use(middleware.MaxBodySize(middleware.DefaultMaxRequestBodySize))
 
 	// Create a route along /static that will serve contents from the ./public_files folder.
 	staticFileServer(mux, publicfiles.PublicFiles)

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher.go
@@ -3,8 +3,8 @@ package paymentdispatchers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
+	"github.com/shopspring/decimal"
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
@@ -58,11 +58,20 @@ var _ PaymentDispatcherInterface = (*StellarPaymentDispatcher)(nil)
 func (s *StellarPaymentDispatcher) sendPaymentsToTSS(ctx context.Context, sdpDBTx, tssDBTx db.DBTransaction, tenantID string, pendingPayments []*data.Payment) error {
 	var transactions []txSubStore.Transaction
 	for _, payment := range pendingPayments {
-		// TODO: change TSS to use string amount [SDP-483]
-		amount, err := strconv.ParseFloat(payment.Amount, 64)
+		// Parse via decimal first to canonically validate the amount string
+		// (rejects over-precision values before any float64 round-trip).
+		amountDec, err := decimal.NewFromString(payment.Amount)
 		if err != nil {
 			return fmt.Errorf("parsing payment amount %s for payment ID %s: %w", payment.Amount, payment.ID, err)
 		}
+
+		const stellarMaxDecimalPlaces = 7
+		if !amountDec.Equal(amountDec.Truncate(stellarMaxDecimalPlaces)) {
+			return fmt.Errorf("payment amount %s for payment ID %s exceeds Stellar's %d decimal place precision", payment.Amount, payment.ID, stellarMaxDecimalPlaces)
+		}
+
+		// TODO: change TSS to use string amount [SDP-483]
+		amount, _ := amountDec.Float64()
 
 		memo, err := s.memoResolver.GetMemo(ctx, *payment.ReceiverWallet)
 		if err != nil {

--- a/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
+++ b/internal/services/paymentdispatchers/stellar_payment_dispatcher_test.go
@@ -79,7 +79,19 @@ func Test_StellarPaymentDispatcher_DispatchPayments_failure(t *testing.T) {
 			paymentsToDispatch: []*data.Payment{
 				{ID: "123", Amount: "invalid-amount"},
 			},
-			wantErr: fmt.Errorf("parsing payment amount invalid-amount for payment ID 123: strconv.ParseFloat: parsing \"invalid-amount\": invalid syntax"),
+			wantErr: fmt.Errorf("parsing payment amount invalid-amount for payment ID 123: can't convert invalid-amount to decimal"),
+			fnSetup: func(t *testing.T, mDistAccountResolver *mocks.MockDistributionAccountResolver) {
+				mDistAccountResolver.On("DistributionAccountFromContext", ctx).
+					Return(schema.TransactionAccount{Type: schema.DistributionAccountStellarEnv}, nil).
+					Once()
+			},
+		},
+		{
+			name: "payment amount exceeds 7 decimal places",
+			paymentsToDispatch: []*data.Payment{
+				{ID: "456", Amount: "1.12345678"},
+			},
+			wantErr: fmt.Errorf("payment amount 1.12345678 for payment ID 456 exceeds Stellar's 7 decimal place precision"),
 			fnSetup: func(t *testing.T, mDistAccountResolver *mocks.MockDistributionAccountResolver) {
 				mDistAccountResolver.On("DistributionAccountFromContext", ctx).
 					Return(schema.TransactionAccount{Type: schema.DistributionAccountStellarEnv}, nil).

--- a/internal/transactionsubmission/payment_transaction_handler.go
+++ b/internal/transactionsubmission/payment_transaction_handler.go
@@ -63,7 +63,7 @@ func (h *PaymentTransactionHandler) BuildInnerTransaction(ctx context.Context, t
 
 	var operation txnbuild.Operation
 	var txMemo txnbuild.Memo
-	amount := strconv.FormatFloat(txJob.Transaction.Amount, 'f', 6, 32)
+	amount := strconv.FormatFloat(txJob.Transaction.Amount, 'f', 7, 64)
 
 	if strkey.IsValidEd25519PublicKey(txJob.Transaction.Destination) {
 		memo, err := txJob.Transaction.BuildMemo()

--- a/internal/transactionsubmission/payment_transaction_handler_test.go
+++ b/internal/transactionsubmission/payment_transaction_handler_test.go
@@ -267,7 +267,7 @@ func Test_PaymentHandler_BuildInnerTransaction(t *testing.T) {
 				}
 
 				var operation txnbuild.Operation
-				amount := strconv.FormatFloat(txJob.Transaction.Amount, 'f', 6, 32)
+				amount := strconv.FormatFloat(txJob.Transaction.Amount, 'f', 7, 64)
 				if strkey.IsValidEd25519PublicKey(tc.destinationAddress) {
 					operation = &txnbuild.Payment{
 						SourceAccount: distributionKP.Address(),

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -1972,7 +1972,7 @@ func Test_TransactionWorker_buildAndSignTransaction(t *testing.T) {
 			Operations: []txnbuild.Operation{
 				&txnbuild.Payment{
 					SourceAccount: distributionKP.Address(),
-					Amount:        strconv.FormatFloat(txJob.Transaction.Amount, 'f', 6, 32),
+					Amount:        strconv.FormatFloat(txJob.Transaction.Amount, 'f', 7, 64),
 					Destination:   txJob.Transaction.Destination,
 					Asset:         &txnbuild.CreditAsset{Code: txJob.Transaction.AssetCode, Issuer: txJob.Transaction.AssetIssuer},
 				},

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"mime"
+	"net/http"
+)
+
+// HasContentType reports whether the request's Content-Type matches
+// the provided media type (e.g. "application/json", "multipart/form-data").
+//
+// It parses the header using mime.ParseMediaType so it correctly handles
+// parameters like boundary and charset and is RFC-compliant.
+func HasContentType(r *http.Request, expected string) bool {
+	if r == nil {
+		return false
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		return false
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+
+	return mediaType == expected
+}
+
+// IsMultipartFormData reports whether the request's Content-Type
+// is "multipart/form-data".
+func IsMultipartFormData(r *http.Request) bool {
+	return HasContentType(r, "multipart/form-data")
+}

--- a/internal/utils/http_test.go
+++ b/internal/utils/http_test.go
@@ -1,0 +1,136 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHasContentType(t *testing.T) {
+	type tc struct {
+		name     string
+		r        *http.Request
+		expected string
+		want     bool
+	}
+
+	tests := []tc{
+		{
+			name:     "no Content-Type header",
+			r:        &http.Request{Header: http.Header{}},
+			expected: "application/json",
+			want:     false,
+		},
+		{
+			name:     "empty Content-Type header value",
+			r:        &http.Request{Header: http.Header{"Content-Type": []string{""}}},
+			expected: "application/json",
+			want:     false,
+		},
+		{
+			name:     "invalid Content-Type value (parse error)",
+			r:        &http.Request{Header: http.Header{"Content-Type": []string{"not a real content type"}}},
+			expected: "application/json",
+			want:     false,
+		},
+		{
+			name:     "exact match without parameters",
+			r:        &http.Request{Header: http.Header{"Content-Type": []string{"application/json"}}},
+			expected: "application/json",
+			want:     true,
+		},
+		{
+			name:     "mismatch without parameters",
+			r:        &http.Request{Header: http.Header{"Content-Type": []string{"application/xml"}}},
+			expected: "application/json",
+			want:     false,
+		},
+		{
+			name:     "match with parameters (charset)",
+			r:        &http.Request{Header: http.Header{"Content-Type": []string{"application/json; charset=utf-8"}}},
+			expected: "application/json",
+			want:     true,
+		},
+		{
+			name:     "case-insensitive parsing: header value in different case should match",
+			r:        &http.Request{Header: http.Header{"Content-Type": []string{"Multipart/Form-Data; boundary=xyz"}}},
+			expected: "multipart/form-data",
+			want:     true,
+		},
+		{
+			name:     "expected type must match exactly (no wildcard support)",
+			r:        &http.Request{Header: http.Header{"Content-Type": []string{"multipart/form-data; boundary=xyz"}}},
+			expected: "multipart/*",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := HasContentType(tt.r, tt.expected)
+			if got != tt.want {
+				t.Fatalf("HasContentType() = %v, want %v (expected=%q, ct=%q)",
+					got, tt.want, tt.expected, contentTypeForDebug(tt.r))
+			}
+		})
+	}
+}
+
+func TestIsMultipartFormData(t *testing.T) {
+	t.Parallel()
+
+	type tc struct {
+		name string
+		r    *http.Request
+		want bool
+	}
+
+	tests := []tc{
+		{
+			name: "nil request",
+			r:    nil,
+			want: false,
+		},
+		{
+			name: "no Content-Type",
+			r:    &http.Request{Header: http.Header{}},
+			want: false,
+		},
+		{
+			name: "multipart/form-data with boundary",
+			r:    &http.Request{Header: http.Header{"Content-Type": []string{"multipart/form-data; boundary=abc"}}},
+			want: true,
+		},
+		{
+			name: "not multipart/form-data",
+			r:    &http.Request{Header: http.Header{"Content-Type": []string{"application/json; charset=utf-8"}}},
+			want: false,
+		},
+		{
+			name: "invalid Content-Type",
+			r:    &http.Request{Header: http.Header{"Content-Type": []string{"bad"}}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsMultipartFormData(tt.r)
+			if got != tt.want {
+				t.Fatalf("IsMultipartFormData() = %v, want %v (ct=%q)",
+					got, tt.want, contentTypeForDebug(tt.r))
+			}
+		})
+	}
+}
+
+// contentTypeForDebug is only for nicer failure messages in tests.
+func contentTypeForDebug(r *http.Request) string {
+	if r == nil {
+		return "<nil request>"
+	}
+	return r.Header.Get("Content-Type")
+}

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -6,12 +6,12 @@ import (
 	"net/url"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/nyaruka/phonenumbers"
+	"github.com/stellar/go/amount"
 	"golang.org/x/net/html"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
@@ -52,17 +52,25 @@ func ValidatePhoneNumber(phoneNumberStr string) error {
 	return nil
 }
 
-func ValidateAmount(amount string) error {
-	if amount == "" {
+// ValidateAmount checks that s is a positive Stellar classic-asset amount.
+func ValidateAmount(s string) error {
+	if s == "" {
 		return fmt.Errorf("amount cannot be empty")
 	}
 
-	value, err := strconv.ParseFloat(amount, 64)
+	parsed, err := amount.ParseInt64(s)
 	if err != nil {
-		return fmt.Errorf("the provided amount is not a valid number")
+		switch {
+		case strings.Contains(err.Error(), "more than 7 significant digits"):
+			return fmt.Errorf("the provided amount exceeds the maximum supported precision of 7 decimal places")
+		case strings.Contains(err.Error(), "outside bounds of int64"):
+			return fmt.Errorf("the provided amount exceeds the maximum supported value")
+		default:
+			return fmt.Errorf("the provided amount is not a valid number")
+		}
 	}
 
-	if value <= 0 {
+	if parsed <= 0 {
 		return fmt.Errorf("the provided amount must be greater than zero")
 	}
 

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -149,23 +149,70 @@ func Test_ValidatePathIsNotTraversal(t *testing.T) {
 }
 
 func Test_ValidateAmount(t *testing.T) {
+	const (
+		emptyMsg       = "amount cannot be empty"
+		notPositiveMsg = "the provided amount must be greater than zero"
+		invalidMsg     = "the provided amount is not a valid number"
+		tooPreciseMsg  = "the provided amount exceeds the maximum supported precision of 7 decimal places"
+		tooLargeMsg    = "the provided amount exceeds the maximum supported value"
+	)
+
 	testCases := []struct {
-		amount  string
-		wantErr error
+		name       string
+		amount     string
+		wantErrMsg string // empty means no error expected
 	}{
-		{"", fmt.Errorf("amount cannot be empty")},
-		{"notvalidamount", fmt.Errorf("the provided amount is not a valid number")},
-		{"0", fmt.Errorf("the provided amount must be greater than zero")},
-		{"0.00", fmt.Errorf("the provided amount must be greater than zero")},
-		{"1", nil},
-		{"1.00", nil},
-		{"1.01", nil},
+		// empty / unparseable
+		{name: "empty", amount: "", wantErrMsg: emptyMsg},
+		{name: "whitespace", amount: "   ", wantErrMsg: invalidMsg},
+		{name: "non-numeric", amount: "notvalidamount", wantErrMsg: invalidMsg},
+		{name: "trailing garbage", amount: "1.23abc", wantErrMsg: invalidMsg},
+		{name: "hex", amount: "0xFF", wantErrMsg: invalidMsg},
+		{name: "plus sign prefix", amount: "+1.0", wantErrMsg: invalidMsg},
+		{name: "comma decimal separator", amount: "1,23", wantErrMsg: invalidMsg},
+		{name: "multiple dots", amount: "1.2.3", wantErrMsg: invalidMsg},
+		{name: "scientific notation", amount: "1e-7", wantErrMsg: invalidMsg},
+		{name: "over 20 chars", amount: "0.12345678901234567890", wantErrMsg: invalidMsg},
+
+		// non-positive
+		{name: "zero int", amount: "0", wantErrMsg: notPositiveMsg},
+		{name: "zero decimal", amount: "0.00", wantErrMsg: notPositiveMsg},
+		{name: "zero padded to 7dp", amount: "0.0000000", wantErrMsg: notPositiveMsg},
+		{name: "negative int", amount: "-1", wantErrMsg: notPositiveMsg},
+		{name: "negative fractional", amount: "-0.5", wantErrMsg: notPositiveMsg},
+
+		// valid amounts at various precisions
+		{name: "integer", amount: "1"},
+		{name: "2dp", amount: "1.00"},
+		{name: "2dp non-zero", amount: "1.01"},
+		{name: "7dp max precision", amount: "1.1234567"},
+		{name: "smallest unit", amount: "0.0000001"},
+		{name: "large value at 7dp", amount: "999999.9999999"},
+		{name: "7dp with trailing zeros", amount: "1.1000000"},
+		{name: "leading zero integer part", amount: "0.5"},
+		{name: "max int64 amount", amount: "922337203685.4775807"},
+
+		// exceeding 7 decimal places — SDP-2072 silent-rounding scenarios
+		{name: "8dp non-zero last digit", amount: "1.12345678", wantErrMsg: tooPreciseMsg},
+		{name: "8dp padded zero but numerically valid", amount: "1.00000000"},
+		{name: "8dp trailing zero but numerically 7dp", amount: "1.12345670"},
+		{name: "sub-unit rounded up", amount: "0.00000009", wantErrMsg: tooPreciseMsg},
+		{name: "sub-unit rounded to zero", amount: "0.00000001", wantErrMsg: tooPreciseMsg},
+		{name: "9dp", amount: "1.123456789", wantErrMsg: tooPreciseMsg},
+
+		// beyond int64 range — caught by SDK bounds check
+		{name: "overflow just above int64 max", amount: "922337203685.4775808", wantErrMsg: tooLargeMsg},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.amount, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			gotError := ValidateAmount(tc.amount)
-			assert.Equalf(t, tc.wantErr, gotError, "ValidateAmount(%q) should be %v, but got %v", tc.amount, tc.wantErr, gotError)
+			if tc.wantErrMsg == "" {
+				assert.NoErrorf(t, gotError, "ValidateAmount(%q) should be nil, but got %v", tc.amount, gotError)
+				return
+			}
+			require.Errorf(t, gotError, "ValidateAmount(%q) should error, but got nil", tc.amount)
+			assert.Equalf(t, tc.wantErrMsg, gotError.Error(), "ValidateAmount(%q) error mismatch", tc.amount)
 		})
 	}
 }

--- a/stellar-multitenant/pkg/serve/serve.go
+++ b/stellar-multitenant/pkg/serve/serve.go
@@ -127,6 +127,7 @@ func handleHTTP(opts *ServeOptions) *chi.Mux {
 	mux.Use(chimiddleware.RealIP)
 	mux.Use(supporthttp.LoggingMiddleware)
 	mux.Use(middleware.RecoverHandler)
+	mux.Use(middleware.MaxBodySize(middleware.DefaultMaxRequestBodySize))
 
 	mux.Get("/health", httphandler.HealthHandler{
 		GitCommit: opts.GitCommit,


### PR DESCRIPTION
## Summary

Cherry-picks (and one manual port) of HackerOne / security commits from `develop` that are applicable to `meridian-pay`. 

## Commits

| New commit | Source on develop | What |
|---|---|---|
| `b55a5984` | `ccebd315` | SDP-2017: Bound CSV upload size + paginate `page_limit`/`page` (#1064) — covers HackerOne #3555684 |
| `85fa7442` | `a417f553` | Global 10 MB `MaxBodySize` middleware on SDP + admin servers (#1066) |
| `38065081` | `fb2e71d6` | SDP-1116: Reject over-precision amounts in `utils.ValidateAmount` via Stellar SDK `amount.ParseInt64` (#1116) |
| `3860796a` | `5c697f3d` | SDP-2072: Reject over-precision payment amounts in dispatch; use 7dp / 64-bit float formatting (HackerOne #3683774, #1114) — **manually ported** because meridian-pay still uses `float64` for `Transaction.Amount` (pre-SDP-483) |