### PR TITLE
SDP-2106 fix: require client signer when verifying SEP-10 challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Move the SDP metrics port off application Service onto a dedicated ClusterIP Service, and pin the TSS metrics Service to ClusterIP. [#1193](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1193)
 - Move `LOG_SHIPPING_URL` to global section in helm chart as a secret value. [#1193](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1193)
+- Require client signer when verifying SEP-10 challenges [#1196](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1196)
 
 ## [7.0.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/7.0.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.6.1...7.0.0))
 

--- a/internal/services/sep10_service.go
+++ b/internal/services/sep10_service.go
@@ -791,6 +791,11 @@ func (s *sep10Service) fetchSigningKeyFromClientDomain(clientDomain string) (str
 		return "", fmt.Errorf("SIGNING_KEY %s is not a valid Stellar account ID", stellarToml.SigningKey)
 	}
 
+	// otherwise the server's own challenge signature would satisfy the client_domain signature.
+	if stellarToml.SigningKey == s.SEP10SigningKeypair.Address() {
+		return "", fmt.Errorf("SIGNING_KEY of client_domain %s must not be the server signing key", clientDomain)
+	}
+
 	return stellarToml.SigningKey, nil
 }
 

--- a/internal/services/sep10_service.go
+++ b/internal/services/sep10_service.go
@@ -258,6 +258,7 @@ func (s *sep10Service) ValidateChallenge(ctx context.Context, req ValidationRequ
 	// Account exists - verify with threshold
 	if err = s.verifySignaturesWithThreshold(
 		result.Transaction,
+		result.ClientAccountID,
 		result.ClientDomain,
 		account,
 	); err != nil {
@@ -481,73 +482,149 @@ func (s *sep10Service) verifySignaturesForNonExistentAccount(
 	return nil
 }
 
+// ed25519SignerType is the horizon signer type for the only signer keys that can sign a challenge.
+const ed25519SignerType = "ed25519_public_key"
+
+// challengeSigners holds the keys that may legitimately have signed a challenge transaction.
+type challengeSigners struct {
+	accountID    string
+	server       string
+	clientDomain string
+	account      map[string]int // signers able to authenticate the client account, by weight
+}
+
+// addresses returns every candidate key, deduplicated across roles.
+func (cs challengeSigners) addresses() []string {
+	addresses := make([]string, 0, len(cs.account)+2)
+	addresses = append(addresses, cs.server)
+	if cs.clientDomain != "" && cs.clientDomain != cs.server {
+		addresses = append(addresses, cs.clientDomain)
+	}
+
+	for address := range cs.account {
+		if address == cs.server || address == cs.clientDomain {
+			continue
+		}
+		addresses = append(addresses, address)
+	}
+
+	return addresses
+}
+
 func (s *sep10Service) verifySignaturesWithThreshold(
 	tx *txnbuild.Transaction,
+	clientAccountID string,
 	clientDomain string,
 	account *horizon.Account,
 ) error {
-	// Verify client_domain signature if present
+	signers := challengeSigners{
+		accountID: clientAccountID,
+		server:    s.SEP10SigningKeypair.Address(),
+		account:   make(map[string]int, len(account.Signers)),
+	}
+
 	if clientDomain != "" {
 		clientDomainAccountID, err := s.fetchSigningKeyFromClientDomain(clientDomain)
 		if err != nil {
 			return fmt.Errorf("fetching client domain signing key: %w", err)
 		}
-		if err := s.verifyClientSignature(tx, s.NetworkPassphrase, clientDomainAccountID); err != nil {
-			return fmt.Errorf("verifying client domain signature: %w", err)
+		signers.clientDomain = clientDomainAccountID
+	}
+
+	// SEP-10 requires the server's own signature to be excluded when weighing the account's signers.
+	for _, signer := range account.Signers {
+		if signer.Type != ed25519SignerType || signer.Key == signers.server {
+			continue
+		}
+		signers.account[signer.Key] = int(signer.Weight)
+	}
+
+	return s.verifyChallengeSignatures(tx, signers, int(account.Thresholds.MedThreshold))
+}
+
+// verifyChallengeSignatures applies SEP-10's signer rules: every signature must belong to an expected
+// signer, and the client account must be represented by at least one signer of its own.
+func (s *sep10Service) verifyChallengeSignatures(
+	tx *txnbuild.Transaction,
+	signers challengeSigners,
+	threshold int,
+) error {
+	matched, unrecognized, err := attributeSignatures(tx, s.NetworkPassphrase, signers.addresses())
+	if err != nil {
+		return err
+	}
+
+	if !matched[signers.server] {
+		return fmt.Errorf("challenge is not signed by server account %s", signers.server)
+	}
+
+	if signers.clientDomain != "" && !matched[signers.clientDomain] {
+		return fmt.Errorf("verifying client domain signature: challenge is not signed by client domain account %s", signers.clientDomain)
+	}
+
+	totalWeight, signersFound := 0, 0
+	for address, weight := range signers.account {
+		if matched[address] {
+			signersFound++
+			totalWeight += weight
 		}
 	}
 
-	// Verify that the cumulative weight of signatures meets the medium threshold
-	// This allows any combination of account signers (master or non-master) to authenticate
-	threshold := int(account.Thresholds.MedThreshold)
-	if err := s.verifyThreshold(tx, account, threshold); err != nil {
-		return fmt.Errorf("verifying signature threshold: %w", err)
+	if signersFound == 0 {
+		return fmt.Errorf("verifying client signature: challenge is not signed by any signer of account %s", signers.accountID)
+	}
+
+	if totalWeight < threshold {
+		return fmt.Errorf("verifying signature threshold: signatures with weight %d do not meet threshold %d", totalWeight, threshold)
+	}
+
+	if unrecognized > 0 {
+		return fmt.Errorf("challenge has %d unrecognized signature(s)", unrecognized)
 	}
 
 	return nil
 }
 
-// verifyThreshold checks if the sum of the weights of the signers present on the transaction
-// meets or exceeds the required threshold.
-func (s *sep10Service) verifyThreshold(
-	tx *txnbuild.Transaction,
-	account *horizon.Account,
-	threshold int,
-) error {
-	signerWeights := make(map[string]int)
-	for _, signer := range account.Signers {
-		signerWeights[signer.Key] = int(signer.Weight)
-	}
-
-	hash, err := tx.Hash(s.NetworkPassphrase)
+// attributeSignatures matches every signature to at most one candidate key, consuming both, and reports
+// how many signatures could not be attributed.
+func attributeSignatures(tx *txnbuild.Transaction, networkPassphrase string, addresses []string) (map[string]bool, int, error) {
+	hash, err := tx.Hash(networkPassphrase)
 	if err != nil {
-		return fmt.Errorf("computing transaction hash: %w", err)
+		return nil, 0, fmt.Errorf("computing transaction hash: %w", err)
 	}
 
-	usedSigners := make(map[string]bool)
-	totalWeight := 0
+	candidates := make(map[string]*keypair.FromAddress, len(addresses))
+	for _, address := range addresses {
+		kp, parseErr := keypair.ParseAddress(address)
+		if parseErr != nil {
+			continue
+		}
+		candidates[address] = kp
+	}
+
+	matched := make(map[string]bool, len(candidates))
+	unrecognized := 0
 
 	for _, sig := range tx.Signatures() {
-		for signer, weight := range signerWeights {
-			if usedSigners[signer] {
-				continue
-			}
-			kp, err := keypair.ParseAddress(signer)
-			if err != nil {
+		signer := ""
+		for address, kp := range candidates {
+			if matched[address] || kp.Hint() != sig.Hint {
 				continue
 			}
 			if kp.Verify(hash[:], sig.Signature) == nil {
-				totalWeight += weight
-				usedSigners[signer] = true
+				signer = address
 				break
 			}
 		}
+
+		if signer == "" {
+			unrecognized++
+			continue
+		}
+		matched[signer] = true
 	}
 
-	if totalWeight < threshold {
-		return fmt.Errorf("signatures do not meet threshold: got %d, need %d", totalWeight, threshold)
-	}
-	return nil
+	return matched, unrecognized, nil
 }
 
 func (s *sep10Service) generateToken(

--- a/internal/services/sep10_service.go
+++ b/internal/services/sep10_service.go
@@ -404,7 +404,7 @@ func (s *sep10Service) validateChallengeCustom(challengeTx, serverAccountID, net
 		return nil, fmt.Errorf("client_domain manage_data operation is required")
 	}
 
-	if err := s.verifySignature(tx, network, serverAccountID, "server"); err != nil {
+	if err := s.verifyServerSignature(tx, network, serverAccountID); err != nil {
 		return nil, fmt.Errorf("verifying server signature: %w", err)
 	}
 
@@ -418,7 +418,8 @@ func (s *sep10Service) validateChallengeCustom(challengeTx, serverAccountID, net
 	}, nil
 }
 
-func (s *sep10Service) verifySignature(tx *txnbuild.Transaction, network, accountID, accountType string) error {
+// verifyServerSignature does not consume signatures, so it is only safe for the server key, whose signature is consumed again during attribution.
+func (s *sep10Service) verifyServerSignature(tx *txnbuild.Transaction, network, serverAccountID string) error {
 	hash, err := tx.Hash(network)
 	if err != nil {
 		return fmt.Errorf("computing transaction hash: %w", err)
@@ -429,9 +430,9 @@ func (s *sep10Service) verifySignature(tx *txnbuild.Transaction, network, accoun
 		return fmt.Errorf("transaction has no signatures")
 	}
 
-	kp, err := keypair.ParseAddress(accountID)
+	kp, err := keypair.ParseAddress(serverAccountID)
 	if err != nil {
-		return fmt.Errorf("parsing %s account: %w", accountType, err)
+		return fmt.Errorf("parsing server account: %w", err)
 	}
 
 	for _, sig := range signatures {
@@ -440,7 +441,7 @@ func (s *sep10Service) verifySignature(tx *txnbuild.Transaction, network, accoun
 		}
 	}
 
-	return fmt.Errorf("transaction is not signed by %s account %s", accountType, accountID)
+	return fmt.Errorf("transaction is not signed by server account %s", serverAccountID)
 }
 
 // verifySignaturesForNonExistentAccount verifies signatures for accounts that don't exist on the network

--- a/internal/services/sep10_service.go
+++ b/internal/services/sep10_service.go
@@ -172,6 +172,10 @@ func (s *sep10Service) CreateChallenge(ctx context.Context, req ChallengeRequest
 		return nil, ChallengeValidationError(fmt.Sprintf("%s is not a valid account id", req.Account))
 	}
 
+	if req.Account == s.SEP10SigningKeypair.Address() {
+		return nil, ChallengeValidationError("account must not be the server signing key")
+	}
+
 	var clientSigningKey string
 	if req.ClientDomain != "" {
 		var err error
@@ -338,6 +342,9 @@ func (s *sep10Service) validateChallengeCustom(challengeTx, serverAccountID, net
 	}
 
 	clientAccountID := op.SourceAccount
+	if clientAccountID == serverAccountID {
+		return nil, fmt.Errorf("client account must not be the server account")
+	}
 
 	var memo *txnbuild.MemoID
 	if tx.Memo() != nil {
@@ -436,50 +443,28 @@ func (s *sep10Service) verifySignature(tx *txnbuild.Transaction, network, accoun
 	return fmt.Errorf("transaction is not signed by %s account %s", accountType, accountID)
 }
 
-func (s *sep10Service) verifyClientSignature(tx *txnbuild.Transaction, network, clientAccountID string) error {
-	return s.verifySignature(tx, network, clientAccountID, "client")
-}
-
-// verifySignaturesForNonExistentAccount verifies signatures for accounts that don't exist on the network yet.
-// For non-existent accounts, we only verify the client's master key signature (and client_domain if present).
+// verifySignaturesForNonExistentAccount verifies signatures for accounts that don't exist on the network
+// yet, where only the client account's master key can authenticate it.
 func (s *sep10Service) verifySignaturesForNonExistentAccount(
 	tx *txnbuild.Transaction,
 	clientAccountID string,
 	clientDomain string,
 ) error {
-	// Check signature count
-	// Expected: server signature + client signature + optional client_domain signature
-	expectedSigCount := 2 // server + client
-	if clientDomain != "" {
-		expectedSigCount = 3 // server + client + client_domain
+	signers := challengeSigners{
+		accountID: clientAccountID,
+		server:    s.SEP10SigningKeypair.Address(),
+		account:   map[string]int{clientAccountID: 0},
 	}
 
-	actualSigCount := len(tx.Signatures())
-	if actualSigCount != expectedSigCount {
-		return fmt.Errorf(
-			"there is more than one client signer on challenge transaction for an account that doesn't exist: expected %d signatures, got %d",
-			expectedSigCount,
-			actualSigCount,
-		)
-	}
-
-	// Verify client signature
-	if err := s.verifyClientSignature(tx, s.NetworkPassphrase, clientAccountID); err != nil {
-		return fmt.Errorf("verifying client signature for non-existent account: %w", err)
-	}
-
-	// Verify client_domain signature if present
 	if clientDomain != "" {
 		clientDomainAccountID, err := s.fetchSigningKeyFromClientDomain(clientDomain)
 		if err != nil {
 			return fmt.Errorf("fetching client domain signing key: %w", err)
 		}
-		if err = s.verifyClientSignature(tx, s.NetworkPassphrase, clientDomainAccountID); err != nil {
-			return fmt.Errorf("verifying client domain signature for non-existent account: %w", err)
-		}
+		signers.clientDomain = clientDomainAccountID
 	}
 
-	return nil
+	return s.verifyChallengeSignatures(tx, signers, 0)
 }
 
 // ed25519SignerType is the horizon signer type for the only signer keys that can sign a challenge.
@@ -531,9 +516,8 @@ func (s *sep10Service) verifySignaturesWithThreshold(
 		signers.clientDomain = clientDomainAccountID
 	}
 
-	// SEP-10 requires the server's own signature to be excluded when weighing the account's signers.
 	for _, signer := range account.Signers {
-		if signer.Type != ed25519SignerType || signer.Key == signers.server {
+		if signer.Type != ed25519SignerType {
 			continue
 		}
 		signers.account[signer.Key] = int(signer.Weight)
@@ -562,12 +546,14 @@ func (s *sep10Service) verifyChallengeSignatures(
 		return fmt.Errorf("verifying client domain signature: challenge is not signed by client domain account %s", signers.clientDomain)
 	}
 
+	// SEP-10 requires the server's own signature to be excluded when weighing the account's signers.
 	totalWeight, signersFound := 0, 0
 	for address, weight := range signers.account {
-		if matched[address] {
-			signersFound++
-			totalWeight += weight
+		if address == signers.server || !matched[address] {
+			continue
 		}
+		signersFound++
+		totalWeight += weight
 	}
 
 	if signersFound == 0 {

--- a/internal/services/sep10_service_test.go
+++ b/internal/services/sep10_service_test.go
@@ -148,7 +148,7 @@ func createSignedChallenge(t *testing.T, service *sep10Service, kps *testKeypair
 	tx, isSimple := parsed.Transaction()
 	require.True(t, isSimple)
 
-	signedTx, err := tx.Sign("Test SDF Network ; September 2015", kps.server, kps.client, kps.clientDomain)
+	signedTx, err := tx.Sign("Test SDF Network ; September 2015", kps.client, kps.clientDomain)
 	require.NoError(t, err)
 
 	signedTxBase64, err := signedTx.Base64()
@@ -657,7 +657,7 @@ func TestSEP10Service_ValidateChallenge(t *testing.T) {
 		tx, isSimple := parsed.Transaction()
 		require.True(t, isSimple)
 
-		signedTx, err := tx.Sign("Test SDF Network ; September 2015", kps.server, highThresholdKP, kps.clientDomain)
+		signedTx, err := tx.Sign("Test SDF Network ; September 2015", highThresholdKP, kps.clientDomain)
 		require.NoError(t, err)
 
 		signedTxBase64, err := signedTx.Base64()
@@ -927,7 +927,7 @@ func TestSEP10Service_SignatureValidation(t *testing.T) {
 	service, outerErr := createSEP10Service(t, kps, "https://stellar.local:8000", jwtManager, false)
 	require.NoError(t, outerErr)
 
-	t.Run("wrong server signature (extra wrong signature is ignored)", func(t *testing.T) {
+	t.Run("rejects an extra signature from an unknown key", func(t *testing.T) {
 		service.HTTPClient = createMockHTTPClient(t, kps.clientDomain)
 
 		challengeReq := ChallengeRequest{
@@ -953,8 +953,8 @@ func TestSEP10Service_SignatureValidation(t *testing.T) {
 
 		validationReq := ValidationRequest{Transaction: signedTxBase64}
 		resp, err := service.ValidateChallenge(context.Background(), validationReq)
-		require.NoError(t, err)
-		assert.NotNil(t, resp)
+		assert.ErrorContains(t, err, "unrecognized signature")
+		assert.Nil(t, resp)
 	})
 
 	t.Run("wrong client domain signature", func(t *testing.T) {
@@ -975,7 +975,7 @@ func TestSEP10Service_SignatureValidation(t *testing.T) {
 		tx, isSimple := parsed.Transaction()
 		require.True(t, isSimple)
 
-		signedTx, err := tx.Sign("Test SDF Network ; September 2015", kps.server, kps.client, wrongKP)
+		signedTx, err := tx.Sign("Test SDF Network ; September 2015", kps.client, wrongKP)
 		require.NoError(t, err)
 
 		signedTxBase64, err := signedTx.Base64()
@@ -1054,7 +1054,7 @@ func TestSEP10Service_SignatureValidation(t *testing.T) {
 		tx, isSimple := parsed.Transaction()
 		require.True(t, isSimple)
 
-		signedTx, err := tx.Sign("Test SDF Network ; September 2015", kps.server, kps.client)
+		signedTx, err := tx.Sign("Test SDF Network ; September 2015", kps.client)
 		require.NoError(t, err)
 
 		signedTxBase64, err := signedTx.Base64()
@@ -1119,7 +1119,7 @@ func TestSEP10Service_SignatureValidation(t *testing.T) {
 		tx, isSimple := parsed.Transaction()
 		require.True(t, isSimple)
 
-		signedTx, err := tx.Sign("Test SDF Network ; September 2015", kps.server, kps.client, kps.clientDomain)
+		signedTx, err := tx.Sign("Test SDF Network ; September 2015", kps.client, kps.clientDomain)
 		require.NoError(t, err)
 
 		signedTxBase64, err := signedTx.Base64()

--- a/internal/services/sep10_service_test.go
+++ b/internal/services/sep10_service_test.go
@@ -1187,12 +1187,33 @@ func createChallengeTxFor(t *testing.T, service *sep10Service, account, clientDo
 
 // buildRawChallenge assembles a server-signed challenge directly, so tests can submit shapes the service
 // would never issue.
-func buildRawChallenge(t *testing.T, kps *testKeypairs, clientAccountID string) *txnbuild.Transaction {
+func buildRawChallenge(t *testing.T, kps *testKeypairs, clientAccountID, clientDomainAccountID string) *txnbuild.Transaction {
 	t.Helper()
 
 	nonce := make([]byte, 48)
 	_, err := rand.Read(nonce)
 	require.NoError(t, err)
+
+	operations := []txnbuild.Operation{
+		&txnbuild.ManageData{
+			SourceAccount: clientAccountID,
+			Name:          "stellar.local:8000 auth",
+			Value:         []byte(base64.StdEncoding.EncodeToString(nonce)),
+		},
+		&txnbuild.ManageData{
+			SourceAccount: kps.server.Address(),
+			Name:          "web_auth_domain",
+			Value:         []byte("stellar.local:8000"),
+		},
+	}
+
+	if clientDomainAccountID != "" {
+		operations = append(operations, &txnbuild.ManageData{
+			SourceAccount: clientDomainAccountID,
+			Name:          "client_domain",
+			Value:         []byte("chaos.cadia.com"),
+		})
+	}
 
 	currentTime := time.Now().UTC()
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
@@ -1202,18 +1223,7 @@ func buildRawChallenge(t *testing.T, kps *testKeypairs, clientAccountID string) 
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewTimebounds(currentTime.Unix(), currentTime.Add(15*time.Minute).Unix()),
 		},
-		Operations: []txnbuild.Operation{
-			&txnbuild.ManageData{
-				SourceAccount: clientAccountID,
-				Name:          "stellar.local:8000 auth",
-				Value:         []byte(base64.StdEncoding.EncodeToString(nonce)),
-			},
-			&txnbuild.ManageData{
-				SourceAccount: kps.server.Address(),
-				Name:          "web_auth_domain",
-				Value:         []byte("stellar.local:8000"),
-			},
-		},
+		Operations: operations,
 	})
 	require.NoError(t, err)
 
@@ -1318,7 +1328,7 @@ func TestSEP10Service_ValidateChallenge_SignerRequirements(t *testing.T) {
 		})
 		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
 
-		resp, err := validateSignedBy(t, service, buildRawChallenge(t, kps, kps.server.Address()))
+		resp, err := validateSignedBy(t, service, buildRawChallenge(t, kps, kps.server.Address(), ""))
 		assert.Error(t, err)
 		assert.Nil(t, resp)
 	})
@@ -1339,8 +1349,30 @@ func TestSEP10Service_ValidateChallenge_SignerRequirements(t *testing.T) {
 	t.Run("rejects non-existent server account padded with an extra signature", func(t *testing.T) {
 		service := createSEP10ServiceWithHorizon(t, kps, createMockHorizon404(t), false)
 
-		resp, err := validateSignedBy(t, service, buildRawChallenge(t, kps, kps.server.Address()), keypair.MustRandom())
+		resp, err := validateSignedBy(t, service, buildRawChallenge(t, kps, kps.server.Address(), ""), keypair.MustRandom())
 		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("refuses to issue a challenge when the client domain publishes the server signing key", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), true)
+		service.HTTPClient = createMockHTTPClient(t, kps.server)
+
+		_, err := service.CreateChallenge(context.Background(), ChallengeRequest{
+			Account:      kps.client.Address(),
+			HomeDomain:   "stellar.local:8000",
+			ClientDomain: "chaos.cadia.com",
+		})
+		assert.ErrorContains(t, err, "must not be the server signing key")
+	})
+
+	t.Run("rejects challenge whose client_domain operation is sourced to the server signing key", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), false)
+		service.HTTPClient = createMockHTTPClient(t, kps.server)
+
+		tx := buildRawChallenge(t, kps, kps.client.Address(), kps.server.Address())
+		resp, err := validateSignedBy(t, service, tx, kps.client)
+		assert.ErrorContains(t, err, "must not be the server signing key")
 		assert.Nil(t, resp)
 	})
 

--- a/internal/services/sep10_service_test.go
+++ b/internal/services/sep10_service_test.go
@@ -912,7 +912,7 @@ func TestSEP10Service_ValidateChallenge(t *testing.T) {
 		validationReq := ValidationRequest{Transaction: signedTxBase64}
 		_, err = sep10Svc.ValidateChallenge(context.Background(), validationReq)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "there is more than one client signer")
+		assert.Contains(t, err.Error(), "unrecognized signature")
 	})
 }
 
@@ -1184,6 +1184,43 @@ func createChallengeTxFor(t *testing.T, service *sep10Service, account, clientDo
 	return tx
 }
 
+// buildRawChallenge assembles a server-signed challenge directly, so tests can submit shapes the service
+// would never issue.
+func buildRawChallenge(t *testing.T, kps *testKeypairs, clientAccountID string) *txnbuild.Transaction {
+	t.Helper()
+
+	nonce := make([]byte, 48)
+	_, err := rand.Read(nonce)
+	require.NoError(t, err)
+
+	currentTime := time.Now().UTC()
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &txnbuild.SimpleAccount{AccountID: kps.server.Address(), Sequence: -1},
+		IncrementSequenceNum: true,
+		BaseFee:              txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewTimebounds(currentTime.Unix(), currentTime.Add(15*time.Minute).Unix()),
+		},
+		Operations: []txnbuild.Operation{
+			&txnbuild.ManageData{
+				SourceAccount: clientAccountID,
+				Name:          "stellar.local:8000 auth",
+				Value:         []byte(base64.StdEncoding.EncodeToString(nonce)),
+			},
+			&txnbuild.ManageData{
+				SourceAccount: kps.server.Address(),
+				Name:          "web_auth_domain",
+				Value:         []byte("stellar.local:8000"),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	signedTx, err := tx.Sign(testNetworkPassphrase, kps.server)
+	require.NoError(t, err)
+	return signedTx
+}
+
 // validateSignedBy signs the challenge with the given keypairs, if any, and submits it for validation.
 func validateSignedBy(t *testing.T, service *sep10Service, tx *txnbuild.Transaction, signers ...*keypair.Full) (*ValidationResponse, error) {
 	t.Helper()
@@ -1264,14 +1301,23 @@ func TestSEP10Service_ValidateChallenge_SignerRequirements(t *testing.T) {
 		assert.Nil(t, resp)
 	})
 
+	t.Run("refuses to issue a challenge for the server signing key account", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), false)
+
+		_, err := service.CreateChallenge(context.Background(), ChallengeRequest{
+			Account:    kps.server.Address(),
+			HomeDomain: "stellar.local:8000",
+		})
+		assert.ErrorContains(t, err, "account must not be the server signing key")
+	})
+
 	t.Run("rejects challenge issued for the server signing key account", func(t *testing.T) {
 		horizonClient := createMockHorizonClient(kps.server.Address(), horizon.AccountThresholds{MedThreshold: 0}, []horizon.Signer{
 			{Key: kps.server.Address(), Weight: 1, Type: "ed25519_public_key"},
 		})
 		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
 
-		tx := createChallengeTxFor(t, service, kps.server.Address(), "")
-		resp, err := validateSignedBy(t, service, tx)
+		resp, err := validateSignedBy(t, service, buildRawChallenge(t, kps, kps.server.Address()))
 		assert.Error(t, err)
 		assert.Nil(t, resp)
 	})
@@ -1292,8 +1338,7 @@ func TestSEP10Service_ValidateChallenge_SignerRequirements(t *testing.T) {
 	t.Run("rejects non-existent server account padded with an extra signature", func(t *testing.T) {
 		service := createSEP10ServiceWithHorizon(t, kps, createMockHorizon404(t), false)
 
-		tx := createChallengeTxFor(t, service, kps.server.Address(), "")
-		resp, err := validateSignedBy(t, service, tx, keypair.MustRandom())
+		resp, err := validateSignedBy(t, service, buildRawChallenge(t, kps, kps.server.Address()), keypair.MustRandom())
 		assert.Error(t, err)
 		assert.Nil(t, resp)
 	})

--- a/internal/services/sep10_service_test.go
+++ b/internal/services/sep10_service_test.go
@@ -1131,3 +1131,234 @@ func TestSEP10Service_SignatureValidation(t *testing.T) {
 		assert.Contains(t, err.Error(), "fetching client domain signing key")
 	})
 }
+
+func createMockHorizon404(t *testing.T) *horizonclient.MockClient {
+	t.Helper()
+
+	mockClient := &horizonclient.MockClient{}
+	mockClient.On("AccountDetail", mock.AnythingOfType("horizonclient.AccountRequest")).
+		Return(horizon.Account{}, &horizonclient.Error{
+			Problem: problem.P{Status: 404, Title: "Resource Missing"},
+		})
+	return mockClient
+}
+
+// createSEP10ServiceWithHorizon builds a service around a caller-supplied Horizon client.
+func createSEP10ServiceWithHorizon(t *testing.T, kps *testKeypairs, horizonClient horizonclient.ClientInterface, clientAttributionRequired bool) *sep10Service {
+	t.Helper()
+
+	jwtManager, err := sepauth.NewJWTManager("emperors-light-123", 3600000)
+	require.NoError(t, err)
+
+	service, err := NewSEP10Service(
+		jwtManager,
+		testNetworkPassphrase,
+		kps.server.Seed(),
+		"https://stellar.local:8000",
+		true,
+		horizonClient,
+		clientAttributionRequired,
+		createMockSEP10NonceStore(t),
+	)
+	require.NoError(t, err)
+
+	return service.(*sep10Service)
+}
+
+// createChallengeTxFor issues a challenge for account and returns it parsed, carrying only the server signature.
+func createChallengeTxFor(t *testing.T, service *sep10Service, account, clientDomain string) *txnbuild.Transaction {
+	t.Helper()
+
+	challengeResp, err := service.CreateChallenge(context.Background(), ChallengeRequest{
+		Account:      account,
+		HomeDomain:   "stellar.local:8000",
+		ClientDomain: clientDomain,
+	})
+	require.NoError(t, err)
+
+	parsed, err := txnbuild.TransactionFromXDR(challengeResp.Transaction)
+	require.NoError(t, err)
+
+	tx, isSimple := parsed.Transaction()
+	require.True(t, isSimple)
+	return tx
+}
+
+// validateSignedBy signs the challenge with the given keypairs, if any, and submits it for validation.
+func validateSignedBy(t *testing.T, service *sep10Service, tx *txnbuild.Transaction, signers ...*keypair.Full) (*ValidationResponse, error) {
+	t.Helper()
+
+	if len(signers) > 0 {
+		signedTx, err := tx.Sign(testNetworkPassphrase, signers...)
+		require.NoError(t, err)
+		tx = signedTx
+	}
+
+	txBase64, err := tx.Base64()
+	require.NoError(t, err)
+
+	return service.ValidateChallenge(context.Background(), ValidationRequest{Transaction: txBase64})
+}
+
+// TestSEP10Service_ValidateChallenge_SignerRequirements covers the SEP-10 signer rules on the existing-account path:
+// at least one signature from a signer of the client account, no unrecognized signatures, and the server key excluded.
+func TestSEP10Service_ValidateChallenge_SignerRequirements(t *testing.T) {
+	t.Parallel()
+	kps := newTestKeypairs()
+
+	defaultAccount := func() *horizonclient.MockClient {
+		return createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 0}, []horizon.Signer{
+			{Key: kps.client.Address(), Weight: 1, Type: "ed25519_public_key"},
+		})
+	}
+
+	t.Run("rejects challenge submitted without any client signature", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("rejects challenge signed only by a key that is not a signer", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, keypair.MustRandom())
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("rejects challenge signed only by the client_domain key", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), true)
+		service.HTTPClient = createMockHTTPClient(t, kps.clientDomain)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "chaos.cadia.com")
+		resp, err := validateSignedBy(t, service, tx, kps.clientDomain)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("rejects challenge carrying an unrecognized signature", func(t *testing.T) {
+		horizonClient := createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 1}, []horizon.Signer{
+			{Key: kps.client.Address(), Weight: 1, Type: "ed25519_public_key"},
+		})
+		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, kps.client, keypair.MustRandom())
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("rejects challenge carrying a duplicate signature", func(t *testing.T) {
+		horizonClient := createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 1}, []horizon.Signer{
+			{Key: kps.client.Address(), Weight: 1, Type: "ed25519_public_key"},
+		})
+		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, kps.client, kps.client)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("rejects challenge issued for the server signing key account", func(t *testing.T) {
+		horizonClient := createMockHorizonClient(kps.server.Address(), horizon.AccountThresholds{MedThreshold: 0}, []horizon.Signer{
+			{Key: kps.server.Address(), Weight: 1, Type: "ed25519_public_key"},
+		})
+		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
+
+		tx := createChallengeTxFor(t, service, kps.server.Address(), "")
+		resp, err := validateSignedBy(t, service, tx)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("does not count the server signing key towards the account threshold", func(t *testing.T) {
+		horizonClient := createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 5}, []horizon.Signer{
+			{Key: kps.server.Address(), Weight: 10, Type: "ed25519_public_key"},
+			{Key: kps.client.Address(), Weight: 1, Type: "ed25519_public_key"},
+		})
+		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, kps.client)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("rejects non-existent server account padded with an extra signature", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, createMockHorizon404(t), false)
+
+		tx := createChallengeTxFor(t, service, kps.server.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, keypair.MustRandom())
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("accepts master key signature on a zero-threshold account", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, kps.client)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Token)
+	})
+
+	t.Run("accepts multisig meeting the medium threshold", func(t *testing.T) {
+		secondSignerKP := keypair.MustRandom()
+		horizonClient := createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 2}, []horizon.Signer{
+			{Key: kps.client.Address(), Weight: 1, Type: "ed25519_public_key"},
+			{Key: secondSignerKP.Address(), Weight: 1, Type: "ed25519_public_key"},
+		})
+		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, kps.client, secondSignerKP)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Token)
+	})
+
+	t.Run("rejects multisig below the medium threshold", func(t *testing.T) {
+		secondSignerKP := keypair.MustRandom()
+		horizonClient := createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 2}, []horizon.Signer{
+			{Key: kps.client.Address(), Weight: 1, Type: "ed25519_public_key"},
+			{Key: secondSignerKP.Address(), Weight: 1, Type: "ed25519_public_key"},
+		})
+		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, kps.client)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	// A signer the account holder added with weight 0 still authenticates a zero-threshold account: SEP-10 leaves
+	// authenticating below a threshold to the application.
+	t.Run("accepts a weight-zero signer on a zero-threshold account", func(t *testing.T) {
+		horizonClient := createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 0}, []horizon.Signer{
+			{Key: kps.client.Address(), Weight: 0, Type: "ed25519_public_key"},
+		})
+		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, kps.client)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Token)
+	})
+
+	t.Run("ignores non-ed25519 account signers", func(t *testing.T) {
+		horizonClient := createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 1}, []horizon.Signer{
+			{Key: kps.client.Address(), Weight: 1, Type: "ed25519_public_key"},
+			{Key: "XAAACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB7QO7", Weight: 10, Type: "sha256_hash"},
+		})
+		service := createSEP10ServiceWithHorizon(t, kps, horizonClient, false)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "")
+		resp, err := validateSignedBy(t, service, tx, kps.client)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Token)
+	})
+}

--- a/internal/services/sep10_service_test.go
+++ b/internal/services/sep10_service_test.go
@@ -1413,9 +1413,9 @@ func TestSEP10Service_ValidateChallenge_SignerRequirements(t *testing.T) {
 		assert.Nil(t, resp)
 	})
 
-	// A signer the account holder added with weight 0 still authenticates a zero-threshold account: SEP-10 leaves
-	// authenticating below a threshold to the application.
-	t.Run("accepts a weight-zero signer on a zero-threshold account", func(t *testing.T) {
+	// A zero-weight master key is the only weight-0 signer that persists: SetOptions deletes an added signer at weight 0.
+	// SEP-10 leaves authenticating below a threshold to the application, and the account itself set that threshold to 0.
+	t.Run("accepts a zero-weight master key on a zero-threshold account", func(t *testing.T) {
 		horizonClient := createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 0}, []horizon.Signer{
 			{Key: kps.client.Address(), Weight: 0, Type: "ed25519_public_key"},
 		})

--- a/internal/services/sep10_service_test.go
+++ b/internal/services/sep10_service_test.go
@@ -84,7 +84,8 @@ func createSEP10Service(t *testing.T, kps *testKeypairs, baseURL string, jwtMana
 		kps.server.Seed(),
 		baseURL,
 		true,
-		createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 1}, []horizon.Signer{
+		// a default Stellar account has a medium threshold of 0
+		createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 0}, []horizon.Signer{
 			{Key: kps.client.Address(), Weight: 1, Type: "ed25519_public_key"},
 		}),
 		true,


### PR DESCRIPTION
### What

Rewrites SEP-10 challenge signature verification so every signature is attributed to a specific expected key, replacing the previous weight-summing check.

- Require at least one signature from a signer of the client account. Previously the only gate was `totalWeight < med_threshold`, which for a default account evaluates `0 < 0` and passes with no client signature at all.
- Match each signature to exactly one candidate key, and reject any signature that matches none (including a duplicate of an already-matched one).
- Exclude the SEP-10 server signing key from the account's signer set, so the server's own signature can never authenticate a client.
- Refuse to issue or validate a challenge whose client account is the server signing key.
- Apply the same attribution on the non-existent-account path, replacing its signature-count heuristic.
- Remove `verifyThreshold`, replace with `verifyChallengeSignatures` + `attributeSignatures` and
serve both paths.
- Reject a `client_domain` whose `stellar.toml` publishes the server's own SEP-10 signing key, so the server's challenge signature cannot satisfy the `client_domain` proof (copilot review).
- Add 15 new tests covering: 
   - no client signature; 
   - signature from a non-signer; 
   - `client_domain`-only signature; 
   - unrecognized and duplicate signatures; 
   - the server key as client account and as an account signer; 
   - `client_domain` `stellar.toml` publishing server key
   - multisig at and below threshold; 
   - zero-weight master key (a locked account)
   - non-ed25519 signers
- The shared test fixture now uses  `MedThreshold: 1` matching a real default account (previously used `MedThreshold: 1`, which is why the suite was green while the verifier had no client-signature check).

### Why

Currently, the server mints a valid JWT for any default-threshold Stellar account with no client signature. This is a significant SEP-10 protocol-compliance gap, reported by both internal security scans and Hackerone reports e.g. [#3668139](https://hackerone.com/reports/3668139) (Informative). 

This gap produces no reachable security impact: a SEP-10 JWT cannot redirect a disbursement, since linking a Stellar address to a receiver happens only through SEP-24 registration behind OTP and PII checks. Therefore, this is a protocol-compliance fix, not an incident.

Measured against the [SEP-10 token endpoint checks](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#token), SDP currently implements two of the four required for an existing account. The missing two were:
- "remaining signature count is one or more"
- "remaining signatures are signers of the Client Account". 
The count check is unconditional in the spec precisely because the threshold check is qualified with "if any".

[§ Verification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#verification) separately requires the server's signature to be excluded from the weight: "A Server should not assist in authentication."

This also matches Anchor Platform, which delegates to the Java SDK's `Sep10Challenge.verifyChallengeTransactionSigners` and is unaffected by this class of bug. We keep our own reader because Go's `txnbuild.ReadChallengeTx` rejects `client_domain` operations outright, so the SDK helpers can't parse the challenges we issue.

### Behavior changes

- Challenges with no signature from a signer of the account are rejected. This is the fix.
- Challenges carrying an unrecognized or duplicated signature are rejected. This is the only change that could affect a well-behaved client; both SDKs and Anchor Platform already reject it, so any wallet doing this is incompatible with other anchors today.
- No changes to routes, status codes, response bodies, JWT claims, `sub` format, expiry, config flags, or the database. Existing tokens keep working. Error text changed only in logs: `HTTPError.Err` is `json:"-"`, clients still get `{"error":"challenge validation failed"}`.

### Known limitations

- **`client_domain` is still verified against a freshly fetched `stellar.toml` `SIGNING_KEY`** rather than the source account of the `client_domain` operation, as the spec words it. The keys are identical in every non-pathological case, so the security property holds; correcting it is a future PR.
- **A weight-0 signer on a zero-threshold account still authenticates.** The threshold is the account holder's own setting, and SEP-10 § "Verifying Being a Signer" treats authenticating below a threshold as an application decision. The Go SDK, Java SDK and Anchor Platform all behave identically. Note also that `SetOptions` with weight 0 removes a signer, so an attacker cannot add themselves as one. Pinned by a test so it isn't "fixed" later.
- **Muxed (`M...`) accounts remain unsupported**, rejected with a 400 at request validation. The spec only recommends them, and the `memo` mechanism covers the same pooled-account use case.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
