### PR TITLE
SDP-2101 fix: speed up test DB setup via template cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Speed up test DB setup via template cloning to end flaky CI timeout [#1160](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1160) 
+
 ## [6.6.1](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/6.6.1) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.6.0...6.6.1))
 
 ### Fixed

--- a/db/dbtest/dbtest.go
+++ b/db/dbtest/dbtest.go
@@ -1,13 +1,27 @@
 package dbtest
 
 import (
+	"database/sql"
+	"fmt"
+	"hash/fnv"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/lib/pq"
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/stellar/go-stellar-sdk/support/db/dbtest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db/migrations"
+)
+
+var (
+	templatesMu sync.Mutex
+	templates   = map[string]string{} // migration set key -> template db name
 )
 
 func OpenWithoutMigrations(t *testing.T) *dbtest.DB {
@@ -20,20 +34,10 @@ func OpenWithoutMigrations(t *testing.T) *dbtest.DB {
 func openWithMigrations(t *testing.T, configs ...migrations.MigrationRouter) *dbtest.DB {
 	t.Helper()
 
-	db := OpenWithoutMigrations(t)
+	db := dbtest.Postgres(t)
 
-	conn := db.Open()
-	defer conn.Close()
-
-	for _, config := range configs {
-		ms := migrate.MigrationSet{TableName: config.TableName}
-		m := migrate.HttpFileSystemMigrationSource{FileSystem: http.FS(config.FS)}
-		_, err := ms.ExecMax(conn.DB, "postgres", m, migrate.Up, 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
+	tmpl := ensureTemplate(t, db.DSN, configs)
+	createFromTemplate(t, db, tmpl)
 	return db
 }
 
@@ -58,4 +62,99 @@ func OpenWithTSSMigrationsOnly(t *testing.T) *dbtest.DB {
 	t.Helper()
 
 	return openWithMigrations(t, migrations.TSSMigrationRouter)
+}
+
+// Builds and caches one migrated template DB per migration set (once per process)
+func ensureTemplate(t *testing.T, refDSN string, configs []migrations.MigrationRouter) string {
+	t.Helper()
+
+	key := routerKey(configs)
+
+	templatesMu.Lock()
+	defer templatesMu.Unlock()
+	if name, ok := templates[key]; ok {
+		return name
+	}
+
+	// PID keeps templates unique across parallel test binaries; hash separates migration set variants within a process.
+	name := fmt.Sprintf("sdp_tmpl_%d_%s", os.Getpid(), key)
+
+	admin := adminConn(t, refDSN)
+	defer admin.Close()
+
+	mustExec(t, admin, "DROP DATABASE IF EXISTS "+pq.QuoteIdentifier(name))
+	mustExec(t, admin, "CREATE DATABASE "+pq.QuoteIdentifier(name))
+
+	pool, err := sql.Open("postgres", withDBName(t, refDSN, name))
+	require.NoError(t, err, "opening template pool")
+	for _, config := range configs {
+		ms := migrate.MigrationSet{TableName: config.TableName}
+		src := migrate.HttpFileSystemMigrationSource{FileSystem: http.FS(config.FS)}
+		if _, err := ms.ExecMax(pool, "postgres", src, migrate.Up, 0); err != nil {
+			_ = pool.Close()
+			require.NoError(t, err, "migrating template")
+		}
+	}
+	require.NoError(t, pool.Close(), "closing template pool")
+
+	mustExec(t, admin, fmt.Sprintf(
+		"ALTER DATABASE %s WITH ALLOW_CONNECTIONS false IS_TEMPLATE true",
+		pq.QuoteIdentifier(name),
+	))
+
+	templates[key] = name
+	return name
+}
+
+// Re-creates the empty database as a fast clone of the template.
+func createFromTemplate(t *testing.T, db *dbtest.DB, tmpl string) {
+	t.Helper()
+
+	target := dbName(t, db.DSN)
+
+	admin := adminConn(t, db.DSN)
+	defer admin.Close()
+
+	mustExec(t, admin, "DROP DATABASE IF EXISTS "+pq.QuoteIdentifier(target))
+	mustExec(t, admin, fmt.Sprintf(
+		"CREATE DATABASE %s TEMPLATE %s",
+		pq.QuoteIdentifier(target), pq.QuoteIdentifier(tmpl),
+	))
+}
+
+func routerKey(configs []migrations.MigrationRouter) string {
+	h := fnv.New32a()
+	for _, c := range configs {
+		h.Write([]byte(c.TableName))
+		h.Write([]byte{0})
+	}
+	return fmt.Sprintf("%08x", h.Sum32())
+}
+
+func adminConn(t *testing.T, refDSN string) *sql.DB {
+	t.Helper()
+	conn, err := sql.Open("postgres", withDBName(t, refDSN, "postgres"))
+	require.NoError(t, err, "opening admin conn")
+	return conn
+}
+
+func withDBName(t *testing.T, dsn, name string) string {
+	t.Helper()
+	u, err := url.Parse(dsn)
+	require.NoError(t, err, "parsing dsn")
+	u.Path = "/" + name
+	return u.String()
+}
+
+func dbName(t *testing.T, dsn string) string {
+	t.Helper()
+	u, err := url.Parse(dsn)
+	require.NoError(t, err, "parsing dsn")
+	return strings.TrimPrefix(u.Path, "/")
+}
+
+func mustExec(t *testing.T, db *sql.DB, query string) {
+	t.Helper()
+	_, err := db.Exec(query)
+	require.NoErrorf(t, err, "exec %q", query)
 }

--- a/db/dbtest/dbtest_test.go
+++ b/db/dbtest/dbtest_test.go
@@ -3,6 +3,7 @@ package dbtest
 import (
 	"testing"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,8 +31,79 @@ func TestOpen(t *testing.T) {
 	require.NoError(t, err)
 	assert.Greater(t, count, 0)
 
-	// Per-tenant Auth Migrations
+	// Per-tenant TSS Migrations
 	err = session.Get(&count, `SELECT COUNT(*) FROM tss_migrations`)
 	require.NoError(t, err)
 	assert.Greater(t, count, 0)
+}
+
+func TestOpenWithAdminMigrationsOnly(t *testing.T) {
+	db := OpenWithAdminMigrationsOnly(t)
+	defer db.Close()
+	session := db.Open()
+	defer session.Close()
+
+	count := 0
+	err := session.Get(&count, `SELECT COUNT(*) FROM admin_migrations`)
+	require.NoError(t, err)
+	assert.Greater(t, count, 0, "admin migrations should be applied")
+
+	assert.False(t, tableExists(t, session, "sdp_migrations"), "sdp migrations should not be applied")
+	assert.False(t, tableExists(t, session, "auth_migrations"), "auth migrations should not be applied")
+	assert.False(t, tableExists(t, session, "tss_migrations"), "tss migrations should not be applied")
+}
+
+func TestOpenWithTSSMigrationsOnly(t *testing.T) {
+	db := OpenWithTSSMigrationsOnly(t)
+	defer db.Close()
+	session := db.Open()
+	defer session.Close()
+
+	count := 0
+	err := session.Get(&count, `SELECT COUNT(*) FROM tss_migrations`)
+	require.NoError(t, err)
+	assert.Greater(t, count, 0, "tss migrations should be applied")
+
+	assert.False(t, tableExists(t, session, "admin_migrations"), "admin migrations should not be applied")
+	assert.False(t, tableExists(t, session, "sdp_migrations"), "sdp migrations should not be applied")
+	assert.False(t, tableExists(t, session, "auth_migrations"), "auth migrations should not be applied")
+}
+
+func TestOpenWithoutMigrations(t *testing.T) {
+	db := OpenWithoutMigrations(t)
+	defer db.Close()
+	session := db.Open()
+	defer session.Close()
+
+	assert.False(t, tableExists(t, session, "admin_migrations"), "no migrations should be applied")
+	assert.False(t, tableExists(t, session, "sdp_migrations"), "no migrations should be applied")
+	assert.False(t, tableExists(t, session, "auth_migrations"), "no migrations should be applied")
+	assert.False(t, tableExists(t, session, "tss_migrations"), "no migrations should be applied")
+}
+
+func TestClonesAreIsolated(t *testing.T) {
+	db1 := Open(t)
+	defer db1.Close()
+	db2 := Open(t)
+	defer db2.Close()
+
+	session1 := db1.Open()
+	defer session1.Close()
+	session2 := db2.Open()
+	defer session2.Close()
+
+	_, err := session1.Exec(`CREATE TABLE isolation_check (id INT)`)
+	require.NoError(t, err)
+
+	assert.True(t, tableExists(t, session1, "isolation_check"), "table should exist in the clone it was created in")
+	assert.False(t, tableExists(t, session2, "isolation_check"), "table must not leak into a sibling clone")
+}
+
+// Reports whether a table is present in the connected database.
+func tableExists(t *testing.T, session *sqlx.DB, table string) bool {
+	t.Helper()
+	var exists bool
+	err := session.Get(&exists, "SELECT to_regclass($1) IS NOT NULL", table)
+	require.NoError(t, err)
+	return exists
 }


### PR DESCRIPTION
### What

Rework `db/dbtest` so that test databases are created by cloning a pre-migrated template instead of replaying every migration for every test.

- On first use within a test binary, build one migrated "template" database per migration-set, then seal it.
- Each test then gets its database via a fast clone (a file-level copy) rather than running ~127 migrations.
- All public entry points (`Open`, `OpenWithAdminMigrationsOnly`, `OpenWithTSSMigrationsOnly`, `OpenWithoutMigrations`) keep identical signatures (no test files changed).

### Why

The `Go test` job was intermittently failing the release pipeline with panic: test timed out after 3m0s in the `internal/data` package. [Example 1](https://github.com/stellar/stellar-disbursement-platform-backend/actions/runs/28123207457/job/83280237733), [Example 2](https://github.com/stellar/stellar-disbursement-platform-backend/actions/runs/25404279344/job/74511408007)

Root cause: `go test` enforces the `-timeout 3m` per package, and `internal/data` was running at ~2m39s (~88%) of the cap. Because every test re-ran the full migration set against one shared Postgres container, ordinary run-to-run variance on the loaded, high-churn server was enough to occasionally push that single package past 3 minutes. The margin has been shrinking gradually as migrations accumulated (84 --> 102 SDP migrations over the past year), which is why the flake grew more frequent rather than appearing suddenly.

Building the schema once and cloning removes the repeated migration cost. Migrations now run once per process, restoring large headroom rather than just raising the timeout.

| Metric | Pre-fix (avg) | Post-fix (avg) | Improvement |
|--------|---------------:|---------------:|------------:|
| `internal/data` package | 2m39s (159s) | 50s | −69% |
| `internal/serve/httphandler` | 2m24s (144.5s) | 47s | −67% |
| Pure test execution (`gotestsum DONE`) | 3m20s (200s) | 113s (1m53s) | −43% |
| Full test job wall-clock | 4m52s (292s) | 2m52s (172s) | −41% |

Pre-fix passed (n=25) / Post-fix (n=4)

### Known limitations

- Migrations still run once per test binary (per process, per migration-set).
- The 3-minute per-package -timeout is unchanged. This fix widens the margin rather than raising the ceiling.
- Local leftover databases. Templates are process-scoped and named `sdp_tmpl_<pid>_<hash>`. CI's ephemeral container discards them automatically, but on a local machine a few `sdp_tmpl_*` databases may linger between runs (harmless; a one-line psql sweep can remove them if desired).

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [x] Ready for production
