### PR TITLE
SDP-2130 fix: harden receiver-facing messages against HTML injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Harden receiver-facing messages against HTML injection [#1197](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1197)
+
 ### Security and Dependencies
 
 - Move the SDP metrics port off application Service onto a dedicated ClusterIP Service, and pin the TSS metrics Service to ClusterIP. [#1193](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1193)

--- a/internal/htmltemplate/htmltemplate.go
+++ b/internal/htmltemplate/htmltemplate.go
@@ -33,8 +33,10 @@ func ExecuteHTMLTemplate(templateName string, data interface{}) (string, error) 
 	return executedTemplate.String(), nil
 }
 
+// EmptyBodyEmailTemplate wraps a plain-text body in the HTML email shell.
+// Body is a string so html/template escapes it on render; pass raw text, not trusted markup.
 type EmptyBodyEmailTemplate struct {
-	Body template.HTML
+	Body string
 }
 
 func ExecuteHTMLTemplateForEmailEmptyBody(data EmptyBodyEmailTemplate) (string, error) {

--- a/internal/htmltemplate/htmltemplate_test.go
+++ b/internal/htmltemplate/htmltemplate_test.go
@@ -3,7 +3,6 @@ package htmltemplate
 import (
 	"crypto/rand"
 	"fmt"
-	"html/template"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,10 +43,25 @@ func Test_ExecuteHTMLTemplateForEmailEmptyBody(t *testing.T) {
 	randomStr := fmt.Sprintf("%x", b)[:10]
 
 	// check if the random string is imprinted in the template
-	inputData := EmptyBodyEmailTemplate{Body: template.HTML(randomStr)}
+	inputData := EmptyBodyEmailTemplate{Body: randomStr}
 	templateStr, err := ExecuteHTMLTemplateForEmailEmptyBody(inputData)
 	require.NoError(t, err)
 	require.Contains(t, templateStr, randomStr)
+}
+
+// Test_ExecuteHTMLTemplateForEmailEmptyBody_EscapesBody verifies a body with HTML-like content is escaped
+// (not emitted as live markup) when wrapped into the email shell — the sink backstop for operator messages.
+func Test_ExecuteHTMLTemplateForEmailEmptyBody_EscapesBody(t *testing.T) {
+	for _, payload := range []string{
+		"<svg/onload=alert(1)>",
+		"<img/src=x onerror=alert(1)>",
+		`<a/href="https://evil">click</a/>`,
+	} {
+		out, err := ExecuteHTMLTemplateForEmailEmptyBody(EmptyBodyEmailTemplate{Body: payload})
+		require.NoError(t, err)
+		require.NotContains(t, out, payload, "payload must not appear as raw markup")
+		require.Contains(t, out, "&lt;", "payload must be HTML-escaped")
+	}
 }
 
 func Test_ExecuteHTMLTemplateForStaffInvitationEmailMessage(t *testing.T) {

--- a/internal/message/aws_ses_client.go
+++ b/internal/message/aws_ses_client.go
@@ -55,8 +55,9 @@ func (c *awsSESClient) SendMessage(ctx context.Context, message Message) error {
 func generateAWSEmail(message Message, sender string) (*ses.SendEmailInput, error) {
 	emailBody := message.Body
 	var err error
-	// If the email body does not contain an HTML tag, then it is considered as a plain text email:
-	if !strings.Contains(emailBody, "<html") {
+	// Only trusted staff emails are pre-rendered HTML; everything else (receiver messages, unknown types)
+	// is untrusted text and must be escaped, so it can't smuggle live markup past this wrapper.
+	if !message.Type.IsTrustedHTMLBody() {
 		emailBody, err = htmltemplate.ExecuteHTMLTemplateForEmailEmptyBody(htmltemplate.EmptyBodyEmailTemplate{Body: emailBody})
 		if err != nil {
 			return nil, fmt.Errorf("generating html template: %w", err)

--- a/internal/message/aws_ses_client.go
+++ b/internal/message/aws_ses_client.go
@@ -3,7 +3,6 @@ package message
 import (
 	"context"
 	"fmt"
-	"html/template"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -58,7 +57,7 @@ func generateAWSEmail(message Message, sender string) (*ses.SendEmailInput, erro
 	var err error
 	// If the email body does not contain an HTML tag, then it is considered as a plain text email:
 	if !strings.Contains(emailBody, "<html") {
-		emailBody, err = htmltemplate.ExecuteHTMLTemplateForEmailEmptyBody(htmltemplate.EmptyBodyEmailTemplate{Body: template.HTML(emailBody)})
+		emailBody, err = htmltemplate.ExecuteHTMLTemplateForEmailEmptyBody(htmltemplate.EmptyBodyEmailTemplate{Body: emailBody})
 		if err != nil {
 			return nil, fmt.Errorf("generating html template: %w", err)
 		}

--- a/internal/message/aws_ses_client_test.go
+++ b/internal/message/aws_ses_client_test.go
@@ -150,3 +150,18 @@ func Test_generateAWSEmail_success(t *testing.T) {
 	}
 	require.Equal(t, wantEmail, gotEmail)
 }
+
+func Test_generateAWSEmail_escapesUntrustedBodyByType(t *testing.T) {
+	// Untrusted receiver body containing "<html" must be ESCAPED — the old substring fast-path bypass is closed.
+	untrusted := Message{ToEmail: "r@test.com", Title: "t", Type: MessageTypeReceiverOTP, Body: `<html><img src=x onerror=alert(1)>`}
+	got, err := generateAWSEmail(untrusted, "s@test.com")
+	require.NoError(t, err)
+	require.Contains(t, *got.Message.Body.Html.Data, "&lt;html", "untrusted <html body must be escaped")
+	require.NotContains(t, *got.Message.Body.Html.Data, "<img src=x onerror", "no live markup may survive")
+
+	// Trusted staff body (full HTML rendered from an internal template) must pass through UNescaped.
+	trusted := Message{ToEmail: "u@test.com", Title: "t", Type: MessageTypeUserMFA, Body: `<html><body>Your code is 123456</body></html>`}
+	got2, err := generateAWSEmail(trusted, "s@test.com")
+	require.NoError(t, err)
+	require.Equal(t, `<html><body>Your code is 123456</body></html>`, *got2.Message.Body.Html.Data, "trusted staff HTML must be sent as-is")
+}

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -17,6 +17,17 @@ const (
 	MessageTypeReceiverOTP        MessageType = "receiver_otp"
 )
 
+// IsTrustedHTMLBody reports whether this type's body is trusted, fully-formed HTML (staff emails).
+// Everything else — receiver messages and unknown types — is escaped before embedding in an email.
+func (t MessageType) IsTrustedHTMLBody() bool {
+	switch t {
+	case MessageTypeUserForgotPassword, MessageTypeUserMFA, MessageTypeUserInvitation:
+		return true
+	default:
+		return false
+	}
+}
+
 type TemplateVariable string
 
 const (

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -176,3 +176,14 @@ func TestMessage_String(t *testing.T) {
 		})
 	}
 }
+
+func Test_MessageType_IsTrustedHTMLBody(t *testing.T) {
+	trusted := []MessageType{MessageTypeUserForgotPassword, MessageTypeUserMFA, MessageTypeUserInvitation}
+	untrusted := []MessageType{MessageTypeReceiverInvitation, MessageTypeReceiverOTP, MessageType(""), MessageType("something_new")}
+	for _, mt := range trusted {
+		require.True(t, mt.IsTrustedHTMLBody(), "%s should be trusted HTML", mt)
+	}
+	for _, mt := range untrusted {
+		require.False(t, mt.IsTrustedHTMLBody(), "%s must not be trusted (escaped by default)", mt)
+	}
+}

--- a/internal/message/twilio_sendgrid_client.go
+++ b/internal/message/twilio_sendgrid_client.go
@@ -3,7 +3,6 @@ package message
 import (
 	"context"
 	"fmt"
-	"html/template"
 	"strings"
 
 	"github.com/sendgrid/rest"
@@ -42,7 +41,7 @@ func (t *twilioSendGridClient) SendMessage(_ context.Context, message Message) e
 	emailBody := message.Body
 	if !strings.Contains(emailBody, "<html") {
 		var htmlErr error
-		emailBody, htmlErr = htmltemplate.ExecuteHTMLTemplateForEmailEmptyBody(htmltemplate.EmptyBodyEmailTemplate{Body: template.HTML(emailBody)})
+		emailBody, htmlErr = htmltemplate.ExecuteHTMLTemplateForEmailEmptyBody(htmltemplate.EmptyBodyEmailTemplate{Body: emailBody})
 		if htmlErr != nil {
 			return fmt.Errorf("generating html template: %w", htmlErr)
 		}

--- a/internal/message/twilio_sendgrid_client.go
+++ b/internal/message/twilio_sendgrid_client.go
@@ -39,7 +39,9 @@ func (t *twilioSendGridClient) SendMessage(_ context.Context, message Message) e
 	to := mail.NewEmail("", message.ToEmail)
 
 	emailBody := message.Body
-	if !strings.Contains(emailBody, "<html") {
+	// Only trusted staff emails are pre-rendered HTML; everything else (receiver messages, unknown types)
+	// is untrusted text and must be escaped, so it can't smuggle live markup past this wrapper.
+	if !message.Type.IsTrustedHTMLBody() {
 		var htmlErr error
 		emailBody, htmlErr = htmltemplate.ExecuteHTMLTemplateForEmailEmptyBody(htmltemplate.EmptyBodyEmailTemplate{Body: emailBody})
 		if htmlErr != nil {

--- a/internal/message/twilio_sendgrid_client_test.go
+++ b/internal/message/twilio_sendgrid_client_test.go
@@ -157,7 +157,8 @@ foo bar
 
 func Test_TwilioSendGrid_SendMessage_withHTMLContent(t *testing.T) {
 	htmlContent := "<html><body><h1>Hello</h1></body></html>"
-	message := Message{ToEmail: "foo@stellar.org", Title: "test title", Body: htmlContent}
+	// Trusted staff message: its pre-rendered HTML body is sent as-is (untrusted types are escaped instead).
+	message := Message{ToEmail: "foo@stellar.org", Title: "test title", Body: htmlContent, Type: MessageTypeUserInvitation}
 
 	mSendGrid := newMockTwilioSendGridClient(t)
 

--- a/internal/serve/httphandler/receiver_send_otp_handler.go
+++ b/internal/serve/httphandler/receiver_send_otp_handler.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"net/http"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/stellar/go-stellar-sdk/support/log"

--- a/internal/services/send_receiver_wallets_invite_service.go
+++ b/internal/services/send_receiver_wallets_invite_service.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"html/template"
 	"net/url"
 	"path"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/stellar/go-stellar-sdk/strkey"
@@ -188,13 +188,15 @@ func (s SendReceiverWalletInviteService) prepareMessage(ctx context.Context, rwa
 		}
 	}
 
+	// text/template keeps the body raw so it renders correctly over SMS; the email path escapes it at the
+	// wrapper (EmptyBodyEmailTemplate), so operator-authored markup can never reach the receiver as live HTML.
 	content := new(strings.Builder)
 	err := msgTemplate.Execute(content, struct {
 		OrganizationName string
-		RegistrationLink template.HTML
+		RegistrationLink string
 	}{
 		OrganizationName: organization.Name,
-		RegistrationLink: template.HTML(registrationLink),
+		RegistrationLink: registrationLink,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("executing registration message template: %w", err)

--- a/internal/services/send_receiver_wallets_invite_service_test.go
+++ b/internal/services/send_receiver_wallets_invite_service_test.go
@@ -679,7 +679,9 @@ func TestSendReceiverWalletInviteService_SendInvite(t *testing.T) {
 
 		rec2RW := data.CreateReceiverWalletFixture(t, ctx, dbConnectionPool, receiver2.ID, wallet2.ID, data.ReadyReceiversWalletStatus)
 
-		customInvitationMessage := "My custom receiver wallet registration invite. MyOrg 👋"
+		// Special chars and a tag must stay RAW in msg.Body: the body is shared with the SMS channel, so it
+		// must not be HTML-escaped here; the email path escapes at the wrapper instead (see Design F).
+		customInvitationMessage := "Save 20% & win <b>now</b>! MyOrg 👋"
 		err = models.Organizations.Update(ctx, &data.OrganizationUpdate{ReceiverRegistrationMessageTemplate: &customInvitationMessage})
 		require.NoError(t, err)
 

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -257,6 +257,8 @@ func containsHTMLTag(s string) bool {
 			return false
 		case html.StartTagToken, html.EndTagToken, html.SelfClosingTagToken:
 			return true
+		default:
+			// text, comments, doctype — keep scanning
 		}
 	}
 }

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -22,8 +22,6 @@ var (
 	// RxPhone is a regex used to validate phone number, according with the E.164 standard https://en.wikipedia.org/wiki/E.164
 	rxPhone = regexp.MustCompile(`^\+[1-9]{1}[0-9]{9,14}$`)
 	rxOTP   = regexp.MustCompile(`^\d{6}$`)
-	// Any HTML-like tag: <a ...>, </div>, <STYLE>...</STYLE>, etc.
-	rxHTMLTag = regexp.MustCompile(`(?i)<\s*/?\s*[a-z][a-z0-9]*(\s+[^>]*)?>`)
 	// "javascript:" URL scheme anywhere in the string.
 	rxJSScheme                = regexp.MustCompile(`(?i)\bjavascript\s*:`)
 	rxCSSExpr                 = regexp.MustCompile(`(?i)\bexpression\s*\(`)
@@ -230,21 +228,35 @@ func ValidateURLScheme(link string, scheme ...string) error {
 	return nil
 }
 
-// ValidateNoHTML returns an error if the input contains HTML tags, JavaScript schemes, or CSS expressions,
-// as detected by regular expressions, either in encoded or decoded form.
+// ValidateNoHTML errors if the input contains HTML tags, JS schemes, or CSS expressions, encoded or not.
+// Tags are detected with the HTML tokenizer (not a regex) so evasions like <svg/onload=...> are caught.
 func ValidateNoHTML(s string) error {
 	if s == "" {
 		return nil
 	}
 
-	if rxHTMLTag.MatchString(s) || rxJSScheme.MatchString(s) || rxCSSExpr.MatchString(s) {
+	if containsHTMLTag(s) || rxJSScheme.MatchString(s) || rxCSSExpr.MatchString(s) {
 		return errors.New("input contains HTML or active content")
 	}
 
 	unescaped := html.UnescapeString(s)
-	if rxHTMLTag.MatchString(unescaped) || rxJSScheme.MatchString(unescaped) || rxCSSExpr.MatchString(unescaped) {
+	if containsHTMLTag(unescaped) || rxJSScheme.MatchString(unescaped) || rxCSSExpr.MatchString(unescaped) {
 		return errors.New("input contains HTML or active content")
 	}
 
 	return nil
+}
+
+// containsHTMLTag reports whether s contains any HTML tag, using the tokenizer so slash-separated tags
+// like <svg/onload=...> (missed by a regex, but live elements in a browser) are detected.
+func containsHTMLTag(s string) bool {
+	z := html.NewTokenizer(strings.NewReader(s))
+	for {
+		switch z.Next() {
+		case html.ErrorToken:
+			return false
+		case html.StartTagToken, html.EndTagToken, html.SelfClosingTagToken:
+			return true
+		}
+	}
 }

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -452,6 +452,9 @@ func Test_ValidateNoHTML_Valid(t *testing.T) {
 		"Whitespace    \n\t  ",
 		"This doesn't contain any HTML tags or scripts.",
 		"Text with word expression but not as code.",
+		"Claim your payment: {{.RegistrationLink}}",
+		"Meeting at 3 < 5 pm, see you",
+		"Price <100 dollars, save 20% & more",
 	}
 
 	for i, tc := range validTestCases {
@@ -476,6 +479,11 @@ func Test_ValidateNoHTML(t *testing.T) {
 		"JAVASCRIPT:ALERT(localStorage.getItem('sdp_session'))",
 		"javascript:alert('XSS')",
 		"JAVASCRIPT:ALERT('XSS')",
+		// Slash-separated tags: missed by a regex denylist, parsed as live elements by browsers.
+		"<svg/onload=alert(document.domain)>",
+		"<img/src=x onerror=alert(document.domain)>",
+		`<a/href="https://evil.com">legit text</a/>`,
+		"<svg/onload=alert(1)>",
 	}
 
 	for i, tc := range rawHTMLTestCases {


### PR DESCRIPTION
### What

Complement to #1198.

Fix the HTML-injection bypass in custom messages (HackerOne #3970481), including both the receiver registration invitation message and the OTP message (unreported). The fix involves 2 layers:

1. **Harden `ValidateNoHTML`**: replace the bypassable tag regex with the HTML tokenizer, so parser-level evasions like `<svg/onload=...>`, `<img/src=x ...>`, and slash-closed tags are detected the way a browser parses them.
2. **Neutralize the render sink**: render the invite/OTP body with `text/template` (kept raw so SMS is unaffected) and HTML escape it at the email wrapper only. Operator-authored markup can no longer reach the receiver's email as live HTML, regardless of input validation.
3.  **Trusted-vs-untrusted email bodies decided by `message.Type`, not content: the email clients now escape unless `message.Type.IsTrustedHTMLBody()`; only staff emails (forgot-password, MFA, user invitation) are trusted, pre-rendered HTML; receiver messages and any unknown/empty type are always escaped. This replaces the old `if !strings.Contains(body, "<html")` check, which a body containing the literal `<html` could slip past to reach the client as live HTML (issue raised by Copilot review)

### Why

The old `ValidateNoHTML` regex only matched tags where whitespace/`>` followed the tag name, so `<svg/onload=...>` slipped through and was emitted unescaped into the outbound HTML email. 

The changes give defense-in-depth: input detection (can't save it) + output encoding (can't render it), which is exactly the remediation the report recommended. The sink change also fixes a latent bug where org names containing `&`/`'` rendered as `&amp;`/`&#39;` gibberish over SMS.

### Known limitations

- Input validation still isn't applied on every ingress (the disbursement CSV path) or every operator field (`otp_message_template`). Those are addressed in PR #1198; the sink escaping already protects the email path in the meantime.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
