### PR TITLE
SDP-2149 fix: harden receiver facing messages against unbounded template expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Require a tenant role check on `GET /balances`. [#1206](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1206)
 - Reject token refresh when the token's tenant has been deactivated. [#1207](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1207)
 - Hold TSS transaction and channel-account locks until the envelope's ledger bound expires when Horizon returns an unknown outcome (5xx/timeout). [#1208](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1208)
+- Harden receiver-facing messages against unbounded template expansion. [#1209](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1209)
 
 ### Security and Dependencies
 

--- a/internal/serve/httphandler/disbursement_handler.go
+++ b/internal/serve/httphandler/disbursement_handler.go
@@ -66,6 +66,10 @@ func (d DisbursementHandler) validateRequest(ctx context.Context, req PostDisbur
 		fmt.Sprintf("registration_contact_type must be one of %v", data.AllRegistrationContactTypes()),
 	)
 	v.CheckError(utils.ValidateNoHTML(req.ReceiverRegistrationMessageTemplate), "receiver_registration_message_template", "receiver_registration_message_template cannot contain HTML, JS or CSS")
+	if req.ReceiverRegistrationMessageTemplate != "" {
+		v.CheckError(utils.ValidateStringLength(req.ReceiverRegistrationMessageTemplate, "receiver_registration_message_template", 255), "receiver_registration_message_template", "")
+	}
+	v.CheckError(utils.ValidateMessageTemplate(req.ReceiverRegistrationMessageTemplate), "receiver_registration_message_template", "")
 	if !req.RegistrationContactType.IncludesWalletAddress {
 		trimmedWalletID := strings.TrimSpace(req.WalletID)
 		v.Check(trimmedWalletID != "", "wallet_id", "wallet_id is required")

--- a/internal/serve/httphandler/disbursement_handler_test.go
+++ b/internal/serve/httphandler/disbursement_handler_test.go
@@ -151,6 +151,20 @@ func Test_DisbursementHandler_validateRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "🔴 receiver_registration_message_template contains an unbounded range construct",
+			request: PostDisbursementRequest{
+				Name:                                "disbursement 1",
+				AssetID:                             "61dbfa89-943a-413c-b862-a2177384d321",
+				WalletID:                            wallet.ID,
+				RegistrationContactType:             data.RegistrationContactTypePhone,
+				VerificationField:                   data.VerificationTypeDateOfBirth,
+				ReceiverRegistrationMessageTemplate: "{{range 1000}}{{range 1000}}A{{end}}{{end}}",
+			},
+			expectedErrors: map[string]interface{}{
+				"receiver_registration_message_template": "message template may only contain text and field substitutions like {{.OTP}}",
+			},
+		},
+		{
 			name: "🟢 all fields are valid",
 			request: PostDisbursementRequest{
 				Name:                    "disbursement 1",

--- a/internal/serve/httphandler/profile_handler.go
+++ b/internal/serve/httphandler/profile_handler.go
@@ -203,10 +203,15 @@ func (h ProfileHandler) PatchOrganizationProfile(rw http.ResponseWriter, req *ht
 		if *reqBody.ReceiverRegistrationMessageTemplate != "" {
 			validator.CheckError(utils.ValidateStringLength(*reqBody.ReceiverRegistrationMessageTemplate, "receiver_registration_message_template", 255), "receiver_registration_message_template", "")
 		}
+		validator.CheckError(utils.ValidateMessageTemplate(*reqBody.ReceiverRegistrationMessageTemplate), "receiver_registration_message_template", "")
 	}
 
 	if reqBody.OTPMessageTemplate != nil {
 		validator.CheckError(utils.ValidateNoHTML(*reqBody.OTPMessageTemplate), "otp_message_template", "otp_message_template cannot contain HTML, JS or CSS")
+		if *reqBody.OTPMessageTemplate != "" {
+			validator.CheckError(utils.ValidateStringLength(*reqBody.OTPMessageTemplate, "otp_message_template", 255), "otp_message_template", "")
+		}
+		validator.CheckError(utils.ValidateMessageTemplate(*reqBody.OTPMessageTemplate), "otp_message_template", "")
 	}
 
 	if reqBody.OrganizationName != "" {

--- a/internal/serve/httphandler/profile_handler_test.go
+++ b/internal/serve/httphandler/profile_handler_test.go
@@ -424,6 +424,54 @@ func Test_ProfileHandler_PatchOrganizationProfile_Failures(t *testing.T) {
 			}`,
 		},
 		{
+			name:  "returns BadRequest when otp_message_template contains an unbounded range construct",
+			token: "token",
+			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
+				authManagerMock.
+					On("GetUserByID", mock.Anything, mock.Anything).
+					Return(user, nil).
+					Once()
+			},
+			getRequestFn: func(t *testing.T, ctx context.Context) *http.Request {
+				reqBody := `{
+					"otp_message_template": "{{range 9223372036854775807}}{{end}}{{.OTP}}"
+				}`
+				return createOrganizationProfileMultipartRequest(t, ctx, url, "", "", reqBody, new(bytes.Buffer))
+			},
+			networkType:    utils.PubnetNetworkType,
+			wantStatusCode: http.StatusBadRequest,
+			wantRespBody: `{
+				"error": "The request was invalid in some way.",
+				"extras": {
+					"otp_message_template": "message template may only contain text and field substitutions like {{.OTP}}"
+				}
+			}`,
+		},
+		{
+			name:  "returns BadRequest when receiver_registration_message_template contains an unbounded range construct",
+			token: "token",
+			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {
+				authManagerMock.
+					On("GetUserByID", mock.Anything, mock.Anything).
+					Return(user, nil).
+					Once()
+			},
+			getRequestFn: func(t *testing.T, ctx context.Context) *http.Request {
+				reqBody := `{
+					"receiver_registration_message_template": "{{range 1000}}{{range 1000}}A{{end}}{{end}}"
+				}`
+				return createOrganizationProfileMultipartRequest(t, ctx, url, "", "", reqBody, new(bytes.Buffer))
+			},
+			networkType:    utils.PubnetNetworkType,
+			wantStatusCode: http.StatusBadRequest,
+			wantRespBody: `{
+				"error": "The request was invalid in some way.",
+				"extras": {
+					"receiver_registration_message_template": "message template may only contain text and field substitutions like {{.OTP}}"
+				}
+			}`,
+		},
+		{
 			name:  "returns BadRequest when organization_name contains HTML",
 			token: "token",
 			mockAuthManagerFn: func(authManagerMock *auth.AuthManagerMock) {

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"text/template"
+	"text/template/parse"
 	"time"
 	"unicode/utf8"
 
@@ -260,5 +262,67 @@ func containsHTMLTag(s string) bool {
 		default:
 			// text, comments, doctype — keep scanning
 		}
+	}
+}
+
+// ValidateMessageTemplate rejects anything but literal text and simple field substitutions like {{.OTP}}, so a
+// stored template can't loop or expand without bound at render time (CWE-400). Length and HTML are checked separately.
+func ValidateMessageTemplate(s string) error {
+	// Empty means "use the default"; nothing to render.
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+
+	tmpl, err := template.New("").Parse(s)
+	if err != nil {
+		return fmt.Errorf("message template is not valid: %w", err)
+	}
+	// A {{define}} adds a second named template to the set; only plain substitution templates are allowed.
+	if len(tmpl.Templates()) > 1 {
+		return errors.New("message template may not define nested templates")
+	}
+	if tmpl.Tree == nil || tmpl.Tree.Root == nil {
+		return nil
+	}
+	return validateTemplateNodes(tmpl.Tree.Root)
+}
+
+// validateTemplateNodes allows only text and single-field-substitution actions; every branching node is rejected.
+func validateTemplateNodes(root *parse.ListNode) error {
+	for _, n := range root.Nodes {
+		switch node := n.(type) {
+		case *parse.TextNode:
+			// literal text is inert
+		case *parse.ActionNode:
+			if err := validateActionPipe(node.Pipe); err != nil {
+				return err
+			}
+		default:
+			return errors.New("message template may only contain text and field substitutions like {{.OTP}}")
+		}
+	}
+	return nil
+}
+
+// validateActionPipe permits only {{.Field}} or {{.}}: no declarations, pipelines, or function calls.
+func validateActionPipe(pipe *parse.PipeNode) error {
+	if pipe == nil {
+		return errors.New("message template contains an empty action")
+	}
+	if len(pipe.Decl) > 0 {
+		return errors.New("message template may not declare variables")
+	}
+	if len(pipe.Cmds) != 1 {
+		return errors.New("message template may not use pipelines")
+	}
+	cmd := pipe.Cmds[0]
+	if len(cmd.Args) != 1 {
+		return errors.New("message template may only substitute a single field, like {{.OTP}}")
+	}
+	switch cmd.Args[0].(type) {
+	case *parse.FieldNode, *parse.DotNode:
+		return nil
+	default:
+		return errors.New("message template may only substitute fields like {{.OTP}}, not function calls or expressions")
 	}
 }

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -501,3 +501,50 @@ func Test_ValidateNoHTML(t *testing.T) {
 		})
 	}
 }
+
+func Test_ValidateMessageTemplate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		template    string
+		expectError bool
+	}{
+		// allowed
+		{name: "empty is allowed", template: "", expectError: false},
+		{name: "blank is allowed", template: "   ", expectError: false},
+		{name: "plain text", template: "You have a payment waiting for you.", expectError: false},
+		{name: "single field substitution", template: "Your code is {{.OTP}}", expectError: false},
+		{name: "field with surrounding spaces", template: "Your code is {{ .OTP }}", expectError: false},
+		{name: "multiple field substitutions", template: "{{.OTP}} is your {{.OrganizationName}} code", expectError: false},
+		{name: "chained field", template: "Hello {{.Receiver.Name}}", expectError: false},
+		{name: "dot", template: "{{.}}", expectError: false},
+
+		// rejected: expansion / control constructs
+		{name: "range over int (amplification)", template: "{{range 1000}}A{{end}}", expectError: true},
+		{name: "nested range", template: "{{range 1000}}{{range 1000}}A{{end}}{{end}}", expectError: true},
+		{name: "range over int (infinite loop)", template: "{{range 9223372036854775807}}{{end}}", expectError: true},
+		{name: "if block", template: "{{if .OTP}}x{{end}}", expectError: true},
+		{name: "with block", template: "{{with .OTP}}{{.}}{{end}}", expectError: true},
+		{name: "define/template", template: `{{define "T"}}x{{end}}{{template "T"}}`, expectError: true},
+
+		// rejected: function calls (printf width is its own amplification vector)
+		{name: "printf width amplification", template: `{{printf "%9999999d" 1}}`, expectError: true},
+		{name: "function pipeline", template: "{{.OTP | printf \"%s\"}}", expectError: true},
+
+		// rejected: variable declaration
+		{name: "variable declaration", template: "{{$x := .OTP}}{{$x}}", expectError: true},
+
+		// rejected: unparseable
+		{name: "unbalanced braces", template: "{{.OTP", expectError: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMessageTemplate(tc.template)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

Add a `ValidateMessageTemplate` check and apply it, alongside the existing HTML and length checks, to the three operator-supplied receiver message templates:

- the organization OTP template + registration template (`PATCH /organization`)
- the per-disbursement template (`POST /disbursements`)

These fields may now contain only literal text and simple field substitutions like `{{.OTP}}`. Loops (`{{range}}`), conditionals, nested templates, and function calls are rejected at write time.

### Why

These templates are rendered with Go's `text/template`. Since Go 1.24, `{{range N}}` iterates over an integer, so a tiny stored template such as `{{range 9223372036854775807}}{{end}}` can loop forever, or a nested range can emit gigabytes, at render time (CWE-400: Uncontrolled Resource Consumption).

The render runs inside the shared API/scheduler process, so a single tenant could exhaust memory or hang the process and degrade service for every other tenant. The only prior check on these fields was `ValidateNoHTML`, which a `{{range}}` payload passes cleanly.

### Known limitations

- Write-time only: This closes the issue for all new writes. Templates stored before this change are not retroactively scrubbed; if a deployment might already hold one, reset non-conforming rows to the default separately.
- **Per-disbursement length is now capped at 255** to match the organization fields. An existing longer per-disbursement message would be rejected on its next edit.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] Tests are included (if applicable)
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] If contracts changed, run the `Contract WASM Artifacts` workflow and open a PR to update the WASMs on `dev`
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Preview deployment works as expected
- [ ] Ready for production
