### PR TITLE
SDP-2122 fix: expose circle transaction ID for both payouts and transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add `distribution-account rotate --wallet-id` to rotate any distribution wallet's account, and `distribution-account rotate-wallet-dek` to rotate a wallet's signing key. [#1178](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1178)
 - Add optional Prometheus/Grafana wiring and wallet-tagged structured transaction logging for the SDP and TSS services. [#1178](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1178)
 - Add distribution-account scoping when creating or editing API-key [#1183](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1183)
-- Add `CircleTransactionID` and `CircleTransactionType` columns to the payments CSV export. [#1188](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1188).
+- Add `CircleTransactionID` and `CircleTransactionType` columns to the payments CSV export. [#1188](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1188)
+
+### Changed
+
+- Payment response field `circle_transfer_request_id` is renamed to `circle_transaction_id` (affects `GET /payments` and GET `/payments/{id}`). [#1188](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1188)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add `distribution-account rotate --wallet-id` to rotate any distribution wallet's account, and `distribution-account rotate-wallet-dek` to rotate a wallet's signing key. [#1178](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1178)
 - Add optional Prometheus/Grafana wiring and wallet-tagged structured transaction logging for the SDP and TSS services. [#1178](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1178)
 - Add distribution-account scoping when creating or editing API-key [#1183](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1183)
+- Add `CircleTransactionID` and `CircleTransactionType` columns to the payments CSV export. [#1188](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1188).
 
 ### Fixed
 
@@ -22,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Harden MFA code validation and device trust. [#1177](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1177)
 - Fix and harden distribution-account scoping on receiver reads and writes. [#1186](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1186)
 - Fix multi-wallet cutover doc and remove preflight script. [#1187](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1187)
+- Expose Circle transaction ID for payments made through both Payouts (previously returned `null`) and Transfers API. [#1188](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1188)
 
 ### Security and Dependencies
 

--- a/docs/multi-wallet/CUTOVER.md
+++ b/docs/multi-wallet/CUTOVER.md
@@ -107,6 +107,7 @@ Then smoke test that an existing tenant still lists and starts disbursements as 
 For API integrators:
 - When authenticating **with an API key**, tenant-wide endpoints (`/organization`, `/organization/circle-config`, `/distribution-wallets`) require the key to be **minted by an Owner**.
 - The `X-Wallet-Id` **request header** becomes required when creating disbursements, payments and receivers via direct API call, once a tenant has more than one active distribution account. Existing integrations keep working until a second account is added.
+- The payment response field `circle_transfer_request_id` is **renamed to `circle_transaction_id`**, and a new `circle_transaction_type` field (`PAYOUT` or `TRANSFER`) says which Circle API produced it. The old field only ever held Transfers API IDs and was always absent for tenants on the Payouts API; the new one carries whichever ID applies. Affects `GET /payments` and `GET /payments/{id}`.
 
 ## Rollback: destructive once the new code has run
 

--- a/internal/data/circle_transfer_requests.go
+++ b/internal/data/circle_transfer_requests.go
@@ -254,10 +254,14 @@ func (m CircleTransferRequestModel) PopulateCircleTransactionInfo(ctx context.Co
 		return fmt.Errorf("getting circle transfers for payment IDs: %w", err)
 	}
 
+	// Cleared when there is no row, so the result always reflects the DB rather than prior state.
 	for i := range payments {
-		if request, ok := requestsByPaymentID[payments[i].ID]; ok {
-			payments[i].CircleTransactionID, payments[i].CircleTransactionType = request.CircleTransactionInfo()
+		request, ok := requestsByPaymentID[payments[i].ID]
+		if !ok {
+			payments[i].CircleTransactionID, payments[i].CircleTransactionType = nil, nil
+			continue
 		}
+		payments[i].CircleTransactionID, payments[i].CircleTransactionType = request.CircleTransactionInfo()
 	}
 
 	return nil

--- a/internal/data/circle_transfer_requests.go
+++ b/internal/data/circle_transfer_requests.go
@@ -44,6 +44,30 @@ func (s CircleTransferStatus) IsCompleted() bool {
 	return slices.Contains(CompletedCircleStatuses(), s)
 }
 
+// CircleTransactionType identifies which Circle API produced a payment's identifier. Not reusing
+// circle.APIType* — internal/circle imports internal/data, so importing back would be a cycle.
+type CircleTransactionType string
+
+const (
+	CircleTransactionTypePayout   CircleTransactionType = "PAYOUT"
+	CircleTransactionTypeTransfer CircleTransactionType = "TRANSFER"
+)
+
+// CircleTransactionInfo returns the Circle-side ID and the API that produced it. The
+// circle_transfer_or_payout CHECK guarantees at most one is set; both are nil before submission.
+func (r *CircleTransferRequest) CircleTransactionInfo() (*string, *CircleTransactionType) {
+	switch {
+	case r.CirclePayoutID != nil && *r.CirclePayoutID != "":
+		t := CircleTransactionTypePayout
+		return r.CirclePayoutID, &t
+	case r.CircleTransferID != nil && *r.CircleTransferID != "":
+		t := CircleTransactionTypeTransfer
+		return r.CircleTransferID, &t
+	default:
+		return nil, nil
+	}
+}
+
 type CircleTransferRequestUpdate struct {
 	CircleTransferID  string               `db:"circle_transfer_id"`
 	CirclePayoutID    string               `db:"circle_payout_id"`
@@ -181,7 +205,7 @@ func (m CircleTransferRequestModel) Get(ctx context.Context, sqlExec db.SQLExecu
 
 func (m CircleTransferRequestModel) GetCurrentTransfersForPaymentIDs(ctx context.Context, sqlExec db.SQLExecuter, paymentIDs []string) (map[string]*CircleTransferRequest, error) {
 	if len(paymentIDs) == 0 {
-		return nil, fmt.Errorf("paymentIDs is required")
+		return map[string]*CircleTransferRequest{}, nil
 	}
 
 	query := `
@@ -211,6 +235,32 @@ func (m CircleTransferRequestModel) GetCurrentTransfersForPaymentIDs(ctx context
 	}
 
 	return circleTransferRequestsByPaymentID, nil
+}
+
+// PopulateCircleTransactionInfo fills in each payment's Circle identifier in place, resolved per
+// row so accounts holding both payout- and transfer-backed payments work.
+func (m CircleTransferRequestModel) PopulateCircleTransactionInfo(ctx context.Context, sqlExec db.SQLExecuter, payments []Payment) error {
+	if len(payments) == 0 {
+		return nil
+	}
+
+	paymentIDs := make([]string, len(payments))
+	for i, payment := range payments {
+		paymentIDs[i] = payment.ID
+	}
+
+	requestsByPaymentID, err := m.GetCurrentTransfersForPaymentIDs(ctx, sqlExec, paymentIDs)
+	if err != nil {
+		return fmt.Errorf("getting circle transfers for payment IDs: %w", err)
+	}
+
+	for i := range payments {
+		if request, ok := requestsByPaymentID[payments[i].ID]; ok {
+			payments[i].CircleTransactionID, payments[i].CircleTransactionType = request.CircleTransactionInfo()
+		}
+	}
+
+	return nil
 }
 
 func (m CircleTransferRequestModel) Update(ctx context.Context, sqlExec db.SQLExecuter, idempotencyKey string, update CircleTransferRequestUpdate) (*CircleTransferRequest, error) {

--- a/internal/data/circle_transfer_requests_test.go
+++ b/internal/data/circle_transfer_requests_test.go
@@ -580,10 +580,9 @@ func Test_CircleTransferRequestModel_GetCurrentTransfersForPaymentIDs(t *testing
 		expectedErr    string
 	}{
 		{
-			name:           "return an error if paymentIDs is empty",
+			name:           "returns an empty map if paymentIDs is empty",
 			paymentIDs:     []string{},
-			expectedResult: nil,
-			expectedErr:    "paymentIDs is required",
+			expectedResult: map[string]*CircleTransferRequest{},
 		},
 		{
 			name:       "🎉 successfully finds circle current transfer request",
@@ -680,6 +679,127 @@ func Test_CircleTransferRequestModel_GetCurrentTransfersForPaymentIDs(t *testing
 			}
 		})
 	}
+}
+
+func Test_CircleTransferRequest_CircleTransactionInfo(t *testing.T) {
+	testCases := []struct {
+		name         string
+		request      CircleTransferRequest
+		expectedID   *string
+		expectedType *CircleTransactionType
+	}{
+		{
+			name:         "payout ID set",
+			request:      CircleTransferRequest{CirclePayoutID: utils.StringPtr("payout-1")},
+			expectedID:   utils.StringPtr("payout-1"),
+			expectedType: utils.Ptr(CircleTransactionTypePayout),
+		},
+		{
+			name:         "transfer ID set",
+			request:      CircleTransferRequest{CircleTransferID: utils.StringPtr("transfer-1")},
+			expectedID:   utils.StringPtr("transfer-1"),
+			expectedType: utils.Ptr(CircleTransactionTypeTransfer),
+		},
+		{
+			name:    "neither set, request never reached Circle",
+			request: CircleTransferRequest{},
+		},
+		{
+			name:    "empty-string pointers are treated as unset",
+			request: CircleTransferRequest{CirclePayoutID: utils.StringPtr(""), CircleTransferID: utils.StringPtr("")},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotType := tc.request.CircleTransactionInfo()
+			assert.Equal(t, tc.expectedID, gotID)
+			assert.Equal(t, tc.expectedType, gotType)
+		})
+	}
+}
+
+func Test_CircleTransferRequestModel_PopulateCircleTransactionInfo(t *testing.T) {
+	dbConnectionPool := testutils.GetDBConnectionPool(t)
+
+	ctx := context.Background()
+	m := CircleTransferRequestModel{dbConnectionPool: dbConnectionPool}
+
+	models, outerErr := NewModels(dbConnectionPool)
+	require.NoError(t, outerErr)
+	asset := CreateAssetFixture(t, ctx, dbConnectionPool, "USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVV")
+	wallet := CreateWalletFixture(t, ctx, dbConnectionPool, "wallet1", "https://www.wallet.com", "www.wallet.com", "wallet1://")
+	disbursement := CreateDisbursementFixture(t, ctx, dbConnectionPool, models.Disbursements, &Disbursement{
+		Wallet: wallet,
+		Status: ReadyDisbursementStatus,
+		Asset:  asset,
+	})
+	receiver := CreateReceiverFixture(t, ctx, dbConnectionPool, &Receiver{})
+	rw := CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver.ID, wallet.ID, ReadyReceiversWalletStatus)
+
+	newPayment := func(amount string) *Payment {
+		return CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &Payment{
+			ReceiverWallet: rw,
+			Disbursement:   disbursement,
+			Asset:          *asset,
+			Amount:         amount,
+			Status:         DraftPaymentStatus,
+		})
+	}
+
+	t.Run("no-op on an empty slice", func(t *testing.T) {
+		require.NoError(t, m.PopulateCircleTransactionInfo(ctx, dbConnectionPool, nil))
+	})
+
+	t.Run("resolves payout, transfer and no-row payments in one call", func(t *testing.T) {
+		DeleteAllCircleTransferRequests(t, ctx, dbConnectionPool)
+
+		transferPayment, payoutPayment, plainPayment := newPayment("100"), newPayment("200"), newPayment("300")
+		CreateCircleTransferRequestFixture(t, ctx, dbConnectionPool, CircleTransferRequest{
+			PaymentID:        transferPayment.ID,
+			CircleTransferID: utils.StringPtr("transfer-1"),
+		})
+		CreateCircleTransferRequestFixture(t, ctx, dbConnectionPool, CircleTransferRequest{
+			PaymentID:      payoutPayment.ID,
+			CirclePayoutID: utils.StringPtr("payout-1"),
+		})
+
+		payments := []Payment{*transferPayment, *payoutPayment, *plainPayment}
+		require.NoError(t, m.PopulateCircleTransactionInfo(ctx, dbConnectionPool, payments))
+
+		assert.Equal(t, "transfer-1", *payments[0].CircleTransactionID)
+		assert.Equal(t, CircleTransactionTypeTransfer, *payments[0].CircleTransactionType)
+		assert.Equal(t, "payout-1", *payments[1].CircleTransactionID)
+		assert.Equal(t, CircleTransactionTypePayout, *payments[1].CircleTransactionType)
+		assert.Nil(t, payments[2].CircleTransactionID)
+		assert.Nil(t, payments[2].CircleTransactionType)
+	})
+
+	t.Run("uses the most recent request when a payment was retried", func(t *testing.T) {
+		DeleteAllCircleTransferRequests(t, ctx, dbConnectionPool)
+
+		payment := newPayment("400")
+		// The older attempt must be 'failed' to satisfy the partial unique index on payment_id.
+		failedStatus := CircleTransferStatusFailed
+		older := CreateCircleTransferRequestFixture(t, ctx, dbConnectionPool, CircleTransferRequest{
+			PaymentID:      payment.ID,
+			CirclePayoutID: utils.StringPtr("payout-old"),
+			Status:         &failedStatus,
+		})
+		_, err := dbConnectionPool.ExecContext(ctx,
+			"UPDATE circle_transfer_requests SET created_at = NOW() - INTERVAL '1 hour' WHERE idempotency_key = $1",
+			older.IdempotencyKey)
+		require.NoError(t, err)
+
+		CreateCircleTransferRequestFixture(t, ctx, dbConnectionPool, CircleTransferRequest{
+			PaymentID:      payment.ID,
+			CirclePayoutID: utils.StringPtr("payout-new"),
+		})
+
+		payments := []Payment{*payment}
+		require.NoError(t, m.PopulateCircleTransactionInfo(ctx, dbConnectionPool, payments))
+		assert.Equal(t, "payout-new", *payments[0].CircleTransactionID)
+	})
 }
 
 func Test_CircleTransferRequestModel_GetPendingReconciliation(t *testing.T) {

--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -21,19 +21,20 @@ type Payment struct {
 	Amount               string `json:"amount" db:"amount"`
 	StellarTransactionID string `json:"stellar_transaction_id" db:"stellar_transaction_id"`
 	// TODO: evaluate if we will keep or remove StellarOperationID
-	StellarOperationID      string               `json:"stellar_operation_id" db:"stellar_operation_id"`
-	Status                  PaymentStatus        `json:"status" db:"status"`
-	StatusHistory           PaymentStatusHistory `json:"status_history,omitempty" db:"status_history"`
-	Type                    PaymentType          `json:"type" db:"type"`
-	SourceWalletID          string               `json:"source_wallet_id" db:"source_wallet_id"`
-	Disbursement            *Disbursement        `json:"disbursement,omitempty" db:"disbursement"`
-	Asset                   Asset                `json:"asset"`
-	ReceiverWallet          *ReceiverWallet      `json:"receiver_wallet,omitempty" db:"receiver_wallet"`
-	CreatedAt               time.Time            `json:"created_at" db:"created_at"`
-	UpdatedAt               time.Time            `json:"updated_at" db:"updated_at"`
-	ExternalPaymentID       string               `json:"external_payment_id,omitempty" db:"external_payment_id"`
-	CircleTransferRequestID *string              `json:"circle_transfer_request_id,omitempty"`
-	SenderAddress           string               `json:"sender_address,omitempty" db:"sender_address"`
+	StellarOperationID    string                 `json:"stellar_operation_id" db:"stellar_operation_id"`
+	Status                PaymentStatus          `json:"status" db:"status"`
+	StatusHistory         PaymentStatusHistory   `json:"status_history,omitempty" db:"status_history"`
+	Type                  PaymentType            `json:"type" db:"type"`
+	SourceWalletID        string                 `json:"source_wallet_id" db:"source_wallet_id"`
+	Disbursement          *Disbursement          `json:"disbursement,omitempty" db:"disbursement"`
+	Asset                 Asset                  `json:"asset"`
+	ReceiverWallet        *ReceiverWallet        `json:"receiver_wallet,omitempty" db:"receiver_wallet"`
+	CreatedAt             time.Time              `json:"created_at" db:"created_at"`
+	UpdatedAt             time.Time              `json:"updated_at" db:"updated_at"`
+	ExternalPaymentID     string                 `json:"external_payment_id,omitempty" db:"external_payment_id"`
+	CircleTransactionID   *string                `json:"circle_transaction_id,omitempty"`
+	CircleTransactionType *CircleTransactionType `json:"circle_transaction_type,omitempty"`
+	SenderAddress         string                 `json:"sender_address,omitempty" db:"sender_address"`
 }
 
 type PaymentType string

--- a/internal/serve/httphandler/export_handler.go
+++ b/internal/serve/httphandler/export_handler.go
@@ -63,24 +63,25 @@ func (e ExportHandler) ExportDisbursements(rw http.ResponseWriter, r *http.Reque
 }
 
 type PaymentCSV struct {
-	ID                      string
-	Amount                  string
-	StellarTransactionID    string
-	Status                  data.PaymentStatus
-	Type                    data.PaymentType
-	DisbursementID          string `csv:"Disbursement.ID"`
-	Asset                   data.Asset
-	Wallet                  data.Wallet
-	ReceiverID              string                     `csv:"Receiver.ID"`
-	ReceiverPhoneNumber     string                     `csv:"Receiver.PhoneNumber"`
-	ReceiverEmail           string                     `csv:"Receiver.Email"`
-	ReceiverExternalID      string                     `csv:"Receiver.ExternalID"`
-	ReceiverWalletAddress   string                     `csv:"ReceiverWallet.Address"`
-	ReceiverWalletStatus    data.ReceiversWalletStatus `csv:"ReceiverWallet.Status"`
-	CreatedAt               time.Time
-	UpdatedAt               time.Time
-	ExternalPaymentID       string
-	CircleTransferRequestID *string
+	ID                    string
+	Amount                string
+	StellarTransactionID  string
+	Status                data.PaymentStatus
+	Type                  data.PaymentType
+	DisbursementID        string `csv:"Disbursement.ID"`
+	Asset                 data.Asset
+	Wallet                data.Wallet
+	ReceiverID            string                     `csv:"Receiver.ID"`
+	ReceiverPhoneNumber   string                     `csv:"Receiver.PhoneNumber"`
+	ReceiverEmail         string                     `csv:"Receiver.Email"`
+	ReceiverExternalID    string                     `csv:"Receiver.ExternalID"`
+	ReceiverWalletAddress string                     `csv:"ReceiverWallet.Address"`
+	ReceiverWalletStatus  data.ReceiversWalletStatus `csv:"ReceiverWallet.Status"`
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+	ExternalPaymentID     string
+	CircleTransactionID   string
+	CircleTransactionType data.CircleTransactionType
 }
 
 func (e ExportHandler) ExportPayments(rw http.ResponseWriter, r *http.Request) {
@@ -113,6 +114,11 @@ func (e ExportHandler) ExportPayments(rw http.ResponseWriter, r *http.Request) {
 	payments, err := e.Models.Payment.GetAll(ctx, queryParams, e.Models.DBConnectionPool, data.QueryTypeSelectAll)
 	if err != nil {
 		httperror.InternalError(ctx, "Failed to get payments", err, nil).Render(rw)
+		return
+	}
+
+	if err = e.Models.CircleTransferRequests.PopulateCircleTransactionInfo(ctx, e.Models.DBConnectionPool, payments); err != nil {
+		httperror.InternalError(ctx, "Failed to get Circle transaction info", err, nil).Render(rw)
 		return
 	}
 
@@ -175,19 +181,24 @@ func (e ExportHandler) convertPaymentsToCSV(payments []data.Payment, receiversMa
 			return nil, fmt.Errorf("receiver %s does not exist in the map", payment.ReceiverWallet.Receiver.ID)
 		}
 		paymentCSV := &PaymentCSV{
-			ID:                      payment.ID,
-			Amount:                  payment.Amount,
-			StellarTransactionID:    payment.StellarTransactionID,
-			Status:                  payment.Status,
-			Type:                    payment.Type,
-			Asset:                   payment.Asset,
-			ReceiverPhoneNumber:     receiver.PhoneNumber,
-			ReceiverEmail:           receiver.Email,
-			ReceiverExternalID:      receiver.ExternalID,
-			CreatedAt:               payment.CreatedAt,
-			UpdatedAt:               payment.UpdatedAt,
-			ExternalPaymentID:       payment.ExternalPaymentID,
-			CircleTransferRequestID: payment.CircleTransferRequestID,
+			ID:                   payment.ID,
+			Amount:               payment.Amount,
+			StellarTransactionID: payment.StellarTransactionID,
+			Status:               payment.Status,
+			Type:                 payment.Type,
+			Asset:                payment.Asset,
+			ReceiverPhoneNumber:  receiver.PhoneNumber,
+			ReceiverEmail:        receiver.Email,
+			ReceiverExternalID:   receiver.ExternalID,
+			CreatedAt:            payment.CreatedAt,
+			UpdatedAt:            payment.UpdatedAt,
+			ExternalPaymentID:    payment.ExternalPaymentID,
+		}
+		if payment.CircleTransactionID != nil {
+			paymentCSV.CircleTransactionID = *payment.CircleTransactionID
+		}
+		if payment.CircleTransactionType != nil {
+			paymentCSV.CircleTransactionType = *payment.CircleTransactionType
 		}
 		if payment.Type == data.PaymentTypeDisbursement && payment.Disbursement != nil {
 			paymentCSV.DisbursementID = payment.Disbursement.ID

--- a/internal/serve/httphandler/export_handler_test.go
+++ b/internal/serve/httphandler/export_handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/data"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/testutils"
+	"github.com/stellar/stellar-disbursement-platform-backend/internal/utils"
 )
 
 func Test_ExportHandler_ExportDisbursements(t *testing.T) {
@@ -220,6 +221,23 @@ func Test_ExportHandler_ExportPayments(t *testing.T) {
 		ExternalPaymentID: "PAY03",
 	})
 
+	// Transfers- and Payouts-backed payments in the same account; the other two stay non-Circle.
+	data.CreateCircleTransferRequestFixture(t, ctx, dbConnectionPool, data.CircleTransferRequest{
+		PaymentID:        pendingPayment.ID,
+		CircleTransferID: utils.StringPtr("circle-transfer-id-1"),
+	})
+	data.CreateCircleTransferRequestFixture(t, ctx, dbConnectionPool, data.CircleTransferRequest{
+		PaymentID:      successfulPayment.ID,
+		CirclePayoutID: utils.StringPtr("circle-payout-id-1"),
+	})
+
+	expectedCircleInfo := map[string][2]string{
+		pendingPayment.ID:    {"circle-transfer-id-1", "TRANSFER"},
+		successfulPayment.ID: {"circle-payout-id-1", "PAYOUT"},
+		directPayment.ID:     {"", ""},
+		failedPayment.ID:     {"", ""},
+	}
+
 	tests := []struct {
 		name               string
 		queryParams        string
@@ -287,7 +305,7 @@ func Test_ExportHandler_ExportPayments(t *testing.T) {
 				"ID", "Amount", "StellarTransactionID", "Status", "Type",
 				"Disbursement.ID", "Asset.Code", "Asset.Issuer", "Wallet.Name", "Receiver.ID",
 				"Receiver.PhoneNumber", "Receiver.Email", "Receiver.ExternalID", "ReceiverWallet.Address", "ReceiverWallet.Status",
-				"CreatedAt", "UpdatedAt", "ExternalPaymentID", "CircleTransferRequestID",
+				"CreatedAt", "UpdatedAt", "ExternalPaymentID", "CircleTransactionID", "CircleTransactionType",
 			}
 			assert.Equal(t, expectedHeaders, header)
 
@@ -318,6 +336,10 @@ func Test_ExportHandler_ExportPayments(t *testing.T) {
 				if tc.expectedPayments[i].Type == data.PaymentTypeDisbursement {
 					assert.Equal(t, tc.expectedPayments[i].Disbursement.ID, row[5])
 				}
+
+				circleInfo := expectedCircleInfo[tc.expectedPayments[i].ID]
+				assert.Equal(t, circleInfo[0], row[18])
+				assert.Equal(t, circleInfo[1], row[19])
 			}
 		})
 	}

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -51,7 +51,7 @@ func (r *RetryPaymentsRequest) validate() *httperror.HTTPError {
 
 // decorateWithCircleTransactionInfo is not gated on the account being Circle: resolution is per
 // payment row, and non-Circle tenants simply have no circle_transfer_requests rows to find.
-func (p PaymentsHandler) decorateWithCircleTransactionInfo(ctx context.Context, sqlExec db.SQLExecuter, payments ...data.Payment) ([]data.Payment, error) {
+func (p PaymentsHandler) decorateWithCircleTransactionInfo(ctx context.Context, sqlExec db.SQLExecuter, payments []data.Payment) ([]data.Payment, error) {
 	if err := p.Models.CircleTransferRequests.PopulateCircleTransactionInfo(ctx, sqlExec, payments); err != nil {
 		return nil, fmt.Errorf("populating circle transaction info: %w", err)
 	}
@@ -90,7 +90,7 @@ func (p PaymentsHandler) GetPayment(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	payments, err := p.decorateWithCircleTransactionInfo(ctx, p.DBConnectionPool, *payment)
+	payments, err := p.decorateWithCircleTransactionInfo(ctx, p.DBConnectionPool, []data.Payment{*payment})
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot retrieve payment with circle info", err, nil).Render(w)
 		return
@@ -234,7 +234,7 @@ func (p PaymentsHandler) getPaymentsWithCount(ctx context.Context, queryParams *
 			}
 		}
 
-		payments, err := p.decorateWithCircleTransactionInfo(ctx, dbTx, payments...)
+		payments, err := p.decorateWithCircleTransactionInfo(ctx, dbTx, payments)
 		if err != nil {
 			return nil, fmt.Errorf("adding circle info to payments: %w", err)
 		}

--- a/internal/serve/httphandler/payments_handler.go
+++ b/internal/serve/httphandler/payments_handler.go
@@ -49,34 +49,11 @@ func (r *RetryPaymentsRequest) validate() *httperror.HTTPError {
 	return nil
 }
 
-func (p PaymentsHandler) decorateWithCircleTransactionInfo(ctx context.Context, payments ...data.Payment) ([]data.Payment, error) {
-	if len(payments) == 0 {
-		return payments, nil
-	}
-
-	distAccount, err := p.DistributionAccountResolver.DistributionAccountFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving distribution account: %w", err)
-	}
-
-	if !distAccount.IsCircle() {
-		return payments, nil
-	}
-
-	paymentIDs := make([]string, len(payments))
-	for i, payment := range payments {
-		paymentIDs[i] = payment.ID
-	}
-
-	transfersByPaymentID, err := p.Models.CircleTransferRequests.GetCurrentTransfersForPaymentIDs(ctx, p.DBConnectionPool, paymentIDs)
-	if err != nil {
-		return nil, fmt.Errorf("getting circle transfers for payment IDs: %w", err)
-	}
-
-	for i, payment := range payments {
-		if transfer, ok := transfersByPaymentID[payment.ID]; ok {
-			payments[i].CircleTransferRequestID = transfer.CircleTransferID
-		}
+// decorateWithCircleTransactionInfo is not gated on the account being Circle: resolution is per
+// payment row, and non-Circle tenants simply have no circle_transfer_requests rows to find.
+func (p PaymentsHandler) decorateWithCircleTransactionInfo(ctx context.Context, sqlExec db.SQLExecuter, payments ...data.Payment) ([]data.Payment, error) {
+	if err := p.Models.CircleTransferRequests.PopulateCircleTransactionInfo(ctx, sqlExec, payments); err != nil {
+		return nil, fmt.Errorf("populating circle transaction info: %w", err)
 	}
 
 	return payments, nil
@@ -113,7 +90,7 @@ func (p PaymentsHandler) GetPayment(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	payments, err := p.decorateWithCircleTransactionInfo(ctx, *payment)
+	payments, err := p.decorateWithCircleTransactionInfo(ctx, p.DBConnectionPool, *payment)
 	if err != nil {
 		httperror.InternalError(ctx, "Cannot retrieve payment with circle info", err, nil).Render(w)
 		return
@@ -257,7 +234,7 @@ func (p PaymentsHandler) getPaymentsWithCount(ctx context.Context, queryParams *
 			}
 		}
 
-		payments, err := p.decorateWithCircleTransactionInfo(ctx, payments...)
+		payments, err := p.decorateWithCircleTransactionInfo(ctx, dbTx, payments...)
 		if err != nil {
 			return nil, fmt.Errorf("adding circle info to payments: %w", err)
 		}

--- a/internal/serve/httphandler/payments_handler_test.go
+++ b/internal/serve/httphandler/payments_handler_test.go
@@ -245,7 +245,7 @@ func Test_PaymentHandler_GetPayments_CirclePayments(t *testing.T) {
 		Amount:         "200",
 		Status:         data.DraftPaymentStatus,
 	})
-	data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
+	payment3 := data.CreatePaymentFixture(t, ctx, dbConnectionPool, models.Payment, &data.Payment{
 		ReceiverWallet: rwReady,
 		Disbursement:   disbursement,
 		Asset:          *asset,
@@ -253,6 +253,7 @@ func Test_PaymentHandler_GetPayments_CirclePayments(t *testing.T) {
 		Status:         data.DraftPaymentStatus,
 	})
 
+	// payment1 is Transfers-backed and payment2 Payouts-backed, in the same account.
 	data.CreateCircleTransferRequestFixture(t, ctx, dbConnectionPool, data.CircleTransferRequest{
 		IdempotencyKey:   "idempotency-key-1",
 		PaymentID:        payment1.ID,
@@ -260,98 +261,64 @@ func Test_PaymentHandler_GetPayments_CirclePayments(t *testing.T) {
 	})
 
 	data.CreateCircleTransferRequestFixture(t, ctx, dbConnectionPool, data.CircleTransferRequest{
-		IdempotencyKey:   "idempotency-key-2",
-		PaymentID:        payment2.ID,
-		CircleTransferID: utils.StringPtr("circle-transfer-id-2"),
+		IdempotencyKey: "idempotency-key-2",
+		PaymentID:      payment2.ID,
+		CirclePayoutID: utils.StringPtr("circle-payout-id-2"),
 	})
 
-	testCases := []struct {
-		name          string
-		prepareMocks  func(t *testing.T, mDistributionAccountResolver *sigMocks.MockDistributionAccountResolver)
-		runAssertions func(t *testing.T, responseStatus int, response string)
-	}{
-		{
-			name: "returns error when distribution account resolver fails",
-			prepareMocks: func(t *testing.T, mDistributionAccountResolver *sigMocks.MockDistributionAccountResolver) {
-				t.Helper()
-
-				mDistributionAccountResolver.
-					On("DistributionAccountFromContext", mock.Anything).
-					Return(schema.TransactionAccount{}, errors.New("unexpected error")).
-					Once()
-			},
-			runAssertions: func(t *testing.T, responseStatus int, response string) {
-				t.Helper()
-
-				assert.Equal(t, http.StatusInternalServerError, responseStatus)
-				assert.JSONEq(t, `{"error":"Cannot retrieve payments"}`, response)
-			},
-		},
-		{
-			name: "successfully returns payments with circle transaction IDs",
-			prepareMocks: func(t *testing.T, mDistributionAccountResolver *sigMocks.MockDistributionAccountResolver) {
-				t.Helper()
-
-				mDistributionAccountResolver.
-					On("DistributionAccountFromContext", mock.Anything).
-					Return(schema.TransactionAccount{Type: schema.DistributionAccountCircleDBVault}, nil).
-					Maybe()
-			},
-			runAssertions: func(t *testing.T, responseStatus int, response string) {
-				t.Helper()
-
-				assert.Equal(t, http.StatusOK, responseStatus)
-
-				var actualResponse httpresponse.PaginatedResponse
-				err := json.Unmarshal([]byte(response), &actualResponse)
-				require.NoError(t, err)
-
-				assert.Equal(t, 3, actualResponse.Pagination.Total)
-
-				var payments []data.Payment
-				err = json.Unmarshal(actualResponse.Data, &payments)
-				require.NoError(t, err)
-
-				assert.Len(t, payments, 3)
-				for _, payment := range payments {
-					if payment.ID == payment1.ID {
-						assert.Equal(t, "circle-transfer-id-1", *payment.CircleTransferRequestID)
-					}
-					if payment.ID == payment2.ID {
-						assert.Equal(t, "circle-transfer-id-2", *payment.CircleTransferRequestID)
-					}
-					if payment.ID != payment1.ID && payment.ID != payment2.ID {
-						assert.Nil(t, payment.CircleTransferRequestID)
-					}
-				}
-			},
-		},
+	// No DistributionAccountResolver: the Circle info is resolved per payment row, not per account.
+	h := &PaymentsHandler{
+		Models:           models,
+		DBConnectionPool: dbConnectionPool,
+		AuthManager:      newWalletScopeOwnerMock(),
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			mDistributionAccountResolver := sigMocks.NewMockDistributionAccountResolver(t)
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/payments", nil)
+	require.NoError(t, err)
+	withTestUserCtx(h.GetPayments).ServeHTTP(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
 
-			tc.prepareMocks(t, mDistributionAccountResolver)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-			h := &PaymentsHandler{
-				Models:                      models,
-				DBConnectionPool:            dbConnectionPool,
-				DistributionAccountResolver: mDistributionAccountResolver,
-				AuthManager:                 newWalletScopeOwnerMock(),
-			}
+	var actualResponse httpresponse.PaginatedResponse
+	require.NoError(t, json.Unmarshal(respBody, &actualResponse))
+	assert.Equal(t, 3, actualResponse.Pagination.Total)
 
-			rr := httptest.NewRecorder()
-			req, err := http.NewRequest(http.MethodGet, "/payments", nil)
-			require.NoError(t, err)
-			withTestUserCtx(h.GetPayments).ServeHTTP(rr, req)
-			resp := rr.Result()
-			defer resp.Body.Close()
-			respBody, err := io.ReadAll(resp.Body)
-			require.NoError(t, err)
+	var payments []data.Payment
+	require.NoError(t, json.Unmarshal(actualResponse.Data, &payments))
+	require.Len(t, payments, 3)
 
-			tc.runAssertions(t, resp.StatusCode, string(respBody))
-		})
+	for _, payment := range payments {
+		switch payment.ID {
+		case payment1.ID:
+			assert.Equal(t, "circle-transfer-id-1", *payment.CircleTransactionID)
+			assert.Equal(t, data.CircleTransactionTypeTransfer, *payment.CircleTransactionType)
+		case payment2.ID:
+			assert.Equal(t, "circle-payout-id-2", *payment.CircleTransactionID)
+			assert.Equal(t, data.CircleTransactionTypePayout, *payment.CircleTransactionType)
+		case payment3.ID:
+			assert.Nil(t, payment.CircleTransactionID)
+			assert.Nil(t, payment.CircleTransactionType)
+		}
+	}
+
+	// Assert on the raw keys too: unmarshalling into data.Payment cannot catch a wrong json tag.
+	var rawPayments []map[string]any
+	require.NoError(t, json.Unmarshal(actualResponse.Data, &rawPayments))
+	for _, raw := range rawPayments {
+		switch raw["id"] {
+		case payment2.ID:
+			assert.Equal(t, "circle-payout-id-2", raw["circle_transaction_id"])
+			assert.Equal(t, "PAYOUT", raw["circle_transaction_type"])
+		case payment3.ID:
+			assert.NotContains(t, raw, "circle_transaction_id")
+			assert.NotContains(t, raw, "circle_transaction_type")
+		}
+		assert.NotContains(t, raw, "circle_transfer_request_id")
 	}
 }
 


### PR DESCRIPTION
### What

Rename the payment API's Circle identifier and populate it for both Circle APIs.

- `circle_transfer_request_id` becomes `circle_transaction_id`, plus new `circle_transaction_type` (PAYOUT / TRANSFER). Breaking change, recorded in `CUTOVER.md`.
- The payments CSV export drops the always-empty `CircleTransferRequestID` column and gains `CircleTransactionID` / `CircleTransactionType`.
- New `CircleTransferRequestModel.PopulateCircleTransactionInfo`, shared by `GET /payments`, `GET /payments/{id}` and the CSV export.
- `decorateWithCircleTransactionInfo` loses its `IsCircle()` gate: resolution is per payment row, not per tenant. Now receives `dbTx` instead of reading outside its own transaction.

### Why

- The API under-reported. The decorator copied only `circle_transfer_id` and ignored `circle_payout_id`, so every Payouts-API tenant got null, despite both columns being in the row it had already fetched.

- The CSV was worse. Its column was never populated for anyone: `Payment.CircleTransferRequestID` had no db tag and the export never ran the decorator. Blank for every tenant since the column was added.

### Known limitations

- The lookup is a sequential scan. The only `payment_id` index is partial (`WHERE status IS DISTINCT FROM 'failed'`) and the query has no status predicate, so the planner can't use it. On an unpaginated export of a large tenant that's one full scan of `circle_transfer_requests`. A plain `payment_id` index would fix it.

- Non-Circle tenants pay for it: dropping the gate means one extra no-op query per payments request. Empty table, sub-millisecond. They also get two permanently blank CSV columns instead of one.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
