### PR TITLE
SDP-2131 fix: validate receiver-facing message input on every write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Validate receiver-facing message input on every write path. [#1198](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1198)
+
 ### Security and Dependencies
 
 - Move the SDP metrics port off application Service onto a dedicated ClusterIP Service, and pin the TSS metrics Service to ClusterIP. [#1193](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1193)

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -138,6 +138,11 @@ func (d DisbursementHandler) PostDisbursement(w http.ResponseWriter, r *http.Req
 }
 
 func (d DisbursementHandler) createNewDisbursement(ctx context.Context, httpReq *http.Request, sqlExec db.SQLExecuter, userID string, req PostDisbursementRequest) (*data.Disbursement, *httperror.HTTPError) {
+	// Validate here so every ingress path (JSON and multipart/CSV) is covered — both funnel through this function.
+	if v := d.validateRequest(ctx, req); v.HasErrors() {
+		return nil, httperror.BadRequest("", nil, v.Errors)
+	}
+
 	var wallet *data.Wallet
 	var err error
 
@@ -796,11 +801,7 @@ func (d DisbursementHandler) postDisbursementWithInstructions(ctx context.Contex
 }
 
 func (d DisbursementHandler) postDisbursementOnly(ctx context.Context, r *http.Request, req PostDisbursementRequest, user *auth.User) (*data.Disbursement, *httperror.HTTPError) {
-	v := d.validateRequest(ctx, req)
-	if v.HasErrors() {
-		return nil, httperror.BadRequest("", nil, v.Errors)
-	}
-
+	// Validation runs inside createNewDisbursement so it also covers the multipart/CSV path.
 	return d.createNewDisbursement(ctx, r, d.Models.DBConnectionPool, user.ID, req)
 }
 

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -2619,6 +2619,23 @@ func Test_DisbursementHandler_PostDisbursement_WithInstructions(t *testing.T) {
 			expectedStatus: http.StatusCreated,
 		},
 		{
+			name: "🔴 receiver_registration_message_template contains HTML (multipart/CSV path)",
+			disbursementData: map[string]interface{}{
+				"name":                                   "disbursement with html template",
+				"asset_id":                               asset.ID,
+				"wallet_id":                              enabledWallet.ID,
+				"registration_contact_type":              data.RegistrationContactTypePhone,
+				"verification_field":                     data.VerificationTypeDateOfBirth,
+				"receiver_registration_message_template": "<b>Claim</b> your payment",
+			},
+			csvRecords: [][]string{
+				{"phone", "id", "amount", "verification"},
+				{"+380445555555", "123456789", "100.5", "1990-01-01"},
+			},
+			expectedStatus:  http.StatusBadRequest,
+			expectedMessage: "receiver_registration_message_template cannot contain HTML, JS or CSS",
+		},
+		{
 			name: "🔴 disabled wallet",
 			disbursementData: map[string]interface{}{
 				"name":                      "disbursement with disabled wallet",

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -205,7 +205,12 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 		}
 	}
 
+	if reqBody.OTPMessageTemplate != nil {
+		validator.CheckError(utils.ValidateNoHTML(*reqBody.OTPMessageTemplate), "otp_message_template", "otp_message_template cannot contain HTML, JS or CSS")
+	}
+
 	if reqBody.OrganizationName != "" {
+		validator.CheckError(utils.ValidateNoHTML(reqBody.OrganizationName), "organization_name", "organization_name cannot contain HTML, JS or CSS")
 		validator.CheckError(utils.ValidateStringLength(reqBody.OrganizationName, "organization_name", 64), "organization_name", "")
 	}
 

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -400,6 +400,54 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			}`,
 		},
 		{
+			name:  "returns BadRequest when otp_message_template contains HTML",
+			token: "token",
+			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
+				authManagerMock.
+					On("GetUserByID", mock.Anything, mock.Anything).
+					Return(user, nil).
+					Once()
+			},
+			getRequestFn: func(t *testing.T, ctx context.Context) *http.Request {
+				reqBody := `{
+					"otp_message_template": "<a href='evil.com'>Your code</a>"
+				}`
+				return createOrganizationProfileMultipartRequest(t, ctx, url, "", "", reqBody, new(bytes.Buffer))
+			},
+			networkType:    utils.PubnetNetworkType,
+			wantStatusCode: http.StatusBadRequest,
+			wantRespBody: `{
+				"error": "The request was invalid in some way.",
+				"extras": {
+					"otp_message_template": "otp_message_template cannot contain HTML, JS or CSS"
+				}
+			}`,
+		},
+		{
+			name:  "returns BadRequest when organization_name contains HTML",
+			token: "token",
+			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
+				authManagerMock.
+					On("GetUserByID", mock.Anything, mock.Anything).
+					Return(user, nil).
+					Once()
+			},
+			getRequestFn: func(t *testing.T, ctx context.Context) *http.Request {
+				reqBody := `{
+					"organization_name": "<b>Evil</b> Corp"
+				}`
+				return createOrganizationProfileMultipartRequest(t, ctx, url, "", "", reqBody, new(bytes.Buffer))
+			},
+			networkType:    utils.PubnetNetworkType,
+			wantStatusCode: http.StatusBadRequest,
+			wantRespBody: `{
+				"error": "The request was invalid in some way.",
+				"extras": {
+					"organization_name": "organization_name cannot contain HTML, JS or CSS"
+				}
+			}`,
+		},
+		{
 			name:  "returns BadRequest when receiver_registration_message_template exceeds 255 characters",
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {


### PR DESCRIPTION
### What

Complement to #1197.

Apply existing input validation where it was being skipped:
1. **Disbursement multipart/CSV path**: move `validateRequest` into `createNewDisbursement` so both ingress paths validate metadata. The CSV path (the dashboard flow) previously skipped all of it.
2. **`otp_message_template`** and **`organization_name`**: add `ValidateNoHTML` in `PATCH /organization`; these operator editable fields that reach receiver messages were never HTML-checked.

### Why

`postDisbursementWithInstructions` bypassed `validateRequest`, so CSV-created disbursements skipped name/asset/contact type/verification-field checks *and* the `ValidateNoHTML` on the invite template, letting HTML into receiver emails unvalidated by the backend (some fields are still validated client-side). 

The OTP template and org name reached receiver messages with the same gap. Consolidating validation into the single shared function means it can't be silently bypassed again.

### Known limitations

- Validation is consolidated into `createNewDisbursement`, which does a second wallet lookup on the JSON path; negligible cost for a single, un-bypassable validation point.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
