### PR TITLE
SDP-2104 fix: pin CI cargo-audit install with --locked flag

### DIFF
--- a/.github/workflows/contract_build.yml
+++ b/.github/workflows/contract_build.yml
@@ -35,10 +35,7 @@ jobs:
         uses: stellar/actions/rust-cache@main
 
       - name: Install cargo-audit
-        run: |
-          if ! command -v cargo-audit &> /dev/null; then
-            cargo install cargo-audit
-          fi
+        run: cargo install cargo-audit --locked
 
       - name: Format check
         run: cargo fmt -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Speed up test DB setup via template cloning to end flaky CI timeout [#1160](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1160) 
 - Migrations only soft-delete Vibrant Assist when it has no receiver wallets [#1162](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1162)
 
+### Security and Dependencies
+
+- Pin cargo-audit install in contract build job with --locked flag. [#1171](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1171)
+
 ## [6.6.1](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/6.6.1) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.6.0...6.6.1))
 
 ### Fixed


### PR DESCRIPTION
### What

- Add `--locked` flag to `cargo install cargo-audit`
- Remove `command -v cargo-audit` guard (never fires, `rust-cache` doesn't cache `~/.cargo/bin`).

### Why

`contract_build.yml` runs `cargo install cargo-audit` without `--locked`, so cargo re-resolves `cargo-audit`'s dependencies from [crates.io](http://crates.io/) on every run.

On 2026-07-14, `kstring` 2.0.3 was published with its MSRV raised from 1.73 to 1.96.0. CI is pinned to Rust 1.92.0, so the install now fails:

```bash
error: failed to compile `cargo-audit v0.22.2`
  rustc 1.92.0 is not supported by the following package:
    kstring@2.0.3 requires rustc 1.96.0
```

The job dies at the install step, before fmt/clippy/audit/test run. Since `contract_build` triggers on `pull_request`, every open PR is blocked, including PRs that touch no Rust code.

### Known limitations

- Typical limitation when using `--locked`: reliance on package author updating lockfile in order to ensure up-to-date transitive dependencies. Detection coverage is unaffected: advisory data is always fetched live from RustSec database.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [x] Ready for production
