### PR TITLE
SDP-2093 fix: include direct payments in receiver and wallet stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix exclusion of `DIRECT` payments in receiver and wallet stats queries. [#1139](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1139)
+
 ## [6.5.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/6.5.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.4.0...6.5.0))
 
 ### Added

--- a/internal/data/receivers.go
+++ b/internal/data/receivers.go
@@ -214,7 +214,6 @@ func (r *ReceiverModel) GetAll(ctx context.Context, sqlExec db.SQLExecuter, quer
 				COALESCE(SUM(p.amount) FILTER(WHERE p.asset_id = a.id AND p.status = 'SUCCESS'), '0') as received_amount
 			FROM receivers r
 			JOIN payments p ON r.id = p.receiver_id
-			JOIN disbursements d ON p.disbursement_id = d.id
 			JOIN assets a ON a.id = p.asset_id
 			GROUP BY (r.id, a.code, a.issuer)
 		), receiver_stats_aggregate AS (

--- a/internal/data/receivers_test.go
+++ b/internal/data/receivers_test.go
@@ -388,6 +388,67 @@ func Test_ReceiversModel_Get(t *testing.T) {
 		commitErr := dbTx.Commit()
 		require.NoError(t, commitErr)
 	})
+
+	t.Run("counts payments of all types in receiver stats", func(t *testing.T) {
+		DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
+		DeleteAllDisbursementFixtures(t, ctx, dbConnectionPool)
+
+		// Successful DISBURSEMENT payment of 100.
+		disbursement.Name = "disbursement 1"
+		disbursement.Asset = asset
+		d := CreateDisbursementFixture(t, ctx, dbConnectionPool, &disbursementModel, &disbursement)
+
+		payment.Status = SuccessPaymentStatus
+		payment.Disbursement = d
+		payment.Asset = *asset
+		payment.Amount = "100"
+		CreatePaymentFixture(t, ctx, dbConnectionPool, &paymentModel, &payment)
+
+		// Successful DIRECT payment of 200.
+		payment.Status = SuccessPaymentStatus
+		payment.Type = PaymentTypeDirect
+		payment.Disbursement = nil
+		payment.Amount = "200"
+		CreatePaymentFixture(t, ctx, dbConnectionPool, &paymentModel, &payment)
+
+		dbTx, err := dbConnectionPool.BeginTxx(ctx, nil)
+		require.NoError(t, err)
+		// Defer a rollback in case anything fails.
+		defer func() {
+			err = dbTx.Rollback()
+			require.Error(t, err, "not in transaction")
+		}()
+
+		actual, err := receiverModel.Get(ctx, dbTx, receiver.ID)
+		require.NoError(t, err)
+		expected := Receiver{
+			ID:          receiver.ID,
+			ExternalID:  receiver.ExternalID,
+			Email:       receiver.Email,
+			PhoneNumber: receiver.PhoneNumber,
+			CreatedAt:   receiver.CreatedAt,
+			UpdatedAt:   receiver.UpdatedAt,
+			ReceiverStats: ReceiverStats{
+				TotalPayments:      "2",
+				SuccessfulPayments: "2",
+				FailedPayments:     "0",
+				CanceledPayments:   "0",
+				RemainingPayments:  "0",
+				RegisteredWallets:  "0",
+				ReceivedAmounts: []Amount{
+					{
+						AssetCode:      "USDC",
+						AssetIssuer:    "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV",
+						ReceivedAmount: "300.0000000",
+					},
+				},
+			},
+		}
+		assert.Equal(t, expected, *actual)
+
+		err = dbTx.Commit()
+		require.NoError(t, err)
+	})
 }
 
 func Test_ReceiversModel_Count(t *testing.T) {

--- a/internal/data/receivers_wallet.go
+++ b/internal/data/receivers_wallet.go
@@ -141,8 +141,7 @@ func (rw *ReceiverWalletModel) GetWithReceiverIDs(ctx context.Context, sqlExec d
 			a.issuer as asset_issuer,
 			COALESCE(SUM(p.amount) FILTER(WHERE p.asset_id = a.id AND p.status = 'SUCCESS'), '0') as received_amount
 		FROM receiver_wallets_cte rwc
-		JOIN payments p ON rwc.receiver_id = p.receiver_id
-		JOIN disbursements d ON p.disbursement_id = d.id AND rwc.wallet_id = d.wallet_id
+		JOIN payments p ON rwc.id = p.receiver_wallet_id
 		JOIN assets a ON a.id = p.asset_id
 		GROUP BY (rwc.id, a.code, a.issuer)
 	), receiver_wallets_stats_aggregate AS (

--- a/internal/data/receivers_wallet_test.go
+++ b/internal/data/receivers_wallet_test.go
@@ -528,6 +528,93 @@ func Test_ReceiversWalletModelGetWithReceiverId(t *testing.T) {
 		err = dbTx.Commit()
 		require.NoError(t, err)
 	})
+
+	t.Run("attributes payments of all types to correct wallet", func(t *testing.T) {
+		DeleteAllPaymentsFixtures(t, ctx, dbConnectionPool)
+		DeleteAllDisbursementFixtures(t, ctx, dbConnectionPool)
+
+		walletA := CreateWalletFixture(t, ctx, dbConnectionPool, "wallet-A", "https://www.wallet-a.com", "www.wallet-a.com", "wallet-a://")
+		walletB := CreateWalletFixture(t, ctx, dbConnectionPool, "wallet-B", "https://www.wallet-b.com", "www.wallet-b.com", "wallet-b://")
+		rwA := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, walletA.ID, RegisteredReceiversWalletStatus)
+		rwB := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, walletB.ID, RegisteredReceiversWalletStatus)
+
+		// walletA: successful DISBURSEMENT payment of 100 ...
+		disbursement.Name = "disbursement A"
+		disbursement.Wallet = walletA
+		dA := CreateDisbursementFixture(t, ctx, dbConnectionPool, &disbursementModel, &disbursement)
+
+		payment.Status = SuccessPaymentStatus
+		payment.Disbursement = dA
+		payment.Amount = "100"
+		payment.ReceiverWallet = rwA
+		CreatePaymentFixture(t, ctx, dbConnectionPool, &paymentModel, &payment)
+
+		// walletA: successful DIRECT payment of 200
+		payment.Status = SuccessPaymentStatus
+		payment.Type = PaymentTypeDirect
+		payment.Disbursement = nil
+		payment.Amount = "200"
+		payment.ReceiverWallet = rwA
+		CreatePaymentFixture(t, ctx, dbConnectionPool, &paymentModel, &payment)
+
+		// walletB: successful DIRECT payment of 500.
+		payment.Status = SuccessPaymentStatus
+		payment.Disbursement = nil
+		payment.Amount = "500"
+		payment.ReceiverWallet = rwB
+		CreatePaymentFixture(t, ctx, dbConnectionPool, &paymentModel, &payment)
+
+		dbTx, err := dbConnectionPool.BeginTxx(ctx, nil)
+		require.NoError(t, err)
+		// Defer a rollback in case anything fails.
+		defer func() {
+			err = dbTx.Rollback()
+			require.Error(t, err, "not in transaction")
+		}()
+
+		actual, err := receiverWalletModel.GetWithReceiverIDs(ctx, dbTx, ReceiverIDs{receiver.ID})
+		require.NoError(t, err)
+
+		statsByWalletID := make(map[string]ReceiverWalletStats, len(actual))
+		for _, rw := range actual {
+			statsByWalletID[rw.ID] = rw.ReceiverWalletStats
+		}
+
+		// walletA counts both payments (DISBURSEMENT + DIRECT): 2 received, 300 total.
+		assert.Equal(t, ReceiverWalletStats{
+			TotalPayments:     "2",
+			PaymentsReceived:  "2",
+			FailedPayments:    "0",
+			CanceledPayments:  "0",
+			RemainingPayments: "0",
+			ReceivedAmounts: []Amount{
+				{
+					AssetCode:      "USDC",
+					AssetIssuer:    "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV",
+					ReceivedAmount: "300.0000000",
+				},
+			},
+		}, statsByWalletID[rwA.ID])
+
+		// walletB: only its own DIRECT payment
+		assert.Equal(t, ReceiverWalletStats{
+			TotalPayments:     "1",
+			PaymentsReceived:  "1",
+			FailedPayments:    "0",
+			CanceledPayments:  "0",
+			RemainingPayments: "0",
+			ReceivedAmounts: []Amount{
+				{
+					AssetCode:      "USDC",
+					AssetIssuer:    "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV",
+					ReceivedAmount: "500.0000000",
+				},
+			},
+		}, statsByWalletID[rwB.ID])
+
+		err = dbTx.Commit()
+		require.NoError(t, err)
+	})
 }
 
 func Test_GetByReceiverIDAndWalletDomain(t *testing.T) {


### PR DESCRIPTION
### What

Update queries in `receivers.go` and `receivers_wallet.go` to return both payments of type `DISBURSEMENT` and `DIRECT`.

### Why

Receiver/wallet queries were not updated when direct payments were introduced to the SDP. As a result, several user-facing payment stat fields show incorrect / misleading results because they only include payments tied to disbursements; direct payments are excluded. Affected fields are:

* From the query in `receivers.go:204-219`:
  * Receiver Details - top box: `total received`, `total payments`, `successful payments`, `failed payments`, `canceled payments`, `remaining payments` and `successful payment rate` (calculated based on the previous).
  * Receivers - receivers list: `total payments`, `successful`, `amount(s) received` columns
  * Receivers - CSV export 
  * Payment Details - receiver panel: `total payments`, `successful payments` and `amount(s) received`

* From the query in `receivers_wallet.go:132-147`:
  * Receiver Details - wallets section: `total payments received`, and `total amount received`

This is confusing to the user, since it is inconsistent with other areas of the dashboard (like the Home / Analytics dashboard and the balance field in Receiver Details - wallets).

### Known limitations

[N/A]

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
