### PR TITLE
SDP-2114 chore: select distribution account scope at API key creation and edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add append-only audit tables for disbursements, payments, and distribution-wallet memberships, with an owner-only endpoint to read membership history. [#1178](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1178)
 - Add `distribution-account rotate --wallet-id` to rotate any distribution wallet's account, and `distribution-account rotate-wallet-dek` to rotate a wallet's signing key. [#1178](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1178)
 - Add optional Prometheus/Grafana wiring and wallet-tagged structured transaction logging for the SDP and TSS services. [#1178](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1178)
+- Add distribution-account scoping when creating or editing API-key [#1183](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1183)
 
 ### Fixed
 

--- a/db/migrations/sdp-migrations/2026-08-12.0-scope-api-keys-to-distribution-wallets.sql
+++ b/db/migrations/sdp-migrations/2026-08-12.0-scope-api-keys-to-distribution-wallets.sql
@@ -15,7 +15,20 @@ UPDATE api_keys
 SET distribution_wallet_ids = ARRAY [(SELECT id FROM distribution_wallets WHERE is_default LIMIT 1)]
 WHERE EXISTS (SELECT 1 FROM distribution_wallets WHERE is_default);
 
+-- The audit trigger writes an explicit column list, so the new column has to reach api_keys_audit
+-- too or scope changes go unrecorded. create_audit_table only CREATE TABLE IF NOT EXISTS, so the
+-- column is added by hand; re-running it then regenerates the trigger function over all columns.
+ALTER TABLE api_keys_audit
+    ADD COLUMN distribution_wallet_ids VARCHAR(36) [];
+
+SELECT create_audit_table('api_keys');
+
 -- +migrate Down
 
 ALTER TABLE api_keys
     DROP COLUMN IF EXISTS distribution_wallet_ids;
+
+ALTER TABLE api_keys_audit
+    DROP COLUMN IF EXISTS distribution_wallet_ids;
+
+SELECT create_audit_table('api_keys');

--- a/db/migrations/sdp-migrations/2026-08-12.0-scope-api-keys-to-distribution-wallets.sql
+++ b/db/migrations/sdp-migrations/2026-08-12.0-scope-api-keys-to-distribution-wallets.sql
@@ -9,7 +9,7 @@ ALTER TABLE api_keys
 COMMENT ON COLUMN api_keys.distribution_wallet_ids IS
     'Distribution wallets this key may act on. Empty = no wallet-scoped access, never "all".';
 
--- Existing keys have only ever transacted on the default wallet, so scoping them to it is the
+-- Existing keys pre-dating multi-wallet support have only ever transacted on the default wallet, so scoping them to it is the
 -- no-change answer. Guarded on the default row existing so this stays a no-op on an unseeded schema.
 UPDATE api_keys
 SET distribution_wallet_ids = ARRAY [(SELECT id FROM distribution_wallets WHERE is_default LIMIT 1)]

--- a/db/migrations/sdp-migrations/2026-08-12.0-scope-api-keys-to-distribution-wallets.sql
+++ b/db/migrations/sdp-migrations/2026-08-12.0-scope-api-keys-to-distribution-wallets.sql
@@ -1,0 +1,21 @@
+-- Gives each API key its own distribution-wallet scope instead of deriving it from the creator's
+-- live wallet_memberships. Empty means no wallet-scoped access (fail closed), never "all".
+
+-- +migrate Up
+
+ALTER TABLE api_keys
+    ADD COLUMN distribution_wallet_ids VARCHAR(36) [] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN api_keys.distribution_wallet_ids IS
+    'Distribution wallets this key may act on. Empty = no wallet-scoped access, never "all".';
+
+-- Existing keys have only ever transacted on the default wallet, so scoping them to it is the
+-- no-change answer. Guarded on the default row existing so this stays a no-op on an unseeded schema.
+UPDATE api_keys
+SET distribution_wallet_ids = ARRAY [(SELECT id FROM distribution_wallets WHERE is_default LIMIT 1)]
+WHERE EXISTS (SELECT 1 FROM distribution_wallets WHERE is_default);
+
+-- +migrate Down
+
+ALTER TABLE api_keys
+    DROP COLUMN IF EXISTS distribution_wallet_ids;

--- a/internal/data/api_keys.go
+++ b/internal/data/api_keys.go
@@ -429,12 +429,11 @@ func (m *APIKeyModel) ValidateRawKeyAndUpdateLastUsed(ctx context.Context, raw s
 		`
 
 		var a APIKey
-		err := tx.QueryRowxContext(ctx, selectQ, id).Scan(
+		if scanErr := tx.QueryRowxContext(ctx, selectQ, id).Scan(
 			&a.ID, &a.KeyHash, &a.Salt, &a.ExpiryDate,
 			&a.Permissions, &a.AllowedIPs, &a.DistributionWalletIDs, &a.CreatedBy, &a.LastUsedAt,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("API key not found: %w", err)
+		); scanErr != nil {
+			return nil, fmt.Errorf("API key not found: %w", scanErr)
 		}
 
 		// 3) Verify hash
@@ -455,11 +454,11 @@ func (m *APIKeyModel) ValidateRawKeyAndUpdateLastUsed(ctx context.Context, raw s
 			          distribution_wallet_ids, created_by, last_used_at
 		`
 
-		if err := tx.QueryRowxContext(ctx, updateQ, id).Scan(
+		if updateErr := tx.QueryRowxContext(ctx, updateQ, id).Scan(
 			&a.ID, &a.KeyHash, &a.Salt, &a.ExpiryDate,
 			&a.Permissions, &a.AllowedIPs, &a.DistributionWalletIDs, &a.CreatedBy, &a.LastUsedAt,
-		); err != nil {
-			return nil, fmt.Errorf("failed to update last_used_at: %w", err)
+		); updateErr != nil {
+			return nil, fmt.Errorf("failed to update last_used_at: %w", updateErr)
 		}
 
 		return &a, nil

--- a/internal/data/api_keys.go
+++ b/internal/data/api_keys.go
@@ -483,7 +483,8 @@ func (m *APIKeyModel) Update(ctx context.Context, id, createdBy string, perms AP
 			SET permissions = $1,
 				allowed_ips = $2,
 				distribution_wallet_ids = COALESCE($5::VARCHAR(36)[], distribution_wallet_ids),
-				updated_at = NOW()
+				updated_at = NOW(),
+				updated_by = $4
 			WHERE id = $3
 			AND created_by = $4
 		 RETURNING

--- a/internal/data/api_keys.go
+++ b/internal/data/api_keys.go
@@ -162,19 +162,34 @@ func ValidateAllowedIPs(ips []string) error {
 }
 
 type APIKey struct {
-	ID          string            `db:"id" json:"id"`
-	Name        string            `db:"name" json:"name"`
-	KeyHash     string            `db:"key_hash" json:"-"`
-	Salt        string            `db:"salt" json:"-"`
-	ExpiryDate  *time.Time        `db:"expiry_date" json:"expiry_date,omitempty"`
-	Permissions APIKeyPermissions `db:"permissions" json:"permissions"`
-	AllowedIPs  IPList            `db:"allowed_ips" json:"allowed_ips,omitempty"`
-	CreatedAt   time.Time         `db:"created_at" json:"created_at"`
-	CreatedBy   string            `db:"created_by" json:"created_by,omitempty"`
-	UpdatedAt   time.Time         `db:"updated_at" json:"updated_at"`
-	UpdatedBy   string            `db:"updated_by" json:"updated_by,omitempty"`
-	LastUsedAt  *time.Time        `db:"last_used_at" json:"last_used_at,omitempty"`
-	Key         string            `db:"-" json:"key,omitempty"`
+	ID                    string            `db:"id" json:"id"`
+	Name                  string            `db:"name" json:"name"`
+	KeyHash               string            `db:"key_hash" json:"-"`
+	Salt                  string            `db:"salt" json:"-"`
+	ExpiryDate            *time.Time        `db:"expiry_date" json:"expiry_date,omitempty"`
+	Permissions           APIKeyPermissions `db:"permissions" json:"permissions"`
+	AllowedIPs            IPList            `db:"allowed_ips" json:"allowed_ips,omitempty"`
+	DistributionWalletIDs pq.StringArray    `db:"distribution_wallet_ids" json:"distribution_wallet_ids"`
+	CreatedAt             time.Time         `db:"created_at" json:"created_at"`
+	CreatedBy             string            `db:"created_by" json:"created_by,omitempty"`
+	UpdatedAt             time.Time         `db:"updated_at" json:"updated_at"`
+	UpdatedBy             string            `db:"updated_by" json:"updated_by,omitempty"`
+	LastUsedAt            *time.Time        `db:"last_used_at" json:"last_used_at,omitempty"`
+	Key                   string            `db:"-" json:"key,omitempty"`
+}
+
+// WalletScope returns the wallets this key may act on, never nil: the shared read-scope helpers
+// read a nil scope as "owner, show everything".
+func (a *APIKey) WalletScope() []string {
+	if a.DistributionWalletIDs == nil {
+		return []string{}
+	}
+	return a.DistributionWalletIDs
+}
+
+// CanActOnWallet reports whether walletID is inside this key's scope.
+func (a *APIKey) CanActOnWallet(walletID string) bool {
+	return slices.Contains(a.DistributionWalletIDs, walletID)
 }
 
 func (a *APIKey) HasPermission(req APIKeyPermission) bool {
@@ -252,12 +267,16 @@ func (m *APIKeyModel) Insert(
 	name string,
 	permissions []APIKeyPermission,
 	allowedIPs []string,
+	distributionWalletIDs []string,
 	expiry *time.Time,
 	createdBy string,
 ) (*APIKey, error) {
 	var apiKey *APIKey
 	if allowedIPs == nil {
 		allowedIPs = IPList{}
+	}
+	if distributionWalletIDs == nil {
+		distributionWalletIDs = []string{}
 	}
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
@@ -283,28 +302,30 @@ func (m *APIKeyModel) Insert(
 		keyHash := hex.EncodeToString(h.Sum(nil))
 
 		candidate := &APIKey{
-			Name:        name,
-			KeyHash:     keyHash,
-			Salt:        salt,
-			ExpiryDate:  expiry,
-			Permissions: APIKeyPermissions(permissions),
-			AllowedIPs:  IPList(allowedIPs),
-			CreatedBy:   createdBy,
-			UpdatedBy:   createdBy,
+			Name:                  name,
+			KeyHash:               keyHash,
+			Salt:                  salt,
+			ExpiryDate:            expiry,
+			Permissions:           APIKeyPermissions(permissions),
+			AllowedIPs:            IPList(allowedIPs),
+			DistributionWalletIDs: pq.StringArray(distributionWalletIDs),
+			CreatedBy:             createdBy,
+			UpdatedBy:             createdBy,
 		}
 
 		const q = `
             INSERT INTO api_keys (
                 name, key_hash, salt,
-                expiry_date, permissions, allowed_ips,
+                expiry_date, permissions, allowed_ips, distribution_wallet_ids,
                 created_by, updated_by
-            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
             RETURNING id, created_at, updated_at
         `
 
 		row := m.dbConnectionPool.QueryRowxContext(ctx, q,
 			candidate.Name, candidate.KeyHash, candidate.Salt,
 			candidate.ExpiryDate, candidate.Permissions, candidate.AllowedIPs,
+			candidate.DistributionWalletIDs,
 			candidate.CreatedBy, candidate.UpdatedBy,
 		)
 		if err := row.Scan(&candidate.ID, &candidate.CreatedAt, &candidate.UpdatedAt); err != nil {
@@ -332,14 +353,15 @@ func (m *APIKeyModel) GetAll(ctx context.Context, createdBy string) ([]*APIKey, 
 	apiKeys := []*APIKey{}
 	query := `
         SELECT
-            id, 
+            id,
 			name,
-    		expiry_date, 
-			permissions, 
+    		expiry_date,
+			permissions,
 			allowed_ips,
-    		created_at, 
+			distribution_wallet_ids,
+    		created_at,
 			created_by,
-    		updated_at, 
+    		updated_at,
 			updated_by,
     		last_used_at
         FROM
@@ -362,7 +384,7 @@ func (m *APIKeyModel) GetByID(ctx context.Context, id, createdBy string) (*APIKe
 	const q = `
       SELECT
         id, name,
-        expiry_date, permissions, allowed_ips,
+        expiry_date, permissions, allowed_ips, distribution_wallet_ids,
         created_at, created_by,
         updated_at, updated_by,
         last_used_at
@@ -392,13 +414,14 @@ func (m *APIKeyModel) ValidateRawKeyAndUpdateLastUsed(ctx context.Context, raw s
 	result, err := db.RunInTransactionWithResult(ctx, m.dbConnectionPool, nil, func(tx db.DBTransaction) (*APIKey, error) {
 		// 2) Fetch data and update last_used_at
 		const selectQ = `
-		SELECT 
+		SELECT
 			id,
 			key_hash,
 			salt,
 			expiry_date,
 			permissions,
 			allowed_ips,
+			distribution_wallet_ids,
 			created_by,
 			last_used_at
 		FROM api_keys
@@ -408,7 +431,7 @@ func (m *APIKeyModel) ValidateRawKeyAndUpdateLastUsed(ctx context.Context, raw s
 		var a APIKey
 		err := tx.QueryRowxContext(ctx, selectQ, id).Scan(
 			&a.ID, &a.KeyHash, &a.Salt, &a.ExpiryDate,
-			&a.Permissions, &a.AllowedIPs, &a.CreatedBy, &a.LastUsedAt,
+			&a.Permissions, &a.AllowedIPs, &a.DistributionWalletIDs, &a.CreatedBy, &a.LastUsedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("API key not found: %w", err)
@@ -425,15 +448,16 @@ func (m *APIKeyModel) ValidateRawKeyAndUpdateLastUsed(ctx context.Context, raw s
 
 		// 4) Update last_used_at
 		const updateQ = `
-			UPDATE api_keys 
-			SET last_used_at = NOW() 
+			UPDATE api_keys
+			SET last_used_at = NOW()
 			WHERE id = $1
-			RETURNING id, key_hash, salt, expiry_date, permissions, allowed_ips, created_by, last_used_at
+			RETURNING id, key_hash, salt, expiry_date, permissions, allowed_ips,
+			          distribution_wallet_ids, created_by, last_used_at
 		`
 
 		if err := tx.QueryRowxContext(ctx, updateQ, id).Scan(
 			&a.ID, &a.KeyHash, &a.Salt, &a.ExpiryDate,
-			&a.Permissions, &a.AllowedIPs, &a.CreatedBy, &a.LastUsedAt,
+			&a.Permissions, &a.AllowedIPs, &a.DistributionWalletIDs, &a.CreatedBy, &a.LastUsedAt,
 		); err != nil {
 			return nil, fmt.Errorf("failed to update last_used_at: %w", err)
 		}
@@ -447,24 +471,32 @@ func (m *APIKeyModel) ValidateRawKeyAndUpdateLastUsed(ctx context.Context, raw s
 	return result, nil
 }
 
-func (m *APIKeyModel) Update(ctx context.Context, id, createdBy string, perms APIKeyPermissions, ips []string) (*APIKey, error) {
+// Update replaces the key's permissions and allowed IPs. A nil walletIDs leaves the key's wallet
+// scope as it is; a non-nil one replaces it (including empty, meaning no wallet access).
+func (m *APIKeyModel) Update(ctx context.Context, id, createdBy string, perms APIKeyPermissions, ips []string, walletIDs []string) (*APIKey, error) {
+	var walletParam any
+	if walletIDs != nil {
+		walletParam = pq.StringArray(walletIDs)
+	}
+
 	query := `
 		UPDATE api_keys
 			SET permissions = $1,
 				allowed_ips = $2,
+				distribution_wallet_ids = COALESCE($5::VARCHAR(36)[], distribution_wallet_ids),
 				updated_at = NOW()
 			WHERE id = $3
 			AND created_by = $4
 		 RETURNING
 		   id, name,
-		   expiry_date, permissions, allowed_ips,
+		   expiry_date, permissions, allowed_ips, distribution_wallet_ids,
 		   created_at, created_by,
 		   updated_at, updated_by,
 		   last_used_at
 	`
 
 	var key APIKey
-	if err := m.dbConnectionPool.GetContext(ctx, &key, query, perms, IPList(ips), id, createdBy); err != nil {
+	if err := m.dbConnectionPool.GetContext(ctx, &key, query, perms, IPList(ips), id, createdBy, walletParam); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrRecordNotFound
 		}

--- a/internal/data/api_keys_test.go
+++ b/internal/data/api_keys_test.go
@@ -181,7 +181,7 @@ func Test_APIKeyModel_Insert(t *testing.T) {
 		name := "Stygies VIII Archive Key"
 		createdBy := "00000000-0000-0000-0000-000000000000"
 
-		key, err := models.APIKeys.Insert(ctx, name, perms, ips, &expiry, createdBy)
+		key, err := models.APIKeys.Insert(ctx, name, perms, ips, nil, &expiry, createdBy)
 		require.NoError(t, err)
 
 		assert.Equal(t, name, key.Name)
@@ -399,7 +399,7 @@ func Test_APIKeyModel_Update(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			updated, err := models.APIKeys.Update(ctx, tc.id, tc.creatorID, tc.perms, tc.ips)
+			updated, err := models.APIKeys.Update(ctx, tc.id, tc.creatorID, tc.perms, tc.ips, nil)
 			if tc.wantErr != nil {
 				assert.ErrorIs(t, err, tc.wantErr)
 				return
@@ -633,6 +633,7 @@ func createAPIKeyFixture(t *testing.T, ctx context.Context, pool db.DBConnection
 		name,
 		perms,
 		ips,
+		nil,
 		expiry,
 		createdBy,
 	)

--- a/internal/data/receivers.go
+++ b/internal/data/receivers.go
@@ -278,9 +278,12 @@ func newReceiverQuery(baseQuery string, queryParams *QueryParams, sqlExec db.SQL
 		qb.AddCondition("r.created_at <= ?", queryParams.Filters[FilterKeyCreatedAtBefore])
 	}
 	if walletIDs, ok := queryParams.Filters[FilterKeySourceWalletIDs].([]string); ok {
-		// Membership-filtered visibility: a receiver is visible to callers whose
-		// wallets have paid them at least once.
-		qb.AddCondition("EXISTS (SELECT 1 FROM payments pw WHERE pw.receiver_id = r.id AND pw.source_wallet_id = ANY(?))", pq.Array(walletIDs))
+		// A receiver is visible to callers whose wallets have paid them. One nobody has paid yet
+		// belongs to no account, so it stays tenant-wide until its first payment.
+		qb.AddCondition(`(
+			EXISTS (SELECT 1 FROM payments pw WHERE pw.receiver_id = r.id AND pw.source_wallet_id = ANY(?))
+			OR NOT EXISTS (SELECT 1 FROM payments pw WHERE pw.receiver_id = r.id)
+		)`, pq.Array(walletIDs))
 	}
 
 	switch queryType {

--- a/internal/sdpcontext/context.go
+++ b/internal/sdpcontext/context.go
@@ -82,7 +82,7 @@ func SetTokenInContext(ctx context.Context, token string) context.Context {
 // GetAPIKeyFromContext retrieves the API key from the context.
 func GetAPIKeyFromContext(ctx context.Context) (*data.APIKey, error) {
 	apiKey, ok := ctx.Value(apiKeyContextKey{}).(*data.APIKey)
-	if !ok {
+	if !ok || apiKey == nil {
 		return nil, ErrAPIKeyNotFoundInContext
 	}
 	return apiKey, nil

--- a/internal/serve/httphandler/api_key_handler.go
+++ b/internal/serve/httphandler/api_key_handler.go
@@ -86,7 +86,7 @@ func (h APIKeyHandler) grantableWallets(ctx context.Context, alreadyHeld []strin
 		return grantable
 	}
 
-	if actingKey, keyErr := sdpcontext.GetAPIKeyFromContext(ctx); keyErr == nil && actingKey != nil {
+	if actingKey, keyErr := sdpcontext.GetAPIKeyFromContext(ctx); keyErr == nil {
 		return withinReach(actingKey.WalletScope()), nil
 	}
 

--- a/internal/serve/httphandler/api_key_handler.go
+++ b/internal/serve/httphandler/api_key_handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -15,6 +16,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
 
 // APIKeyCacheInvalidator is implemented by whatever caches validated API keys in
@@ -28,22 +30,71 @@ type APIKeyCacheInvalidator interface {
 }
 
 type APIKeyHandler struct {
-	Models *data.Models
+	Models      *data.Models
+	AuthManager auth.AuthManager
 	// CacheInvalidator is optional. If nil, no cache invalidation is attempted
 	// (e.g. in tests that exercise the handler without the auth middleware's cache).
 	CacheInvalidator APIKeyCacheInvalidator
 }
 
 type CreateAPIKeyRequest struct {
-	Name        string                  `json:"name"`
-	Permissions []data.APIKeyPermission `json:"permissions"`
-	ExpiryDate  *time.Time              `json:"expiry_date,omitempty"`
-	AllowedIPs  any                     `json:"allowed_ips,omitempty"` // Can be a string or array of strings
+	Name                  string                  `json:"name"`
+	Permissions           []data.APIKeyPermission `json:"permissions"`
+	ExpiryDate            *time.Time              `json:"expiry_date,omitempty"`
+	AllowedIPs            any                     `json:"allowed_ips,omitempty"` // Can be a string or array of strings
+	DistributionWalletIDs []string                `json:"distribution_wallet_ids,omitempty"`
+}
+
+// grantableWallets returns the wallets the caller may put on a key, for creation and for edits.
+//
+// Only active wallets can be added, mirroring the enforce_wallet_membership_wallet_active trigger
+// on wallet_memberships: an archived account takes no new grants, whether the grantee is a person
+// or a key. alreadyHeld (the key's current scope, empty on creation) is admitted regardless, so an
+// account archived after the fact stays on its key — keeping it grants nothing new, and refusing it
+// would make an unrelated permissions edit impossible to save. Such a wallet goes on serving reads
+// and failing writes, exactly as it does for a membership that predates the archive.
+//
+// Minting via API key is capped at the acting key's own scope, so a key cannot mint a broader one.
+func (h APIKeyHandler) grantableWallets(ctx context.Context, alreadyHeld []string) ([]string, *httperror.HTTPError) {
+	wallets, err := h.Models.DistributionWallets.GetAll(ctx, h.Models.DBConnectionPool, false)
+	if err != nil {
+		return nil, httperror.InternalError(ctx, "Cannot list distribution wallets", err, nil)
+	}
+	activeIDs := make([]string, 0, len(wallets))
+	for _, wallet := range wallets {
+		activeIDs = append(activeIDs, wallet.ID)
+	}
+
+	withinReach := func(reach []string) []string {
+		grantable := slices.Clone(alreadyHeld)
+		for _, id := range reach {
+			if slices.Contains(activeIDs, id) && !slices.Contains(grantable, id) {
+				grantable = append(grantable, id)
+			}
+		}
+		return grantable
+	}
+
+	if actingKey, keyErr := sdpcontext.GetAPIKeyFromContext(ctx); keyErr == nil && actingKey != nil {
+		return withinReach(actingKey.WalletScope()), nil
+	}
+
+	scope, httpErr := resolveWalletReadScope(ctx, h.AuthManager, h.Models)
+	if httpErr != nil {
+		return nil, httpErr
+	}
+	if scope == nil {
+		// Owners hold no membership rows, so their reach is the active set itself.
+		return withinReach(activeIDs), nil
+	}
+	return withinReach(scope), nil
 }
 
 type UpdateAPIKeyRequest struct {
 	Permissions []data.APIKeyPermission `json:"permissions"`
 	AllowedIPs  any                     `json:"allowed_ips,omitempty"` // Can be a string or array of strings
+	// Omitted leaves the key's wallet scope untouched; an explicit list replaces it.
+	DistributionWalletIDs []string `json:"distribution_wallet_ids,omitempty"`
 }
 
 func (h APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
@@ -79,6 +130,29 @@ func (h APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Omitting the field entirely inherits the creator's own access, so a client written before
+	// wallet scoping existed still gets a working key. An explicit [] means "no wallet access" and
+	// is honored as written.
+	grantable, scopeErr := h.grantableWallets(ctx, nil)
+	if scopeErr != nil {
+		scopeErr.Render(w)
+		return
+	}
+
+	var walletIDs []string
+	if req.DistributionWalletIDs == nil {
+		walletIDs = grantable
+	} else {
+		walletIDs = slices.Compact(slices.Sorted(slices.Values(req.DistributionWalletIDs)))
+		for _, walletID := range walletIDs {
+			if !slices.Contains(grantable, walletID) {
+				httperror.Forbidden(
+					"a key cannot be scoped to a distribution account the creator has no access to", nil, nil).Render(w)
+				return
+			}
+		}
+	}
+
 	userID, err := sdpcontext.GetUserIDFromContext(ctx)
 	if err != nil {
 		httperror.InternalError(ctx, "User identification error", nil, nil).Render(w)
@@ -90,6 +164,7 @@ func (h APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		req.Name,
 		req.Permissions,
 		allowedIPs,
+		walletIDs,
 		req.ExpiryDate,
 		userID,
 	)
@@ -178,7 +253,35 @@ func (h APIKeyHandler) UpdateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updated, err := h.Models.APIKeys.Update(ctx, keyID, userID, req.Permissions, ips)
+	// Omitting the field leaves the key's scope untouched, so there is nothing to authorize.
+	var walletIDs []string
+	if req.DistributionWalletIDs != nil {
+		current, getErr := h.Models.APIKeys.GetByID(ctx, keyID, userID)
+		if getErr != nil {
+			if errors.Is(getErr, data.ErrRecordNotFound) {
+				httperror.NotFound("API key not found", nil, nil).Render(w)
+			} else {
+				httperror.InternalError(ctx, "Failed to retrieve API key", getErr, nil).Render(w)
+			}
+			return
+		}
+
+		walletIDs = slices.Compact(slices.Sorted(slices.Values(req.DistributionWalletIDs)))
+		grantable, scopeErr := h.grantableWallets(ctx, current.WalletScope())
+		if scopeErr != nil {
+			scopeErr.Render(w)
+			return
+		}
+		for _, walletID := range walletIDs {
+			if !slices.Contains(grantable, walletID) {
+				httperror.Forbidden(
+					"a key cannot be scoped to a distribution account the editor has no access to", nil, nil).Render(w)
+				return
+			}
+		}
+	}
+
+	updated, err := h.Models.APIKeys.Update(ctx, keyID, userID, req.Permissions, ips, walletIDs)
 	if err != nil {
 		if errors.Is(err, data.ErrRecordNotFound) {
 			httperror.NotFound("API key not found", nil, nil).Render(w)
@@ -188,7 +291,7 @@ func (h APIKeyHandler) UpdateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The permissions/allowed_ips just written must be enforced on the very next
+	// The permissions/allowed_ips/wallet scope just written must be enforced on the very next
 	// request that uses this key, not whenever the auth cache's TTL happens to
 	// expire - so evict it now.
 	if h.CacheInvalidator != nil {

--- a/internal/serve/httphandler/api_key_handler.go
+++ b/internal/serve/httphandler/api_key_handler.go
@@ -45,6 +45,17 @@ type CreateAPIKeyRequest struct {
 	DistributionWalletIDs []string                `json:"distribution_wallet_ids,omitempty"`
 }
 
+// normalizeWalletIDs sorts and dedupes a requested scope, never returning nil: slices.Sorted over
+// an empty request yields nil, which downstream reads as "leave the scope untouched" — the opposite
+// of the explicit [] the caller sent.
+func normalizeWalletIDs(requested []string) []string {
+	normalized := slices.Compact(slices.Sorted(slices.Values(requested)))
+	if normalized == nil {
+		return []string{}
+	}
+	return normalized
+}
+
 // grantableWallets returns the wallets the caller may put on a key, for creation and for edits.
 //
 // Only active wallets can be added, mirroring the enforce_wallet_membership_wallet_active trigger
@@ -143,7 +154,7 @@ func (h APIKeyHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	if req.DistributionWalletIDs == nil {
 		walletIDs = grantable
 	} else {
-		walletIDs = slices.Compact(slices.Sorted(slices.Values(req.DistributionWalletIDs)))
+		walletIDs = normalizeWalletIDs(req.DistributionWalletIDs)
 		for _, walletID := range walletIDs {
 			if !slices.Contains(grantable, walletID) {
 				httperror.Forbidden(
@@ -266,7 +277,7 @@ func (h APIKeyHandler) UpdateKey(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		walletIDs = slices.Compact(slices.Sorted(slices.Values(req.DistributionWalletIDs)))
+		walletIDs = normalizeWalletIDs(req.DistributionWalletIDs)
 		grantable, scopeErr := h.grantableWallets(ctx, current.WalletScope())
 		if scopeErr != nil {
 			scopeErr.Render(w)

--- a/internal/serve/httphandler/api_key_handler_test.go
+++ b/internal/serve/httphandler/api_key_handler_test.go
@@ -250,6 +250,44 @@ func Test_CreateAPIKey_WalletScope(t *testing.T) {
 			"once dropped, an archived account cannot be put back")
 	})
 
+	// An explicit [] on edit has to clear the scope. Omitting the field is what means "leave it
+	// alone", and the two must not collapse into each other on the way to the DB.
+	t.Run("an explicit empty list on edit clears the scope, omitting it does not", func(t *testing.T) {
+		handler, ctx, walletA, _ := setup(t, owner)
+
+		rr := create(t, handler, ctx, map[string]any{
+			"name": "scope-clearing key", "permissions": []string{"read:payments"},
+			"distribution_wallet_ids": []string{walletA.ID},
+		})
+		require.Equal(t, http.StatusCreated, rr.Code)
+		var created data.APIKey
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &created))
+
+		patch := func(body map[string]any) data.APIKey {
+			b, marshalErr := json.Marshal(body)
+			require.NoError(t, marshalErr)
+			req := httptest.NewRequestWithContext(ctx, http.MethodPatch, "/api-keys/"+created.ID, bytes.NewReader(b))
+			chiCtx := chi.NewRouteContext()
+			chiCtx.URLParams.Add("id", created.ID)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+			rr := httptest.NewRecorder()
+			handler.UpdateKey(rr, req)
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			var updated data.APIKey
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &updated))
+			return updated
+		}
+
+		kept := patch(map[string]any{"permissions": []string{"read:payments", "read:exports"}})
+		assert.Equal(t, []string{walletA.ID}, []string(kept.DistributionWalletIDs))
+
+		cleared := patch(map[string]any{
+			"permissions": []string{"read:payments"}, "distribution_wallet_ids": []string{},
+		})
+		assert.Empty(t, cleared.DistributionWalletIDs, "an explicit [] must reach the DB as empty, not nil")
+	})
+
 	t.Run("a key minting a key cannot widen the scope it holds", func(t *testing.T) {
 		handler, ctx, walletA, walletBID := setup(t, developer)
 		// The acting key names only walletA, so walletB is out of reach even though the request

--- a/internal/serve/httphandler/api_key_handler_test.go
+++ b/internal/serve/httphandler/api_key_handler_test.go
@@ -11,13 +11,16 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 )
 
 const adminUserID = "b9c29a1a-4d30-4b99-8c5f-0546054be91b"
@@ -41,10 +44,235 @@ func setupHandler(t *testing.T) (APIKeyHandler, context.Context) {
 	models, err := data.NewModels(pool)
 	require.NoError(t, err)
 
-	handler := APIKeyHandler{Models: models}
+	// The creator is an Owner, so a key that names no wallets inherits every active wallet.
+	authManagerMock := &auth.AuthManagerMock{}
+	authManagerMock.On("GetUserByID", mock.Anything, adminUserID).
+		Return(&auth.User{ID: adminUserID, IsOwner: true}, nil).Maybe()
+
+	handler := APIKeyHandler{Models: models, AuthManager: authManagerMock}
 	ctx := sdpcontext.SetUserIDInContext(context.Background(), adminUserID)
 
 	return handler, ctx
+}
+
+// Test_CreateAPIKey_WalletScope covers the creation-time ceiling: what a creator may put on a key
+// is their own access, and nothing about the key changes afterwards when that access does.
+func Test_CreateAPIKey_WalletScope(t *testing.T) {
+	const developerUserID = "d24d2a52-9a4d-4b2f-b1b1-4d9f2a7f0c31"
+
+	setup := func(t *testing.T, user *auth.User) (APIKeyHandler, context.Context, *data.DistributionWallet, string) {
+		t.Helper()
+		pool := getDBConnectionPool(t)
+		models, err := data.NewModels(pool)
+		require.NoError(t, err)
+
+		ctx := sdpcontext.SetUserIDInContext(context.Background(), user.ID)
+		walletA := data.EnsureDefaultDistributionWalletFixture(t, ctx, pool)
+		var walletBID string
+		require.NoError(t, pool.GetContext(ctx, &walletBID, `
+			INSERT INTO distribution_wallets (name, distribution_account_type)
+			VALUES ('scope-wallet-b', 'DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT') RETURNING id`))
+
+		if !user.IsOwner {
+			_, err = models.WalletMemberships.Insert(ctx, pool, user.ID, walletA.ID, data.DeveloperUserRole, nil)
+			require.NoError(t, err)
+		}
+
+		authManagerMock := &auth.AuthManagerMock{}
+		authManagerMock.On("GetUserByID", mock.Anything, user.ID).Return(user, nil).Maybe()
+
+		return APIKeyHandler{Models: models, AuthManager: authManagerMock}, ctx, walletA, walletBID
+	}
+
+	create := func(t *testing.T, handler APIKeyHandler, ctx context.Context, body map[string]any) *httptest.ResponseRecorder {
+		t.Helper()
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api-keys", bytes.NewReader(b))
+		rr := httptest.NewRecorder()
+		handler.CreateAPIKey(rr, req)
+		return rr
+	}
+
+	developer := &auth.User{ID: developerUserID, Roles: []string{string(data.DeveloperUserRole)}}
+	owner := &auth.User{ID: adminUserID, IsOwner: true}
+
+	t.Run("a non-owner may scope a key to a wallet they hold", func(t *testing.T) {
+		handler, ctx, walletA, _ := setup(t, developer)
+		rr := create(t, handler, ctx, map[string]any{
+			"name":                    "developer key",
+			"permissions":             []string{"read:payments"},
+			"distribution_wallet_ids": []string{walletA.ID},
+		})
+		require.Equal(t, http.StatusCreated, rr.Code)
+
+		var got data.APIKey
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		assert.Equal(t, []string{walletA.ID}, []string(got.DistributionWalletIDs))
+	})
+
+	t.Run("a non-owner may not scope a key beyond their own memberships", func(t *testing.T) {
+		handler, ctx, _, walletBID := setup(t, developer)
+		rr := create(t, handler, ctx, map[string]any{
+			"name":                    "overreaching key",
+			"permissions":             []string{"read:payments"},
+			"distribution_wallet_ids": []string{walletBID},
+		})
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+		assert.NotContains(t, rr.Body.String(), "scope-wallet-b", "the refusal discloses no wallet detail")
+	})
+
+	t.Run("omitting the field inherits a non-owner's memberships, not the tenant", func(t *testing.T) {
+		handler, ctx, walletA, walletBID := setup(t, developer)
+		rr := create(t, handler, ctx, map[string]any{
+			"name": "inheriting key", "permissions": []string{"read:payments"},
+		})
+		require.Equal(t, http.StatusCreated, rr.Code)
+
+		var got data.APIKey
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		assert.Equal(t, []string{walletA.ID}, []string(got.DistributionWalletIDs))
+		assert.NotContains(t, got.DistributionWalletIDs, walletBID)
+	})
+
+	t.Run("omitting the field inherits every active wallet for an owner", func(t *testing.T) {
+		handler, ctx, walletA, walletBID := setup(t, owner)
+		rr := create(t, handler, ctx, map[string]any{
+			"name": "owner key", "permissions": []string{"read:payments"},
+		})
+		require.Equal(t, http.StatusCreated, rr.Code)
+
+		var got data.APIKey
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		assert.ElementsMatch(t, []string{walletA.ID, walletBID}, []string(got.DistributionWalletIDs))
+	})
+
+	t.Run("an explicit empty list is honored as no wallet access", func(t *testing.T) {
+		handler, ctx, _, _ := setup(t, owner)
+		rr := create(t, handler, ctx, map[string]any{
+			"name": "org-only key", "permissions": []string{"read:organization"},
+			"distribution_wallet_ids": []string{},
+		})
+		require.Equal(t, http.StatusCreated, rr.Code)
+
+		var got data.APIKey
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		assert.Empty(t, got.DistributionWalletIDs)
+	})
+
+	t.Run("an archived account cannot be named on a new key", func(t *testing.T) {
+		handler, ctx, _, walletBID := setup(t, owner)
+		_, err := handler.Models.DBConnectionPool.ExecContext(ctx,
+			`UPDATE distribution_wallets SET status = 'ARCHIVED', archived_at = NOW() WHERE id = $1`, walletBID)
+		require.NoError(t, err)
+
+		rr := create(t, handler, ctx, map[string]any{
+			"name": "archived key", "permissions": []string{"read:payments"},
+			"distribution_wallet_ids": []string{walletBID},
+		})
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("inheriting on creation skips archived accounts", func(t *testing.T) {
+		handler, ctx, walletA, walletBID := setup(t, owner)
+		_, err := handler.Models.DBConnectionPool.ExecContext(ctx,
+			`UPDATE distribution_wallets SET status = 'ARCHIVED', archived_at = NOW() WHERE id = $1`, walletBID)
+		require.NoError(t, err)
+
+		rr := create(t, handler, ctx, map[string]any{
+			"name": "inheriting key", "permissions": []string{"read:payments"},
+		})
+		require.Equal(t, http.StatusCreated, rr.Code)
+
+		var got data.APIKey
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		assert.Equal(t, []string{walletA.ID}, []string(got.DistributionWalletIDs))
+	})
+
+	// An account archived after the key was scoped to it stays put: keeping it grants nothing new,
+	// and refusing it would make an unrelated permissions edit impossible to save.
+	t.Run("an edit keeps an account archived since the key was created", func(t *testing.T) {
+		handler, ctx, walletA, walletBID := setup(t, owner)
+
+		rr := create(t, handler, ctx, map[string]any{
+			"name": "long-lived key", "permissions": []string{"read:payments"},
+			"distribution_wallet_ids": []string{walletA.ID, walletBID},
+		})
+		require.Equal(t, http.StatusCreated, rr.Code)
+		var created data.APIKey
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &created))
+
+		_, err := handler.Models.DBConnectionPool.ExecContext(ctx,
+			`UPDATE distribution_wallets SET status = 'ARCHIVED', archived_at = NOW() WHERE id = $1`, walletBID)
+		require.NoError(t, err)
+
+		patch := func(body map[string]any) *httptest.ResponseRecorder {
+			b, marshalErr := json.Marshal(body)
+			require.NoError(t, marshalErr)
+			req := httptest.NewRequestWithContext(ctx, http.MethodPatch, "/api-keys/"+created.ID, bytes.NewReader(b))
+			chiCtx := chi.NewRouteContext()
+			chiCtx.URLParams.Add("id", created.ID)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+			rr := httptest.NewRecorder()
+			handler.UpdateKey(rr, req)
+			return rr
+		}
+
+		resent := patch(map[string]any{
+			"permissions":             []string{"read:payments", "read:exports"},
+			"distribution_wallet_ids": []string{walletA.ID, walletBID},
+		})
+		require.Equal(t, http.StatusOK, resent.Code)
+		var updated data.APIKey
+		require.NoError(t, json.Unmarshal(resent.Body.Bytes(), &updated))
+		assert.ElementsMatch(t, []string{walletA.ID, walletBID}, []string(updated.DistributionWalletIDs))
+
+		omitted := patch(map[string]any{"permissions": []string{"read:payments"}})
+		require.Equal(t, http.StatusOK, omitted.Code)
+		require.NoError(t, json.Unmarshal(omitted.Body.Bytes(), &updated))
+		assert.ElementsMatch(t, []string{walletA.ID, walletBID}, []string(updated.DistributionWalletIDs),
+			"an edit that does not mention wallets leaves the scope alone")
+
+		dropped := patch(map[string]any{
+			"permissions":             []string{"read:payments"},
+			"distribution_wallet_ids": []string{walletA.ID},
+		})
+		require.Equal(t, http.StatusOK, dropped.Code)
+		require.NoError(t, json.Unmarshal(dropped.Body.Bytes(), &updated))
+		assert.Equal(t, []string{walletA.ID}, []string(updated.DistributionWalletIDs),
+			"removing an archived account is always allowed")
+
+		readded := patch(map[string]any{
+			"permissions":             []string{"read:payments"},
+			"distribution_wallet_ids": []string{walletA.ID, walletBID},
+		})
+		assert.Equal(t, http.StatusForbidden, readded.Code,
+			"once dropped, an archived account cannot be put back")
+	})
+
+	t.Run("a key minting a key cannot widen the scope it holds", func(t *testing.T) {
+		handler, ctx, walletA, walletBID := setup(t, developer)
+		// The acting key names only walletA, so walletB is out of reach even though the request
+		// arrives with write:all and the creator is resolvable.
+		keyCtx := sdpcontext.SetAPIKeyInContext(ctx, &data.APIKey{
+			ID:                    "acting-key",
+			Permissions:           data.APIKeyPermissions{data.WriteAll},
+			CreatedBy:             developerUserID,
+			DistributionWalletIDs: pq.StringArray{walletA.ID},
+		})
+
+		rr := create(t, handler, keyCtx, map[string]any{
+			"name": "child key", "permissions": []string{"read:payments"},
+			"distribution_wallet_ids": []string{walletBID},
+		})
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+
+		rr = create(t, handler, keyCtx, map[string]any{
+			"name": "sibling key", "permissions": []string{"read:payments"},
+			"distribution_wallet_ids": []string{walletA.ID},
+		})
+		assert.Equal(t, http.StatusCreated, rr.Code)
+	})
 }
 
 func Test_CreateAPIKey_WithAllFields(t *testing.T) {
@@ -123,6 +351,7 @@ func TestUpdateKey_AllowedIPsHandling(t *testing.T) {
 		"Techpriest Archive Key",
 		[]data.APIKeyPermission{data.ReadAll},
 		[]string{"10.0.0.0/8"},
+		nil,
 		nil,
 		adminUserID,
 	)
@@ -339,6 +568,7 @@ func Test_GetAllAPIKeys(t *testing.T) {
 			[]data.APIKeyPermission{data.ReadAll},
 			nil,
 			nil,
+			nil,
 			userID,
 		)
 		require.NoError(t, err)
@@ -347,6 +577,7 @@ func Test_GetAllAPIKeys(t *testing.T) {
 			"Cicatrix Maledictum Cipher",
 			[]data.APIKeyPermission{data.ReadStatistics},
 			[]string{"203.0.113.0/24"},
+			nil,
 			nil,
 			userID,
 		)
@@ -399,7 +630,7 @@ func Test_DeleteAPIKeyEndpoints(t *testing.T) {
 			ctx,
 			"Tempestus Scion Key",
 			[]data.APIKeyPermission{data.ReadAll},
-			nil, nil,
+			nil, nil, nil,
 			adminUserID,
 		)
 		require.NoError(t, err)
@@ -423,7 +654,7 @@ func Test_DeleteAPIKeyEndpoints(t *testing.T) {
 			ctx,
 			"Stormcaller Relic Key",
 			[]data.APIKeyPermission{data.ReadAll},
-			nil, nil,
+			nil, nil, nil,
 			adminUserID,
 		)
 		require.NoError(t, err)
@@ -457,6 +688,7 @@ func Test_GetAPIKeyByIDEndpoints(t *testing.T) {
 			"Vox Imperator Index Key",
 			[]data.APIKeyPermission{data.ReadStatistics, data.ReadExports},
 			[]string{"198.51.100.0/24"},
+			nil,
 			&expiry,
 			adminUserID,
 		)
@@ -495,7 +727,7 @@ func Test_GetAPIKeyByIDEndpoints(t *testing.T) {
 			ctx,
 			"Iridium Tomb Key",
 			[]data.APIKeyPermission{data.ReadAll},
-			nil, nil,
+			nil, nil, nil,
 			adminUserID,
 		)
 		require.NoError(t, err)
@@ -528,6 +760,7 @@ func Test_UpdateKeyEndpoints(t *testing.T) {
 		"Adeptus Mechanicus Secret Key",
 		[]data.APIKeyPermission{data.ReadAll, data.ReadStatistics},
 		[]string{"10.0.0.0/8"},
+		nil,
 		nil,
 		adminUserID,
 	)

--- a/internal/serve/httphandler/assets_handler.go
+++ b/internal/serve/httphandler/assets_handler.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
@@ -161,10 +162,16 @@ func (c AssetsHandler) getBalanceInfo(
 // path that never had one, and no 400. resolveSourceWalletForWrite's own header-less fallback is
 // deliberately not reused here — it 400s tenants with more than one active wallet, which would
 // break the existing add/remove-asset flow for them instead of extending it.
+//
+// An API key never takes the header-less shortcut: its scope is explicit, so falling back to the
+// tenant default would let a key scoped to one wallet edit another wallet's trustlines.
 func (c AssetsHandler) resolveTrustlineAccountForWrite(req *http.Request, noFundedAccountMsg string) (schema.TransactionAccount, *httperror.HTTPError) {
 	ctx := req.Context()
 
-	if req.Header.Get(XWalletIDHeader) == "" {
+	_, keyErr := sdpcontext.GetAPIKeyFromContext(ctx)
+	viaAPIKey := keyErr == nil
+
+	if req.Header.Get(XWalletIDHeader) == "" && !viaAPIKey {
 		distributionAccount, err := c.DistributionAccountFromContext(ctx)
 		if err != nil {
 			err = fmt.Errorf("resolving distribution account from context: %w", err)

--- a/internal/serve/httphandler/circle_config_handler.go
+++ b/internal/serve/httphandler/circle_config_handler.go
@@ -3,19 +3,24 @@ package httphandler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/support/render/httpjson"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/monitor"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
+	ctxHelper "github.com/stellar/stellar-disbursement-platform-backend/internal/serve/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
 	sdpUtils "github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
@@ -29,11 +34,28 @@ type CircleConfigHandler struct {
 	CircleClientConfigModel     circle.ClientConfigModelInterface
 	DistributionAccountResolver signing.DistributionAccountResolver
 	MonitorService              monitor.MonitorServiceInterface
+	AuthManager                 auth.AuthManager
 }
 
 type PatchCircleConfigRequest struct {
 	WalletID *string `json:"wallet_id"`
 	APIKey   *string `json:"api_key"`
+}
+
+func (h CircleConfigHandler) ensureCallerIsOwner(ctx context.Context) *httperror.HTTPError {
+	user, err := ctxHelper.GetUserFromContext(ctx, h.AuthManager)
+	if err != nil {
+		if errors.Is(err, auth.ErrUserNotFound) {
+			return httperror.Unauthorized("", err, nil)
+		}
+		return httperror.InternalError(ctx, "Cannot get user from context", err, nil)
+	}
+
+	if !user.IsOwner && !slices.Contains(user.Roles, string(data.OwnerUserRole)) {
+		return httperror.Forbidden("", nil, nil)
+	}
+
+	return nil
 }
 
 // validate validates the request.
@@ -47,6 +69,11 @@ func (r PatchCircleConfigRequest) validate() error {
 // Patch is a handler to configure the Circle API access.
 func (h CircleConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	if httpErr := h.ensureCallerIsOwner(ctx); httpErr != nil {
+		httpErr.Render(w)
+		return
+	}
 
 	tnt, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {

--- a/internal/serve/httphandler/circle_config_handler_test.go
+++ b/internal/serve/httphandler/circle_config_handler_test.go
@@ -18,13 +18,20 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/db"
 	"github.com/stellar/stellar-disbursement-platform-backend/db/dbtest"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/circle"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
 	sigMocks "github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing/mocks"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
+)
+
+const (
+	ownerUserID    = "8f3c1e26-9c40-4a12-9c58-2a6cbd2f7a10"
+	nonOwnerUserID = "1d1c3a1e-7a55-4f0e-9d0a-3d5f7b9c1e42"
 )
 
 func TestCircleConfigHandler_Patch(t *testing.T) {
@@ -37,6 +44,14 @@ func TestCircleConfigHandler_Patch(t *testing.T) {
 	// Creates a tenant and inserts it in the context
 	tnt := schema.Tenant{ID: "test-tenant-id"}
 	ctx := sdpcontext.SetTenantInContext(context.Background(), &tnt)
+	ctx = sdpcontext.SetTokenInContext(ctx, "test-token")
+	ctx = sdpcontext.SetUserIDInContext(ctx, ownerUserID)
+
+	authManagerMock := &auth.AuthManagerMock{}
+	authManagerMock.On("GetUserByID", mock.Anything, ownerUserID).
+		Return(&auth.User{ID: ownerUserID, IsOwner: true}, nil).Maybe()
+	authManagerMock.On("GetUserByID", mock.Anything, nonOwnerUserID).
+		Return(&auth.User{ID: nonOwnerUserID, Roles: []string{string(data.FinancialControllerUserRole)}}, nil).Maybe()
 
 	kp := keypair.MustRandom()
 	encryptionPassphrase := kp.Seed()
@@ -58,10 +73,41 @@ func TestCircleConfigHandler_Patch(t *testing.T) {
 	testCases := []struct {
 		name           string
 		prepareMocksFn func(t *testing.T, mDistributionAccountResolver *sigMocks.MockDistributionAccountResolver, mCircleClient *circle.MockClient, mTenantManager *tenant.TenantManagerMock)
+		requestCtx     context.Context
 		requestBody    string
 		statusCode     int
 		assertions     func(t *testing.T, rr *httptest.ResponseRecorder)
 	}{
+		{
+			name:        "fails closed when no acting user can be resolved",
+			requestCtx:  sdpcontext.SetTenantInContext(context.Background(), &tnt),
+			requestBody: string(validRequestBody),
+			statusCode:  http.StatusInternalServerError,
+			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+
+				assert.JSONEq(t, `{"error": "Cannot get user from context"}`, rr.Body.String())
+			},
+		},
+		{
+			// RequirePermission short-circuits past the route's Owner check on the API key path,
+			// so a key minted by a non-owner has to be stopped here instead.
+			name: "returns Forbidden for an API key whose creator is not an Owner",
+			requestCtx: sdpcontext.SetUserIDInContext(
+				sdpcontext.SetAPIKeyInContext(
+					sdpcontext.SetTenantInContext(context.Background(), &tnt),
+					&data.APIKey{ID: "ak-1", Permissions: data.APIKeyPermissions{data.WriteAll}, CreatedBy: nonOwnerUserID},
+				),
+				nonOwnerUserID,
+			),
+			requestBody: string(validRequestBody),
+			statusCode:  http.StatusForbidden,
+			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+
+				assert.JSONEq(t, `{"error": "You don't have permission to perform this action."}`, rr.Body.String())
+			},
+		},
 		{
 			name: "returns bad request if distribution account type is not Circle",
 			prepareMocksFn: func(t *testing.T, mDistAccResolver *sigMocks.MockDistributionAccountResolver, mCircleClient *circle.MockClient, mTenantManager *tenant.TenantManagerMock) {
@@ -186,6 +232,12 @@ func TestCircleConfigHandler_Patch(t *testing.T) {
 				Encrypter:               &encrypter,
 				EncryptionPassphrase:    encryptionPassphrase,
 				CircleClientConfigModel: &ccm,
+				AuthManager:             authManagerMock,
+			}
+
+			requestCtx := ctx
+			if tc.requestCtx != nil {
+				requestCtx = tc.requestCtx
 			}
 
 			if tc.prepareMocksFn != nil {
@@ -205,7 +257,7 @@ func TestCircleConfigHandler_Patch(t *testing.T) {
 			url := "/organization/circle-config"
 			r.Patch(url, handler.Patch)
 
-			rr := testutils.Request(t, ctx, r, url, http.MethodPatch, strings.NewReader(tc.requestBody))
+			rr := testutils.Request(t, requestCtx, r, url, http.MethodPatch, strings.NewReader(tc.requestBody))
 			assert.Equal(t, tc.statusCode, rr.Code)
 			tc.assertions(t, rr)
 		})

--- a/internal/serve/httphandler/distribution_wallets_handler.go
+++ b/internal/serve/httphandler/distribution_wallets_handler.go
@@ -195,9 +195,16 @@ func (h DistributionWalletsHandler) ensureWalletInReadScope(ctx context.Context,
 // "The acting user must be an Owner" is the rule, mirroring what the route gate intended, rather
 // than a per-wallet scope check: these operations are tenant-wide (create, promote-to-default) or
 // hand out authority itself, and Owner is deliberately not grantable per wallet
-// (PostDistributionWalletMembership rejects it), so no membership can stand in for it. On the API
-// key path the acting identity is the key's creator — the middleware sets
+// (PostDistributionWalletMembership rejects it), so no membership can stand in for it.
+//
+// On the API key path the acting identity is the key's creator — the middleware sets
 // SetUserIDInContext(apiKey.CreatedBy) — so a key minted by a non-owner is denied here.
+//
+// This is the one place a key still resolves its creator. Ownership is not expressible on a key:
+// its permissions and wallet scope say what it may touch, never that it speaks for the tenant. The
+// alternative to asking the creator is refusing keys outright, which would take a capability
+// owner-minted keys have today. Note the consequence — deactivating or deleting the creator
+// withdraws their keys from tenant administration, while leaving every other endpoint working.
 //
 // It fails closed: an acting user that cannot be resolved (missing from the context, deleted
 // since the key was created) is rejected, never passed through.

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -360,6 +360,10 @@ func (p PaymentsHandler) PostDirectPayment(w http.ResponseWriter, r *http.Reques
 	}
 	user, err := p.AuthManager.GetUserByID(ctx, userID)
 	if err != nil {
+		if errors.Is(err, auth.ErrUserNotFound) {
+			httperror.Unauthorized("", err, nil).Render(w)
+			return
+		}
 		httperror.InternalError(ctx, "Cannot get user", err, nil).Render(w)
 		return
 	}

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
+	ctxHelper "github.com/stellar/stellar-disbursement-platform-backend/internal/serve/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/validators"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/transactionsubmission/engine/signing"
@@ -90,10 +91,26 @@ type PatchUserPasswordRequest struct {
 	NewPassword     string `json:"new_password"`
 }
 
+func (h ProfileHandler) ensureCallerIsOwner(ctx context.Context) (*auth.User, *httperror.HTTPError) {
+	user, err := ctxHelper.GetUserFromContext(ctx, h.AuthManager)
+	if err != nil {
+		if errors.Is(err, auth.ErrUserNotFound) {
+			return nil, httperror.Unauthorized("", err, nil)
+		}
+		return nil, httperror.InternalError(ctx, "Cannot get user from context", err, nil)
+	}
+
+	if !user.IsOwner && !slices.Contains(user.Roles, string(data.OwnerUserRole)) {
+		return nil, httperror.Forbidden("", nil, nil)
+	}
+
+	return user, nil
+}
+
 func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	_, user, httpErr := getTokenAndUser(ctx, h.AuthManager)
+	user, httpErr := h.ensureCallerIsOwner(ctx)
 	if httpErr != nil {
 		httpErr.Render(rw)
 		return

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -137,7 +137,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 	require.NoError(t, err)
 
 	url := "/profile/organization"
-	user := &auth.User{ID: "user-id"}
+	user := &auth.User{ID: "user-id", IsOwner: true}
 	testCases := []struct {
 		name              string
 		token             string
@@ -148,22 +148,21 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 		networkType       utils.NetworkType
 	}{
 		{
-			name: "returns Unauthorized when no token is found",
+			name: "fails closed when no acting user can be resolved",
 			getRequestFn: func(t *testing.T, ctx context.Context) *http.Request {
 				return httptest.NewRequest(http.MethodPatch, url, nil).WithContext(ctx)
 			},
-			wantStatusCode: http.StatusUnauthorized,
-			wantRespBody:   `{"error": "Not authorized."}`,
+			wantStatusCode: http.StatusInternalServerError,
+			wantRespBody:   `{"error": "Cannot get user from context"}`,
 		},
 		{
-			// The route admits Financial Controllers as well as Owners, but the webhook URL is
-			// where every payment and disbursement event in the tenant is delivered — a non-owner
-			// must not be able to redirect the event stream to an endpoint they control.
+			// The whole endpoint is Owner-only now, enforced in the handler so it holds on the API
+			// key path too — a non-owner no longer reaches the webhook URL's own check.
 			name:  "returns Forbidden when a non-owner tries to set the webhook URL",
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(&auth.User{
 						ID:    "fc-user-id",
 						Roles: []string{data.FinancialControllerUserRole.String()},
@@ -178,7 +177,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 					`{"webhook_url": "https://attacker.example.com/hook"}`, buf)
 			},
 			wantStatusCode: http.StatusForbidden,
-			wantRespBody:   `{"error": "only owners can change the webhook URL"}`,
+			wantRespBody:   `{"error": "You don't have permission to perform this action."}`,
 		},
 		{
 			// Same request shape, owner instead — must get past the gate. It fails later on the
@@ -188,7 +187,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(&auth.User{
 						ID:      "owner-user-id",
 						IsOwner: true,
@@ -212,7 +211,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -227,7 +226,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -247,7 +246,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -267,7 +266,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -287,7 +286,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -310,7 +309,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -333,7 +332,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -357,7 +356,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -381,7 +380,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -405,7 +404,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -429,7 +428,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -456,6 +455,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			ctx := context.Background()
 			if tc.token != "" {
 				ctx = sdpcontext.SetTokenInContext(ctx, tc.token)
+				ctx = sdpcontext.SetUserIDInContext(ctx, "test-user-id")
 			}
 
 			// Setup password validator
@@ -520,7 +520,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 	require.NoError(t, err)
 
 	url := "/profile/organization"
-	user := &auth.User{ID: "user-id"}
+	user := &auth.User{ID: "user-id", IsOwner: true}
 	testCases := []struct {
 		name                     string
 		token                    string
@@ -535,7 +535,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -552,7 +552,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -569,7 +569,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -610,7 +610,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
 				authManagerMock.
-					On("GetUser", mock.Anything, "token").
+					On("GetUserByID", mock.Anything, mock.Anything).
 					Return(user, nil).
 					Once()
 			},
@@ -664,6 +664,7 @@ func Test_ProfileHandler_PatchOrganizationProfile_Successful(t *testing.T) {
 			ctx := context.Background()
 			if tc.token != "" {
 				ctx = sdpcontext.SetTokenInContext(ctx, tc.token)
+				ctx = sdpcontext.SetUserIDInContext(ctx, "test-user-id")
 			}
 
 			// Assert DB before

--- a/internal/serve/httphandler/receiver_handler.go
+++ b/internal/serve/httphandler/receiver_handler.go
@@ -65,7 +65,8 @@ func (rh ReceiverHandler) GetReceiver(w http.ResponseWriter, r *http.Request) {
 			if scope != nil {
 				var visible bool
 				if visErr := dbTx.GetContext(ctx, &visible, `
-					SELECT EXISTS (SELECT 1 FROM payments pw WHERE pw.receiver_id = $1 AND pw.source_wallet_id = ANY($2))`,
+					SELECT EXISTS (SELECT 1 FROM payments pw WHERE pw.receiver_id = $1 AND pw.source_wallet_id = ANY($2))
+						OR NOT EXISTS (SELECT 1 FROM payments pw WHERE pw.receiver_id = $1)`,
 					receiverID, pq.Array(scope)); visErr != nil {
 					return nil, fmt.Errorf("checking receiver visibility: %w", visErr)
 				}

--- a/internal/serve/httphandler/receiver_visibility_test.go
+++ b/internal/serve/httphandler/receiver_visibility_test.go
@@ -97,4 +97,37 @@ func Test_ReceiverVisibility_R1(t *testing.T) {
 		rr = doAs(owner.ID, fmt.Sprintf("/receivers/%s", receiverFromB.ID))
 		assert.Equal(t, http.StatusOK, rr.Code)
 	})
+
+	// Receivers are created tenant-wide by roles with no say in which account pays them, so an
+	// unpaid receiver belongs to no account and stays visible to everyone. Its first payment is
+	// what assigns it, and from then on the filter applies.
+	t.Run("an unpaid receiver is tenant-wide until its first payment", func(t *testing.T) {
+		unpaid := data.CreateReceiverFixture(t, ctx, dbConnectionPool, &data.Receiver{})
+
+		rr := doAs(memberA.ID, "/receivers")
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), unpaid.ID, "the creator must be able to find what they just created")
+
+		rr = doAs(memberA.ID, fmt.Sprintf("/receivers/%s", unpaid.ID))
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Paid from walletB, which memberA holds no membership on: it now belongs to that account.
+		d := data.CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &data.Disbursement{
+			Name: "recv-disb-claims-unpaid", SourceWalletID: walletBID, Status: data.StartedDisbursementStatus,
+		})
+		rw := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, unpaid.ID, d.Wallet.ID, data.ReadyReceiversWalletStatus)
+		data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+			ReceiverWallet: rw, Disbursement: d, Asset: *d.Asset, Amount: "3", Status: data.DraftPaymentStatus,
+		})
+
+		rr = doAs(memberA.ID, "/receivers")
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.NotContains(t, rr.Body.String(), unpaid.ID)
+
+		rr = doAs(memberA.ID, fmt.Sprintf("/receivers/%s", unpaid.ID))
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+
+		rr = doAs(owner.ID, fmt.Sprintf("/receivers/%s", unpaid.ID))
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
 }

--- a/internal/serve/httphandler/wallet_scope.go
+++ b/internal/serve/httphandler/wallet_scope.go
@@ -26,7 +26,7 @@ import (
 // creation, so it neither depends on its creator still being active nor moves when their
 // memberships change.
 func resolveWalletReadScope(ctx context.Context, authManager auth.AuthManager, models *data.Models) ([]string, *httperror.HTTPError) {
-	if apiKey, err := sdpcontext.GetAPIKeyFromContext(ctx); err == nil && apiKey != nil {
+	if apiKey, err := sdpcontext.GetAPIKeyFromContext(ctx); err == nil {
 		return apiKey.WalletScope(), nil
 	}
 
@@ -96,7 +96,7 @@ func resolveWalletListScope(ctx context.Context, req *http.Request, authManager 
 // For an API key the wallet dimension is its own scope and the role dimension is its permission
 // set, already checked by RequirePermission on the route — so the key's scope is the whole answer.
 func ensureWalletActionAllowed(ctx context.Context, authManager auth.AuthManager, models *data.Models, walletID string, requiredRoles ...data.UserRole) *httperror.HTTPError {
-	if apiKey, err := sdpcontext.GetAPIKeyFromContext(ctx); err == nil && apiKey != nil {
+	if apiKey, err := sdpcontext.GetAPIKeyFromContext(ctx); err == nil {
 		if !apiKey.CanActOnWallet(walletID) {
 			return httperror.Forbidden(services.ErrWalletActionForbidden.Error(), nil, nil)
 		}
@@ -269,7 +269,7 @@ const XWalletIDHeader = "X-Wallet-Id"
 // owner identity to earn the honest 404). The header only selects — it never grants.
 func resolveSourceWalletForWrite(ctx context.Context, req *http.Request, authManager auth.AuthManager, models *data.Models, requiredRoles ...data.UserRole) (*data.DistributionWallet, *httperror.HTTPError) {
 	apiKey, keyErr := sdpcontext.GetAPIKeyFromContext(ctx)
-	viaAPIKey := keyErr == nil && apiKey != nil
+	viaAPIKey := keyErr == nil
 
 	var user *auth.User
 	if !viaAPIKey {

--- a/internal/serve/httphandler/wallet_scope.go
+++ b/internal/serve/httphandler/wallet_scope.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	ctxHelper "github.com/stellar/stellar-disbursement-platform-backend/internal/serve/auth"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/services"
@@ -20,7 +21,15 @@ import (
 // resolveWalletReadScope computes the caller's read-visibility scope for
 // membership-filtered endpoints (taxonomy): nil = Owner, no filtering; non-nil = the exact
 // wallet set the caller may see (possibly empty).
+//
+// An API key answers from its own stored scope and never loads a user: a key's reach is fixed at
+// creation, so it neither depends on its creator still being active nor moves when their
+// memberships change.
 func resolveWalletReadScope(ctx context.Context, authManager auth.AuthManager, models *data.Models) ([]string, *httperror.HTTPError) {
+	if apiKey, err := sdpcontext.GetAPIKeyFromContext(ctx); err == nil && apiKey != nil {
+		return apiKey.WalletScope(), nil
+	}
+
 	user, err := ctxHelper.GetUserFromContext(ctx, authManager)
 	if err != nil {
 		if errors.Is(err, auth.ErrUserNotFound) {
@@ -83,7 +92,17 @@ func resolveWalletListScope(ctx context.Context, req *http.Request, authManager 
 // ensureWalletActionAllowed gates a state transition on the caller's wallet membership
 // Owners pass; everyone else needs a qualifying role on the wallet. Returns a 403
 // that discloses no wallet details.
+//
+// For an API key the wallet dimension is its own scope and the role dimension is its permission
+// set, already checked by RequirePermission on the route — so the key's scope is the whole answer.
 func ensureWalletActionAllowed(ctx context.Context, authManager auth.AuthManager, models *data.Models, walletID string, requiredRoles ...data.UserRole) *httperror.HTTPError {
+	if apiKey, err := sdpcontext.GetAPIKeyFromContext(ctx); err == nil && apiKey != nil {
+		if !apiKey.CanActOnWallet(walletID) {
+			return httperror.Forbidden(services.ErrWalletActionForbidden.Error(), nil, nil)
+		}
+		return nil
+	}
+
 	user, err := ctxHelper.GetUserFromContext(ctx, authManager)
 	if err != nil {
 		if errors.Is(err, auth.ErrUserNotFound) {
@@ -244,17 +263,35 @@ const XWalletIDHeader = "X-Wallet-Id"
 //     indistinguishable to non-owners); Owners get an honest 404 for unknown ids
 //   - archived wallets accept no new disbursements or payments → 400 (only after the caller
 //     proves entitlement, so archived-ness is not leaked)
+//
+// An API key resolves against its own scope throughout: it never loads a user, a key naming exactly
+// one wallet keeps working without the header, and an unknown id is always a 403 (a key has no
+// owner identity to earn the honest 404). The header only selects — it never grants.
 func resolveSourceWalletForWrite(ctx context.Context, req *http.Request, authManager auth.AuthManager, models *data.Models, requiredRoles ...data.UserRole) (*data.DistributionWallet, *httperror.HTTPError) {
-	user, err := ctxHelper.GetUserFromContext(ctx, authManager)
-	if err != nil {
-		if errors.Is(err, auth.ErrUserNotFound) {
-			return nil, httperror.Unauthorized("", err, nil)
+	apiKey, keyErr := sdpcontext.GetAPIKeyFromContext(ctx)
+	viaAPIKey := keyErr == nil && apiKey != nil
+
+	var user *auth.User
+	if !viaAPIKey {
+		var err error
+		user, err = ctxHelper.GetUserFromContext(ctx, authManager)
+		if err != nil {
+			if errors.Is(err, auth.ErrUserNotFound) {
+				return nil, httperror.Unauthorized("", err, nil)
+			}
+			return nil, httperror.InternalError(ctx, "Cannot get user from context", err, nil)
 		}
-		return nil, httperror.InternalError(ctx, "Cannot get user from context", err, nil)
 	}
 
 	dbPool := models.DBConnectionPool
 	headerWalletID := req.Header.Get(XWalletIDHeader)
+
+	// A key naming one wallet is unambiguous without the header. The tenant-level fallback below
+	// only fires when exactly one wallet is active, so without this an existing integration would
+	// start failing the moment its tenant adds a second wallet.
+	if headerWalletID == "" && viaAPIKey && len(apiKey.WalletScope()) == 1 {
+		headerWalletID = apiKey.WalletScope()[0]
+	}
 
 	var wallet *data.DistributionWallet
 	if headerWalletID == "" {
@@ -275,7 +312,7 @@ func resolveSourceWalletForWrite(ctx context.Context, req *http.Request, authMan
 			}
 			// Unknown wallet: Owners get an honest 404; everyone else gets the same 403 as
 			// an unentitled wallet — existence is never disclosed.
-			if user.IsOwner {
+			if !viaAPIKey && user.IsOwner {
 				return nil, httperror.NotFound("distribution wallet not found", getErr, nil)
 			}
 			return nil, httperror.Forbidden(services.ErrWalletActionForbidden.Error(), getErr, nil)
@@ -283,7 +320,11 @@ func resolveSourceWalletForWrite(ctx context.Context, req *http.Request, authMan
 		wallet = loaded
 	}
 
-	if authzErr := services.EnsureUserCanActOnWallet(ctx, dbPool, models.WalletMemberships, user, wallet.ID, requiredRoles...); authzErr != nil {
+	if viaAPIKey {
+		if !apiKey.CanActOnWallet(wallet.ID) {
+			return nil, httperror.Forbidden(services.ErrWalletActionForbidden.Error(), nil, nil)
+		}
+	} else if authzErr := services.EnsureUserCanActOnWallet(ctx, dbPool, models.WalletMemberships, user, wallet.ID, requiredRoles...); authzErr != nil {
 		if errors.Is(authzErr, services.ErrWalletActionForbidden) {
 			return nil, httperror.Forbidden(services.ErrWalletActionForbidden.Error(), authzErr, nil)
 		}

--- a/internal/serve/httphandler/wallet_scope_test.go
+++ b/internal/serve/httphandler/wallet_scope_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -152,10 +153,11 @@ func Test_APIKeyWalletReadScope(t *testing.T) {
 	})
 
 	apiKey := &data.APIKey{
-		ID:          "api-key-1",
-		Name:        "reader",
-		CreatedBy:   creator.ID,
-		Permissions: data.APIKeyPermissions{data.ReadDistributionWallets},
+		ID:                    "api-key-1",
+		Name:                  "reader",
+		CreatedBy:             creator.ID,
+		Permissions:           data.APIKeyPermissions{data.ReadDistributionWallets},
+		DistributionWalletIDs: pq.StringArray{walletA.ID},
 	}
 	withAPIKey := func(path string) *httptest.ResponseRecorder {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -186,13 +188,13 @@ func Test_APIKeyWalletReadScope(t *testing.T) {
 		}
 	}
 
-	t.Run("capabilities: outside the creator's scope returns 404", func(t *testing.T) {
+	t.Run("capabilities: outside the key's scope returns 404", func(t *testing.T) {
 		rr := withAPIKey(fmt.Sprintf("/distribution-wallets/%s/capabilities", walletBID))
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 		assert.NotContains(t, rr.Body.String(), "api-key-wallet-b")
 	})
 
-	t.Run("capabilities: inside the creator's scope it is served, and follows the creator's "+
+	t.Run("capabilities: inside the key's scope it is served, and follows the creator's "+
 		"membership role rather than the key's permissions", func(t *testing.T) {
 		rr := withAPIKey(fmt.Sprintf("/distribution-wallets/%s/capabilities", walletA.ID))
 		require.Equal(t, http.StatusOK, rr.Code)
@@ -202,6 +204,58 @@ func Test_APIKeyWalletReadScope(t *testing.T) {
 		assert.Contains(t, body, `"can_create_disbursement": false`)
 		assert.Contains(t, body, `"can_start_disbursement": false`)
 	})
+
+	// The wallet the key may reach is now the key's own column, not a live read of the creator's
+	// memberships: revoking that membership leaves the key's reach untouched.
+	t.Run("capabilities: scope follows the key, not the creator's memberships", func(t *testing.T) {
+		_, err := dbConnectionPool.ExecContext(ctx,
+			`DELETE FROM wallet_memberships WHERE user_id = $1`, creator.ID)
+		require.NoError(t, err)
+
+		rr := withAPIKey(fmt.Sprintf("/distribution-wallets/%s/capabilities", walletA.ID))
+		assert.Equal(t, http.StatusOK, rr.Code, "the key still reaches the wallet named on it")
+	})
+}
+
+// Test_APIKeyWalletScopeIsItsOwn pins the decoupling: a key's reach is the column on the key, not
+// a live projection of its creator's memberships, so it neither moves when those memberships
+// change nor collapses when the creator is deactivated or deleted.
+func Test_APIKeyWalletScopeIsItsOwn(t *testing.T) {
+	ctx := context.Background()
+
+	authManagerMock := &auth.AuthManagerMock{}
+	// Any user lookup at all is a regression here: the key must answer without one. The mock is
+	// deliberately left with no expectations, so a call fails the test.
+
+	scopedKey := &data.APIKey{ID: "k1", DistributionWalletIDs: pq.StringArray{"wallet-a", "wallet-b"}}
+	unscopedKey := &data.APIKey{ID: "k2"}
+
+	t.Run("read scope is the key's own list", func(t *testing.T) {
+		reqCtx := sdpcontext.SetAPIKeyInContext(ctx, scopedKey)
+		scope, httpErr := resolveWalletReadScope(reqCtx, authManagerMock, nil)
+		require.Nil(t, httpErr)
+		assert.Equal(t, []string{"wallet-a", "wallet-b"}, scope)
+	})
+
+	t.Run("an empty scope is empty, never tenant-wide", func(t *testing.T) {
+		reqCtx := sdpcontext.SetAPIKeyInContext(ctx, unscopedKey)
+		scope, httpErr := resolveWalletReadScope(reqCtx, authManagerMock, nil)
+		require.Nil(t, httpErr)
+		require.NotNil(t, scope, "nil would read as owner/tenant-wide downstream")
+		assert.Empty(t, scope)
+		assert.False(t, walletInReadScope(scope, "wallet-a"))
+	})
+
+	t.Run("actions are gated on the key's scope", func(t *testing.T) {
+		reqCtx := sdpcontext.SetAPIKeyInContext(ctx, scopedKey)
+		require.Nil(t, ensureWalletActionAllowed(reqCtx, authManagerMock, nil, "wallet-a"))
+
+		httpErr := ensureWalletActionAllowed(reqCtx, authManagerMock, nil, "wallet-c")
+		require.NotNil(t, httpErr)
+		assert.Equal(t, http.StatusForbidden, httpErr.StatusCode)
+	})
+
+	authManagerMock.AssertExpectations(t)
 }
 
 // capabilityEnforcementSites points each matrix entry at the code that actually enforces it:

--- a/internal/serve/middleware/api_keys_middleware_test.go
+++ b/internal/serve/middleware/api_keys_middleware_test.go
@@ -26,7 +26,7 @@ func Test_APIKeyOrJWTAuthenticate_SuccessfulAPIKey(t *testing.T) {
 	expiry := time.Now().Add(1 * time.Hour)
 	keyObj, err := apiKeyModel.Insert(context.Background(),
 		"Ahrimanskey", []data.APIKeyPermission{data.ReadStatistics},
-		[]string{"127.0.0.1"}, &expiry, "11111111-1111-1111-1111-111111111111",
+		[]string{"127.0.0.1"}, nil, &expiry, "11111111-1111-1111-1111-111111111111",
 	)
 	require.NoError(t, err)
 
@@ -58,7 +58,7 @@ func Test_APIKeyOrJWTAuthenticate_ExpiredKey(t *testing.T) {
 	expiry := time.Now().Add(-1 * time.Hour)
 	keyObj, err := apiKeyModel.Insert(context.Background(),
 		"Ahrimanskey", []data.APIKeyPermission{data.ReadStatistics},
-		nil, &expiry, "22222222-2222-2222-2222-222222222222",
+		nil, nil, &expiry, "22222222-2222-2222-2222-222222222222",
 	)
 	require.NoError(t, err)
 
@@ -84,7 +84,7 @@ func Test_APIKeyOrJWTAuthenticate_IPRestriction(t *testing.T) {
 	expiry := time.Now().Add(1 * time.Hour)
 	keyObj, err := apiKeyModel.Insert(context.Background(),
 		"Ahrimanskey", []data.APIKeyPermission{data.ReadStatistics},
-		[]string{"10.0.0.6", "10.0.0.8", "10.0.0.5"}, &expiry, "33333333-3333-3333-3333-333333333333",
+		[]string{"10.0.0.6", "10.0.0.8", "10.0.0.5"}, nil, &expiry, "33333333-3333-3333-3333-333333333333",
 	)
 	require.NoError(t, err)
 
@@ -241,7 +241,7 @@ func setupCrossTenantAPIKeys(t *testing.T) (apiKeys *data.APIKeyModel, ctxA, ctx
 
 	key, err := models.APIKeys.Insert(ctxA,
 		"Cross Tenant Probe", []data.APIKeyPermission{data.ReadStatistics},
-		nil, nil, "11111111-1111-1111-1111-111111111111",
+		nil, nil, nil, "11111111-1111-1111-1111-111111111111",
 	)
 	require.NoError(t, err)
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -200,9 +200,9 @@ func (opts *ServeOptions) SetupDependencies() error {
 	opts.Sep10Service = sep10Service
 
 	if opts.EnableSep45 {
-		sep45NonceStore, err := services.NewNonceStore(opts.MtnDBConnectionPool, services.DefaultSEP45NonceExpiration)
-		if err != nil {
-			return fmt.Errorf("initializing SEP 45 nonce store: %w", err)
+		sep45NonceStore, nonceErr := services.NewNonceStore(opts.MtnDBConnectionPool, services.DefaultSEP45NonceExpiration)
+		if nonceErr != nil {
+			return fmt.Errorf("initializing SEP 45 nonce store: %w", nonceErr)
 		}
 		rpcClient, rpcErr := dependencyinjection.NewRPCClient(context.Background(), opts.RPCConfig)
 		if rpcErr != nil {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -407,6 +407,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		)).Route("/api-keys", func(r chi.Router) {
 			apiKeyHandler := httphandler.APIKeyHandler{
 				Models:           o.Models,
+				AuthManager:      authManager,
 				CacheInvalidator: apiKeyAuthenticator,
 			}
 			r.Get("/{id}", apiKeyHandler.GetAPIKeyByID)
@@ -730,7 +731,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 			// Write operations with different role permissions
 			r.With(middleware.RequirePermission(
 				data.WriteOrganization,
-				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole, data.FinancialControllerUserRole),
+				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole),
 			)).Patch("/", profileHandler.PatchOrganizationProfile)
 
 			r.With(middleware.RequirePermission(
@@ -738,6 +739,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 				middleware.AnyRoleMiddleware(authManager, data.OwnerUserRole),
 			)).Patch("/circle-config", httphandler.CircleConfigHandler{
 				NetworkType:                 o.NetworkType,
+				AuthManager:                 authManager,
 				CircleFactory:               circle.NewClient,
 				TenantManager:               o.tenantManager,
 				Encrypter:                   &utils.DefaultPrivateKeyEncrypter{},

--- a/internal/serve/serve_api_key_test.go
+++ b/internal/serve/serve_api_key_test.go
@@ -134,11 +134,13 @@ func Test_handleHTTP_APIKeyAuthentication(t *testing.T) {
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name:           "key whose creator was deactivated is rejected, not a 500",
+			// The key answers out of its own wallet scope and never loads its creator, so
+			// offboarding the person who minted it does not take the integration down with them.
+			name:           "key whose creator was deactivated keeps working",
 			method:         http.MethodGet,
 			path:           "/disbursements",
 			apiKey:         deactivatedCreatorAPIKey.Key,
-			expectedStatus: http.StatusUnauthorized,
+			expectedStatus: http.StatusOK,
 		},
 	}
 
@@ -705,7 +707,12 @@ func createTestAPIKey(t *testing.T, db db.DBConnectionPool, name string, perms [
 		expiry = &exp
 	}
 
-	apiKey, err := models.APIKeys.Insert(ctx, name, perms, allowedIPs, expiry, createdBy)
+	// Scoped to the default wallet, matching what the migration does to every key that predates
+	// wallet scoping and what CreateAPIKey defaults a single-wallet tenant's new keys to.
+	defaultWallet, err := models.DistributionWallets.GetDefault(ctx, db)
+	require.NoError(t, err)
+
+	apiKey, err := models.APIKeys.Insert(ctx, name, perms, allowedIPs, []string{defaultWallet.ID}, expiry, createdBy)
 	require.NoError(t, err)
 	require.NotNil(t, apiKey)
 


### PR DESCRIPTION
### What

Give each API key its own distribution-account scope instead of deriving it from whoever created it.

- New `api_keys.distribution_wallet_ids` column. Existing keys are backfilled to the tenant's default account.
- The scope is chosen at creation and editable via `PATCH /api-keys/{id}`. A creator can only grant accounts they can reach themselves, and only active ones; a key minting another key can't widen its own scope.
- At request time the key's own column decides what it can read and write. No user lookup happens on that path (except on endpoints that did prior to Multi-wallet, as well as certain Owner-only endpoints).
- `POST/DELETE /assets` no longer lets a key skip the account check by omitting the `X-Wallet-Id` header.
- Revoking someone's wallet access no longer narrows keys they minted (restoring intended design).
- `PATCH /organization/circle-config` and `PATCH /organization` are now Owner-only and reachable via API-key.

### Why

A key's reach was a live projection of its creator's wallet memberships. Deactivating the creator silently killed the key, editing their memberships silently changed what every key they'd minted could touch, and a key could never be scoped more narrowly than the person. 

In addition, there were write endpoints that could edit tenant-wide settings via API-key. While it was intended that both Developers and Owners had this capability prior to multi-wallet, it now clashes with the intent of distribution-account scoped memberships, therefore these are now Owner-only.

### Known limitations

- A manually created receiver can disappear from your list once another account pays them. That follows from deriving receiver visibility from payments.
- Receiver writes are also inadequately distribution-account membership scoped. These will be addressed in a follow-up PR.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
