### PR TITLE
SDP-2145 fix: reject token refresh for deactivated tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Harden receiver-facing messages against HTML injection [#1197](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1197)
 - Validate receiver-facing message input on every write path. [#1198](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1198)
+- Reject token refresh when the token's tenant has been deactivated. [#1207](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1207)
 
 ### Security and Dependencies
 

--- a/internal/serve/httphandler/refresh_token_handler.go
+++ b/internal/serve/httphandler/refresh_token_handler.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/serve/httperror"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 type RefreshTokenHandler struct {
-	AuthManager auth.AuthManager
+	AuthManager   auth.AuthManager
+	TenantManager tenant.ManagerInterface
 }
 
 func (h RefreshTokenHandler) PostRefreshToken(rw http.ResponseWriter, req *http.Request) {
@@ -22,6 +24,18 @@ func (h RefreshTokenHandler) PostRefreshToken(rw http.ResponseWriter, req *http.
 	if err != nil {
 		httperror.Unauthorized("", nil, nil).Render(rw)
 		return
+	}
+
+	// Don't extend session when token's own tenant no longer resolves (deactivated / deleted)
+	if tenantID, tenantIDErr := h.AuthManager.GetTenantID(ctx, token); tenantIDErr == nil && tenantID != "" {
+		if _, tenantErr := h.TenantManager.GetTenantByID(ctx, tenantID); tenantErr != nil {
+			if errors.Is(tenantErr, tenant.ErrTenantDoesNotExist) {
+				httperror.Unauthorized("", tenantErr, nil).Render(rw)
+				return
+			}
+			httperror.InternalError(ctx, "Cannot resolve tenant for token refresh", tenantErr, nil).Render(rw)
+			return
+		}
 	}
 
 	refreshedToken, err := h.AuthManager.RefreshToken(ctx, token)

--- a/internal/serve/httphandler/refresh_token_handler_test.go
+++ b/internal/serve/httphandler/refresh_token_handler_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-disbursement-platform-backend/internal/sdpcontext"
+	"github.com/stellar/stellar-disbursement-platform-backend/pkg/schema"
 	"github.com/stellar/stellar-disbursement-platform-backend/stellar-auth/pkg/auth"
+	"github.com/stellar/stellar-disbursement-platform-backend/stellar-multitenant/pkg/tenant"
 )
 
 func Test_RefreshTokenHandler(t *testing.T) {
@@ -21,8 +23,9 @@ func Test_RefreshTokenHandler(t *testing.T) {
 	authManager := auth.NewAuthManager(
 		auth.WithCustomJWTManagerOption(jwtManagerMock),
 	)
+	tenantManagerMock := &tenant.TenantManagerMock{}
 
-	handler := &RefreshTokenHandler{AuthManager: authManager}
+	handler := &RefreshTokenHandler{AuthManager: authManager, TenantManager: tenantManagerMock}
 	url := "/refresh-token"
 
 	ctx := context.Background()
@@ -50,10 +53,11 @@ func Test_RefreshTokenHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 		require.NoError(t, err)
 
+		// Invalid token: the tenant lookup is skipped and RefreshToken renders the response.
 		jwtManagerMock.
 			On("ValidateToken", req.Context(), "mytoken").
 			Return(false, nil).
-			Once()
+			Times(2)
 
 		http.HandlerFunc(handler.PostRefreshToken).ServeHTTP(w, req)
 
@@ -76,7 +80,7 @@ func Test_RefreshTokenHandler(t *testing.T) {
 		jwtManagerMock.
 			On("ValidateToken", req.Context(), "mytoken").
 			Return(false, errors.New("unexpected error")).
-			Once()
+			Times(2)
 
 		http.HandlerFunc(handler.PostRefreshToken).ServeHTTP(w, req)
 
@@ -89,7 +93,7 @@ func Test_RefreshTokenHandler(t *testing.T) {
 		assert.JSONEq(t, `{"error": "Cannot refresh user token"}`, string(respBody))
 	})
 
-	t.Run("returns the refreshed token", func(t *testing.T) {
+	t.Run("returns Unauthorized when the token's tenant has been deactivated", func(t *testing.T) {
 		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
 
 		w := httptest.NewRecorder()
@@ -100,8 +104,45 @@ func Test_RefreshTokenHandler(t *testing.T) {
 			On("ValidateToken", req.Context(), "mytoken").
 			Return(true, nil).
 			Once().
+			On("GetTenantIDFromToken", req.Context(), "mytoken").
+			Return("deactivated-tenant-id", nil).
+			Once()
+		tenantManagerMock.
+			On("GetTenantByID", req.Context(), "deactivated-tenant-id").
+			Return(nil, tenant.ErrTenantDoesNotExist).
+			Once()
+
+		http.HandlerFunc(handler.PostRefreshToken).ServeHTTP(w, req)
+
+		resp := w.Result()
+
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.JSONEq(t, `{"error": "Not authorized."}`, string(respBody))
+	})
+
+	t.Run("returns the refreshed token", func(t *testing.T) {
+		ctx = sdpcontext.SetTokenInContext(ctx, "mytoken")
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+		require.NoError(t, err)
+
+		jwtManagerMock.
+			On("ValidateToken", req.Context(), "mytoken").
+			Return(true, nil).
+			Times(2).
+			On("GetTenantIDFromToken", req.Context(), "mytoken").
+			Return("tenant-id", nil).
+			Once().
 			On("RefreshToken", req.Context(), "mytoken", mock.AnythingOfType("time.Time")).
 			Return("myrefreshedtoken", nil).
+			Once()
+		tenantManagerMock.
+			On("GetTenantByID", req.Context(), "tenant-id").
+			Return(&schema.Tenant{ID: "tenant-id", Name: "tenant-name"}, nil).
 			Once()
 
 		http.HandlerFunc(handler.PostRefreshToken).ServeHTTP(w, req)
@@ -116,4 +157,5 @@ func Test_RefreshTokenHandler(t *testing.T) {
 	})
 
 	jwtManagerMock.AssertExpectations(t)
+	tenantManagerMock.AssertExpectations(t)
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -464,7 +464,7 @@ func handleHTTP(o ServeOptions) *chi.Mux {
 		r.With(middleware.RequirePermission(
 			data.ReadAll,
 			middleware.AnyRoleMiddleware(authManager),
-		)).Post("/refresh-token", httphandler.RefreshTokenHandler{AuthManager: authManager}.PostRefreshToken)
+		)).Post("/refresh-token", httphandler.RefreshTokenHandler{AuthManager: authManager, TenantManager: o.tenantManager}.PostRefreshToken)
 
 		// Disbursement endpoints
 		r.Route("/disbursements", func(r chi.Router) {

--- a/stellar-auth/pkg/auth/jwt_manager.go
+++ b/stellar-auth/pkg/auth/jwt_manager.go
@@ -65,24 +65,30 @@ func (m *defaultJWTManager) parseToken(tokenString string) (*jwtgo.Token, *claim
 }
 
 func (m *defaultJWTManager) GenerateToken(ctx context.Context, user *User, expiresAt time.Time) (string, error) {
+	tenantID := ""
+	// TODO: Always throw this error after migrations are merged [SDP-953]
+	if currentTenant, err := sdpcontext.GetTenantFromContext(ctx); err != nil {
+		log.Ctx(ctx).Error(err)
+	} else {
+		tenantID = currentTenant.ID
+	}
+
+	return m.signToken(user, tenantID, expiresAt)
+}
+
+// signToken builds and signs a token for the given user and tenant.
+func (m *defaultJWTManager) signToken(user *User, tenantID string, expiresAt time.Time) (string, error) {
 	esPrivateKey, err := jwtgo.ParseECPrivateKeyFromPEM([]byte(m.privateKey))
 	if err != nil {
 		return "", fmt.Errorf("parsing EC Private Key: %w", err)
 	}
 
 	c := &claims{
-		User: user,
+		User:     user,
+		TenantID: tenantID,
 		RegisteredClaims: jwtgo.RegisteredClaims{
 			ExpiresAt: jwtgo.NewNumericDate(expiresAt),
 		},
-	}
-
-	// TODO: Always throw this error after migrations are merged [SDP-953]
-	currentTenant, err := sdpcontext.GetTenantFromContext(ctx)
-	if err != nil {
-		log.Ctx(ctx).Error(err)
-	} else {
-		c.TenantID = currentTenant.ID
 	}
 
 	token := jwtgo.NewWithClaims(jwtgo.SigningMethodES256, c)
@@ -109,7 +115,7 @@ func (m *defaultJWTManager) RefreshToken(ctx context.Context, tokenString string
 		return tokenString, nil
 	}
 
-	tokenString, err = m.GenerateToken(ctx, c.User, expiresAt)
+	tokenString, err = m.signToken(c.User, c.TenantID, expiresAt)
 	if err != nil {
 		return "", fmt.Errorf("generating new refreshed token: %w", err)
 	}

--- a/stellar-auth/pkg/auth/jwt_manager_test.go
+++ b/stellar-auth/pkg/auth/jwt_manager_test.go
@@ -140,6 +140,25 @@ func Test_DefaultJWTManager_RefreshToken(t *testing.T) {
 
 		assert.NotEqual(t, token, refreshedToken)
 	})
+
+	t.Run("preserves the token's tenant on refresh, ignoring the context tenant", func(t *testing.T) {
+		expiresAt := time.Now().Add(time.Minute * tokenRefreshWindow)
+		token, err := jwtManager.GenerateToken(ctx, &User{}, expiresAt)
+		require.NoError(t, err)
+
+		// Refresh under a different context tenant: the refreshed token must keep the original one.
+		otherTenant := schema.Tenant{ID: "other-tenant-id", Name: "other-tenant"}
+		otherCtx := sdpcontext.SetTenantInContext(context.Background(), &otherTenant)
+
+		newExpiresAt := time.Now().Add(time.Minute * 5)
+		refreshedToken, err := jwtManager.RefreshToken(otherCtx, token, newExpiresAt)
+		require.NoError(t, err)
+		require.NotEqual(t, token, refreshedToken)
+
+		tenantID, err := jwtManager.GetTenantIDFromToken(otherCtx, refreshedToken)
+		require.NoError(t, err)
+		assert.Equal(t, currentTenant.ID, tenantID)
+	})
 }
 
 func Test_DefaultJWTManager_parseToken(t *testing.T) {


### PR DESCRIPTION
### What

- Token refresh now rejects (401) a token whose tenant has been deactivated or deleted.
- The re-signed token preserves the original tenant from the token's claims instead of re-reading it from the request context.

### Why

Follow-up to PRs #1205 and #1206. Two problems: 
- `RefreshToken` re-validated only the signature and expiry, so a deactivated tenant's users could keep a session alive indefinitely; 
- Because re-signing pulled the tenant from context, a refresh carrying a victim `SDP-Tenant-Name` header rewrote the new token's `tenant_id` to the victim, laundering the header choice into a properly signed claim. 

Rejecting refresh for unresolved tenants ends the session on offboarding, and preserving the claim removes the laundering.

### Known limitations
- Does not add token revocation or a denylist; the existing "cannot invalidate an issued token before expiry" behaviour (the `RefreshToken` TODO) is unchanged.
- Adds a per-refresh tenant lookup on a low-frequency endpoint.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
