### PR TITLE
SDP-2103 fix: migrations only delete Vibrant Assist when it has no receiver wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Migrations only soft-delete Vibrant Assist when it has no receiver wallets [#1162](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1162)
+
+
 ## [6.6.1](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/6.6.1) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.6.0...6.6.1))
 
 ### Fixed

--- a/db/migrations/sdp-migrations/2026-07-03.0-restore-in-use-vibrant-assist-wallet.sql
+++ b/db/migrations/sdp-migrations/2026-07-03.0-restore-in-use-vibrant-assist-wallet.sql
@@ -1,0 +1,16 @@
+-- Restore Vibrant Assist wallet where 2026-01-16.0 soft-deleted it despite >= 1 associated receiver_wallets.
+
+-- +migrate Up
+UPDATE wallets
+SET
+    enabled = TRUE,
+    deleted_at = NULL
+WHERE name = 'Vibrant Assist'
+    AND deleted_at IS NOT NULL
+    AND EXISTS (
+        SELECT 1
+        FROM receiver_wallets
+        WHERE wallet_id = wallets.id
+    );
+
+-- +migrate Down


### PR DESCRIPTION
### What

A new migration is added that restores Vibrant Assist where it has associated `receiver_wallets`. This includes if they are in `REGISTERED` status (in contrast with [#1007](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1007), because it cannot be assumed that an operator upgrading their SDP version in such a case intends to discontinue this wallet).

### Why

The data migration `db/migrations/sdp-migrations/2026-01-16.0-remove-vibrant-assist wallet.sql` (from [#1021](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1021), shipped in `6.1.0`) unconditionally soft-deletes the Vibrant Assist wallet.

This runs for every tenant on upgrade, including tenants that are actively using Vibrant Assist with in flight receiver registrations. It bypasses the safety guard that [#1007](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1007) added to `DELETE /wallets/:id` (which refuses to delete a wallet that has `receiver_wallets` in `DRAFT/READY`), so a wallet with pending registrations gets removed out from under the tenant with no warning.

Once the wallet is soft-deleted (`enabled = FALSE`, `deleted_at` set), a tenant that depended on it is left in a partially broken state that cannot be recovered from the dashboard/API. Recovery currently requires a manual, per-tenant SQL update, which is not something tenants should have to do.

### Known limitations

- This migration resurrects intentionally-retired Vibrant Assist wallets, not only `6.1.0`-deleted ones. Thus, a tenant who deliberately retired Vibrant Assist will have it silently re-enabled. This is a deliberate trade-off: it is preferable that the tenant re-deletes the deprecated wallet from the dashboard, *rather than forcing a tenant still using Vibrant Assist to manually re-enable it via a direct database query*.
- This migration contains an intentionally empty `+migrate Down`. A rollback would reintroduce the problem this migration is intended to solve, as well as soft-delete all in-use Vibrant Assist wallets manually restored since `6.1.0`. 

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production