### PR TITLE
SDP-2146 fix: TSS holds bundle lock on unknown Horizon outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Fail closed when token tenant cannot be resolved. [#1205](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1205)
 - Require a tenant role check on `GET /balances`. [#1206](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1206)
 - Reject token refresh when the token's tenant has been deactivated. [#1207](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1207)
+- Hold TSS transaction and channel-account locks until the envelope's ledger bound expires when Horizon returns an unknown outcome (5xx/timeout). [#1208](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1208)
 
 ### Security and Dependencies
 

--- a/internal/transactionsubmission/README.md
+++ b/internal/transactionsubmission/README.md
@@ -27,6 +27,8 @@ Instead of each Horizon error code being handled in a bespoke manner, they are c
 - `504`: Timeouts
 - `400`'s with error code `tx_insufficient_fee`, `tx_too_late`, `tx_bad_seq`
 
+A `504` (or any other `5xx`, or a client-side timeout) is different from a `4xx`: it means the outcome is unknown. The submitted envelope may have reached stellar-core and may still be included until its ledger bound. In that case the TSS keeps the transaction and its channel account locked until `locked_until_ledger_number` (which equals the envelope's `MaxLedger`, roughly 10 ledgers ahead) expires. Once it does, the worker looks the hash up on Horizon: if the transaction landed it is marked successful, and only if it never landed is a fresh transaction built. Rebuilding earlier would let the same payment be submitted twice. The trade-off is that during a Horizon outage every in-flight channel account is held for one lock window, so size `NUM_CHANNEL_ACCOUNTS` accordingly.
+
 ## Transaction Submitter
 ### CLI Usage: `tss`
 ```sh

--- a/internal/transactionsubmission/README.md
+++ b/internal/transactionsubmission/README.md
@@ -27,8 +27,6 @@ Instead of each Horizon error code being handled in a bespoke manner, they are c
 - `504`: Timeouts
 - `400`'s with error code `tx_insufficient_fee`, `tx_too_late`, `tx_bad_seq`
 
-A `504` (or any other `5xx`, or a client-side timeout) is different from a `4xx`: it means the outcome is unknown. The submitted envelope may have reached stellar-core and may still be included until its ledger bound. In that case the TSS keeps the transaction and its channel account locked until `locked_until_ledger_number` (which equals the envelope's `MaxLedger`, roughly 10 ledgers ahead) expires. Once it does, the worker looks the hash up on Horizon: if the transaction landed it is marked successful, and only if it never landed is a fresh transaction built. Rebuilding earlier would let the same payment be submitted twice. The trade-off is that during a Horizon outage every in-flight channel account is held for one lock window, so size `NUM_CHANNEL_ACCOUNTS` accordingly.
-
 ## Transaction Submitter
 ### CLI Usage: `tss`
 ```sh

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -203,6 +203,11 @@ func (tw *TransactionWorker) runJob(ctx context.Context, txJob *TxJob) error {
 //
 //	Horizon: 400 tx_too_late, unexpected errors
 //	RPC: unexpected errors
+//
+// Errors that keep the bundle locked until its ledger bound expires, because the recorded envelope may still be
+// included (only when a hash was recorded and the handler does not rebuild on retry):
+//
+//	Horizon: 5xx (incl. 504 Timeout), client-side timeouts, transport errors
 func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob *TxJob, hTxResp horizon.Transaction, txErr utils.TransactionError) error {
 	// Emit the failure with discrete, structured fields (horizon_status_code, tx_result_code,
 	// operation_result_codes, ...) so operators can filter/alert on specific result codes, instead of
@@ -241,7 +246,8 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 			tw.crashTrackerClient.LogAndReportErrors(ctx, txErr, fmt.Sprintf("%s transaction error - cannot be retried", strings.ToLower(txErr.GetErrorType())))
 		}
 	} else {
-		if txErr.IsRetryable() && tw.txHandler.RequiresRebuildOnRetry() {
+		requiresRebuild := tw.txHandler.RequiresRebuildOnRetry()
+		if requiresRebuild {
 			if _, prepareErr := tw.txModel.PrepareTransactionForReprocessing(ctx, tw.dbConnectionPool, txJob.Transaction.ID); prepareErr != nil {
 				return fmt.Errorf("preparing transaction for reprocessing: %w", prepareErr)
 			}
@@ -250,6 +256,14 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 		var horizonErr utils.HorizonSpecificError
 		if errors.As(txErr, &horizonErr) && horizonErr.IsBadSequence() {
 			tw.crashTrackerClient.LogAndReportErrors(ctx, txErr, "tx_bad_seq detected!")
+		}
+
+		if !requiresRebuild && txJob.Transaction.StellarTransactionHash.Valid && txErr.IsOutcomeUnknown() {
+			log.Ctx(ctx).WithFields(log.F{
+				"tx_hash":                    txJob.Transaction.StellarTransactionHash.String,
+				"locked_until_ledger_number": txJob.LockedUntilLedgerNumber,
+			}).Warn("unknown Horizon outcome; holding transaction and channel account locks until the ledger bound expires")
+			return nil
 		}
 	}
 
@@ -307,8 +321,8 @@ func (tw *TransactionWorker) markTransactionAsError(ctx context.Context, txJob *
 
 // TODO: add tests
 // unlockJob will unlock the channel account and transaction instantaneously, so they can be made available ASAP. If
-// this method is not called, the algorithm will fall back to get these resources qutomatically unlocked when their
-// `locked-to-ledger` expire.
+// this method is not called, the algorithm will fall back to get these resources automatically unlocked when their
+// `locked-to-ledger` expire, which is required when the submission outcome is unknown (the envelope may still land).
 func (tw *TransactionWorker) unlockJob(ctx context.Context, txJob *TxJob) error {
 	_, err := tw.chAccModel.Unlock(ctx, tw.dbConnectionPool, txJob.ChannelAccount.PublicKey)
 	if err != nil {
@@ -391,6 +405,7 @@ func (tw *TransactionWorker) reconcileSubmittedTransaction(ctx context.Context, 
 		return fmt.Errorf("unexpected error: %w", hWrapperErr)
 	}
 
+	// Authoritative 404: a bundle with a hash is only reselected after its lock (== MaxLedger) expires or a definitive 4xx.
 	log.Ctx(ctx).Warnf("Previous transaction didn't make through, marking %v for resubmission...", txJob)
 
 	_, err = tw.txModel.PrepareTransactionForReprocessing(ctx, tw.dbConnectionPool, txJob.Transaction.ID)

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -205,7 +205,7 @@ func (tw *TransactionWorker) runJob(ctx context.Context, txJob *TxJob) error {
 //	RPC: unexpected errors
 //
 // Errors that keep the bundle locked until its ledger bound expires, because the recorded envelope may still be
-// included (only when a hash was recorded and the handler does not rebuild on retry):
+// included (any handler, whenever a hash was already recorded for the attempt):
 //
 //	Horizon: 5xx (incl. 504 Timeout), client-side timeouts, transport errors
 func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob *TxJob, hTxResp horizon.Transaction, txErr utils.TransactionError) error {
@@ -246,24 +246,23 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 			tw.crashTrackerClient.LogAndReportErrors(ctx, txErr, fmt.Sprintf("%s transaction error - cannot be retried", strings.ToLower(txErr.GetErrorType())))
 		}
 	} else {
-		requiresRebuild := tw.txHandler.RequiresRebuildOnRetry()
-		if isRetryable && requiresRebuild {
-			if _, prepareErr := tw.txModel.PrepareTransactionForReprocessing(ctx, tw.dbConnectionPool, txJob.Transaction.ID); prepareErr != nil {
-				return fmt.Errorf("preparing transaction for reprocessing: %w", prepareErr)
-			}
-		}
-
 		var horizonErr utils.HorizonSpecificError
 		if errors.As(txErr, &horizonErr) && horizonErr.IsBadSequence() {
 			tw.crashTrackerClient.LogAndReportErrors(ctx, txErr, "tx_bad_seq detected!")
 		}
 
-		if !requiresRebuild && txJob.Transaction.StellarTransactionHash.Valid && txErr.IsOutcomeUnknown() {
+		if txJob.Transaction.StellarTransactionHash.Valid && txErr.IsOutcomeUnknown() {
 			log.Ctx(ctx).WithFields(log.F{
 				"tx_hash":                    txJob.Transaction.StellarTransactionHash.String,
 				"locked_until_ledger_number": txJob.LockedUntilLedgerNumber,
 			}).Warn("unknown Horizon outcome; holding transaction and channel account locks until the ledger bound expires")
 			return nil
+		}
+
+		if isRetryable && tw.txHandler.RequiresRebuildOnRetry() {
+			if _, prepareErr := tw.txModel.PrepareTransactionForReprocessing(ctx, tw.dbConnectionPool, txJob.Transaction.ID); prepareErr != nil {
+				return fmt.Errorf("preparing transaction for reprocessing: %w", prepareErr)
+			}
 		}
 	}
 

--- a/internal/transactionsubmission/transaction_worker.go
+++ b/internal/transactionsubmission/transaction_worker.go
@@ -247,7 +247,7 @@ func (tw *TransactionWorker) handleFailedTransaction(ctx context.Context, txJob 
 		}
 	} else {
 		requiresRebuild := tw.txHandler.RequiresRebuildOnRetry()
-		if requiresRebuild {
+		if isRetryable && requiresRebuild {
 			if _, prepareErr := tw.txModel.PrepareTransactionForReprocessing(ctx, tw.dbConnectionPool, txJob.Transaction.ID); prepareErr != nil {
 				return fmt.Errorf("preparing transaction for reprocessing: %w", prepareErr)
 			}

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -1279,10 +1279,15 @@ func Test_TransactionWorker_handleFailedTransaction_notDefinitiveErrorButTrigger
 	err = tw.handleFailedTransaction(context.Background(), &txJob, hTransaction, hErr)
 	require.NoError(t, err)
 
-	// Assert transaction status
+	// Assert transaction status: a 400 is a definitive rejection, so the bundle is released and the hash is kept.
 	updatedTx, err := tw.txModel.Get(ctx, txJob.Transaction.ID)
 	require.NoError(t, err)
 	assert.Equal(t, store.TransactionStatusProcessing, updatedTx.Status)
+	assert.True(t, updatedTx.StellarTransactionHash.Valid)
+	assert.False(t, updatedTx.IsLocked(1))
+	updatedChAcc, err := store.NewChannelAccountModel(dbConnectionPool).Get(ctx, dbConnectionPool, txJob.ChannelAccount.PublicKey, 0)
+	require.NoError(t, err)
+	assert.False(t, updatedChAcc.IsLocked(1))
 }
 
 func Test_TransactionWorker_handleFailedTransaction_retryableErrorThatDoesntTriggerJitter(t *testing.T) {
@@ -1293,12 +1298,14 @@ func Test_TransactionWorker_handleFailedTransaction_retryableErrorThatDoesntTrig
 	defer dbConnectionPool.Close()
 
 	testCases := []struct {
-		name string
-		hErr *utils.HorizonErrorWrapper
+		name         string
+		hErr         *utils.HorizonErrorWrapper
+		wantLockHeld bool
 	}{
-		// - 400 - tx_too_late
+		// - 400 - tx_too_late: definitive rejection, the bundle is released.
 		{
-			name: "400 (tx_too_late) - Bad Request",
+			name:         "400 (tx_too_late) - Bad Request",
+			wantLockHeld: false,
 			hErr: utils.NewHorizonErrorWrapper(horizonclient.Error{
 				Problem: problem.P{
 					Status: http.StatusBadRequest,
@@ -1310,19 +1317,21 @@ func Test_TransactionWorker_handleFailedTransaction_retryableErrorThatDoesntTrig
 				},
 			}),
 		},
-		// - 502 - unable to connect to horizon
+		// - 502 - unable to connect to horizon: outcome unknown, the bundle stays locked.
 		{
-			name: "502 - Bad Gateway",
+			name:         "502 - Bad Gateway - outcome unknown",
+			wantLockHeld: true,
 			hErr: utils.NewHorizonErrorWrapper(horizonclient.Error{
 				Problem: problem.P{
 					Status: http.StatusBadGateway,
 				},
 			}),
 		},
-		// unexpected error
+		// non-Horizon error (client timeout, transport failure): outcome unknown, the bundle stays locked.
 		{
-			name: "502 - Bad Gateway",
-			hErr: utils.NewHorizonErrorWrapper(errors.New("foo bar error")),
+			name:         "non-Horizon error - outcome unknown",
+			hErr:         utils.NewHorizonErrorWrapper(errors.New("foo bar error")),
+			wantLockHeld: true,
 		},
 	}
 
@@ -1389,10 +1398,283 @@ func Test_TransactionWorker_handleFailedTransaction_retryableErrorThatDoesntTrig
 			err = tw.handleFailedTransaction(context.Background(), &txJob, hTransaction, tc.hErr)
 			require.NoError(t, err)
 
-			// Assert transaction status
+			// Assert transaction status, hash and lock state
 			updatedTx, err := tw.txModel.Get(ctx, txJob.Transaction.ID)
 			require.NoError(t, err)
 			assert.Equal(t, store.TransactionStatusProcessing, updatedTx.Status)
+			assert.True(t, updatedTx.StellarTransactionHash.Valid)
+			assert.True(t, updatedTx.XDRSent.Valid)
+			assert.Equal(t, tc.wantLockHeld, updatedTx.IsLocked(1))
+			updatedChAcc, err := store.NewChannelAccountModel(dbConnectionPool).Get(ctx, dbConnectionPool, txJob.ChannelAccount.PublicKey, 0)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantLockHeld, updatedChAcc.IsLocked(1))
+			if tc.wantLockHeld {
+				assert.Equal(t, int32(2), updatedTx.LockedUntilLedgerNumber.Int32)
+				assert.Equal(t, int32(2), updatedChAcc.LockedUntilLedgerNumber.Int32)
+			}
+		})
+	}
+}
+
+func Test_TransactionWorker_handleFailedTransaction_unknownOutcomeHoldsLock(t *testing.T) {
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	const (
+		currentLedger  = 1
+		lockedToLedger = 2
+		txHash         = "3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889"
+		envelopeXDR    = "AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAACgAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAAAO5rKAAAAAAAAAAABVvwF9wAAAEAKZ7IPj/46PuWU6ZOtyMosctNAkXRNX9WCAI5RnfRk+AyxDLoDZP/9l3NvsxQtWj9juQOuoBlFLnWu8intgxQA"
+		distAccount    = "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"
+	)
+	horizonErrWithStatus := func(status int) *utils.HorizonErrorWrapper {
+		return utils.NewHorizonErrorWrapper(horizonclient.Error{Problem: problem.P{Status: status}})
+	}
+
+	testCases := []struct {
+		name            string
+		hErr            *utils.HorizonErrorWrapper
+		setHash         bool
+		requiresRebuild bool
+		wantLockHeld    bool
+		wantHashKept    bool
+	}{
+		{
+			name:         "504 with recorded hash holds the lock",
+			hErr:         horizonErrWithStatus(http.StatusGatewayTimeout),
+			setHash:      true,
+			wantLockHeld: true,
+			wantHashKept: true,
+		},
+		{
+			name:         "non-Horizon error (client timeout, transport) with recorded hash holds the lock",
+			hErr:         utils.NewHorizonErrorWrapper(errors.New("context deadline exceeded")),
+			setHash:      true,
+			wantLockHeld: true,
+			wantHashKept: true,
+		},
+		{
+			name:         "429 with recorded hash is a definitive rejection: unlocks and keeps the hash",
+			hErr:         horizonErrWithStatus(http.StatusTooManyRequests),
+			setHash:      true,
+			wantLockHeld: false,
+			wantHashKept: true,
+		},
+		{
+			name:         "504 without a recorded hash unlocks (nothing was submitted)",
+			hErr:         horizonErrWithStatus(http.StatusGatewayTimeout),
+			setHash:      false,
+			wantLockHeld: false,
+			wantHashKept: false,
+		},
+		{
+			name:            "504 with recorded hash but a rebuild-on-retry handler wipes the hash and unlocks",
+			hErr:            horizonErrWithStatus(http.StatusGatewayTimeout),
+			setHash:         true,
+			requiresRebuild: true,
+			wantLockHeld:    false,
+			wantHashKept:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			defer store.DeleteAllFromChannelAccounts(t, ctx, dbConnectionPool)
+			defer store.DeleteAllTransactionFixtures(t, ctx, dbConnectionPool)
+
+			tw := getTransactionWorkerInstance(t, dbConnectionPool, &MockTransactionHandler{})
+			tw.jobUUID = uuid.NewString()
+			txJob := createTxJobFixture(t, ctx, dbConnectionPool, true, currentLedger, lockedToLedger, uuid.NewString())
+			if tc.setHash {
+				tx, updateErr := tw.txModel.UpdateStellarTransactionHashXDRSentAndDistributionAccount(ctx, txJob.Transaction.ID, txHash, envelopeXDR, distAccount)
+				require.NoError(t, updateErr)
+				txJob.Transaction = *tx
+			}
+
+			mockTxProcessingLimiter := engineMocks.NewMockTransactionProcessingLimiter(t)
+			mockTxProcessingLimiter.On("AdjustLimitIfNeeded", tc.hErr).Return().Once()
+			tw.txProcessingLimiter = mockTxProcessingLimiter
+
+			mMonitorClient := sdpMonitor.NewMockMonitorClient(t)
+			mMonitorClient.
+				On("MonitorCounters", sdpMonitor.PaymentErrorTag, mock.Anything).
+				Return(nil).
+				Once()
+			tw.monitorSvc = tssMonitor.TSSMonitorService{
+				Version:       "0.01",
+				GitCommitHash: "0xABC",
+				Client:        mMonitorClient,
+			}
+
+			transactionHandler := &MockTransactionHandler{}
+			transactionHandler.
+				On("MonitorTransactionProcessingFailed", ctx, &txJob, mock.Anything, true, tc.hErr.Error()).
+				Run(func(args mock.Arguments) {
+					mMonitorClient.MonitorCounters(sdpMonitor.PaymentErrorTag, map[string]string{"error_type": "transaction_error"})
+				}).
+				Return()
+			transactionHandler.
+				On("RequiresRebuildOnRetry").
+				Return(tc.requiresRebuild).
+				Once()
+			tw.txHandler = transactionHandler
+
+			// Run test:
+			err := tw.handleFailedTransaction(ctx, &txJob, horizon.Transaction{}, tc.hErr)
+			require.NoError(t, err)
+			transactionHandler.AssertExpectations(t)
+
+			// Assert transaction status, hash and lock state
+			updatedTx, err := tw.txModel.Get(ctx, txJob.Transaction.ID)
+			require.NoError(t, err)
+			assert.Equal(t, store.TransactionStatusProcessing, updatedTx.Status)
+			assert.Equal(t, tc.wantHashKept, updatedTx.StellarTransactionHash.Valid)
+			assert.Equal(t, tc.wantHashKept, updatedTx.XDRSent.Valid)
+			assert.Equal(t, tc.wantLockHeld, updatedTx.IsLocked(currentLedger))
+
+			updatedChAcc, err := store.NewChannelAccountModel(dbConnectionPool).Get(ctx, dbConnectionPool, txJob.ChannelAccount.PublicKey, 0)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantLockHeld, updatedChAcc.IsLocked(currentLedger))
+
+			if tc.wantLockHeld {
+				assert.Equal(t, int32(lockedToLedger), updatedTx.LockedUntilLedgerNumber.Int32)
+				assert.Equal(t, int32(lockedToLedger), updatedChAcc.LockedUntilLedgerNumber.Int32)
+			}
+		})
+	}
+}
+
+func Test_TransactionWorker_heldBundleReselectedAfterExpiry(t *testing.T) {
+	dbt := dbtest.OpenWithTSSMigrationsOnly(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	const (
+		currentLedger  = 1
+		lockedToLedger = 2
+		expiredLedger  = lockedToLedger + 1
+		txHash         = "3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889"
+		envelopeXDR    = "AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAACgAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAAAO5rKAAAAAAAAAAABVvwF9wAAAEAKZ7IPj/46PuWU6ZOtyMosctNAkXRNX9WCAI5RnfRk+AyxDLoDZP/9l3NvsxQtWj9juQOuoBlFLnWu8intgxQA"
+		distAccount    = "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU"
+		resultXDR      = "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAOAAAAAAAAAABw2JZZYIt4n/WXKcnDow3mbTBMPrOnldetgvGUlpTSEQAAAAA="
+	)
+
+	// holdAndReselect runs a 504 through the worker so the bundle is held, proves the poll loop cannot select it while
+	// the ledger bound is live, and returns the bundle as reselected once the bound has passed.
+	holdAndReselect := func(t *testing.T, ctx context.Context) (TransactionWorker, TxJob) {
+		t.Helper()
+
+		tw := getTransactionWorkerInstance(t, dbConnectionPool, &MockTransactionHandler{})
+		tw.jobUUID = uuid.NewString()
+		txJob := createTxJobFixture(t, ctx, dbConnectionPool, true, currentLedger, lockedToLedger, uuid.NewString())
+		tx, err := tw.txModel.UpdateStellarTransactionHashXDRSentAndDistributionAccount(ctx, txJob.Transaction.ID, txHash, envelopeXDR, distAccount)
+		require.NoError(t, err)
+		txJob.Transaction = *tx
+
+		hErr := utils.NewHorizonErrorWrapper(horizonclient.Error{Problem: problem.P{Status: http.StatusGatewayTimeout}})
+		mockTxProcessingLimiter := engineMocks.NewMockTransactionProcessingLimiter(t)
+		mockTxProcessingLimiter.On("AdjustLimitIfNeeded", hErr).Return().Once()
+		tw.txProcessingLimiter = mockTxProcessingLimiter
+
+		mMonitorClient := sdpMonitor.NewMockMonitorClient(t)
+		mMonitorClient.On("MonitorCounters", sdpMonitor.PaymentErrorTag, mock.Anything).Return(nil).Once()
+		tw.monitorSvc = tssMonitor.TSSMonitorService{Version: "0.01", GitCommitHash: "0xABC", Client: mMonitorClient}
+
+		transactionHandler := &MockTransactionHandler{}
+		transactionHandler.
+			On("MonitorTransactionProcessingFailed", ctx, &txJob, mock.Anything, true, hErr.Error()).
+			Run(func(args mock.Arguments) {
+				mMonitorClient.MonitorCounters(sdpMonitor.PaymentErrorTag, map[string]string{"error_type": "transaction_error"})
+			}).
+			Return()
+		transactionHandler.On("RequiresRebuildOnRetry").Return(false).Once()
+		tw.txHandler = transactionHandler
+
+		// STEP 1: the 504 holds the bundle.
+		err = tw.handleFailedTransaction(ctx, &txJob, horizon.Transaction{}, hErr)
+		require.NoError(t, err)
+
+		bundleModel, err := store.NewChannelTransactionBundleModel(dbConnectionPool)
+		require.NoError(t, err)
+
+		// STEP 2: while the ledger bound is still live, the poll loop cannot select the bundle.
+		bundles, err := bundleModel.LoadAndLockTuples(ctx, lockedToLedger, lockedToLedger+preconditions.IncrementForMaxLedgerBounds, 10)
+		require.NoError(t, err)
+		assert.Empty(t, bundles)
+
+		// STEP 3: once the ledger bound has passed, the bundle is reselected with its hash intact.
+		bundles, err = bundleModel.LoadAndLockTuples(ctx, expiredLedger, expiredLedger+preconditions.IncrementForMaxLedgerBounds, 10)
+		require.NoError(t, err)
+		require.Len(t, bundles, 1)
+		assert.Equal(t, txJob.Transaction.ID, bundles[0].Transaction.ID)
+		assert.Equal(t, txHash, bundles[0].Transaction.StellarTransactionHash.String)
+		assert.Equal(t, expiredLedger+preconditions.IncrementForMaxLedgerBounds, bundles[0].LockedUntilLedgerNumber)
+
+		return tw, TxJob(*bundles[0])
+	}
+
+	testCases := []struct {
+		name              string
+		horizonTxResponse horizon.Transaction
+		horizonTxError    error
+		wantStatus        store.TransactionStatus
+		wantHashKept      bool
+	}{
+		{
+			name:              "reconcile finds the original landed and marks it SUCCESS",
+			horizonTxResponse: horizon.Transaction{Successful: true, ResultXdr: resultXDR},
+			wantStatus:        store.TransactionStatusSuccess,
+			wantHashKept:      true,
+		},
+		{
+			name:           "reconcile gets an authoritative 404 and wipes the hash for a rebuild",
+			horizonTxError: horizonclient.Error{Problem: problem.P{Status: http.StatusNotFound}},
+			wantStatus:     store.TransactionStatusProcessing,
+			wantHashKept:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			defer store.DeleteAllFromChannelAccounts(t, ctx, dbConnectionPool)
+			defer store.DeleteAllTransactionFixtures(t, ctx, dbConnectionPool)
+
+			tw, reselectedJob := holdAndReselect(t, ctx)
+
+			// STEP 4: the reselected bundle goes through runJob, which routes it to reconcile because the hash is set.
+			mockLedgerNumberTracker := preconditionsMocks.NewMockLedgerNumberTracker(t)
+			mockLedgerNumberTracker.On("GetLedgerNumber").Return(expiredLedger, nil).Times(2)
+			tw.engine.LedgerNumberTracker = mockLedgerNumberTracker
+
+			hMock := &horizonclient.MockClient{}
+			hMock.On("TransactionDetail", txHash).Return(tc.horizonTxResponse, tc.horizonTxError).Once()
+			tw.engine.HorizonClient = hMock
+
+			transactionHandler := &MockTransactionHandler{}
+			transactionHandler.On("MonitorTransactionProcessingSuccess", ctx, &reselectedJob, mock.Anything).Return()
+			transactionHandler.On("MonitorTransactionReconciliationSuccess", ctx, &reselectedJob, mock.Anything, mock.Anything).Return()
+			tw.txHandler = transactionHandler
+
+			err := tw.runJob(ctx, &reselectedJob)
+			require.NoError(t, err)
+			hMock.AssertExpectations(t)
+
+			updatedTx, err := tw.txModel.Get(ctx, reselectedJob.Transaction.ID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantStatus, updatedTx.Status)
+			assert.Equal(t, tc.wantHashKept, updatedTx.StellarTransactionHash.Valid)
+			assert.False(t, updatedTx.IsLocked(expiredLedger))
+
+			updatedChAcc, err := store.NewChannelAccountModel(dbConnectionPool).Get(ctx, dbConnectionPool, reselectedJob.ChannelAccount.PublicKey, 0)
+			require.NoError(t, err)
+			assert.False(t, updatedChAcc.IsLocked(expiredLedger))
 		})
 	}
 }
@@ -2274,10 +2556,23 @@ func Test_TransactionWorker_submit(t *testing.T) {
 		name                       string
 		horizonResponse            horizon.Transaction
 		horizonError               error
+		setHash                    bool
 		wantFinalTransactionStatus store.TransactionStatus
 		wantFinalResultXDR         string
+		wantLockHeld               bool
 		prepareMocks               func(*testing.T, TxJob, *crashtracker.MockCrashTrackerClient)
 	}{
+		{
+			name:                       "504 with a recorded hash keeps the tx PROCESSING and holds the bundle lock",
+			horizonResponse:            horizon.Transaction{},
+			horizonError:               horizonclient.Error{Problem: problem.P{Status: http.StatusGatewayTimeout}},
+			setHash:                    true,
+			wantFinalTransactionStatus: store.TransactionStatusProcessing,
+			wantLockHeld:               true,
+			prepareMocks: func(t *testing.T, txJob TxJob, _ *crashtracker.MockCrashTrackerClient) {
+				// No crash-tracker report for a timeout
+			},
+		},
 		{
 			name:                       "unrecoverable horizon error is handled and tx status is marked as ERROR",
 			horizonResponse:            horizon.Transaction{},
@@ -2305,6 +2600,13 @@ func Test_TransactionWorker_submit(t *testing.T) {
 			defer store.DeleteAllTransactionFixtures(t, ctx, dbConnectionPool)
 
 			txJob := createTxJobFixture(t, ctx, dbConnectionPool, true, 1, 2, uuid.NewString())
+			if tc.setHash {
+				const txHash = "3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889"
+				const envelopeXDR = "AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAACgAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAAAO5rKAAAAAAAAAAABVvwF9wAAAEAKZ7IPj/46PuWU6ZOtyMosctNAkXRNX9WCAI5RnfRk+AyxDLoDZP/9l3NvsxQtWj9juQOuoBlFLnWu8intgxQA"
+				tx, updateErr := txModel.UpdateStellarTransactionHashXDRSentAndDistributionAccount(ctx, txJob.Transaction.ID, txHash, envelopeXDR, "GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU")
+				require.NoError(t, updateErr)
+				txJob.Transaction = *tx
+			}
 			feeBumpTx := &txnbuild.FeeBumpTransaction{}
 
 			mockHorizonClient := &horizonclient.MockClient{}
@@ -2337,6 +2639,9 @@ func Test_TransactionWorker_submit(t *testing.T) {
 				Return().
 				Once()
 
+			// Only consulted on the retryable path (e.g. the 504 case).
+			transactionHandler.On("RequiresRebuildOnRetry").Return(false).Maybe()
+
 			transactionWorker := TransactionWorker{
 				dbConnectionPool: dbConnectionPool,
 				txModel:          txModel,
@@ -2363,11 +2668,12 @@ func Test_TransactionWorker_submit(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.wantFinalTransactionStatus, refreshedTx.Status)
 			assert.Equal(t, tc.wantFinalResultXDR, refreshedTx.XDRReceived.String)
+			assert.Equal(t, tc.wantLockHeld, refreshedTx.IsLocked(1))
 
-			// check if the channel account was unlocked:
+			// check whether the channel account was unlocked (or deliberately held):
 			refreshedChAcc, err := chAccModel.Get(ctx, dbConnectionPool, txJob.ChannelAccount.PublicKey, 0)
 			require.NoError(t, err)
-			assert.False(t, refreshedChAcc.IsLocked(int32(txJob.LockedUntilLedgerNumber)))
+			assert.Equal(t, tc.wantLockHeld, refreshedChAcc.IsLocked(int32(txJob.LockedUntilLedgerNumber)))
 
 			mockHorizonClient.AssertExpectations(t)
 			mockCrashTrackerClient.AssertExpectations(t)

--- a/internal/transactionsubmission/transaction_worker_test.go
+++ b/internal/transactionsubmission/transaction_worker_test.go
@@ -1383,7 +1383,7 @@ func Test_TransactionWorker_handleFailedTransaction_retryableErrorThatDoesntTrig
 			transactionHandler.
 				On("RequiresRebuildOnRetry").
 				Return(false).
-				Once()
+				Maybe()
 
 			tw.txHandler = transactionHandler
 
@@ -1471,8 +1471,16 @@ func Test_TransactionWorker_handleFailedTransaction_unknownOutcomeHoldsLock(t *t
 			wantHashKept: false,
 		},
 		{
-			name:            "504 with recorded hash but a rebuild-on-retry handler wipes the hash and unlocks",
+			name:            "504 with recorded hash and a rebuild-on-retry handler holds the lock too",
 			hErr:            horizonErrWithStatus(http.StatusGatewayTimeout),
+			setHash:         true,
+			requiresRebuild: true,
+			wantLockHeld:    true,
+			wantHashKept:    true,
+		},
+		{
+			name:            "429 with recorded hash and a rebuild-on-retry handler wipes the hash and unlocks",
+			hErr:            horizonErrWithStatus(http.StatusTooManyRequests),
 			setHash:         true,
 			requiresRebuild: true,
 			wantLockHeld:    false,
@@ -1520,7 +1528,7 @@ func Test_TransactionWorker_handleFailedTransaction_unknownOutcomeHoldsLock(t *t
 			transactionHandler.
 				On("RequiresRebuildOnRetry").
 				Return(tc.requiresRebuild).
-				Once()
+				Maybe()
 			tw.txHandler = transactionHandler
 
 			// Run test:
@@ -1567,7 +1575,7 @@ func Test_TransactionWorker_heldBundleReselectedAfterExpiry(t *testing.T) {
 
 	// holdAndReselect runs a 504 through the worker so the bundle is held, proves the poll loop cannot select it while
 	// the ledger bound is live, and returns the bundle as reselected once the bound has passed.
-	holdAndReselect := func(t *testing.T, ctx context.Context) (TransactionWorker, TxJob) {
+	holdAndReselect := func(t *testing.T, ctx context.Context, requiresRebuild bool) (TransactionWorker, TxJob) {
 		t.Helper()
 
 		tw := getTransactionWorkerInstance(t, dbConnectionPool, &MockTransactionHandler{})
@@ -1593,7 +1601,7 @@ func Test_TransactionWorker_heldBundleReselectedAfterExpiry(t *testing.T) {
 				mMonitorClient.MonitorCounters(sdpMonitor.PaymentErrorTag, map[string]string{"error_type": "transaction_error"})
 			}).
 			Return()
-		transactionHandler.On("RequiresRebuildOnRetry").Return(false).Once()
+		transactionHandler.On("RequiresRebuildOnRetry").Return(requiresRebuild).Maybe()
 		tw.txHandler = transactionHandler
 
 		// STEP 1: the 504 holds the bundle.
@@ -1621,6 +1629,7 @@ func Test_TransactionWorker_heldBundleReselectedAfterExpiry(t *testing.T) {
 
 	testCases := []struct {
 		name              string
+		requiresRebuild   bool
 		horizonTxResponse horizon.Transaction
 		horizonTxError    error
 		wantStatus        store.TransactionStatus
@@ -1638,6 +1647,13 @@ func Test_TransactionWorker_heldBundleReselectedAfterExpiry(t *testing.T) {
 			wantStatus:     store.TransactionStatusProcessing,
 			wantHashKept:   false,
 		},
+		{
+			name:              "rebuild-on-retry handler (wallet creation) is held too and reconciled to SUCCESS",
+			requiresRebuild:   true,
+			horizonTxResponse: horizon.Transaction{Successful: true, ResultXdr: resultXDR},
+			wantStatus:        store.TransactionStatusSuccess,
+			wantHashKept:      true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1646,7 +1662,7 @@ func Test_TransactionWorker_heldBundleReselectedAfterExpiry(t *testing.T) {
 			defer store.DeleteAllFromChannelAccounts(t, ctx, dbConnectionPool)
 			defer store.DeleteAllTransactionFixtures(t, ctx, dbConnectionPool)
 
-			tw, reselectedJob := holdAndReselect(t, ctx)
+			tw, reselectedJob := holdAndReselect(t, ctx, tc.requiresRebuild)
 
 			// STEP 4: the reselected bundle goes through runJob, which routes it to reconcile because the hash is set.
 			mockLedgerNumberTracker := preconditionsMocks.NewMockLedgerNumberTracker(t)

--- a/internal/transactionsubmission/utils/errors.go
+++ b/internal/transactionsubmission/utils/errors.go
@@ -22,6 +22,7 @@ type TransactionError interface {
 	IsRetryable() bool
 	ShouldMarkAsError() bool
 	ShouldReportToCrashTracker() bool
+	IsOutcomeUnknown() bool
 	GetErrorType() string
 }
 
@@ -154,6 +155,12 @@ func (e *HorizonErrorWrapper) IsRateLimit() bool {
 
 func (e *HorizonErrorWrapper) IsGatewayTimeout() bool {
 	return e.IsHorizonError() && e.StatusCode == http.StatusGatewayTimeout
+}
+
+// IsOutcomeUnknown is true when Horizon returned no verdict on the envelope (non-Horizon error, or any 5xx incl. 504),
+// so it may still be included until its ledger bound.
+func (e *HorizonErrorWrapper) IsOutcomeUnknown() bool {
+	return !e.IsHorizonError() || e.StatusCode == 0 || e.StatusCode >= http.StatusInternalServerError
 }
 
 func (e *HorizonErrorWrapper) HasResultCodes() bool {
@@ -508,6 +515,11 @@ func (e *RPCErrorWrapper) IsRateLimit() bool {
 // IsGatewayTimeout returns true if this is a gateway timeout error (similar to Horizon)
 func (e *RPCErrorWrapper) IsGatewayTimeout() bool {
 	return e.SimulationError != nil && e.SimulationError.Type == stellar.SimulationErrorTypeNetwork
+}
+
+// IsOutcomeUnknown is true when the RPC gave no verdict: a network failure or a non-simulation error.
+func (e *RPCErrorWrapper) IsOutcomeUnknown() bool {
+	return e.SimulationError == nil || e.SimulationError.Type == stellar.SimulationErrorTypeNetwork
 }
 
 // ShouldMarkAsError determines whether a transaction needs to be marked as an error based on the

--- a/internal/transactionsubmission/utils/errors_test.go
+++ b/internal/transactionsubmission/utils/errors_test.go
@@ -339,6 +339,55 @@ func Test_HorizonErrorWrapper_IsGatewayTimeout(t *testing.T) {
 	}
 }
 
+func Test_HorizonErrorWrapper_IsOutcomeUnknown(t *testing.T) {
+	testCases := []struct {
+		name        string
+		originalErr error
+		wantResult  bool
+	}{
+		{
+			name:        "non-horizon error (client timeout, transport), returns TRUE",
+			originalErr: fmt.Errorf("context deadline exceeded"),
+			wantResult:  true,
+		},
+		{
+			name:        "horizon error without a problem body, returns TRUE",
+			originalErr: horizonclient.Error{},
+			wantResult:  true,
+		},
+		{
+			name:        "horizon error whose problem body has no status (proxy JSON), returns TRUE",
+			originalErr: horizonclient.Error{Problem: problem.P{Title: "Bad Gateway"}},
+			wantResult:  true,
+		},
+		{
+			name:        "504 horizon error, returns TRUE",
+			originalErr: horizonclient.Error{Problem: problem.P{Status: http.StatusGatewayTimeout}},
+			wantResult:  true,
+		},
+		{
+			name: "400 horizon error with retryable result code, returns FALSE",
+			originalErr: horizonclient.Error{Problem: problem.P{
+				Status: http.StatusBadRequest,
+				Extras: map[string]interface{}{"result_codes": map[string]interface{}{"transaction": "tx_insufficient_fee"}},
+			}},
+			wantResult: false,
+		},
+		{
+			name:        "429 horizon error, returns FALSE",
+			originalErr: horizonclient.Error{Problem: problem.P{Status: http.StatusTooManyRequests}},
+			wantResult:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hErr := NewHorizonErrorWrapper(tc.originalErr)
+			require.Equal(t, tc.wantResult, hErr.IsOutcomeUnknown())
+		})
+	}
+}
+
 func Test_HorizonErrorWrapper_handleExtrasResultCodes(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -1770,6 +1819,53 @@ func Test_RPCErrorWrapper_IsRetryable(t *testing.T) {
 			assert.Equal(t, tc.wantRetryable, wrapper.IsRetryable())
 		})
 	}
+}
+
+func Test_RPCErrorWrapper_IsOutcomeUnknown(t *testing.T) {
+	testCases := []struct {
+		name               string
+		errorType          stellar.SimulationErrorType
+		wantOutcomeUnknown bool
+	}{
+		{
+			name:               "network error - outcome unknown",
+			errorType:          stellar.SimulationErrorTypeNetwork,
+			wantOutcomeUnknown: true,
+		},
+		{
+			name:               "resource error - verdict received",
+			errorType:          stellar.SimulationErrorTypeResource,
+			wantOutcomeUnknown: false,
+		},
+		{
+			name:               "auth error - verdict received",
+			errorType:          stellar.SimulationErrorTypeAuth,
+			wantOutcomeUnknown: false,
+		},
+		{
+			name:               "contract execution error - verdict received",
+			errorType:          stellar.SimulationErrorTypeContractExecution,
+			wantOutcomeUnknown: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			simErr := &stellar.SimulationError{
+				Type:     tc.errorType,
+				Err:      errors.New("test error"),
+				Response: nil,
+			}
+			wrapper := NewRPCErrorWrapper(simErr)
+
+			assert.Equal(t, tc.wantOutcomeUnknown, wrapper.IsOutcomeUnknown())
+		})
+	}
+
+	t.Run("nil simulation error", func(t *testing.T) {
+		wrapper := &RPCErrorWrapper{SimulationError: nil}
+		assert.True(t, wrapper.IsOutcomeUnknown())
+	})
 }
 
 func Test_RPCErrorWrapper_IsRateLimit(t *testing.T) {


### PR DESCRIPTION
### What

When a Horizon submission ends without a verdict (a 5xx, including 504, or a client-side timeout or connection failure), the Transaction Submission Service now keeps the transaction and its channel account locked until the envelope's ledger bound expires. Before, it unlocked both immediately.

- `TransactionError` gains `IsOutcomeUnknown()`. The Horizon wrapper returns true for any 5xx and for errors with no usable problem body; false for every 4xx. The RPC wrapper returns true for network failures.
- `handleFailedTransaction` returns without unlocking when the outcome is unknown and a hash was already recorded for this attempt. 
- Tests cover the held and released cases, the production `submit` path, and the full cycle: hold, expiry, reselection, reconcile to `SUCCESS` or rebuild.

### Why

TSS records the hash and signed envelope before submitting. On a 504 the envelope has usually reached stellar-core and stays includable for about ten ledgers. The old code released the bundle at once, so the next poll re-selected the transaction, paired it with a different channel account, got a 404 on the still-pending hash, wiped it, and rebuilt a second envelope with an independent sequence. **For payment transactions, if the first one then landed, the receiver was paid twice and SDP recorded only the second hash.**

The lock value equals the envelope's `MaxLedger`, and the ledger tracker reads Horizon's own ingested height. So once the lock expires and the row is re-selected, Horizon has seen every ledger the original could be in, and the reconcile lookup is authoritative: found means success, not found means rebuild. 

### Known limitations

- During a Horizon outage each in-flight channel account is held for one lock window, about a minute. Size `NUM_CHANNEL_ACCOUNTS` accordingly.
- Transactions whose original never lands now wait out the full ledger bound before rebuilding, rather than a poll or two.
- Reconcile does not yet check the current ledger against the envelope's `MaxLedger`. Not needed after this change, since reconcile is only reached after expiry or a definitive rejection, but can be added as defense-in-depth, together with wiping a rejected envelope's hash immediately on retryable 4xx.
- Every handler sets the inner `MaxLedger` equal to the bundle lock, and their unit tests pin it, but nothing enforces this at runtime. A guard can be added as defense-in-depth.
- Connection-level failures on the submit POST (refused, DNS) are held too, although the envelope never left the client. Conservative; the `AccountDetail` path already burns the same window during an outage.
- Held bundles are counted under the "marked for reprocessing" metric label. A dedicated label is planned for the follow-up.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
