### PR TITLE
SDP-2132 chore: verify SEP-10 client domain against operation source account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Move the SDP metrics port off application Service onto a dedicated ClusterIP Service, and pin the TSS metrics Service to ClusterIP. [#1193](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1193)
 - Move `LOG_SHIPPING_URL` to global section in helm chart as a secret value. [#1193](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1193)
 - Require client signer when verifying SEP-10 challenges [#1196](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1196)
+- Verify the SEP-10 `client_domain` signature against the operation source account. [#1199](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1199)
+- Return `400 Bad Request` instead of `500` when a `client_domain` signing key cannot be resolved. [#1199](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1199)
 
 ## [7.0.0](https://github.com/stellar/stellar-disbursement-platform-backend/releases/tag/7.0.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-backend/compare/6.6.1...7.0.0))
 

--- a/internal/services/sep10_service.go
+++ b/internal/services/sep10_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/protocols/horizon"
 	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
@@ -113,7 +114,9 @@ type ChallengeValidationResult struct {
 	HomeDomain      string
 	Memo            *txnbuild.MemoID
 	ClientDomain    string
-	Nonce           string
+	// ClientDomainAccountID is the source account of the client_domain operation, i.e. the key that must sign.
+	ClientDomainAccountID string
+	Nonce                 string
 }
 
 func NewSEP10Service(
@@ -181,7 +184,8 @@ func (s *sep10Service) CreateChallenge(ctx context.Context, req ChallengeRequest
 		var err error
 		clientSigningKey, err = s.fetchSigningKeyFromClientDomain(req.ClientDomain)
 		if err != nil {
-			return nil, fmt.Errorf("fetching client domain signing key: %w", err)
+			log.Ctx(ctx).Errorf("resolving client_domain %s signing key: %v", req.ClientDomain, err)
+			return nil, ChallengeValidationError("unable to resolve a valid SIGNING_KEY from the client_domain stellar.toml")
 		}
 	}
 
@@ -201,6 +205,10 @@ func (s *sep10Service) CreateChallenge(ctx context.Context, req ChallengeRequest
 
 	tx, err := s.buildChallengeTx(ctx, req.Account, webAuthDomain, req.HomeDomain, req.ClientDomain, clientSigningKey, memoParam)
 	if err != nil {
+		var validationErr ChallengeValidationError
+		if errors.As(err, &validationErr) {
+			return nil, validationErr
+		}
 		return nil, fmt.Errorf("building challenge transaction %w", err)
 	}
 
@@ -239,7 +247,7 @@ func (s *sep10Service) ValidateChallenge(ctx context.Context, req ValidationRequ
 			if verifyErr := s.verifySignaturesForNonExistentAccount(
 				result.Transaction,
 				result.ClientAccountID,
-				result.ClientDomain,
+				result.ClientDomainAccountID,
 			); verifyErr != nil {
 				return nil, verifyErr
 			}
@@ -263,7 +271,7 @@ func (s *sep10Service) ValidateChallenge(ctx context.Context, req ValidationRequ
 	if err = s.verifySignaturesWithThreshold(
 		result.Transaction,
 		result.ClientAccountID,
-		result.ClientDomain,
+		result.ClientDomainAccountID,
 		account,
 	); err != nil {
 		return nil, err
@@ -367,7 +375,7 @@ func (s *sep10Service) validateChallengeCustom(challengeTx, serverAccountID, net
 		return nil, fmt.Errorf("random nonce before encoding as base64 should be 48 bytes long")
 	}
 
-	var clientDomain string
+	var clientDomain, clientDomainAccountID string
 	foundClientDomain := false
 	for i, operation := range operations[1:] {
 		manageDataOp, ok := operation.(*txnbuild.ManageData)
@@ -391,7 +399,12 @@ func (s *sep10Service) validateChallengeCustom(challengeTx, serverAccountID, net
 			if _, err := xdr.AddressToAccountId(manageDataOp.SourceAccount); err != nil {
 				return nil, fmt.Errorf("client_domain operation has invalid source account: %w", err)
 			}
+			// otherwise the server's own challenge signature would satisfy the client_domain signature.
+			if manageDataOp.SourceAccount == serverAccountID {
+				return nil, fmt.Errorf("client_domain operation must not be sourced to the server account")
+			}
 			clientDomain = string(manageDataOp.Value)
+			clientDomainAccountID = manageDataOp.SourceAccount
 			foundClientDomain = true
 		default:
 			if manageDataOp.SourceAccount != serverAccountID {
@@ -409,12 +422,13 @@ func (s *sep10Service) validateChallengeCustom(challengeTx, serverAccountID, net
 	}
 
 	return &ChallengeValidationResult{
-		Transaction:     tx,
-		ClientAccountID: clientAccountID,
-		HomeDomain:      matchedHomeDomain,
-		Memo:            memo,
-		ClientDomain:    clientDomain,
-		Nonce:           nonceB64,
+		Transaction:           tx,
+		ClientAccountID:       clientAccountID,
+		HomeDomain:            matchedHomeDomain,
+		Memo:                  memo,
+		ClientDomain:          clientDomain,
+		ClientDomainAccountID: clientDomainAccountID,
+		Nonce:                 nonceB64,
 	}, nil
 }
 
@@ -449,20 +463,13 @@ func (s *sep10Service) verifyServerSignature(tx *txnbuild.Transaction, network, 
 func (s *sep10Service) verifySignaturesForNonExistentAccount(
 	tx *txnbuild.Transaction,
 	clientAccountID string,
-	clientDomain string,
+	clientDomainAccountID string,
 ) error {
 	signers := challengeSigners{
-		accountID: clientAccountID,
-		server:    s.SEP10SigningKeypair.Address(),
-		account:   map[string]int{clientAccountID: 0},
-	}
-
-	if clientDomain != "" {
-		clientDomainAccountID, err := s.fetchSigningKeyFromClientDomain(clientDomain)
-		if err != nil {
-			return fmt.Errorf("fetching client domain signing key: %w", err)
-		}
-		signers.clientDomain = clientDomainAccountID
+		accountID:       clientAccountID,
+		server:          s.SEP10SigningKeypair.Address(),
+		clientDomainKey: clientDomainAccountID,
+		account:         map[string]int{clientAccountID: 0},
 	}
 
 	return s.verifyChallengeSignatures(tx, signers, 0)
@@ -473,22 +480,22 @@ const ed25519SignerType = "ed25519_public_key"
 
 // challengeSigners holds the keys that may legitimately have signed a challenge transaction.
 type challengeSigners struct {
-	accountID    string
-	server       string
-	clientDomain string
-	account      map[string]int // signers able to authenticate the client account, by weight
+	accountID       string
+	server          string
+	clientDomainKey string
+	account         map[string]int // signers able to authenticate the client account, by weight
 }
 
 // addresses returns every candidate key, deduplicated across roles.
 func (cs challengeSigners) addresses() []string {
 	addresses := make([]string, 0, len(cs.account)+2)
 	addresses = append(addresses, cs.server)
-	if cs.clientDomain != "" && cs.clientDomain != cs.server {
-		addresses = append(addresses, cs.clientDomain)
+	if cs.clientDomainKey != "" && cs.clientDomainKey != cs.server {
+		addresses = append(addresses, cs.clientDomainKey)
 	}
 
 	for address := range cs.account {
-		if address == cs.server || address == cs.clientDomain {
+		if address == cs.server || address == cs.clientDomainKey {
 			continue
 		}
 		addresses = append(addresses, address)
@@ -500,21 +507,14 @@ func (cs challengeSigners) addresses() []string {
 func (s *sep10Service) verifySignaturesWithThreshold(
 	tx *txnbuild.Transaction,
 	clientAccountID string,
-	clientDomain string,
+	clientDomainAccountID string,
 	account *horizon.Account,
 ) error {
 	signers := challengeSigners{
-		accountID: clientAccountID,
-		server:    s.SEP10SigningKeypair.Address(),
-		account:   make(map[string]int, len(account.Signers)),
-	}
-
-	if clientDomain != "" {
-		clientDomainAccountID, err := s.fetchSigningKeyFromClientDomain(clientDomain)
-		if err != nil {
-			return fmt.Errorf("fetching client domain signing key: %w", err)
-		}
-		signers.clientDomain = clientDomainAccountID
+		accountID:       clientAccountID,
+		server:          s.SEP10SigningKeypair.Address(),
+		clientDomainKey: clientDomainAccountID,
+		account:         make(map[string]int, len(account.Signers)),
 	}
 
 	for _, signer := range account.Signers {
@@ -543,8 +543,8 @@ func (s *sep10Service) verifyChallengeSignatures(
 		return fmt.Errorf("challenge is not signed by server account %s", signers.server)
 	}
 
-	if signers.clientDomain != "" && !matched[signers.clientDomain] {
-		return fmt.Errorf("verifying client domain signature: challenge is not signed by client domain account %s", signers.clientDomain)
+	if signers.clientDomainKey != "" && !matched[signers.clientDomainKey] {
+		return fmt.Errorf("verifying client domain signature: challenge is not signed by client domain account %s", signers.clientDomainKey)
 	}
 
 	// SEP-10 requires the server's own signature to be excluded when weighing the account's signers.
@@ -694,7 +694,12 @@ func (s *sep10Service) buildChallengeTx(ctx context.Context, clientAccountID, we
 
 	if clientDomainAccountID != "" {
 		if _, parseErr := keypair.ParseAddress(clientDomainAccountID); parseErr != nil {
-			return nil, fmt.Errorf("invalid client domain account ID: %s is not a valid Stellar account ID", clientDomainAccountID)
+			return nil, ChallengeValidationError(fmt.Sprintf("client_domain SIGNING_KEY %s is not a valid Stellar account ID", clientDomainAccountID))
+		}
+		// otherwise the server's own challenge signature would satisfy the client_domain signature.
+		if clientDomainAccountID == s.SEP10SigningKeypair.Address() {
+			log.Ctx(ctx).Errorf("client_domain %s publishes the server signing key as its SIGNING_KEY", clientDomain)
+			return nil, ChallengeValidationError("client_domain must not publish the server signing key as its SIGNING_KEY")
 		}
 	}
 
@@ -789,11 +794,6 @@ func (s *sep10Service) fetchSigningKeyFromClientDomain(clientDomain string) (str
 
 	if _, parseErr := keypair.ParseAddress(stellarToml.SigningKey); parseErr != nil {
 		return "", fmt.Errorf("SIGNING_KEY %s is not a valid Stellar account ID", stellarToml.SigningKey)
-	}
-
-	// otherwise the server's own challenge signature would satisfy the client_domain signature.
-	if stellarToml.SigningKey == s.SEP10SigningKeypair.Address() {
-		return "", fmt.Errorf("SIGNING_KEY of client_domain %s must not be the server signing key", clientDomain)
 	}
 
 	return stellarToml.SigningKey, nil

--- a/internal/services/sep10_service_test.go
+++ b/internal/services/sep10_service_test.go
@@ -368,7 +368,7 @@ func TestSEP10Service_CreateChallenge(t *testing.T) {
 				ClientDomain: "invalid-domain.com",
 			},
 			expectError: true,
-			errMsg:      "unable to fetch stellar.toml from invalid-domain.com",
+			errMsg:      "unable to resolve a valid SIGNING_KEY from the client_domain stellar.toml",
 		},
 		{
 			name: "timeout validation",
@@ -1129,7 +1129,7 @@ func TestSEP10Service_SignatureValidation(t *testing.T) {
 		validationReq := ValidationRequest{Transaction: signedTxBase64}
 		_, err = service.ValidateChallenge(context.Background(), validationReq)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "fetching client domain signing key")
+		assert.Contains(t, err.Error(), "verifying client domain signature")
 	})
 }
 
@@ -1363,16 +1363,17 @@ func TestSEP10Service_ValidateChallenge_SignerRequirements(t *testing.T) {
 			HomeDomain:   "stellar.local:8000",
 			ClientDomain: "chaos.cadia.com",
 		})
-		assert.ErrorContains(t, err, "must not be the server signing key")
+		var validationErr ChallengeValidationError
+		require.ErrorAs(t, err, &validationErr)
+		assert.ErrorContains(t, err, "client_domain must not publish the server signing key")
 	})
 
 	t.Run("rejects challenge whose client_domain operation is sourced to the server signing key", func(t *testing.T) {
 		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), false)
-		service.HTTPClient = createMockHTTPClient(t, kps.server)
 
 		tx := buildRawChallenge(t, kps, kps.client.Address(), kps.server.Address())
 		resp, err := validateSignedBy(t, service, tx, kps.client)
-		assert.ErrorContains(t, err, "must not be the server signing key")
+		assert.ErrorContains(t, err, "client_domain operation must not be sourced to the server account")
 		assert.Nil(t, resp)
 	})
 
@@ -1438,5 +1439,102 @@ func TestSEP10Service_ValidateChallenge_SignerRequirements(t *testing.T) {
 		resp, err := validateSignedBy(t, service, tx, kps.client)
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp.Token)
+	})
+}
+
+// createRotatingMockHTTPClient serves firstKP's SIGNING_KEY on the first fetch and thenKP's on every fetch after,
+// simulating a client domain that rotates its key mid-flow.
+func createRotatingMockHTTPClient(t *testing.T, firstKP, thenKP *keypair.Full) *mocks.HTTPClientMock {
+	mockClient := mocks.NewHTTPClientMock(t)
+
+	fetches := 0
+	mockClient.
+		On("Get", mock.AnythingOfType("string")).
+		Return(func(_ string) *http.Response {
+			fetches++
+			kp := firstKP
+			if fetches > 1 {
+				kp = thenKP
+			}
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader("SIGNING_KEY = \"" + kp.Address() + "\"\n")),
+			}
+		}, nil)
+	return mockClient
+}
+
+// TestSEP10Service_ClientDomainVerification covers SEP-10's rule that the client_domain signature is verified
+// against the source account of the client_domain operation, and the status a client domain failure maps to.
+func TestSEP10Service_ClientDomainVerification(t *testing.T) {
+	t.Parallel()
+	kps := newTestKeypairs()
+
+	defaultAccount := func() *horizonclient.MockClient {
+		return createMockHorizonClient(kps.client.Address(), horizon.AccountThresholds{MedThreshold: 0}, []horizon.Signer{
+			{Key: kps.client.Address(), Weight: 1, Type: "ed25519_public_key"},
+		})
+	}
+
+	t.Run("verifies the client domain signature against the challenge operation source account", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), true)
+		service.HTTPClient = createRotatingMockHTTPClient(t, kps.clientDomain, keypair.MustRandom())
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "chaos.cadia.com")
+		resp, err := validateSignedBy(t, service, tx, kps.client, kps.clientDomain)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Token)
+	})
+
+	t.Run("rejects a signature from the client domain's current key when the challenge pinned another", func(t *testing.T) {
+		rotatedKP := keypair.MustRandom()
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), true)
+		service.HTTPClient = createRotatingMockHTTPClient(t, kps.clientDomain, rotatedKP)
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "chaos.cadia.com")
+		resp, err := validateSignedBy(t, service, tx, kps.client, rotatedKP)
+		assert.ErrorContains(t, err, "client domain")
+		assert.Nil(t, resp)
+	})
+
+	t.Run("does not fetch the client domain stellar.toml during validation", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), true)
+
+		mockClient := mocks.NewHTTPClientMock(t)
+		mockClient.
+			On("Get", mock.AnythingOfType("string")).
+			Return(&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader("SIGNING_KEY = \"" + kps.clientDomain.Address() + "\"\n")),
+			}, nil).
+			Once()
+		service.HTTPClient = mockClient
+
+		tx := createChallengeTxFor(t, service, kps.client.Address(), "chaos.cadia.com")
+		resp, err := validateSignedBy(t, service, tx, kps.client, kps.clientDomain)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Token)
+	})
+
+	t.Run("reports an unresolvable client domain signing key as client input", func(t *testing.T) {
+		service := createSEP10ServiceWithHorizon(t, kps, defaultAccount(), true)
+
+		mockClient := mocks.NewHTTPClientMock(t)
+		mockClient.
+			On("Get", mock.AnythingOfType("string")).
+			Return(func(_ string) *http.Response {
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(""))}
+			}, nil)
+		service.HTTPClient = mockClient
+
+		_, err := service.CreateChallenge(context.Background(), ChallengeRequest{
+			Account:      kps.client.Address(),
+			HomeDomain:   "stellar.local:8000",
+			ClientDomain: "chaos.cadia.com",
+		})
+
+		var validationErr ChallengeValidationError
+		require.ErrorAs(t, err, &validationErr)
+		assert.NotContains(t, err.Error(), "SIGNING_KEY not present")
 	})
 }


### PR DESCRIPTION
### What

- Verify the `client_domain` signature against the **source account of the `client_domain` operation** (the key SDP resolved at issuance and sealed into the challenge with its own signature) instead of re-fetching the domain's `stellar.toml` during validation. The validation path no longer makes an outbound request.
- Reject a challenge whose `client_domain` operation is sourced to the server account, so the parser stays decidable from the transaction alone. The equivalent creation-side guard moved from the TOML fetcher into `buildChallengeTx`, next to where the operation is built.
- Return `400` instead of `500` when a `client_domain` signing key can't be resolved, with a fixed generic message. The specific cause is logged at error level, as before.

### Why

These were the last two SEP-10 conformance gaps after #1196.

The [token endpoint checklist](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#token) says: "verify that the transaction was signed by the source account of the Manage Data operation." [§ Verifying the Client Domain](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#verifying-the-client-domain) says an unresolvable `SIGNING_KEY` should return `400 Bad Request`.

Re-resolving the key at validation trusted *more* external state, not less; the challenge is server-signed, so the operation's source account can't be tampered with, while a third party's TOML can change or become unreachable between the two fetches. Dropping the second fetch also removes an availability dependency on every wallet vendor's web server, and an amplifier: signature verification runs before the nonce is consumed, so a single challenge could be resubmitted repeatedly to trigger unbounded outbound fetches.

The client-facing message is deliberately generic for all fetch and TOML failures: the caller chooses the host, so reporting "connection refused" vs. "404" vs. "no SIGNING_KEY" would give an unauthenticated caller an internal reachability oracle.

### Known limitations


- **Behaviour change:** a wallet whose `stellar.toml` lags its own signer mid-rotation goes from intermittently succeeding to consistently failing until its TOML catches up. The new outcome is deterministic and matches every conformant anchor, including Anchor Platform.
- The `500` to `400` change is on `GET /sep10/auth` only (`POST` already returned 400). Clients that retry only on `5xx` will no longer retry these.
- Three distinct causes share one client-facing message by design; the specific cause is in the logs.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
