### PR TITLE
SDP-2143 fix: fail closed when token tenant cannot be resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Harden receiver-facing messages against HTML injection [#1197](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1197)
 - Validate receiver-facing message input on every write path. [#1198](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1198)
+- Fail closed when token tenant cannot be resolved. [#1205](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1205)
 
 ### Security and Dependencies
 

--- a/internal/serve/middleware/middleware.go
+++ b/internal/serve/middleware/middleware.go
@@ -117,12 +117,31 @@ func AuthenticateMiddleware(authManager auth.AuthManager, tenantManager tenant.M
 
 			// Attempt fetching tenant ID from token
 			tenantID, err := authManager.GetTenantID(ctx, token)
-			if err == nil && tenantID != "" {
-				currentTenant, tenantErr := tenantManager.GetTenantByID(ctx, tenantID)
-				if tenantErr == nil && currentTenant != nil {
-					ctx = sdpcontext.SetTenantInContext(ctx, currentTenant)
+			if err != nil {
+				if !errors.Is(err, auth.ErrInvalidToken) && !errors.Is(err, auth.ErrUserNotFound) {
+					log.Ctx(ctx).Error(fmt.Errorf("getting tenant ID from token: %w", err))
 				}
+				httperror.Unauthorized("", nil, nil).Render(rw)
+				return
 			}
+			if tenantID == "" {
+				// A token that carries no tenant cannot be trusted to run under the header tenant.
+				httperror.Unauthorized("", nil, nil).Render(rw)
+				return
+			}
+			currentTenant, tenantErr := tenantManager.GetTenantByID(ctx, tenantID)
+			switch {
+			case errors.Is(tenantErr, tenant.ErrTenantDoesNotExist):
+				httperror.Unauthorized("", nil, nil).Render(rw)
+				return
+			case tenantErr != nil:
+				httperror.InternalError(ctx, "", fmt.Errorf("getting tenant by ID from token: %w", tenantErr), nil).Render(rw)
+				return
+			case currentTenant == nil:
+				httperror.Unauthorized("", nil, nil).Render(rw)
+				return
+			}
+			ctx = sdpcontext.SetTenantInContext(ctx, currentTenant)
 
 			// Add the user ID to the request context logger
 			ctx = log.Set(ctx, log.Ctx(ctx).WithField("user_id", userID))

--- a/internal/serve/middleware/middleware_test.go
+++ b/internal/serve/middleware/middleware_test.go
@@ -299,6 +299,124 @@ func Test_AuthenticateMiddleware(t *testing.T) {
 		assert.JSONEq(t, `{"error":"Not authorized."}`, string(respBody))
 	})
 
+	t.Run("returns Unauthorized when the token carries no tenant", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/authenticated", nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer token")
+		// An empty tenant claim must not be allowed to run under the header-supplied tenant.
+		req.Header.Set(TenantHeaderKey, "victim_tenant")
+
+		mAuthManager.
+			On("GetUserID", mock.Anything, "token").
+			Return("test_user_id", nil).
+			Once()
+		mAuthManager.
+			On("GetTenantID", mock.Anything, "token").
+			Return("", nil).
+			Once()
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.JSONEq(t, `{"error":"Not authorized."}`, string(respBody))
+	})
+
+	t.Run("returns Unauthorized when the token's tenant cannot be resolved (deactivated/deleted)", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/authenticated", nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer token")
+		// A caller naming another tenant in the header must not be able to ride it in when the
+		// token's own tenant no longer resolves.
+		req.Header.Set(TenantHeaderKey, "victim_tenant")
+
+		mAuthManager.
+			On("GetUserID", mock.Anything, "token").
+			Return("test_user_id", nil).
+			Once()
+		mAuthManager.
+			On("GetTenantID", mock.Anything, "token").
+			Return("test_tenant_id", nil).
+			Once()
+		mTenantManager.
+			On("GetTenantByID", mock.Anything, "test_tenant_id").
+			Return((*schema.Tenant)(nil), tenant.ErrTenantDoesNotExist).
+			Once()
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.JSONEq(t, `{"error":"Not authorized."}`, string(respBody))
+	})
+
+	t.Run("returns InternalServerError when the tenant lookup fails unexpectedly", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/authenticated", nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer token")
+
+		mAuthManager.
+			On("GetUserID", mock.Anything, "token").
+			Return("test_user_id", nil).
+			Once()
+		mAuthManager.
+			On("GetTenantID", mock.Anything, "token").
+			Return("test_tenant_id", nil).
+			Once()
+		mTenantManager.
+			On("GetTenantByID", mock.Anything, "test_tenant_id").
+			Return((*schema.Tenant)(nil), errors.New("connection refused")).
+			Once()
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	})
+
+	t.Run("returns Unauthorized when the tenant ID cannot be read from the token", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/authenticated", nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer token")
+
+		mAuthManager.
+			On("GetUserID", mock.Anything, "token").
+			Return("test_user_id", nil).
+			Once()
+		mAuthManager.
+			On("GetTenantID", mock.Anything, "token").
+			Return("", auth.ErrInvalidToken).
+			Once()
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.JSONEq(t, `{"error":"Not authorized."}`, string(respBody))
+	})
+
 	t.Run("returns the response successfully", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/authenticated", nil)
 		require.NoError(t, err)

--- a/stellar-auth/pkg/auth/jwt_manager.go
+++ b/stellar-auth/pkg/auth/jwt_manager.go
@@ -76,7 +76,7 @@ func (m *defaultJWTManager) GenerateToken(ctx context.Context, user *User, expir
 		},
 	}
 
-	// A token must always be scoped to a tenant. 
+	// A token must always be scoped to a tenant.
 	// Fail closed rather than issuing a tenantless token.
 	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {

--- a/stellar-auth/pkg/auth/jwt_manager.go
+++ b/stellar-auth/pkg/auth/jwt_manager.go
@@ -82,6 +82,9 @@ func (m *defaultJWTManager) GenerateToken(ctx context.Context, user *User, expir
 	if err != nil {
 		return "", fmt.Errorf("getting tenant from context to generate token: %w", err)
 	}
+	if currentTenant == nil || currentTenant.ID == "" {
+		return "", fmt.Errorf("generating token: no tenant scoped in context")
+	}
 	c.TenantID = currentTenant.ID
 
 	token := jwtgo.NewWithClaims(jwtgo.SigningMethodES256, c)

--- a/stellar-auth/pkg/auth/jwt_manager.go
+++ b/stellar-auth/pkg/auth/jwt_manager.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	jwtgo "github.com/golang-jwt/jwt/v4"
-	"github.com/stellar/go-stellar-sdk/support/log"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 )
@@ -77,13 +76,13 @@ func (m *defaultJWTManager) GenerateToken(ctx context.Context, user *User, expir
 		},
 	}
 
-	// TODO: Always throw this error after migrations are merged [SDP-953]
+	// A token must always be scoped to a tenant. 
+	// Fail closed rather than issuing a tenantless token.
 	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
 	if err != nil {
-		log.Ctx(ctx).Error(err)
-	} else {
-		c.TenantID = currentTenant.ID
+		return "", fmt.Errorf("getting tenant from context to generate token: %w", err)
 	}
+	c.TenantID = currentTenant.ID
 
 	token := jwtgo.NewWithClaims(jwtgo.SigningMethodES256, c)
 

--- a/stellar-auth/pkg/auth/jwt_manager_test.go
+++ b/stellar-auth/pkg/auth/jwt_manager_test.go
@@ -56,6 +56,16 @@ func Test_DefaultJWTManager_GenerateToken(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, currentTenant.ID, tenantID)
 	})
+
+	t.Run("returns error when there is no tenant in the context", func(t *testing.T) {
+		jwtManager := newDefaultJWTManager(withECKeypair(testPublicKey, testPrivateKey))
+
+		expiresAt := time.Now().Add(time.Minute * 5)
+		token, err := jwtManager.GenerateToken(context.Background(), &User{}, expiresAt)
+
+		assert.ErrorContains(t, err, "getting tenant from context to generate token")
+		assert.Empty(t, token)
+	})
 }
 
 func Test_DefaultJWTManager_ValidateToken(t *testing.T) {

--- a/stellar-auth/pkg/auth/jwt_manager_test.go
+++ b/stellar-auth/pkg/auth/jwt_manager_test.go
@@ -66,6 +66,28 @@ func Test_DefaultJWTManager_GenerateToken(t *testing.T) {
 		assert.ErrorContains(t, err, "getting tenant from context to generate token")
 		assert.Empty(t, token)
 	})
+
+	t.Run("returns error (no panic) when the context holds a nil tenant", func(t *testing.T) {
+		jwtManager := newDefaultJWTManager(withECKeypair(testPublicKey, testPrivateKey))
+		nilCtx := sdpcontext.SetTenantInContext(context.Background(), (*schema.Tenant)(nil))
+
+		expiresAt := time.Now().Add(time.Minute * 5)
+		token, err := jwtManager.GenerateToken(nilCtx, &User{}, expiresAt)
+
+		assert.ErrorContains(t, err, "no tenant scoped in context")
+		assert.Empty(t, token)
+	})
+
+	t.Run("returns error when the context tenant has an empty ID", func(t *testing.T) {
+		jwtManager := newDefaultJWTManager(withECKeypair(testPublicKey, testPrivateKey))
+		emptyIDCtx := sdpcontext.SetTenantInContext(context.Background(), &schema.Tenant{ID: ""})
+
+		expiresAt := time.Now().Add(time.Minute * 5)
+		token, err := jwtManager.GenerateToken(emptyIDCtx, &User{}, expiresAt)
+
+		assert.ErrorContains(t, err, "no tenant scoped in context")
+		assert.Empty(t, token)
+	})
 }
 
 func Test_DefaultJWTManager_ValidateToken(t *testing.T) {


### PR DESCRIPTION
### What

Makes `AuthenticateMiddleware` reject any authenticated request whose token does not resolve to an active tenant, instead of silently falling back to the client-supplied `SDP-Tenant-Name` header.

- `internal/serve/middleware/middleware.go`: the tenant block now fails closed. A token whose tenant id cannot be read, is empty, or resolves to a deactivated/deleted tenant returns 401; an unexpected tenant-lookup error returns 500. Only a clean resolution sets the tenant in context. 
- `stellar-auth/pkg/auth/jwt_manager.go: GenerateToken` now returns an error when there is no tenant in the context, rather than logging and issuing a tenantless token. This retires the long-standing `[SDP-953] TODO` and guarantees the middleware's empty-tenant rejection can never be undermined by an issued token.
- Tests: new `AuthenticateMiddleware` subtests for the deactivated-tenant, empty-tenant, unexpected-error, and unreadable claim cases, and a new `GenerateToken` case asserting it errors with no tenant in context.

### Why

Tenant selection runs in two middlewares. `ResolveTenantFromRequestMiddleware` seeds the context tenant from the client `SDP-Tenant-Name` header, and `AuthenticateMiddleware` is meant to overwrite it with the token's signed `tenant_id`. That overwrite only happened on a successful lookup, with no else branch, so when the token's tenant could not be resolved the request continued under whatever tenant the caller named in the header. The durable trigger for this is a deactivated or deleted tenant, whose lookup is filtered out. 

This let a user of a deactivated tenant read another  tenant's Circle balances on the one tenant-scoped route without a role check, `GET /balances`. Failing closed on any unresolved tenant removes the fallback for every route on this middleware, and the issuance change removes the only way an empty-tenant token could otherwise exist.

### Known limitations

- This is the middleware root fix only. Adding a role check to `GET /balances` and hardening the refresh path against extending a deactivated tenant's session are tracked as separate follow-up PRs. With this change merged, both of those endpoints already reject a deactivated-tenant token at the middleware; the follow-ups are defense-in-depth.
- `parseToken` does not explicitly pin the ES256 signing method. This is not exploitable, `alg:none` and `HMAC-downgrade` both fail because a typed EC public key is returned, but pinning the method is worth adding as separate defense-in-depth.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production


[SDP-953]: https://stellarorg.atlassian.net/browse/SDP-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ