### PR TITLE
SDP-2084 doc: update contributing.md with branch naming rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,16 +30,16 @@ Contributions that appear to be made solely for gaining credits or building fake
 
 * Branches follow these naming conventions:
     * `feat/SDP-123-description` for features. `SDP-123` is the ticket/issue number.
-
     * `bugfix/SDP-123-description` for bugs/fixes.
-
     * `chore/SDP-123-description` for general cleanups, continuous improvements, documentation, etc.
-
     * `release/x.x.x` for releases (usually created automatically by CI), e.g. `release/6.4.0`
 
 ### Pull Requests
 
-* **Title:** PR titles start with ticket/issue number (if applicable), feat, fix, refactor, ci, or doc, followed by a short description of the change.
+* **Title:** PR titles contain the following:
+    * ticket/issue number (e.g. `SDP-123`) (if applicable)
+    * `feat`, `fix`, `refactor`, `ci`, `chore` or `doc`
+    * A short description of the change
 * **Branching:** PRs must be opened against the `develop` branch.
 * **Scope:** PRs must be focused and not contain unrelated commits.
 * **Refactoring:** Explicitly differentiate refactoring PRs and feature PRs. Refactoring PRs don’t change functionality. They usually touch a lot more code, and are reviewed in less detail. Avoid refactoring in feature PRs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,17 @@ Contributions that appear to be made solely for gaining credits or building fake
 * Label issues with `bug` if they're clearly a bug.
 * Label issues with `feature request` if they're a feature request.
 
+### Branches
+
+* Branches follow these naming conventions:
+    * `feat/SDP-123-description` for features. `SDP-123` is the jira ticket number.
+
+    * `bugfix/SDP-123-description` for bugs/fixes.  
+
+    * `chore/SDP-123-description` for general cleanups, continuous improvements, documentation, etc.
+
+    * `release/x.x.x` for releases (usually created automatically by CI), e.g. `release/6.4.0` 
+
 ### Pull Requests
 
 * **Title:** PR titles start with feat, fix, refactor, ci, or doc, followed by a short description of the change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,17 +29,17 @@ Contributions that appear to be made solely for gaining credits or building fake
 ### Branches
 
 * Branches follow these naming conventions:
-    * `feat/SDP-123-description` for features. `SDP-123` is the jira ticket number.
+    * `feat/SDP-123-description` for features. `SDP-123` is the Jira ticket number.
 
-    * `bugfix/SDP-123-description` for bugs/fixes.  
+    * `bugfix/SDP-123-description` for bugs/fixes.
 
     * `chore/SDP-123-description` for general cleanups, continuous improvements, documentation, etc.
 
-    * `release/x.x.x` for releases (usually created automatically by CI), e.g. `release/6.4.0` 
+    * `release/x.x.x` for releases (usually created automatically by CI), e.g. `release/6.4.0`
 
 ### Pull Requests
 
-* **Title:** PR titles start with feat, fix, refactor, ci, or doc, followed by a short description of the change.
+* **Title:** PR titles start with Jira ticket number (if applicable), feat, fix, refactor, ci, or doc, followed by a short description of the change.
 * **Branching:** PRs must be opened against the `develop` branch.
 * **Scope:** PRs must be focused and not contain unrelated commits.
 * **Refactoring:** Explicitly differentiate refactoring PRs and feature PRs. Refactoring PRs don’t change functionality. They usually touch a lot more code, and are reviewed in less detail. Avoid refactoring in feature PRs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Contributions that appear to be made solely for gaining credits or building fake
 ### Branches
 
 * Branches follow these naming conventions:
-    * `feat/SDP-123-description` for features. `SDP-123` is the Jira ticket number.
+    * `feat/SDP-123-description` for features. `SDP-123` is the ticket/issue number.
 
     * `bugfix/SDP-123-description` for bugs/fixes.
 
@@ -39,7 +39,7 @@ Contributions that appear to be made solely for gaining credits or building fake
 
 ### Pull Requests
 
-* **Title:** PR titles start with Jira ticket number (if applicable), feat, fix, refactor, ci, or doc, followed by a short description of the change.
+* **Title:** PR titles start with ticket/issue number (if applicable), feat, fix, refactor, ci, or doc, followed by a short description of the change.
 * **Branching:** PRs must be opened against the `develop` branch.
 * **Scope:** PRs must be focused and not contain unrelated commits.
 * **Refactoring:** Explicitly differentiate refactoring PRs and feature PRs. Refactoring PRs don’t change functionality. They usually touch a lot more code, and are reviewed in less detail. Avoid refactoring in feature PRs.


### PR DESCRIPTION
### What

Update contributing.md with branch naming rules and update PR title rules.

### Why

To make branch and PR naming conventions clear and transparent to contributors and to eliminate confusion.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [x] Preview deployment works as expected
- [x] Ready for production