### PR TITLE
SDP-2110 fix: harden mfa code validation and device trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Verify automated release cloudformation version migration. [#1158](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1158)
 - Speed up test DB setup via template cloning to end flaky CI timeout [#1160](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1160) 
 - Migrations only soft-delete Vibrant Assist when it has no receiver wallets [#1162](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1162)
+- Harden MFA code validation and device trust. [#1177](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1177)
 
 ### Security and Dependencies
 

--- a/db/migrations/auth-migrations/2026-08-07.0-alter-auth_user_mfa_codes-add-attempts-column.sql
+++ b/db/migrations/auth-migrations/2026-08-07.0-alter-auth_user_mfa_codes-add-attempts-column.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE auth_user_mfa_codes
+    ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0;
+
+-- +migrate Down
+ALTER TABLE auth_user_mfa_codes
+    DROP COLUMN attempts;

--- a/db/migrations/auth-migrations/2026-08-07.0-alter-auth_user_mfa_codes-add-attempts-column.sql
+++ b/db/migrations/auth-migrations/2026-08-07.0-alter-auth_user_mfa_codes-add-attempts-column.sql
@@ -2,6 +2,12 @@
 ALTER TABLE auth_user_mfa_codes
     ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0;
 
+-- The primary key is (device_id, auth_user_id), so an auth_user_id-only filter cannot use it.
+-- Index auth_user_id to keep per-user operations bounded.
+CREATE INDEX idx_auth_user_mfa_codes_auth_user_id ON auth_user_mfa_codes (auth_user_id);
+
 -- +migrate Down
+DROP INDEX idx_auth_user_mfa_codes_auth_user_id;
+
 ALTER TABLE auth_user_mfa_codes
     DROP COLUMN attempts;

--- a/internal/serve/httphandler/mfa_handler.go
+++ b/internal/serve/httphandler/mfa_handler.go
@@ -91,9 +91,12 @@ func (h MFAHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// Step 3: Authenticate the user with the MFA code
 	token, err := h.AuthManager.AuthenticateMFA(ctx, deviceID, reqBody.MFACode, reqBody.RememberMe)
 	if err != nil {
-		if errors.Is(err, auth.ErrMFACodeInvalid) {
+		switch {
+		case errors.Is(err, auth.ErrMFACodeInvalid):
 			httperror.Unauthorized("", err, nil).Render(rw)
-		} else {
+		case errors.Is(err, auth.ErrMFAAttemptsExhausted):
+			httperror.Unauthorized("Too many incorrect attempts. Please request a new code using the Resend code option.", err, nil).Render(rw)
+		default:
 			log.Ctx(ctx).Errorf("authenticating user: %s", err.Error())
 			httperror.InternalError(ctx, "Cannot authenticate user", err, nil).Render(rw)
 		}

--- a/internal/serve/httphandler/mfa_handler_test.go
+++ b/internal/serve/httphandler/mfa_handler_test.go
@@ -210,6 +210,23 @@ func Test_MFAHandler_ServeHTTP(t *testing.T) {
 			wantResponseBody: `{"error": "Not authorized."}`,
 		},
 		{
+			name:     "🔴[401] when the MFA attempt limit is exhausted",
+			reqBody:  `{"mfa_code":"123456","recaptcha_token":"token"}`,
+			deviceID: deviceID,
+			prepareMocks: func(t *testing.T, reCAPTCHAValidatorMock *validators.ReCAPTCHAValidatorMock, authManagerMock *auth.AuthManagerMock) {
+				reCAPTCHAValidatorMock.
+					On("IsTokenValid", mock.Anything, "token").
+					Return(true, nil).
+					Once()
+				authManagerMock.
+					On("AuthenticateMFA", mock.Anything, deviceID, "123456", mock.AnythingOfType("bool")).
+					Return("", auth.ErrMFAAttemptsExhausted).
+					Once()
+			},
+			wantStatusCode:   http.StatusUnauthorized,
+			wantResponseBody: `{"error": "Too many incorrect attempts. Please request a new code using the Resend code option."}`,
+		},
+		{
 			name:     "🔴[500] when the MFA validation returns an unexpedted error",
 			reqBody:  `{"mfa_code":"123456","recaptcha_token":"token"}`,
 			deviceID: deviceID,

--- a/internal/serve/httphandler/reset_password_handler_test.go
+++ b/internal/serve/httphandler/reset_password_handler_test.go
@@ -71,8 +71,10 @@ func Test_ResetPasswordHandlerPost(t *testing.T) {
 	const method = "POST"
 
 	authenticatorMock := &auth.AuthenticatorMock{}
+	mfaManagerMock := &auth.MFAManagerMock{}
 	authManager := auth.NewAuthManager(
 		auth.WithCustomAuthenticatorOption(authenticatorMock),
+		auth.WithCustomMFAManagerOption(mfaManagerMock),
 	)
 	pwValidator, err := utils.GetPasswordValidatorInstance()
 	require.NoError(t, err)
@@ -94,6 +96,10 @@ func Test_ResetPasswordHandlerPost(t *testing.T) {
 
 		authenticatorMock.
 			On("ResetPassword", req.Context(), "goodtoken", "!1Az?2By.3Cx").
+			Return("user-id", nil).
+			Once()
+		mfaManagerMock.
+			On("ForgetAllDevices", req.Context(), "user-id").
 			Return(nil).
 			Once()
 
@@ -115,7 +121,7 @@ func Test_ResetPasswordHandlerPost(t *testing.T) {
 
 		authenticatorMock.
 			On("ResetPassword", req.Context(), "badtoken", "!1Az?2By.3Cx").
-			Return(auth.ErrInvalidResetPasswordToken).
+			Return("", auth.ErrInvalidResetPasswordToken).
 			Once()
 
 		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
@@ -138,7 +144,7 @@ func Test_ResetPasswordHandlerPost(t *testing.T) {
 
 		authenticatorMock.
 			On("ResetPassword", req.Context(), "expiredtoken", "!1Az?2By.3Cx").
-			Return(auth.ErrExpiredResetPasswordToken).
+			Return("", auth.ErrExpiredResetPasswordToken).
 			Once()
 
 		http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
@@ -184,4 +190,5 @@ func Test_ResetPasswordHandlerPost(t *testing.T) {
 	})
 
 	authenticatorMock.AssertExpectations(t)
+	mfaManagerMock.AssertExpectations(t)
 }

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -399,16 +399,15 @@ func (am *defaultAuthManager) GetMFACode(ctx context.Context, deviceID, userID s
 }
 
 func (am *defaultAuthManager) AuthenticateMFA(ctx context.Context, deviceID, code string, rememberMe bool) (string, error) {
-	if rememberMe {
-		err := am.mfaManager.RememberDevice(ctx, deviceID, code)
-		if err != nil {
-			return "", fmt.Errorf("error remembering device ID %s: %w", deviceID, err)
-		}
-	}
-
 	userID, err := am.mfaManager.ValidateMFACode(ctx, deviceID, code)
 	if err != nil {
 		return "", fmt.Errorf("error validating MFA code: %w", err)
+	}
+	
+	if rememberMe {
+		if err := am.mfaManager.RememberDevice(ctx, deviceID, userID); err != nil {
+			return "", fmt.Errorf("error remembering device ID %s: %w", deviceID, err)
+		}
 	}
 
 	user, err := am.authenticator.GetUser(ctx, userID)

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -422,7 +422,7 @@ func (am *defaultAuthManager) AuthenticateMFA(ctx context.Context, deviceID, cod
 	}
 
 	if rememberMe {
-		if err := am.mfaManager.RememberDevice(ctx, deviceID, userID); err != nil {
+		if err = am.mfaManager.RememberDevice(ctx, deviceID, userID); err != nil {
 			return "", fmt.Errorf("error remembering device ID %s: %w", deviceID, err)
 		}
 	}

--- a/stellar-auth/pkg/auth/auth.go
+++ b/stellar-auth/pkg/auth/auth.go
@@ -174,6 +174,13 @@ func (am *defaultAuthManager) UpdateUser(ctx context.Context, tokenString, first
 		return fmt.Errorf("error updating user: %w", err)
 	}
 
+	// If the password changed, revoke every remembered device for the user.
+	if password != "" {
+		if err := am.mfaManager.ForgetAllDevices(ctx, user.ID); err != nil {
+			return fmt.Errorf("error forgetting devices after updating user ID %s: %w", user.ID, err)
+		}
+	}
+
 	return nil
 }
 
@@ -192,12 +199,17 @@ func (am *defaultAuthManager) ForgotPassword(ctx context.Context, sqlExec db.SQL
 
 // ResetPassword sets the user's new password using a valid reset token generated in the ForgotPassword flow.
 func (am *defaultAuthManager) ResetPassword(ctx context.Context, resetToken, newPassword string) error {
-	err := am.authenticator.ResetPassword(ctx, resetToken, newPassword)
+	userID, err := am.authenticator.ResetPassword(ctx, resetToken, newPassword)
 	if err != nil {
 		if errors.Is(err, ErrInvalidResetPasswordToken) {
 			return fmt.Errorf("invalid token in auth reset password: %w", err)
 		}
 		return fmt.Errorf("error on reset password: %w", err)
+	}
+
+	// The password changed, so revoke every remembered device for the user.
+	if err := am.mfaManager.ForgetAllDevices(ctx, userID); err != nil {
+		return fmt.Errorf("error forgetting devices after reset password for user ID %s: %w", userID, err)
 	}
 
 	return nil
@@ -221,6 +233,11 @@ func (am *defaultAuthManager) UpdatePassword(ctx context.Context, tokenString, c
 	err = am.authenticator.UpdatePassword(ctx, user, currentPassword, newPassword)
 	if err != nil {
 		return fmt.Errorf("updating password: %w", err)
+	}
+
+	// The password changed, so revoke every remembered device for the user.
+	if err := am.mfaManager.ForgetAllDevices(ctx, user.ID); err != nil {
+		return fmt.Errorf("error forgetting devices after updating password for user ID %s: %w", user.ID, err)
 	}
 
 	return nil
@@ -403,7 +420,7 @@ func (am *defaultAuthManager) AuthenticateMFA(ctx context.Context, deviceID, cod
 	if err != nil {
 		return "", fmt.Errorf("error validating MFA code: %w", err)
 	}
-	
+
 	if rememberMe {
 		if err := am.mfaManager.RememberDevice(ctx, deviceID, userID); err != nil {
 			return "", fmt.Errorf("error remembering device ID %s: %w", deviceID, err)

--- a/stellar-auth/pkg/auth/auth_test.go
+++ b/stellar-auth/pkg/auth/auth_test.go
@@ -1609,6 +1609,25 @@ func Test_AuthManager_AuthenticateMFA(t *testing.T) {
 		mfaManagerMock.AssertExpectations(t)
 	})
 
+	t.Run("returns error and does not remember the device when the attempt limit is exhausted", func(t *testing.T) {
+		mfaManagerMock := &MFAManagerMock{}
+		authManager := NewAuthManager(WithCustomMFAManagerOption(mfaManagerMock))
+
+		mfaManagerMock.
+			On("ValidateMFACode", ctx, deviceID, code).
+			Return("", ErrMFAAttemptsExhausted).
+			Once()
+
+		mfaManagerMock.On("RememberDevice", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+		token, err := authManager.AuthenticateMFA(ctx, deviceID, code, true)
+		require.ErrorIs(t, err, ErrMFAAttemptsExhausted)
+		assert.Empty(t, token)
+
+		mfaManagerMock.AssertNotCalled(t, "RememberDevice", mock.Anything, mock.Anything, mock.Anything)
+		mfaManagerMock.AssertExpectations(t)
+	})
+
 	t.Run("remembers the device only after validation, keyed on the user ID", func(t *testing.T) {
 		mfaManagerMock := &MFAManagerMock{}
 		authenticatorMock := &AuthenticatorMock{}

--- a/stellar-auth/pkg/auth/auth_test.go
+++ b/stellar-auth/pkg/auth/auth_test.go
@@ -669,7 +669,8 @@ func Test_AuthManager_ActivateUser(t *testing.T) {
 func Test_AuthManager_UpdateUser(t *testing.T) {
 	authenticatorMock := &AuthenticatorMock{}
 	jwtManagerMock := &JWTManagerMock{}
-	authManager := NewAuthManager(WithCustomJWTManagerOption(jwtManagerMock), WithCustomAuthenticatorOption(authenticatorMock))
+	mfaManagerMock := &MFAManagerMock{}
+	authManager := NewAuthManager(WithCustomJWTManagerOption(jwtManagerMock), WithCustomAuthenticatorOption(authenticatorMock), WithCustomMFAManagerOption(mfaManagerMock))
 
 	ctx := context.Background()
 
@@ -734,7 +735,7 @@ func Test_AuthManager_UpdateUser(t *testing.T) {
 		assert.EqualError(t, err, "error updating user: unexpected error")
 	})
 
-	t.Run("updates user successfully", func(t *testing.T) {
+	t.Run("updates user and forgets remembered devices when the password changes", func(t *testing.T) {
 		token := "mytoken"
 		userID := "user-id"
 		firstName, lastName, email, password := "First", "Last", "email@email.com", "mysecret"
@@ -751,11 +752,43 @@ func Test_AuthManager_UpdateUser(t *testing.T) {
 			On("UpdateUser", ctx, userID, firstName, lastName, email, password).
 			Return(nil).
 			Once()
+		mfaManagerMock.
+			On("ForgetAllDevices", ctx, userID).
+			Return(nil).
+			Once()
 
 		err := authManager.UpdateUser(ctx, token, "First", "Last", "email@email.com", "mysecret")
 
 		assert.Nil(t, err)
 	})
+
+	t.Run("does not forget remembered devices when the password is unchanged", func(t *testing.T) {
+		token := "mytoken"
+		userID := "profile-only-user-id"
+		firstName, lastName, email := "First", "Last", "email@email.com"
+
+		jwtManagerMock.
+			On("ValidateToken", ctx, token).
+			Return(true, nil).
+			Once().
+			On("GetUserFromToken", ctx, token).
+			Return(&User{ID: userID}, nil).
+			Once()
+
+		authenticatorMock.
+			On("UpdateUser", ctx, userID, firstName, lastName, email, "").
+			Return(nil).
+			Once()
+
+		err := authManager.UpdateUser(ctx, token, "First", "Last", "email@email.com", "")
+
+		assert.Nil(t, err)
+		mfaManagerMock.AssertNotCalled(t, "ForgetAllDevices", ctx, userID)
+	})
+
+	jwtManagerMock.AssertExpectations(t)
+	authenticatorMock.AssertExpectations(t)
+	mfaManagerMock.AssertExpectations(t)
 }
 
 func Test_AuthManager_DeactivateUser(t *testing.T) {
@@ -957,8 +990,10 @@ func Test_AuthManager_ForgotPassword(t *testing.T) {
 
 func Test_AuthManager_ResetPassword(t *testing.T) {
 	authenticatorMock := &AuthenticatorMock{}
+	mfaManagerMock := &MFAManagerMock{}
 	authManager := NewAuthManager(
 		WithCustomAuthenticatorOption(authenticatorMock),
+		WithCustomMFAManagerOption(mfaManagerMock),
 	)
 
 	ctx := context.Background()
@@ -966,7 +1001,7 @@ func Test_AuthManager_ResetPassword(t *testing.T) {
 	t.Run("returns error when the reset token is invalid", func(t *testing.T) {
 		authenticatorMock.
 			On("ResetPassword", ctx, "invalidToken", "password123").
-			Return(ErrInvalidResetPasswordToken).
+			Return("", ErrInvalidResetPasswordToken).
 			Once()
 
 		err := authManager.ResetPassword(ctx, "invalidToken", "password123")
@@ -976,16 +1011,34 @@ func Test_AuthManager_ResetPassword(t *testing.T) {
 	t.Run("returns error when authenticator fails", func(t *testing.T) {
 		authenticatorMock.
 			On("ResetPassword", ctx, "validToken", "password123").
-			Return(errUnexpectedError).
+			Return("", errUnexpectedError).
 			Once()
 
 		err := authManager.ResetPassword(ctx, "validToken", "password123")
 		assert.EqualError(t, err, "error on reset password: unexpected error")
 	})
 
+	t.Run("returns error when forgetting devices fails", func(t *testing.T) {
+		authenticatorMock.
+			On("ResetPassword", ctx, "goodtoken", "password123").
+			Return("user-id", nil).
+			Once()
+		mfaManagerMock.
+			On("ForgetAllDevices", ctx, "user-id").
+			Return(errUnexpectedError).
+			Once()
+
+		err := authManager.ResetPassword(ctx, "goodtoken", "password123")
+		assert.EqualError(t, err, "error forgetting devices after reset password for user ID user-id: unexpected error")
+	})
+
 	t.Run("no error with a valid reset token", func(t *testing.T) {
 		authenticatorMock.
 			On("ResetPassword", ctx, "goodtoken", "password123").
+			Return("user-id", nil).
+			Once()
+		mfaManagerMock.
+			On("ForgetAllDevices", ctx, "user-id").
 			Return(nil).
 			Once()
 
@@ -994,12 +1047,14 @@ func Test_AuthManager_ResetPassword(t *testing.T) {
 	})
 
 	authenticatorMock.AssertExpectations(t)
+	mfaManagerMock.AssertExpectations(t)
 }
 
 func Test_AuthManager_UpdatePassword(t *testing.T) {
 	authenticatorMock := &AuthenticatorMock{}
 	jwtManagerMock := &JWTManagerMock{}
-	authManager := NewAuthManager(WithCustomJWTManagerOption(jwtManagerMock), WithCustomAuthenticatorOption(authenticatorMock))
+	mfaManagerMock := &MFAManagerMock{}
+	authManager := NewAuthManager(WithCustomJWTManagerOption(jwtManagerMock), WithCustomAuthenticatorOption(authenticatorMock), WithCustomMFAManagerOption(mfaManagerMock))
 
 	ctx := context.Background()
 
@@ -1090,11 +1145,42 @@ func Test_AuthManager_UpdatePassword(t *testing.T) {
 			On("UpdatePassword", ctx, user, "currentpassword", "newpassword").
 			Return(nil).
 			Once()
+		mfaManagerMock.
+			On("ForgetAllDevices", ctx, user.ID).
+			Return(nil).
+			Once()
 
 		err := authManager.UpdatePassword(ctx, "token", "currentpassword", "newpassword")
 
 		assert.Nil(t, err)
 	})
+
+	t.Run("returns error when forgetting devices fails", func(t *testing.T) {
+		jwtManagerMock.
+			On("ValidateToken", ctx, "token").
+			Return(true, nil).
+			Once().
+			On("GetUserFromToken", ctx, "token").
+			Return(user, nil).
+			Once()
+
+		authenticatorMock.
+			On("UpdatePassword", ctx, user, "currentpassword", "newpassword").
+			Return(nil).
+			Once()
+		mfaManagerMock.
+			On("ForgetAllDevices", ctx, user.ID).
+			Return(errUnexpectedError).
+			Once()
+
+		err := authManager.UpdatePassword(ctx, "token", "currentpassword", "newpassword")
+
+		assert.EqualError(t, err, "error forgetting devices after updating password for user ID user-id: unexpected error")
+	})
+
+	jwtManagerMock.AssertExpectations(t)
+	authenticatorMock.AssertExpectations(t)
+	mfaManagerMock.AssertExpectations(t)
 }
 
 func Test_AuthManager_GetAllUsers(t *testing.T) {

--- a/stellar-auth/pkg/auth/auth_test.go
+++ b/stellar-auth/pkg/auth/auth_test.go
@@ -1499,3 +1499,110 @@ func Test_AuthManager_GetUserID(t *testing.T) {
 	jwtManagerMock.AssertExpectations(t)
 	roleManagerMock.AssertExpectations(t)
 }
+
+func Test_AuthManager_AuthenticateMFA(t *testing.T) {
+	ctx := context.Background()
+	deviceID, code := "device-id", "123456"
+
+	t.Run("returns error and does not remember the device when the code is invalid", func(t *testing.T) {
+		mfaManagerMock := &MFAManagerMock{}
+		authManager := NewAuthManager(WithCustomMFAManagerOption(mfaManagerMock))
+
+		mfaManagerMock.
+			On("ValidateMFACode", ctx, deviceID, code).
+			Return("", ErrMFACodeInvalid).
+			Once()
+
+		mfaManagerMock.On("RememberDevice", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+		token, err := authManager.AuthenticateMFA(ctx, deviceID, code, true)
+		require.ErrorIs(t, err, ErrMFACodeInvalid)
+		assert.Empty(t, token)
+
+		mfaManagerMock.AssertNotCalled(t, "RememberDevice", mock.Anything, mock.Anything, mock.Anything)
+		mfaManagerMock.AssertExpectations(t)
+	})
+
+	t.Run("remembers the device only after validation, keyed on the user ID", func(t *testing.T) {
+		mfaManagerMock := &MFAManagerMock{}
+		authenticatorMock := &AuthenticatorMock{}
+		jwtManagerMock := &JWTManagerMock{}
+		roleManagerMock := &RoleManagerMock{}
+		authManager := NewAuthManager(
+			WithCustomMFAManagerOption(mfaManagerMock),
+			WithCustomAuthenticatorOption(authenticatorMock),
+			WithCustomJWTManagerOption(jwtManagerMock),
+			WithCustomRoleManagerOption(roleManagerMock),
+		)
+
+		userID := "user-id"
+		user := &User{ID: userID, Email: "email@email.com"}
+		roles := []string{"role1"}
+		expectedUser := &User{ID: userID, Email: "email@email.com", Roles: roles}
+		expectedToken := "mytoken"
+
+		validateCall := mfaManagerMock.
+			On("ValidateMFACode", ctx, deviceID, code).
+			Return(userID, nil).
+			Once()
+		rememberCall := mfaManagerMock.
+			On("RememberDevice", ctx, deviceID, userID).
+			Return(nil).
+			Once()
+		mock.InOrder(validateCall, rememberCall)
+
+		authenticatorMock.On("GetUser", ctx, userID).Return(user, nil).Once()
+		roleManagerMock.On("GetUserRoles", ctx, user).Return(roles, nil).Once()
+		jwtManagerMock.
+			On("GenerateToken", ctx, expectedUser, mock.AnythingOfType("time.Time")).
+			Return(expectedToken, nil).
+			Once()
+
+		token, err := authManager.AuthenticateMFA(ctx, deviceID, code, true)
+		require.NoError(t, err)
+		assert.Equal(t, expectedToken, token)
+
+		mfaManagerMock.AssertExpectations(t)
+		authenticatorMock.AssertExpectations(t)
+		jwtManagerMock.AssertExpectations(t)
+		roleManagerMock.AssertExpectations(t)
+	})
+
+	t.Run("does not remember the device when rememberMe is false", func(t *testing.T) {
+		mfaManagerMock := &MFAManagerMock{}
+		authenticatorMock := &AuthenticatorMock{}
+		jwtManagerMock := &JWTManagerMock{}
+		roleManagerMock := &RoleManagerMock{}
+		authManager := NewAuthManager(
+			WithCustomMFAManagerOption(mfaManagerMock),
+			WithCustomAuthenticatorOption(authenticatorMock),
+			WithCustomJWTManagerOption(jwtManagerMock),
+			WithCustomRoleManagerOption(roleManagerMock),
+		)
+
+		userID := "user-id"
+		user := &User{ID: userID, Email: "email@email.com"}
+		roles := []string{"role1"}
+		expectedUser := &User{ID: userID, Email: "email@email.com", Roles: roles}
+		expectedToken := "mytoken"
+
+		mfaManagerMock.On("ValidateMFACode", ctx, deviceID, code).Return(userID, nil).Once()
+		mfaManagerMock.On("RememberDevice", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		authenticatorMock.On("GetUser", ctx, userID).Return(user, nil).Once()
+		roleManagerMock.On("GetUserRoles", ctx, user).Return(roles, nil).Once()
+		jwtManagerMock.
+			On("GenerateToken", ctx, expectedUser, mock.AnythingOfType("time.Time")).
+			Return(expectedToken, nil).
+			Once()
+
+		token, err := authManager.AuthenticateMFA(ctx, deviceID, code, false)
+		require.NoError(t, err)
+		assert.Equal(t, expectedToken, token)
+
+		mfaManagerMock.AssertNotCalled(t, "RememberDevice", mock.Anything, mock.Anything, mock.Anything)
+		mfaManagerMock.AssertExpectations(t)
+		authenticatorMock.AssertExpectations(t)
+		jwtManagerMock.AssertExpectations(t)
+		roleManagerMock.AssertExpectations(t)
+	})
+}

--- a/stellar-auth/pkg/auth/authenticator.go
+++ b/stellar-auth/pkg/auth/authenticator.go
@@ -38,7 +38,8 @@ type Authenticator interface {
 	ActivateUser(ctx context.Context, userID string) error
 	DeactivateUser(ctx context.Context, userID string) error
 	ForgotPassword(ctx context.Context, sqlExec db.SQLExecuter, email string) (string, error)
-	ResetPassword(ctx context.Context, resetToken, password string) error
+	// ResetPassword sets a new password from a valid reset token and returns the ID of the user whose password was changed.
+	ResetPassword(ctx context.Context, resetToken, password string) (string, error)
 	UpdatePassword(ctx context.Context, user *User, currentPassword, newPassword string) error
 	GetAllUsers(ctx context.Context) ([]User, error)
 	GetUser(ctx context.Context, userID string) (*User, error)
@@ -311,8 +312,8 @@ func (a *defaultAuthenticator) ForgotPassword(ctx context.Context, sqlExec db.SQ
 	return resetToken, nil
 }
 
-func (a *defaultAuthenticator) ResetPassword(ctx context.Context, resetToken, password string) error {
-	return db.RunInTransaction(ctx, a.dbConnectionPool, nil, func(dbTx db.DBTransaction) error {
+func (a *defaultAuthenticator) ResetPassword(ctx context.Context, resetToken, password string) (string, error) {
+	return db.RunInTransactionWithResult(ctx, a.dbConnectionPool, nil, func(dbTx db.DBTransaction) (string, error) {
 		query := `
 			SELECT
 				auth_user_id, created_at
@@ -331,33 +332,33 @@ func (a *defaultAuthenticator) ResetPassword(ctx context.Context, resetToken, pa
 		err := dbTx.GetContext(ctx, &aupr, query, resetToken)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return ErrInvalidResetPasswordToken
+				return "", ErrInvalidResetPasswordToken
 			}
-			return fmt.Errorf("error searching password reset token for user in database: %w", err)
+			return "", fmt.Errorf("error searching password reset token for user in database: %w", err)
 		}
 
 		// Token is only valid for 20 minutes
 		if aupr.CreatedAt.Add(time.Minute * 20).Before(time.Now()) {
-			return ErrExpiredResetPasswordToken
+			return "", ErrExpiredResetPasswordToken
 		}
 
 		encryptedPassword, err := a.passwordEncrypter.Encrypt(ctx, password)
 		if err != nil {
-			return fmt.Errorf("error trying to encrypt user password: %w", err)
+			return "", fmt.Errorf("error trying to encrypt user password: %w", err)
 		}
 
 		query = `UPDATE auth_users SET encrypted_password = $1 WHERE id = $2`
 		_, err = dbTx.ExecContext(ctx, query, encryptedPassword, aupr.UserID)
 		if err != nil {
-			return fmt.Errorf("error reseting user password in the database: %w", err)
+			return "", fmt.Errorf("error reseting user password in the database: %w", err)
 		}
 
 		err = a.invalidateResetPasswordToken(ctx, dbTx, resetToken)
 		if err != nil {
-			return fmt.Errorf("error invalidating reset password token: %w", err)
+			return "", fmt.Errorf("error invalidating reset password token: %w", err)
 		}
 
-		return nil
+		return aupr.UserID, nil
 	})
 }
 

--- a/stellar-auth/pkg/auth/authenticator_test.go
+++ b/stellar-auth/pkg/auth/authenticator_test.go
@@ -482,12 +482,12 @@ func Test_DefaultAuthenticator_ResetPassword(t *testing.T) {
 		randUser := CreateRandomAuthUserFixture(t, ctx, dbConnectionPool, passwordEncrypterMock, false)
 		token := CreateResetPasswordTokenFixture(t, ctx, dbConnectionPool, randUser, true, time.Now())
 
-		err := authenticator.ResetPassword(ctx, token, newPassword)
+		_, err := authenticator.ResetPassword(ctx, token, newPassword)
 		assert.ErrorContains(t, err, "error trying to encrypt user password: unexpected error")
 	})
 
 	t.Run("Should treat a not found token error", func(t *testing.T) {
-		err := authenticator.ResetPassword(ctx, "notfoundtoken", "newpassword")
+		_, err := authenticator.ResetPassword(ctx, "notfoundtoken", "newpassword")
 		assert.ErrorIs(t, err, ErrInvalidResetPasswordToken)
 	})
 
@@ -507,8 +507,9 @@ func Test_DefaultAuthenticator_ResetPassword(t *testing.T) {
 		randUser := CreateRandomAuthUserFixture(t, ctx, dbConnectionPool, passwordEncrypterMock, false)
 		token := CreateResetPasswordTokenFixture(t, ctx, dbConnectionPool, randUser, true, time.Now())
 
-		err := authenticator.ResetPassword(ctx, token, newPassword)
+		userID, err := authenticator.ResetPassword(ctx, token, newPassword)
 		require.NoError(t, err)
+		assert.Equal(t, randUser.ID, userID)
 
 		// Token should be invalid after
 		var dbIsValid bool
@@ -537,7 +538,7 @@ func Test_DefaultAuthenticator_ResetPassword(t *testing.T) {
 		randUser := CreateRandomAuthUserFixture(t, ctx, dbConnectionPool, passwordEncrypterMock, false)
 		token := CreateResetPasswordTokenFixture(t, ctx, dbConnectionPool, randUser, true, time.Now().Add(-time.Hour*25))
 
-		err := authenticator.ResetPassword(ctx, token, newPassword)
+		_, err := authenticator.ResetPassword(ctx, token, newPassword)
 		require.ErrorIs(t, err, ErrExpiredResetPasswordToken)
 	})
 

--- a/stellar-auth/pkg/auth/manager.go
+++ b/stellar-auth/pkg/auth/manager.go
@@ -132,3 +132,9 @@ func WithDefaultMFAManagerOption(dbConnectionPool db.DBConnectionPool) AuthManag
 		am.mfaManager = newDefaultMFAManager(withMFADatabaseConnectionPool(dbConnectionPool))
 	}
 }
+
+func WithCustomMFAManagerOption(mfaManager MFAManager) AuthManagerOption {
+	return func(am *defaultAuthManager) {
+		am.mfaManager = mfaManager
+	}
+}

--- a/stellar-auth/pkg/auth/mfa_manager.go
+++ b/stellar-auth/pkg/auth/mfa_manager.go
@@ -19,6 +19,7 @@ type MFAManager interface {
 	GenerateMFACode(ctx context.Context, deviceID, userID string) (string, error)
 	ValidateMFACode(ctx context.Context, deviceID, code string) (string, error)
 	RememberDevice(ctx context.Context, deviceID, userID string) error
+	ForgetAllDevices(ctx context.Context, userID string) error
 }
 
 // defaultMFAManager
@@ -143,6 +144,25 @@ func (m *defaultMFAManager) ForgetDevice(ctx context.Context, deviceID, userID s
 	_, err := m.dbConnectionPool.ExecContext(ctx, query, deviceID, userID)
 	if err != nil {
 		return fmt.Errorf("error expiring device for device ID %s and user ID %s: %w", deviceID, userID, err)
+	}
+	return nil
+}
+
+// ForgetAllDevices expires every remembered device for the user, revoking all
+// trusted "remember me" sessions. It is used when the user's password changes.
+func (m *defaultMFAManager) ForgetAllDevices(ctx context.Context, userID string) error {
+	if userID == "" {
+		return fmt.Errorf("user ID is required")
+	}
+
+	const query = `
+		UPDATE auth_user_mfa_codes
+		SET device_expires_at = null
+		WHERE auth_user_id = $1
+	`
+	_, err := m.dbConnectionPool.ExecContext(ctx, query, userID)
+	if err != nil {
+		return fmt.Errorf("error expiring all devices for user ID %s: %w", userID, err)
 	}
 	return nil
 }

--- a/stellar-auth/pkg/auth/mfa_manager.go
+++ b/stellar-auth/pkg/auth/mfa_manager.go
@@ -18,7 +18,7 @@ type MFAManager interface {
 	MFADeviceRemembered(ctx context.Context, deviceID, userID string) (bool, error)
 	GenerateMFACode(ctx context.Context, deviceID, userID string) (string, error)
 	ValidateMFACode(ctx context.Context, deviceID, code string) (string, error)
-	RememberDevice(ctx context.Context, deviceID, code string) error
+	RememberDevice(ctx context.Context, deviceID, userID string) error
 }
 
 // defaultMFAManager
@@ -121,10 +121,10 @@ func (m *defaultMFAManager) ValidateMFACode(ctx context.Context, deviceID, code 
 }
 
 // RememberDevice updates the device expiry for the device.
-func (m *defaultMFAManager) RememberDevice(ctx context.Context, deviceID, code string) error {
-	err := m.resetDeviceExpiry(ctx, deviceID, code)
+func (m *defaultMFAManager) RememberDevice(ctx context.Context, deviceID, userID string) error {
+	err := m.resetDeviceExpiry(ctx, deviceID, userID)
 	if err != nil {
-		return fmt.Errorf("error updating device expiry for device ID %s and code %s: %w", deviceID, code, err)
+		return fmt.Errorf("error updating device expiry for device ID %s and user ID %s: %w", deviceID, userID, err)
 	}
 	return nil
 }
@@ -239,18 +239,18 @@ func (m *defaultMFAManager) upsertMFACode(ctx context.Context, deviceID, userID,
 }
 
 // resetDeviceExpiry resets the device expiry for the user and device.
-func (m *defaultMFAManager) resetDeviceExpiry(ctx context.Context, deviceID, code string) error {
-	if deviceID == "" || code == "" {
-		return fmt.Errorf("device ID and code are required")
+func (m *defaultMFAManager) resetDeviceExpiry(ctx context.Context, deviceID, userID string) error {
+	if deviceID == "" || userID == "" {
+		return fmt.Errorf("device ID and user ID are required")
 	}
 	const query = `
-		UPDATE auth_user_mfa_codes 
-		SET device_expires_at = $1 
-		WHERE device_id = $2 AND code = $3
+		UPDATE auth_user_mfa_codes
+		SET device_expires_at = $1
+		WHERE device_id = $2 AND auth_user_id = $3
 	`
-	_, err := m.dbConnectionPool.ExecContext(ctx, query, time.Now().Add(mfaDeviceExpiryHours), deviceID, code)
+	_, err := m.dbConnectionPool.ExecContext(ctx, query, time.Now().Add(mfaDeviceExpiryHours), deviceID, userID)
 	if err != nil {
-		return fmt.Errorf("error updating device expiry for device ID %s and code %s: %w", deviceID, code, err)
+		return fmt.Errorf("error updating device expiry for device ID %s and user ID %s: %w", deviceID, userID, err)
 	}
 	return nil
 }

--- a/stellar-auth/pkg/auth/mfa_manager.go
+++ b/stellar-auth/pkg/auth/mfa_manager.go
@@ -195,7 +195,8 @@ func (m *defaultMFAManager) ForgetAllDevices(ctx context.Context, userID string)
 
 // registerFailedMFAAttempt increments the failed-attempt counter for the device's live MFA
 // code and reports whether the per-device attempt cap has now been reached. It is a no-op
-// (returns false) when the device has no live code to count against.
+// (returns false) when the device has no unexpired code to count against, so guesses against
+// an already-expired code (which can never succeed) do not push the user toward a lockout.
 func (m *defaultMFAManager) registerFailedMFAAttempt(ctx context.Context, deviceID string) (bool, error) {
 	if deviceID == "" {
 		return false, fmt.Errorf("device ID is required")
@@ -204,7 +205,7 @@ func (m *defaultMFAManager) registerFailedMFAAttempt(ctx context.Context, device
 		WITH updated AS (
 			UPDATE auth_user_mfa_codes
 			SET attempts = attempts + 1
-			WHERE device_id = $1 AND code_expires_at IS NOT NULL
+			WHERE device_id = $1 AND code_expires_at > NOW()
 			RETURNING attempts
 		)
 		SELECT COALESCE(MAX(attempts), 0) FROM updated

--- a/stellar-auth/pkg/auth/mfa_manager.go
+++ b/stellar-auth/pkg/auth/mfa_manager.go
@@ -105,33 +105,31 @@ func (m *defaultMFAManager) GenerateMFACode(ctx context.Context, deviceID, userI
 // Each failed validation increments a per-device counter; once mfaMaxValidationAttempts is
 // reached the device is locked out (ErrMFAAttemptsExhausted) until a new code is issued.
 func (m *defaultMFAManager) ValidateMFACode(ctx context.Context, deviceID, code string) (string, error) {
-	return db.RunInTransactionWithResult(ctx, m.dbConnectionPool, nil, func(dbTx db.DBTransaction) (string, error) {
-		mc, err := m.getByDeviceAndCode(ctx, deviceID, code)
+	mc, err := m.getByDeviceAndCode(ctx, deviceID, code)
+	if err != nil {
+		if errors.Is(err, ErrMFANoCodeForUserDevice) {
+			// The submitted code matches no pending code for the device. Count the failed
+			// attempt against the device's live code and lock out once the cap is reached.
+			return "", m.failValidation(ctx, deviceID)
+		}
+		return "", fmt.Errorf("error validating MFA code for device ID %s: %w", deviceID, err)
+	}
+
+	// The device is already locked out: reject even a correct code until a new one is issued.
+	if mc.Attempts >= mfaMaxValidationAttempts {
+		return "", ErrMFAAttemptsExhausted
+	}
+
+	if mc.Code == code && mc.CodeExpiresAt != nil && mc.CodeExpiresAt.After(time.Now()) {
+		err = m.expireMFACode(ctx, deviceID, code)
 		if err != nil {
-			if errors.Is(err, ErrMFANoCodeForUserDevice) {
-				// The submitted code matches no pending code for the device. Count the failed
-				// attempt against the device's live code and lock out once the cap is reached.
-				return "", m.failValidation(ctx, deviceID)
-			}
-			return "", fmt.Errorf("error validating MFA code for device ID %s: %w", deviceID, err)
+			return "", fmt.Errorf("error expiring MFA code for device ID %s and code %s: %w", deviceID, code, err)
 		}
+		return mc.UserID, nil
+	}
 
-		// The device is already locked out: reject even a correct code until a new one is issued.
-		if mc.Attempts >= mfaMaxValidationAttempts {
-			return "", ErrMFAAttemptsExhausted
-		}
-
-		if mc.Code == code && mc.CodeExpiresAt != nil && mc.CodeExpiresAt.After(time.Now()) {
-			err = m.expireMFACode(ctx, deviceID, code)
-			if err != nil {
-				return "", fmt.Errorf("error expiring MFA code for device ID %s and code %s: %w", deviceID, code, err)
-			}
-			return mc.UserID, nil
-		}
-
-		// The code matched a row but was expired: count it as a failed attempt too.
-		return "", m.failValidation(ctx, deviceID)
-	})
+	// The code matched a row but was expired: count it as a failed attempt too.
+	return "", m.failValidation(ctx, deviceID)
 }
 
 // failValidation records a failed MFA validation for the device and returns the error to
@@ -194,25 +192,24 @@ func (m *defaultMFAManager) ForgetAllDevices(ctx context.Context, userID string)
 }
 
 // registerFailedMFAAttempt increments the failed-attempt counter for the device's live MFA
-// code and reports whether the per-device attempt cap has now been reached. It is a no-op
-// (returns false) when the device has no unexpired code to count against, so guesses against
-// an already-expired code (which can never succeed) do not push the user toward a lockout.
+// code and reports whether the per-device attempt cap has now been reached.
 func (m *defaultMFAManager) registerFailedMFAAttempt(ctx context.Context, deviceID string) (bool, error) {
 	if deviceID == "" {
 		return false, fmt.Errorf("device ID is required")
 	}
 	const query = `
-		WITH updated AS (
-			UPDATE auth_user_mfa_codes
-			SET attempts = attempts + 1
-			WHERE device_id = $1 AND code_expires_at > NOW()
-			RETURNING attempts
-		)
-		SELECT COALESCE(MAX(attempts), 0) FROM updated
+		UPDATE auth_user_mfa_codes
+		SET attempts = LEAST(attempts + 1, $2)
+		WHERE device_id = $1 AND code_expires_at > NOW()
+		RETURNING attempts
 	`
 	var attempts int
-	err := m.dbConnectionPool.GetContext(ctx, &attempts, query, deviceID)
+	err := m.dbConnectionPool.GetContext(ctx, &attempts, query, deviceID, mfaMaxValidationAttempts)
 	if err != nil {
+		// No live code matched (expired or absent): nothing to count against, not a lockout.
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
 		return false, fmt.Errorf("error registering failed MFA attempt for device ID %s: %w", deviceID, err)
 	}
 	return attempts >= mfaMaxValidationAttempts, nil

--- a/stellar-auth/pkg/auth/mfa_manager.go
+++ b/stellar-auth/pkg/auth/mfa_manager.go
@@ -28,14 +28,16 @@ type defaultMFAManager struct {
 }
 
 const (
-	mfaCodeMaxLength     = 6
-	mfaDeviceExpiryHours = time.Hour * 24 * 7 // 7 days
-	mfaCodeExpiryMinutes = time.Minute * 5    // 5 minutes
+	mfaCodeMaxLength         = 6
+	mfaDeviceExpiryHours     = time.Hour * 24 * 7 // 7 days
+	mfaCodeExpiryMinutes     = time.Minute * 5    // 5 minutes
+	mfaMaxValidationAttempts = 5                  // failed validations allowed per device before a new code is required
 )
 
 var (
 	ErrMFACodeInvalid         = errors.New("MFA code is invalid")
 	ErrMFANoCodeForUserDevice = errors.New("no MFA code for user and device")
+	ErrMFAAttemptsExhausted   = errors.New("too many incorrect MFA code attempts")
 )
 
 type mfaCode struct {
@@ -44,6 +46,7 @@ type mfaCode struct {
 	Code            string     `db:"code"`
 	DeviceExpiresAt *time.Time `db:"device_expires_at"`
 	CodeExpiresAt   *time.Time `db:"code_expires_at"`
+	Attempts        int        `db:"attempts"`
 }
 
 // MFADeviceRemembered checks if the device is remembered for the user.
@@ -99,17 +102,26 @@ func (m *defaultMFAManager) GenerateMFACode(ctx context.Context, deviceID, userI
 }
 
 // ValidateMFACode checks if the MFA code is valid for the device ID and returns the user ID.
+// Each failed validation increments a per-device counter; once mfaMaxValidationAttempts is
+// reached the device is locked out (ErrMFAAttemptsExhausted) until a new code is issued.
 func (m *defaultMFAManager) ValidateMFACode(ctx context.Context, deviceID, code string) (string, error) {
 	return db.RunInTransactionWithResult(ctx, m.dbConnectionPool, nil, func(dbTx db.DBTransaction) (string, error) {
 		mc, err := m.getByDeviceAndCode(ctx, deviceID, code)
 		if err != nil {
 			if errors.Is(err, ErrMFANoCodeForUserDevice) {
-				return "", ErrMFACodeInvalid
+				// The submitted code matches no pending code for the device. Count the failed
+				// attempt against the device's live code and lock out once the cap is reached.
+				return "", m.failValidation(ctx, deviceID)
 			}
 			return "", fmt.Errorf("error validating MFA code for device ID %s: %w", deviceID, err)
 		}
 
-		if mc != nil && mc.Code == code && mc.CodeExpiresAt != nil && mc.CodeExpiresAt.After(time.Now()) {
+		// The device is already locked out: reject even a correct code until a new one is issued.
+		if mc.Attempts >= mfaMaxValidationAttempts {
+			return "", ErrMFAAttemptsExhausted
+		}
+
+		if mc.Code == code && mc.CodeExpiresAt != nil && mc.CodeExpiresAt.After(time.Now()) {
 			err = m.expireMFACode(ctx, deviceID, code)
 			if err != nil {
 				return "", fmt.Errorf("error expiring MFA code for device ID %s and code %s: %w", deviceID, code, err)
@@ -117,8 +129,22 @@ func (m *defaultMFAManager) ValidateMFACode(ctx context.Context, deviceID, code 
 			return mc.UserID, nil
 		}
 
-		return "", ErrMFACodeInvalid
+		// The code matched a row but was expired: count it as a failed attempt too.
+		return "", m.failValidation(ctx, deviceID)
 	})
+}
+
+// failValidation records a failed MFA validation for the device and returns the error to
+// surface: ErrMFAAttemptsExhausted once the attempt cap is reached, otherwise ErrMFACodeInvalid.
+func (m *defaultMFAManager) failValidation(ctx context.Context, deviceID string) error {
+	exhausted, err := m.registerFailedMFAAttempt(ctx, deviceID)
+	if err != nil {
+		return err
+	}
+	if exhausted {
+		return ErrMFAAttemptsExhausted
+	}
+	return ErrMFACodeInvalid
 }
 
 // RememberDevice updates the device expiry for the device.
@@ -167,21 +193,46 @@ func (m *defaultMFAManager) ForgetAllDevices(ctx context.Context, userID string)
 	return nil
 }
 
+// registerFailedMFAAttempt increments the failed-attempt counter for the device's live MFA
+// code and reports whether the per-device attempt cap has now been reached. It is a no-op
+// (returns false) when the device has no live code to count against.
+func (m *defaultMFAManager) registerFailedMFAAttempt(ctx context.Context, deviceID string) (bool, error) {
+	if deviceID == "" {
+		return false, fmt.Errorf("device ID is required")
+	}
+	const query = `
+		WITH updated AS (
+			UPDATE auth_user_mfa_codes
+			SET attempts = attempts + 1
+			WHERE device_id = $1 AND code_expires_at IS NOT NULL
+			RETURNING attempts
+		)
+		SELECT COALESCE(MAX(attempts), 0) FROM updated
+	`
+	var attempts int
+	err := m.dbConnectionPool.GetContext(ctx, &attempts, query, deviceID)
+	if err != nil {
+		return false, fmt.Errorf("error registering failed MFA attempt for device ID %s: %w", deviceID, err)
+	}
+	return attempts >= mfaMaxValidationAttempts, nil
+}
+
 // getByDeviceAndUser gets the MFA code for the user and device.
 func (m *defaultMFAManager) getByDeviceAndUser(ctx context.Context, deviceID, userID string) (*mfaCode, error) {
 	if deviceID == "" || userID == "" {
 		return nil, fmt.Errorf("device ID and user ID are required")
 	}
 	const query = `
-		SELECT 
+		SELECT
 		    device_id,
 		    auth_user_id,
 		    COALESCE(code, '') AS code,
 		    device_expires_at,
-		    code_expires_at
-		FROM 
-		    auth_user_mfa_codes 
-		WHERE 
+		    code_expires_at,
+		    attempts
+		FROM
+		    auth_user_mfa_codes
+		WHERE
 		    device_id = $1 AND
 		    auth_user_id = $2
 	`
@@ -203,15 +254,16 @@ func (m *defaultMFAManager) getByDeviceAndCode(ctx context.Context, deviceID, co
 		return nil, fmt.Errorf("device ID and code are required")
 	}
 	const query = `
-		SELECT 
+		SELECT
 		    device_id,
 		    auth_user_id,
 		    COALESCE(code, '') AS code,
 		    device_expires_at,
-		    code_expires_at
-		FROM 
-		    auth_user_mfa_codes 
-		WHERE 
+		    code_expires_at,
+		    attempts
+		FROM
+		    auth_user_mfa_codes
+		WHERE
 		    device_id = $1 AND
 		    code = $2
 	`
@@ -245,11 +297,13 @@ func (m *defaultMFAManager) upsertMFACode(ctx context.Context, deviceID, userID,
 	if deviceID == "" || userID == "" || code == "" {
 		return fmt.Errorf("device ID, user ID and code are required")
 	}
+	// A freshly issued code always starts with a clean attempt counter, so the "Resend code"
+	// flow lifts any prior lockout for the device.
 	const query = `
-		INSERT INTO auth_user_mfa_codes (auth_user_id, device_id, code, code_expires_at) 
-		VALUES ($1, $2, $3, $4) 
-		ON CONFLICT (auth_user_id, device_id) 
-		DO UPDATE SET code = $3, code_expires_at = $4
+		INSERT INTO auth_user_mfa_codes (auth_user_id, device_id, code, code_expires_at)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (auth_user_id, device_id)
+		DO UPDATE SET code = $3, code_expires_at = $4, attempts = 0
 	`
 	_, err := m.dbConnectionPool.ExecContext(ctx, query, userID, deviceID, code, time.Now().Add(mfaCodeExpiryMinutes))
 	if err != nil {
@@ -281,8 +335,8 @@ func (m *defaultMFAManager) expireMFACode(ctx context.Context, deviceID, code st
 		return fmt.Errorf("device ID and code are required")
 	}
 	const query = `
-		UPDATE auth_user_mfa_codes 
-		SET code = null, code_expires_at = null
+		UPDATE auth_user_mfa_codes
+		SET code = null, code_expires_at = null, attempts = 0
 		WHERE device_id = $1 AND code = $2
 	`
 	_, err := m.dbConnectionPool.ExecContext(ctx, query, deviceID, code)

--- a/stellar-auth/pkg/auth/mfa_manager_test.go
+++ b/stellar-auth/pkg/auth/mfa_manager_test.go
@@ -334,6 +334,58 @@ func Test_defaultMFAManager_ForgetDevice(t *testing.T) {
 	})
 }
 
+func Test_defaultMFAManager_ForgetAllDevices(t *testing.T) {
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	randUser := CreateRandomAuthUserFixture(t, ctx, dbConnectionPool, NewDefaultPasswordEncrypter(), false)
+	otherUser := CreateRandomAuthUserFixture(t, ctx, dbConnectionPool, NewDefaultPasswordEncrypter(), false)
+
+	m := newDefaultMFAManager(withMFADatabaseConnectionPool(dbConnectionPool))
+
+	t.Run("Test error when userID is empty", func(t *testing.T) {
+		err := m.ForgetAllDevices(ctx, "")
+		require.EqualError(t, err, "user ID is required")
+	})
+
+	t.Run("Test forget all devices for the user without affecting other users", func(t *testing.T) {
+		defer cleanup(t, ctx, dbConnectionPool)
+
+		// Remember two devices for the user, and one for a different user.
+		for _, deviceID := range []string{"deviceA", "deviceB"} {
+			_, err := m.GenerateMFACode(ctx, deviceID, randUser.ID)
+			require.NoError(t, err)
+			require.NoError(t, m.RememberDevice(ctx, deviceID, randUser.ID))
+		}
+		_, err := m.GenerateMFACode(ctx, "deviceC", otherUser.ID)
+		require.NoError(t, err)
+		require.NoError(t, m.RememberDevice(ctx, "deviceC", otherUser.ID))
+
+		// Forget every device for the user.
+		err = m.ForgetAllDevices(ctx, randUser.ID)
+		require.NoError(t, err)
+
+		// Both of the user's devices are forgotten.
+		for _, deviceID := range []string{"deviceA", "deviceB"} {
+			mc, err := m.getByDeviceAndUser(ctx, deviceID, randUser.ID)
+			require.NoError(t, err)
+			require.NotNil(t, mc)
+			require.Nil(t, mc.DeviceExpiresAt)
+		}
+
+		// The other user's device is untouched.
+		mc, err := m.getByDeviceAndUser(ctx, "deviceC", otherUser.ID)
+		require.NoError(t, err)
+		require.NotNil(t, mc)
+		require.True(t, mc.DeviceExpiresAt.After(time.Now()))
+	})
+}
+
 func Test_defaultMFAManager_getByDeviceAndCode(t *testing.T) {
 	ctx := context.Background()
 

--- a/stellar-auth/pkg/auth/mfa_manager_test.go
+++ b/stellar-auth/pkg/auth/mfa_manager_test.go
@@ -287,6 +287,28 @@ func Test_defaultMFAManager_ValidateMFACode(t *testing.T) {
 		assert.Equal(t, randUser.ID, userID)
 	})
 
+	t.Run("Test failed guesses against an expired code do not count toward the lockout", func(t *testing.T) {
+		testDeviceID := "expired-code-device"
+		testCode := "424243"
+		// Seed an already-expired code (still present in the row, timestamp in the past).
+		_, err := dbConnectionPool.ExecContext(ctx, `
+            INSERT INTO auth_user_mfa_codes (device_id, code, auth_user_id, device_expires_at, code_expires_at, attempts)
+            VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', NOW() - INTERVAL '1 minute', 0)`, testDeviceID, testCode, randUser.ID)
+		require.NoError(t, err)
+
+		// Many wrong guesses against the dead code stay "invalid" and never trigger a lockout,
+		// because an expired code can never succeed. The remedy is to request a new code.
+		for i := 0; i < mfaMaxValidationAttempts+2; i++ {
+			_, err = m.ValidateMFACode(ctx, testDeviceID, "000000")
+			require.ErrorIs(t, err, ErrMFACodeInvalid)
+		}
+
+		// The attempt counter never moved.
+		mc, err := m.getByDeviceAndUser(ctx, testDeviceID, randUser.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 0, mc.Attempts)
+	})
+
 	t.Run("Test the last allowed attempt succeeds and clears the counter", func(t *testing.T) {
 		testDeviceID := "boundary-device"
 		testCode := "555555"
@@ -439,8 +461,8 @@ func Test_defaultMFAManager_ForgetAllDevices(t *testing.T) {
 
 		// Both of the user's devices are forgotten.
 		for _, deviceID := range []string{"deviceA", "deviceB"} {
-			mc, err := m.getByDeviceAndUser(ctx, deviceID, randUser.ID)
-			require.NoError(t, err)
+			mc, getErr := m.getByDeviceAndUser(ctx, deviceID, randUser.ID)
+			require.NoError(t, getErr)
 			require.NotNil(t, mc)
 			require.Nil(t, mc.DeviceExpiresAt)
 		}

--- a/stellar-auth/pkg/auth/mfa_manager_test.go
+++ b/stellar-auth/pkg/auth/mfa_manager_test.go
@@ -240,6 +240,73 @@ func Test_defaultMFAManager_ValidateMFACode(t *testing.T) {
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, ErrMFACodeInvalid))
 	})
+
+	t.Run("Test device is locked out after reaching the max attempts", func(t *testing.T) {
+		testDeviceID := "lockout-device"
+		testCode := "424242"
+		_, err := dbConnectionPool.ExecContext(ctx, `
+            INSERT INTO auth_user_mfa_codes (device_id, code, auth_user_id, device_expires_at, code_expires_at)
+            VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', NOW() + INTERVAL '1 hour')`, testDeviceID, testCode, randUser.ID)
+		require.NoError(t, err)
+
+		// The first (max-1) wrong guesses report an invalid code.
+		for i := 0; i < mfaMaxValidationAttempts-1; i++ {
+			_, err = m.ValidateMFACode(ctx, testDeviceID, "000000")
+			require.ErrorIs(t, err, ErrMFACodeInvalid)
+		}
+
+		// The guess that reaches the cap reports the device as locked out.
+		_, err = m.ValidateMFACode(ctx, testDeviceID, "000000")
+		require.ErrorIs(t, err, ErrMFAAttemptsExhausted)
+
+		// Even the correct code is now rejected until a new one is issued.
+		_, err = m.ValidateMFACode(ctx, testDeviceID, testCode)
+		require.ErrorIs(t, err, ErrMFAAttemptsExhausted)
+	})
+
+	t.Run("Test issuing a new code resets the attempt counter", func(t *testing.T) {
+		testDeviceID := "reset-device"
+		oldCode := "111111"
+		_, err := dbConnectionPool.ExecContext(ctx, `
+            INSERT INTO auth_user_mfa_codes (device_id, code, auth_user_id, device_expires_at, code_expires_at, attempts)
+            VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', NOW() + INTERVAL '1 hour', $4)`,
+			testDeviceID, oldCode, randUser.ID, mfaMaxValidationAttempts)
+		require.NoError(t, err)
+
+		// The device starts locked out.
+		_, err = m.ValidateMFACode(ctx, testDeviceID, oldCode)
+		require.ErrorIs(t, err, ErrMFAAttemptsExhausted)
+
+		// Issuing a new code (as the Resend code flow does) clears the counter.
+		newCode := "222222"
+		err = m.upsertMFACode(ctx, testDeviceID, randUser.ID, newCode)
+		require.NoError(t, err)
+
+		userID, err := m.ValidateMFACode(ctx, testDeviceID, newCode)
+		require.NoError(t, err)
+		assert.Equal(t, randUser.ID, userID)
+	})
+
+	t.Run("Test the last allowed attempt succeeds and clears the counter", func(t *testing.T) {
+		testDeviceID := "boundary-device"
+		testCode := "555555"
+		// Seed the device one attempt below the cap: a correct code must still be accepted.
+		_, err := dbConnectionPool.ExecContext(ctx, `
+            INSERT INTO auth_user_mfa_codes (device_id, code, auth_user_id, device_expires_at, code_expires_at, attempts)
+            VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', NOW() + INTERVAL '1 hour', $4)`,
+			testDeviceID, testCode, randUser.ID, mfaMaxValidationAttempts-1)
+		require.NoError(t, err)
+
+		userID, err := m.ValidateMFACode(ctx, testDeviceID, testCode)
+		require.NoError(t, err)
+		assert.Equal(t, randUser.ID, userID)
+
+		// A successful validation spends the code and resets the attempt counter.
+		mc, err := m.getByDeviceAndUser(ctx, testDeviceID, randUser.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 0, mc.Attempts)
+		assert.Empty(t, mc.Code)
+	})
 }
 
 func Test_defaultMFAManager_RememberDevice(t *testing.T) {

--- a/stellar-auth/pkg/auth/mfa_manager_test.go
+++ b/stellar-auth/pkg/auth/mfa_manager_test.go
@@ -65,9 +65,9 @@ func Test_defaultMFAManager_MFADeviceRemembered(t *testing.T) {
 		defer cleanup(t, ctx, dbConnectionPool)
 
 		// Generate code for device and remember device
-		code, err := m.GenerateMFACode(ctx, "deviceID", randUser.ID)
+		_, err := m.GenerateMFACode(ctx, "deviceID", randUser.ID)
 		require.NoError(t, err)
-		err = m.RememberDevice(ctx, "deviceID", code)
+		err = m.RememberDevice(ctx, "deviceID", randUser.ID)
 		require.NoError(t, err)
 
 		// Validate device
@@ -255,13 +255,13 @@ func Test_defaultMFAManager_RememberDevice(t *testing.T) {
 
 	m := newDefaultMFAManager(withMFADatabaseConnectionPool(dbConnectionPool))
 
-	t.Run("Test error when deviceID or code is empty", func(t *testing.T) {
+	t.Run("Test error when deviceID or userID is empty", func(t *testing.T) {
 		err := m.RememberDevice(ctx, "", "")
-		require.ErrorContains(t, err, "device ID and code are required")
+		require.ErrorContains(t, err, "device ID and user ID are required")
 		err = m.RememberDevice(ctx, "deviceID", "")
-		require.ErrorContains(t, err, "device ID and code are required")
-		err = m.RememberDevice(ctx, "", "code")
-		require.ErrorContains(t, err, "device ID and code are required")
+		require.ErrorContains(t, err, "device ID and user ID are required")
+		err = m.RememberDevice(ctx, "", "userID")
+		require.ErrorContains(t, err, "device ID and user ID are required")
 	})
 
 	t.Run("Test updating device expiry", func(t *testing.T) {
@@ -272,7 +272,7 @@ func Test_defaultMFAManager_RememberDevice(t *testing.T) {
             VALUES ($1, $2, $3, NOW() - INTERVAL '1 hour', NOW() + INTERVAL '1 hour')`, testDeviceID, testCode, randUser.ID)
 		require.NoError(t, err)
 
-		err = m.RememberDevice(ctx, testDeviceID, testCode)
+		err = m.RememberDevice(ctx, testDeviceID, randUser.ID)
 		require.NoError(t, err)
 
 		mc, err := m.getByDeviceAndUser(ctx, testDeviceID, randUser.ID)
@@ -313,7 +313,7 @@ func Test_defaultMFAManager_ForgetDevice(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 6, len(code))
 
-		err = m.RememberDevice(ctx, testDeviceID, code)
+		err = m.RememberDevice(ctx, testDeviceID, randUser.ID)
 		require.NoError(t, err)
 
 		// Fetch entry and check that device is remembered
@@ -485,13 +485,13 @@ func Test_defaultMFAManager_resetDeviceExpiry(t *testing.T) {
 
 	m := newDefaultMFAManager(withMFADatabaseConnectionPool(dbConnectionPool))
 
-	t.Run("Test error when deviceID or code is empty", func(t *testing.T) {
+	t.Run("Test error when deviceID or userID is empty", func(t *testing.T) {
 		err := m.resetDeviceExpiry(ctx, "", "")
-		assert.EqualError(t, err, "device ID and code are required")
+		assert.EqualError(t, err, "device ID and user ID are required")
 		err = m.resetDeviceExpiry(ctx, "deviceID", "")
-		assert.EqualError(t, err, "device ID and code are required")
-		err = m.resetDeviceExpiry(ctx, "", "code")
-		assert.EqualError(t, err, "device ID and code are required")
+		assert.EqualError(t, err, "device ID and user ID are required")
+		err = m.resetDeviceExpiry(ctx, "", "userID")
+		assert.EqualError(t, err, "device ID and user ID are required")
 	})
 
 	t.Run("Test device expiry reset", func(t *testing.T) {
@@ -502,7 +502,7 @@ func Test_defaultMFAManager_resetDeviceExpiry(t *testing.T) {
             VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour')`, testDeviceID, testCode, randUser.ID)
 		require.NoError(t, err)
 
-		err = m.resetDeviceExpiry(ctx, testDeviceID, testCode)
+		err = m.resetDeviceExpiry(ctx, testDeviceID, randUser.ID)
 		assert.NoError(t, err)
 
 		// Check that the record was updated correctly

--- a/stellar-auth/pkg/auth/mfa_manager_test.go
+++ b/stellar-auth/pkg/auth/mfa_manager_test.go
@@ -264,6 +264,28 @@ func Test_defaultMFAManager_ValidateMFACode(t *testing.T) {
 		require.ErrorIs(t, err, ErrMFAAttemptsExhausted)
 	})
 
+	t.Run("Test the attempt counter stays capped once the device is locked out", func(t *testing.T) {
+		testDeviceID := "capped-device"
+		testCode := "424244"
+		// Seed the device already at the cap with a live code.
+		_, err := dbConnectionPool.ExecContext(ctx, `
+            INSERT INTO auth_user_mfa_codes (device_id, code, auth_user_id, device_expires_at, code_expires_at, attempts)
+            VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', NOW() + INTERVAL '1 hour', $4)`,
+			testDeviceID, testCode, randUser.ID, mfaMaxValidationAttempts)
+		require.NoError(t, err)
+
+		// Further wrong guesses keep reporting the lockout without inflating the stored counter.
+		for i := 0; i < 3; i++ {
+			_, err = m.ValidateMFACode(ctx, testDeviceID, "000000")
+			require.ErrorIs(t, err, ErrMFAAttemptsExhausted)
+		}
+
+		// The counter is held at the cap rather than running away past it.
+		mc, err := m.getByDeviceAndUser(ctx, testDeviceID, randUser.ID)
+		require.NoError(t, err)
+		assert.Equal(t, mfaMaxValidationAttempts, mc.Attempts)
+	})
+
 	t.Run("Test issuing a new code resets the attempt counter", func(t *testing.T) {
 		testDeviceID := "reset-device"
 		oldCode := "111111"

--- a/stellar-auth/pkg/auth/mocks.go
+++ b/stellar-auth/pkg/auth/mocks.go
@@ -102,9 +102,9 @@ func (am *AuthenticatorMock) ForgotPassword(ctx context.Context, sqlExec db.SQLE
 	return args.String(0), args.Error(1)
 }
 
-func (am *AuthenticatorMock) ResetPassword(ctx context.Context, resetToken, password string) error {
+func (am *AuthenticatorMock) ResetPassword(ctx context.Context, resetToken, password string) (string, error) {
 	args := am.Called(ctx, resetToken, password)
-	return args.Error(0)
+	return args.String(0), args.Error(1)
 }
 
 func (am *AuthenticatorMock) UpdatePassword(ctx context.Context, user *User, currentPassword, newPassword string) error {
@@ -194,6 +194,11 @@ func (m *MFAManagerMock) ValidateMFACode(ctx context.Context, deviceID, code str
 
 func (m *MFAManagerMock) RememberDevice(ctx context.Context, deviceID, userID string) error {
 	args := m.Called(ctx, deviceID, userID)
+	return args.Error(0)
+}
+
+func (m *MFAManagerMock) ForgetAllDevices(ctx context.Context, userID string) error {
+	args := m.Called(ctx, userID)
 	return args.Error(0)
 }
 

--- a/stellar-auth/pkg/auth/mocks.go
+++ b/stellar-auth/pkg/auth/mocks.go
@@ -172,6 +172,33 @@ func (rm *RoleManagerMock) UpdateRoles(ctx context.Context, user *User, roleName
 
 var _ RoleManager = (*RoleManagerMock)(nil)
 
+// MFAManager
+type MFAManagerMock struct {
+	mock.Mock
+}
+
+func (m *MFAManagerMock) MFADeviceRemembered(ctx context.Context, deviceID, userID string) (bool, error) {
+	args := m.Called(ctx, deviceID, userID)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *MFAManagerMock) GenerateMFACode(ctx context.Context, deviceID, userID string) (string, error) {
+	args := m.Called(ctx, deviceID, userID)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MFAManagerMock) ValidateMFACode(ctx context.Context, deviceID, code string) (string, error) {
+	args := m.Called(ctx, deviceID, code)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MFAManagerMock) RememberDevice(ctx context.Context, deviceID, userID string) error {
+	args := m.Called(ctx, deviceID, userID)
+	return args.Error(0)
+}
+
+var _ MFAManager = (*MFAManagerMock)(nil)
+
 // AuthManager
 type AuthManagerMock struct {
 	mock.Mock


### PR DESCRIPTION
### What

- Move the `RememberDevice` write to after a successful `ValidateMFACode`, keyed on the user ID validation returns rather than on the submitted code
- Clear device trust on password reset/change
- Add a per-(`auth_user_id`, `device_id`) attempt limiter

### Why

`AuthenticateMFA` (`stellar-auth/pkg/auth/auth.go`) calls `RememberDevice` before `ValidateMFACode`, and `resetDeviceExpiry` (`mfa_manager.go`) matches on (`device_id, code`) with no `code_expires_at` predicate. As a result a `/mfa` request that returns `401` can still write a 7-day device-trust record, and an expired code satisfies that write. Once trust is set, `/login` skips MFA for that device.

Three related weaknesses compound it: expired-but-unused codes are never cleared (no cleanup; `expireMFACode` only runs on success), there is no failed-attempt limiter on the MFA path, and device trust is effectively unrevocable. `ForgetDevice` has no callers and password reset/change does not clear `auth_user_mfa_codes`.

### Known limitations

- A caller for `ForgetDevice` is not implemented.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [x] Ready for production
