### PR TITLE
SDP-2097 fix: verify automated release cloudformation version migration

### DIFF
--- a/.github/workflows/automated_release_process.yml
+++ b/.github/workflows/automated_release_process.yml
@@ -62,11 +62,13 @@ jobs:
           sed -i "s/^appVersion: \".*\"/appVersion: \"$VERSION\"/" helmchart/sdp/Chart.yaml
           sed -i "/^  image:/,/^  [a-z]/ { s|^    tag: \".*\"|    tag: \"$VERSION\"| }" helmchart/sdp/values.yaml
           sed -i "s|fullName: stellar/stellar-disbursement-platform-frontend:.*|fullName: stellar/stellar-disbursement-platform-frontend:$VERSION|" helmchart/sdp/values.yaml
-          sed -i "s/^tag: ".*"/tag: \"$VERSION\"/" cloudformation/eks/helm/values-mainnet.yaml
-          sed -i "s/^tag: ".*"/tag: \"$VERSION\"/" cloudformation/eks/helm/values-testnet.yaml
+          sed -i "/^  image:/,/^  [a-z]/ { s|^    tag: \".*\"|    tag: \"$VERSION\"| }" cloudformation/eks/helm/values-mainnet.yaml
+          sed -i "/^  image:/,/^  [a-z]/ { s|^    tag: \".*\"|    tag: \"$VERSION\"| }" cloudformation/eks/helm/values-testnet.yaml
           sed -i "s|fullName: stellar/stellar-disbursement-platform-frontend:.*|fullName: stellar/stellar-disbursement-platform-frontend:$VERSION|" cloudformation/eks/helm/values-mainnet.yaml
           sed -i "s|fullName: stellar/stellar-disbursement-platform-frontend:.*|fullName: stellar/stellar-disbursement-platform-frontend:$VERSION|" cloudformation/eks/helm/values-testnet.yaml
-          git add main.go helmchart/sdp/Chart.yaml helmchart/sdp/values.yaml
+          git add main.go helmchart/sdp/Chart.yaml helmchart/sdp/values.yaml \
+            cloudformation/eks/helm/values-mainnet.yaml \
+            cloudformation/eks/helm/values-testnet.yaml
 
       - name: Collect release metadata
         id: release-meta

--- a/.github/workflows/templates/release-pr-main.md
+++ b/.github/workflows/templates/release-pr-main.md
@@ -8,6 +8,8 @@ The following tasks have been completed automatically by the release workflow:
 - [x] Bump version in helmchart/sdp/Chart.yaml (version and appVersion)
 - [x] Bump backend image tag in helmchart/sdp/values.yaml
 - [x] Bump frontend image tag in helmchart/sdp/values.yaml
+- [x] Bump backend and frontend image tags in cloudformation/eks/helm/values-mainnet.yaml
+- [x] Bump backend and frontend image tags in cloudformation/eks/helm/values-testnet.yaml
 - [x] Update CHANGELOG.md release entry (Unreleased + optional AI gap-fill)
 - [x] Regenerate helmchart/sdp/README.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Verify automated release cloudformation version migration. [#1158](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1158)
+
 ## [6.6.1](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/6.6.1) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.6.0...6.6.1))
 
 ### Fixed


### PR DESCRIPTION
### What

Fix SDP backend and frontend version tag bumps for cloudformation/eks helm values during automated release workflow.

### Why

Automated release workflow excluded the cloudformation/eks values files when committing its version bumps. A fix was attempted in `6.6.0` release, but implementation was broken.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
