### PR TITLE
SDP-2144 fix: require tenant role check on GET /balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Harden receiver-facing messages against HTML injection [#1197](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1197)
 - Validate receiver-facing message input on every write path. [#1198](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1198)
+- Require a tenant role check on `GET /balances`. [#1206](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1206)
 
 ### Security and Dependencies
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -783,7 +783,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 
 		r.With(middleware.RequirePermission(
 			data.ReadAll,
-			middleware.AnyRoleMiddleware(authManager),
+			middleware.AnyRoleMiddleware(authManager, data.GetAllRoles()...),
 		)).Get("/balances", httphandler.BalancesHandler{
 			DistributionAccountResolver: o.SubmitterEngine.DistributionAccountResolver,
 			CircleService:               o.CircleService,


### PR DESCRIPTION
### What

`GET /balances` now runs the standard per-tenant role check (`GetAllRoles`) instead of the zero-required-roles pass-through.

### Why

A defense-in-depth hardening on top of the middleware fix ([#1250](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1205)) for H1 #4008793.

`/balances` was the only tenant-scoped read using `AnyRoleMiddleware(authManager)` with no roles, which skips the role lookup entirely, and that lookup was the only thing implicitly binding the caller to the tenant. Every comparable read endpoint already uses `GetAllRoles()`.

Aligning `/balances` means a caller who is not a member of the resolved tenant is rejected even if a future change reintroduces a tenant-resolution gap.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
